### PR TITLE
Add middle-click tab closing

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMiddleClickCloser.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMiddleClickCloser.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using DynamicPanels;
+
+// Closes a tab when it is middle-clicked.
+public sealed class PanelTabMiddleClickCloser : MonoBehaviour, IPointerClickHandler
+{
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (eventData.button == PointerEventData.InputButton.Middle)
+        {
+            var tab = GetComponent<PanelTab>();
+            if (tab)
+            {
+                tab.Destroy();
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenuAttacher.cs
@@ -41,5 +41,10 @@ public static class TabHeaderContextMenuAttacher
         {
             tab.gameObject.AddComponent<PanelTabDoubleClickMaximiser>();
         }
+
+        if (tab.GetComponent<PanelTabMiddleClickCloser>() == null)
+        {
+            tab.gameObject.AddComponent<PanelTabMiddleClickCloser>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Allow middle mouse button click on panel tabs to close them
- Automatically add middle-click closer to all tabs via TabHeaderContextMenuAttacher

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c696e36b388327bddbd3c142319f52