### PR TITLE
LE-MISC-002: Parse images from layout

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Editor.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Editor.cs
@@ -178,7 +178,7 @@ namespace Oasis
         public void OnOasisExportClick()
         {
             OasisExporter exporter = new OasisExporter(new FileSystemWrapper(), new ProjectSettingsValidator(), new LayoutValidator());
-            exporter.Export(Project, string.Format("e:\\{0}.json", Project.Settings.Mame.RomName));
+            exporter.Export(Project, string.Format("e:\\SavedLayout\\{0}.json", Project.Settings.Mame.RomName));
         }
 
         public void OnEmulationStartClick()

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component.cs
@@ -64,6 +64,15 @@ namespace Oasis.Layout
             set { _fontSize = value; OnValueSetInvoke(); }
         }
 
+        public static string GetComponentKey(Dictionary<string, object> data) {
+                object n, g;
+                data.TryGetValue("name", out n);
+                data.TryGetValue("guid", out g);
+                string name = n != null ? (string)n:"";
+                string guid = g != null ? (string)g:"";
+                return name + "_" + guid;  
+        }
+
 
         // JP TODO - the plan is to change this base Component class to NOT derive from Monobehaviour, but instead
         // be a pure c# class.  At that point, we can add standard contructor/destructor, and so then for instance

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
@@ -42,6 +42,10 @@ namespace Oasis.Layout
 
             representation["type"] = GetType().Name;
 
+            if (OasisImage != null) {
+                ImageOperations.SaveToPNG(OasisImage, "background_" + Component.GetComponentKey(representation));
+            }
+
             // TODO implement Color encode/decode text format
             Debug.LogWarning("TODO implement Color encode/decode text format");
 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
@@ -89,6 +89,10 @@ namespace Oasis.Layout
             representation["number"] = _number?.ToString();
             representation["outline"] = _outline ? "true" : "false";
 
+            if (OasisImage != null) {
+                ImageOperations.SaveToPNG(OasisImage, Component.GetComponentKey(representation));
+            }
+
             Debug.LogWarning("TODO implement Color encode/decode text format");
 
             return representation;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
@@ -82,6 +82,13 @@ namespace Oasis.Layout
             representation["visible_scale_2d"] = _visibleScale2D.ToString();
             representation["is_reversed"] = _reversed ? "true" : "false";
 
+            if (BandOasisImage != null) {
+                ImageOperations.SaveToPNG(BandOasisImage, "reel_band_" + Component.GetComponentKey(representation));
+            }
+            if (OverlayOasisImage != null) {
+                ImageOperations.SaveToPNG(OverlayOasisImage, "reel_overlay_" + Component.GetComponentKey(representation));
+            }
+
             // TODO need to do IO of string Lists for List<string> ReelSymbolText
 
             return representation;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/View.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/View.cs
@@ -21,15 +21,6 @@ namespace Oasis.Layout
 
         }
 
-        private string GetComponentKey(Dictionary<string, object> data) {
-                object n, g;
-                data.TryGetValue("name", out n);
-                data.TryGetValue("guid", out g);
-                string name = n != null ? (string)n:"";
-                string guid = g != null ? (string)g:"";
-                return name + "_" + guid;  
-        }
-
         public Dictionary<string, object> GetRepresentation()
         {
             Dictionary<string, object> representation = new Dictionary<string, object>();
@@ -39,7 +30,7 @@ namespace Oasis.Layout
             foreach (SerializableDictionary component in Data.Components)
             {
                 Dictionary<string, object> componentData = component.GetRepresentation();
-                string componentKey = GetComponentKey(componentData);
+                string componentKey = Component.GetComponentKey(componentData);
                 if (componentKey != "")
                 {
                     ((Dictionary<string, object>)representation["items"])[componentKey] = component.GetRepresentation();

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Drawing;
+using UnityEngine;
+
+namespace Oasis.Graphics {
+    public class ImageOperations 
+    {
+        public static void SaveToPNG(OasisImage image, string fileUniqueName)
+        {
+            //TODO: Get rid of the ugly hardwiring here.
+            string fileName = string.Format("e:\\SavedLayout\\{0}.png", fileUniqueName);
+            if (!File.Exists(fileName)) {
+                image.FlipY();
+                File.WriteAllBytes(
+                    fileName,
+                    ImageConversion.EncodeArrayToPNG(
+                        image.GetAsByteArray(),
+                        UnityEngine.Experimental.Rendering.GraphicsFormat.B8G8R8A8_SRGB,
+                        (uint)image.Width,
+                        (uint)image.Height
+                    )
+                );
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9d310a486f0ce64aaf87857c33ae6c4


### PR DESCRIPTION
When parsing a layout for it's representation, we need to parse the images from the layout also.

This is the first step in that work. We will extract the images from the existing layout, flip them in the correct way and then store them with a filename to disk.

TODO: We will need to have a better way of saving layouts so that they can be stored into a directory by the user.

TODO: I'm not sure why the internal representation of the layout has two copies of the image (one inverted) but it seems that if we process the first instance of these images, they can be processed in a predictible way.