### PR TITLE
Highlight tab when clicking within its content

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
@@ -43,10 +43,20 @@ namespace Oasis.LayoutEditor
             outline.effectDistance = new Vector2(_highlightThickness, _highlightThickness);
             outline.enabled = false;
 
-            TabClickHandler clickHandler = tab.gameObject.GetComponent<TabClickHandler>();
+            AddClickHandler(tab.gameObject, tab);
+
+            if (tab.Content != null)
+            {
+                AddClickHandler(tab.Content.gameObject, tab);
+            }
+        }
+
+        private void AddClickHandler(GameObject target, PanelTab tab)
+        {
+            TabClickHandler clickHandler = target.GetComponent<TabClickHandler>();
             if (clickHandler == null)
             {
-                clickHandler = tab.gameObject.AddComponent<TabClickHandler>();
+                clickHandler = target.AddComponent<TabClickHandler>();
             }
             clickHandler.Initialize(this, tab);
         }


### PR DESCRIPTION
## Summary
- allow GlobalActiveTabHighlighter to react when tab content is clicked, not just tab header
- factor click handler attachment into helper to support multiple targets

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ab36cd54832799de4e335f4e82ab