### PR TITLE
feat: toggle panel maximise on tab double click

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabDoubleClickMaximiser.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabDoubleClickMaximiser.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+// Toggles a tab's maximise/restore state when it is double-clicked.
+public sealed class PanelTabDoubleClickMaximiser : MonoBehaviour, IPointerClickHandler
+{
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (eventData.button == PointerEventData.InputButton.Left && eventData.clickCount == 2)
+        {
+            var maximiser = GetComponent<PanelTabMaximiser>();
+            if (maximiser)
+            {
+                maximiser.ToggleMaximise();
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
@@ -36,5 +36,10 @@ public static class TabHeaderContextMenuAttacher
         {
             tab.gameObject.AddComponent<PanelTabMaximiser>();
         }
+
+        if (tab.GetComponent<PanelTabDoubleClickMaximiser>() == null)
+        {
+            tab.gameObject.AddComponent<PanelTabDoubleClickMaximiser>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `PanelTabDoubleClickMaximiser` to toggle maximise/restore when a tab is double-clicked
- automatically attach maximise components to tabs without modifying third-party package

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c69260216c8327ad9677c8e1de31bd