### PR TITLE
Add global active tab highlighter

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.UI;
+using DynamicPanels;
+
+namespace Oasis.LayoutEditor
+{
+    public class GlobalActiveTabHighlighter : MonoBehaviour
+    {
+        [SerializeField]
+        private Color _highlightColor = Color.yellow;
+
+        [SerializeField]
+        private float _highlightThickness = 2f;
+
+        private PanelTab _current;
+
+        private void OnEnable()
+        {
+            PanelNotificationCenter.OnActiveTabChanged += OnActiveTabChanged;
+            PanelNotificationCenter.OnTabCreated += OnTabCreated;
+            PanelNotificationCenter.OnTabDestroyed += OnTabDestroyed;
+        }
+
+        private void OnDisable()
+        {
+            PanelNotificationCenter.OnActiveTabChanged -= OnActiveTabChanged;
+            PanelNotificationCenter.OnTabCreated -= OnTabCreated;
+            PanelNotificationCenter.OnTabDestroyed -= OnTabDestroyed;
+        }
+
+        private void OnTabCreated(PanelTab tab)
+        {
+            Outline outline = tab.gameObject.GetComponent<Outline>();
+            if (outline == null)
+                outline = tab.gameObject.AddComponent<Outline>();
+
+            outline.effectColor = _highlightColor;
+            outline.effectDistance = new Vector2(_highlightThickness, _highlightThickness);
+            outline.enabled = false;
+        }
+
+        private void OnActiveTabChanged(PanelTab tab)
+        {
+            if (_current != null)
+            {
+                Outline currentOutline = _current.gameObject.GetComponent<Outline>();
+                if (currentOutline != null)
+                    currentOutline.enabled = false;
+            }
+
+            _current = tab;
+
+            if (_current != null)
+            {
+                Outline newOutline = _current.gameObject.GetComponent<Outline>();
+                if (newOutline == null)
+                    newOutline = _current.gameObject.AddComponent<Outline>();
+
+                newOutline.effectColor = _highlightColor;
+                newOutline.effectDistance = new Vector2(_highlightThickness, _highlightThickness);
+                newOutline.enabled = true;
+            }
+        }
+
+        private void OnTabDestroyed(PanelTab tab)
+        {
+            if (_current == tab)
+            {
+                Outline outline = tab.gameObject.GetComponent<Outline>();
+                if (outline != null)
+                    outline.enabled = false;
+
+                _current = null;
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d90728a8f644779abf6d7eacd8a8faf


### PR DESCRIPTION
## Summary
- highlight active tab using Outline component with configurable color and thickness
- listen for tab creation, activation, and destruction to manage highlighting

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c5a3e417d48327976e7b9d7633b6fc