### PR TITLE
Refactor panel tab maximise logic

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMaximiser.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMaximiser.cs
@@ -1,0 +1,136 @@
+using UnityEngine;
+using DynamicPanels;
+
+// Handles maximising and restoring of a PanelTab's panel.
+public sealed class PanelTabMaximiser : MonoBehaviour
+{
+    bool _maximised;
+    byte[] _savedBytes;
+    PanelHeader _panelHeader;
+    PanelResizeHelper[] _resizeHelpers;
+    PanelTab[] _tabs;
+    Vector2 _lastCanvasSize;
+    Panel _panel;
+
+    public bool IsMaximised => _maximised;
+
+    public void ToggleMaximise()
+    {
+        if (_maximised)
+        {
+            Restore();
+        }
+        else
+        {
+            Maximise();
+        }
+    }
+
+    public void Maximise()
+    {
+        if (_maximised)
+        {
+            return;
+        }
+
+        var tab = GetComponent<PanelTab>();
+        _panel = tab ? tab.Panel : null;
+        if (_panel == null)
+        {
+            return;
+        }
+
+        _savedBytes = PanelSerialization.SerializeCanvasToArray(_panel.Canvas);
+        _panel.Detach();
+        _panel.BringForward();
+        _panel.RectTransform.anchoredPosition = Vector2.zero;
+        _lastCanvasSize = _panel.Canvas.Size;
+        _panel.FloatingSize = _lastCanvasSize;
+
+        _panelHeader = _panel.GetComponentInChildren<PanelHeader>();
+        if (_panelHeader)
+        {
+            _panelHeader.enabled = false;
+        }
+
+        _resizeHelpers = _panel.GetComponentsInChildren<PanelResizeHelper>();
+        foreach (var helper in _resizeHelpers)
+        {
+            if (helper)
+            {
+                helper.enabled = false;
+            }
+        }
+
+        _tabs = _panel.GetComponentsInChildren<PanelTab>();
+        foreach (var t in _tabs)
+        {
+            if (t)
+            {
+                t.enabled = false;
+            }
+        }
+
+        _maximised = true;
+    }
+
+    public void Restore()
+    {
+        if (!_maximised)
+        {
+            return;
+        }
+
+        var tab = GetComponent<PanelTab>();
+        _panel = tab ? tab.Panel : null;
+        if (_panel == null)
+        {
+            _maximised = false;
+            return;
+        }
+
+        if (_panelHeader)
+        {
+            _panelHeader.enabled = true;
+        }
+
+        if (_resizeHelpers != null)
+        {
+            foreach (var helper in _resizeHelpers)
+            {
+                if (helper)
+                {
+                    helper.enabled = true;
+                }
+            }
+        }
+
+        if (_tabs != null)
+        {
+            foreach (var t in _tabs)
+            {
+                if (t)
+                {
+                    t.enabled = true;
+                }
+            }
+        }
+
+        PanelSerialization.DeserializeCanvasFromArray(_panel.Canvas, _savedBytes);
+        _maximised = false;
+    }
+
+    void Update()
+    {
+        if (_maximised && _panel != null)
+        {
+            var size = _panel.Canvas.Size;
+            if (size != _lastCanvasSize)
+            {
+                _lastCanvasSize = size;
+                _panel.FloatingSize = size;
+                _panel.RectTransform.anchoredPosition = Vector2.zero;
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -6,16 +6,10 @@ using DynamicPanels;
 // Context menu for tab headers.
 public sealed class TabHeaderContextMenu : NativeContextMenu
 {
-    bool _maximised;
-    byte[] _savedBytes;
-    PanelHeader _panelHeader;
-    PanelResizeHelper[] _resizeHelpers;
-    PanelTab[] _tabs;
-
     protected override List<NativeContextMenuManager.MenuItemSpec> BuildMenu()
     {
         var tab = GetComponent<PanelTab>();
-        var panel = tab ? tab.Panel : null;
+        var maximiser = GetComponent<PanelTabMaximiser>();
 
         return new List<NativeContextMenuManager.MenuItemSpec>
         {
@@ -23,78 +17,13 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
                 "Maximise",
                 () =>
                 {
-                    if (!panel)
+                    if (maximiser)
                     {
-                        return;
-                    }
-
-                    _maximised = !_maximised;
-                    if (_maximised)
-                    {
-                        _savedBytes = PanelSerialization.SerializeCanvasToArray(panel.Canvas);
-                        panel.Detach();
-                        panel.BringForward();
-                        panel.RectTransform.anchoredPosition = Vector2.zero;
-                        panel.FloatingSize = panel.Canvas.Size;
-
-                        _panelHeader = panel.GetComponentInChildren<PanelHeader>();
-                        if (_panelHeader)
-                        {
-                            _panelHeader.enabled = false;
-                        }
-
-                        _resizeHelpers = panel.GetComponentsInChildren<PanelResizeHelper>();
-                        foreach (var helper in _resizeHelpers)
-                        {
-                            if (helper)
-                            {
-                                helper.enabled = false;
-                            }
-                        }
-
-                        _tabs = panel.GetComponentsInChildren<PanelTab>();
-                        foreach (var t in _tabs)
-                        {
-                            if (t)
-                            {
-                                t.enabled = false;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (_panelHeader)
-                        {
-                            _panelHeader.enabled = true;
-                        }
-
-                        if (_resizeHelpers != null)
-                        {
-                            foreach (var helper in _resizeHelpers)
-                            {
-                                if (helper)
-                                {
-                                    helper.enabled = true;
-                                }
-                            }
-                        }
-
-                        if (_tabs != null)
-                        {
-                            foreach (var t in _tabs)
-                            {
-                                if (t)
-                                {
-                                    t.enabled = true;
-                                }
-                            }
-                        }
-
-                        PanelSerialization.DeserializeCanvasFromArray(panel.Canvas, _savedBytes);
+                        maximiser.ToggleMaximise();
                     }
                 },
                 true,
-                _maximised),
+                maximiser && maximiser.IsMaximised),
             new NativeContextMenuManager.MenuItemSpec(
                 "Close",
                 () =>

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
@@ -1,8 +1,9 @@
 using UnityEngine;
 using DynamicPanels;
 
-// Ensures every PanelTab has a TabHeaderContextMenu component attached.
-// Adds the component to existing tabs and to any tabs created later.
+// Ensures every PanelTab has the components required for context menu and
+// maximise/restore functionality. Adds the components to existing tabs and to
+// any tabs created later.
 public static class TabHeaderContextMenuAttacher
 {
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
@@ -21,9 +22,19 @@ public static class TabHeaderContextMenuAttacher
 
     static void Attach(PanelTab tab)
     {
-        if (tab && tab.GetComponent<TabHeaderContextMenu>() == null)
+        if (!tab)
+        {
+            return;
+        }
+
+        if (tab.GetComponent<TabHeaderContextMenu>() == null)
         {
             tab.gameObject.AddComponent<TabHeaderContextMenu>();
+        }
+
+        if (tab.GetComponent<PanelTabMaximiser>() == null)
+        {
+            tab.gameObject.AddComponent<PanelTabMaximiser>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- extract maximise/restore behaviour into `PanelTabMaximiser` MonoBehaviour
- attach maximiser to all `PanelTab` objects alongside context menu
- update context menu to delegate maximise option to new maximiser and expose state

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c69005ded483279fef5f47f21b6e07