### PR TITLE
Ensure PanelTabs receive TabHeaderContextMenu

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using DynamicPanels;
+
+// Ensures every PanelTab has a TabHeaderContextMenu component attached.
+// Adds the component to existing tabs and to any tabs created later.
+public static class TabHeaderContextMenuAttacher
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void Initialize()
+    {
+        // Attach to existing tabs
+        foreach (var tab in Object.FindObjectsOfType<PanelTab>())
+        {
+            Attach(tab);
+        }
+
+        // Listen for future tabs
+        PanelNotificationCenter.OnTabCreated -= Attach;
+        PanelNotificationCenter.OnTabCreated += Attach;
+    }
+
+    static void Attach(PanelTab tab)
+    {
+        if (tab && tab.GetComponent<TabHeaderContextMenu>() == null)
+        {
+            tab.gameObject.AddComponent<TabHeaderContextMenu>();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Automatically attach `TabHeaderContextMenu` to existing `PanelTab` objects and listen for newly created tabs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c5c2625efc8327be5d2d0eced4e07e