### PR TITLE
Disable resizing and dragging for maximized panel tabs

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -8,6 +8,9 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
 {
     bool _maximised;
     byte[] _savedBytes;
+    PanelHeader _panelHeader;
+    PanelResizeHelper[] _resizeHelpers;
+    PanelTab[] _tabs;
 
     protected override List<NativeContextMenuManager.MenuItemSpec> BuildMenu()
     {
@@ -33,9 +36,60 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
                         panel.BringForward();
                         panel.RectTransform.anchoredPosition = Vector2.zero;
                         panel.FloatingSize = panel.Canvas.Size;
+
+                        _panelHeader = panel.GetComponentInChildren<PanelHeader>();
+                        if (_panelHeader)
+                        {
+                            _panelHeader.enabled = false;
+                        }
+
+                        _resizeHelpers = panel.GetComponentsInChildren<PanelResizeHelper>();
+                        foreach (var helper in _resizeHelpers)
+                        {
+                            if (helper)
+                            {
+                                helper.enabled = false;
+                            }
+                        }
+
+                        _tabs = panel.GetComponentsInChildren<PanelTab>();
+                        foreach (var t in _tabs)
+                        {
+                            if (t)
+                            {
+                                t.enabled = false;
+                            }
+                        }
                     }
                     else
                     {
+                        if (_panelHeader)
+                        {
+                            _panelHeader.enabled = true;
+                        }
+
+                        if (_resizeHelpers != null)
+                        {
+                            foreach (var helper in _resizeHelpers)
+                            {
+                                if (helper)
+                                {
+                                    helper.enabled = true;
+                                }
+                            }
+                        }
+
+                        if (_tabs != null)
+                        {
+                            foreach (var t in _tabs)
+                            {
+                                if (t)
+                                {
+                                    t.enabled = true;
+                                }
+                            }
+                        }
+
                         PanelSerialization.DeserializeCanvasFromArray(panel.Canvas, _savedBytes);
                     }
                 },


### PR DESCRIPTION
## Summary
- prevent tab panels from being resized or dragged while maximized by disabling PanelHeader, PanelResizeHelper and PanelTab components
- restore components and layout when un-maximizing a tab

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c5d0b7211083279f2f0f9cd7840b48