### PR TITLE
OLDFRUIT-001: Tidy up the datapath

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
@@ -181,7 +181,7 @@ namespace Oasis.MAME
         {
             get
             {
-                return Path.Combine(DataPathHelper.DynamicRootPath, kTEMPHardcodedMameExeDirectoryPath);
+                return Path.Combine(DataPathHelper.MAMERootPath);
             }
         }
 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameMpu4ChrSourceCodeLookup.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameMpu4ChrSourceCodeLookup.cs
@@ -20,14 +20,6 @@ namespace Oasis.MAME
         // mame rom name, mame variable name
         private Dictionary<string, string> _romDataReferencesDictionary = null;
 
-        public string SourceCodeDirectoryFullPath
-        {
-            get
-            {
-                return Path.Combine(DataPathHelper.DynamicRootPath, kSourceCodeDirectoryPath);
-            }
-        }
-
         public string[] GetLampColumnData(string mameRomName)
         {
             if(!_initialised)
@@ -59,7 +51,7 @@ namespace Oasis.MAME
         {
             _lampColumnDataDictionary = new Dictionary<string, string[]>();
 
-            string lampColumnDataPath = Path.Combine(SourceCodeDirectoryFullPath, LampColumnDataSourceFilename);
+            string lampColumnDataPath = Path.Combine(DataPathHelper.MAMESourcePath, LampColumnDataSourceFilename);
             string[] lines = File.ReadAllLines(lampColumnDataPath);
 
             foreach(string line in lines)
@@ -140,7 +132,7 @@ namespace Oasis.MAME
 
         private void ProcessRomDataReferencesFile(string filename)
         {
-            string romDataReferencePath = Path.Combine(SourceCodeDirectoryFullPath, filename);
+            string romDataReferencePath = Path.Combine(DataPathHelper.MAMESourcePath, filename);
             string[] lines = File.ReadAllLines(romDataReferencePath);
 
             foreach(string line in lines)

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Utility/DataPathHelper.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Utility/DataPathHelper.cs
@@ -5,36 +5,35 @@ namespace Oasis.Utility
 {
     public static class DataPathHelper
     {
-        public static string DynamicRootPath
+        public static string ProjectRootPath
         {
             get
             {
-                if (Application.isEditor)
-                {
-                    return EditorRootPath;
-                }
-                else
-                {
-                    return BuildRootPath;
-                }
+                return System.IO.Path.GetDirectoryName(Application.dataPath);
             }
         }
 
-        public static string EditorRootPath
+        public static string MAMERootPath
         {
             get
             {
-                // TOIMPROVE - this will differ for different developer PCs, should pull out to 
-                // some kind of config file/scriptable object
-                return "C:\\projects\\GitRepos\\Oasis\\UnityProjectDataDirs\\LayoutEditor";
+                return Path.Combine(DataPathHelper.ProjectRootPath, "Emulators\\MAME\\mame0258");
             }
         }
 
-        public static string BuildRootPath
+        public static string MAMEROMSPath
         {
             get
             {
-                return Application.dataPath;
+                return Path.Combine(DataPathHelper.MAMERootPath, "roms");
+            }
+        }
+
+        public static string MAMESourcePath
+        {
+            get
+            {
+                return Path.Combine(DataPathHelper.ProjectRootPath, "MameSource\\barcrest");
             }
         }
     }


### PR DESCRIPTION
The current implementation relies on a hardwired datapath and this appears to be set up in a very "machine specific" way

This update will make the assumption that the user is going to locate the MAMERootPath and MAMESourcePath within the application directory.

Specifically,

MAMERootPath: Will be "Emulators\\MAME\\mame0258" relative to the application directory

MAMESourcePath: Will be "MameSource\\barcrest" relative to the application dorectory