### PR TITLE
BUGFIX-lamp-name-should-be-unique

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MFME/ExtractImporter.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MFME/ExtractImporter.cs
@@ -160,7 +160,7 @@ namespace Oasis.MFME
                 extractComponentLamp.TextColor.ToColor().g,
                 extractComponentLamp.TextColor.ToColor().b);
 
-            componentLamp.Name = "Lamp";
+            componentLamp.Name = "Lamp_" + lampElement.Number;
             componentLamp.Text = extractComponentLamp.TextBoxText;
 
             componentLamp.Outline = !extractComponentLamp.NoOutline;


### PR DESCRIPTION
Each component, such as a lamp should have a unique identifier, a recent code change removed the unique identifier from the lamp name

This PR puts the missing component back.

The current implementation of serialization de-deplicates components as that each one is distinct. Removing the ID from the lamp identifier causes problems with this deduplication.