### PR TITLE
LE-MISC-004: Images, colour etc for layout export

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component.cs
@@ -142,14 +142,15 @@ namespace Oasis.Layout
                 {"type", GetType().Name},
                 {"guid", Guid},
                 {"name", _name},
+                //TODO: Do we need to include text/fontname etc for every component?
                 {"text", _text},
                 {"fontname", _fontName},
                 {"fontstyle", _fontStyle},
-                {"fontsize", _fontSize.ToString()},
-                {"x", _position.x.ToString()},
-                {"y", _position.y.ToString()},
-                {"width", _size.x.ToString()},
-                {"height", _size.y.ToString()},
+                {"fontsize", _fontSize},
+                {"x", _position.x},
+                {"y", _position.y},
+                {"width", _size.x},
+                {"height", _size.y},
             };
         }
 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component14Segment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component14Segment.cs
@@ -17,9 +17,7 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component14SemicolonSegment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component14SemicolonSegment.cs
@@ -17,9 +17,7 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component16Segment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component16Segment.cs
@@ -17,9 +17,7 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component16SemicolonSegment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component16SemicolonSegment.cs
@@ -17,9 +17,7 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component7Segment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/Component7Segment.cs
@@ -17,9 +17,7 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentAlpha.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentAlpha.cs
@@ -24,10 +24,8 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-            representation["is_reversed"] = _reversed ? "true" : "false";
-
+            representation["is_reversed"] = _reversed;
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
@@ -39,16 +39,13 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-
+            representation["file_path"] = null;
+            representation["color"] = "#" + ColorUtility.ToHtmlStringRGBA(Color);
             if (OasisImage != null) {
-                ImageOperations.SaveToPNG(OasisImage, "background_" + Component.GetComponentKey(representation));
+                representation["file_path"] =  Component.GetComponentKey(representation) + ".png";
+                ImageOperations.SaveToPNG(OasisImage, (string) representation["file_path"]);
             }
-
-            // TODO implement Color encode/decode text format
-            Debug.LogWarning("TODO implement Color encode/decode text format");
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentInput.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentInput.cs
@@ -56,13 +56,11 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-            representation["enabled"] = Input.Enabled ? "true" : "false";
-            representation["inverted"] = Input.Inverted ? "true" : "false";
+            representation["enabled"] = Input.Enabled;
+            representation["inverted"] = Input.Inverted;
             representation["key_code"] = Input.KeyCode.ToString();
             representation["button_number"] = Input.ButtonNumber;
-
             return representation;
         }
 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
@@ -84,17 +84,17 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-            representation["number"] = _number?.ToString();
-            representation["outline"] = _outline ? "true" : "false";
-
+            representation["number"] = _number;
+            representation["outline"] = _outline;
+            representation["on_color"] = "#" + ColorUtility.ToHtmlStringRGB(OnColor);
+            representation["off_color"] = "#" + ColorUtility.ToHtmlStringRGB(OffColor);
+            representation["text_color"] = "#" + ColorUtility.ToHtmlStringRGB(TextColor);
+            representation["file_path"] = null;
             if (OasisImage != null) {
-                ImageOperations.SaveToPNG(OasisImage, Component.GetComponentKey(representation));
+                representation["file_path"] =  Component.GetComponentKey(representation) + ".png";
+                ImageOperations.SaveToPNG(OasisImage, (string) representation["file_path"]);
             }
-
-            Debug.LogWarning("TODO implement Color encode/decode text format");
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
@@ -78,19 +78,21 @@ namespace Oasis.Layout
             Dictionary<string, object> representation = base.GetRepresentation();
 
             representation["type"] = GetType().Name;
-            representation["stops"] = _stops.ToString();
-            representation["visible_scale_2d"] = _visibleScale2D.ToString();
-            representation["is_reversed"] = _reversed ? "true" : "false";
-
+            representation["stops"] = _stops;
+            representation["visible_scale_2d"] = _visibleScale2D;
+            representation["is_reversed"] = _reversed;
+            representation["number"] = _number;
+            representation["reel_symbol_text"] = ReelSymbolText;
+            representation["file_path_band_image"] = null;
+            representation["file_path_overlay_image"] = null;
             if (BandOasisImage != null) {
-                ImageOperations.SaveToPNG(BandOasisImage, "reel_band_" + Component.GetComponentKey(representation));
+                representation["file_path_band_image"] =  "reel_band_" + Component.GetComponentKey(representation) + ".png";
+                ImageOperations.SaveToPNG(BandOasisImage, (string) representation["file_path_band_image"]);
             }
             if (OverlayOasisImage != null) {
-                ImageOperations.SaveToPNG(OverlayOasisImage, "reel_overlay_" + Component.GetComponentKey(representation));
+                representation["file_path_overlay_image"] =  "reel_overlay_" + Component.GetComponentKey(representation) + ".png";
+                ImageOperations.SaveToPNG(OverlayOasisImage, (string) representation["file_path_overlay_image"]);
             }
-
-            // TODO need to do IO of string Lists for List<string> ReelSymbolText
-
             return representation;
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentSegment.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentSegment.cs
@@ -48,12 +48,9 @@ namespace Oasis.Layout
         public override Dictionary<string, object> GetRepresentation() 
         {
             Dictionary<string, object> representation = base.GetRepresentation();
-
             representation["type"] = GetType().Name;
-            representation["number"] = _number?.ToString();
-
-            Debug.LogWarning("TODO implement Color encode/decode text format");
-
+            representation["number"] = _number;
+            representation["color"] = "#" + ColorUtility.ToHtmlStringRGB(Color);
             return representation;
         }
     }


### PR DESCRIPTION
This has been mainly around getting the saved Oasis Project to reflect the state of the editor components. I think I covered most of the stuff we will need here.

* Building on the image export from last night, I have added the filenames to Lamps, Backgrounds, Reels so that they show up in the JSON.
* Color exported as part of background, in RGBA format and represented as an HTML encoding i.e. "#FF0000FF"
* OnColor, OffColor, TextColor exported as part of lamps, in RGB format and represented as an HTML encoding i.e. "#FF0000"
* Color exported as part of segments, in RGB format and represented as an HTML encoding i.e. "#FF0000
* Correct number format used for values in export, instead of using strings everywhere.
* Introduction of null values when a value is unavailable (worth considering "omitempty" type behaviour but leaving as is for now)