### PR TITLE
Make TabHeaderContextMenu Maximise option toggleable

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -6,13 +6,23 @@ using DynamicPanels;
 // Context menu for tab headers.
 public sealed class TabHeaderContextMenu : NativeContextMenu
 {
+    bool _maximised;
+
     protected override List<NativeContextMenuManager.MenuItemSpec> BuildMenu()
     {
         var tab = GetComponent<PanelTab>();
 
         return new List<NativeContextMenuManager.MenuItemSpec>
         {
-            new NativeContextMenuManager.MenuItemSpec("Maximise", () => Debug.Log("Maximise clicked")),
+            new NativeContextMenuManager.MenuItemSpec(
+                "Maximise",
+                () =>
+                {
+                    _maximised = !_maximised;
+                    Debug.Log($"Maximise set to {_maximised}");
+                },
+                true,
+                _maximised),
             new NativeContextMenuManager.MenuItemSpec(
                 "Close",
                 () =>


### PR DESCRIPTION
## Summary
- allow Maximise context menu entry to toggle checked state

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ca62a7708327879f00d8faff3082