### PR TITLE
LE-MISC-001: Update item keys to name + guid

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/View.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/View.cs
@@ -1,5 +1,6 @@
 using Oasis.LayoutEditor;
 using Oasis.LayoutEditor.Tools;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
@@ -20,6 +21,15 @@ namespace Oasis.Layout
 
         }
 
+        private string GetComponentKey(Dictionary<string, object> data) {
+                object n, g;
+                data.TryGetValue("name", out n);
+                data.TryGetValue("guid", out g);
+                string name = n != null ? (string)n:"";
+                string guid = g != null ? (string)g:"";
+                return name + "_" + guid;  
+        }
+
         public Dictionary<string, object> GetRepresentation()
         {
             Dictionary<string, object> representation = new Dictionary<string, object>();
@@ -29,11 +39,10 @@ namespace Oasis.Layout
             foreach (SerializableDictionary component in Data.Components)
             {
                 Dictionary<string, object> componentData = component.GetRepresentation();
-                object name;
-                componentData.TryGetValue("name", out name);
-                if (name != null)
+                string componentKey = GetComponentKey(componentData);
+                if (componentKey != "")
                 {
-                    ((Dictionary<string, object>)representation["items"])[(string)name] = component.GetRepresentation();
+                    ((Dictionary<string, object>)representation["items"])[componentKey] = component.GetRepresentation();
                     continue;
                 }
                 ((List<Dictionary<string, object>>)representation["unknown"]).Add(component.GetRepresentation());


### PR DESCRIPTION
The previous implementation of the keyname for items in the exported oasis project did not use name + guid. This meant that many layout items were missing, this rectifies that by changing the way the key for the items collection is calculated.