### PR TITLE
Use custom TabHighlight for active tab

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
@@ -33,15 +33,15 @@ namespace Oasis.LayoutEditor
 
         private void OnTabCreated(PanelTab tab)
         {
-            Outline outline = tab.gameObject.GetComponent<Outline>();
-            if (outline == null)
+            TabHighlight highlight = tab.gameObject.GetComponent<TabHighlight>();
+            if (highlight == null)
             {
-                outline = tab.gameObject.AddComponent<Outline>();
+                highlight = tab.gameObject.AddComponent<TabHighlight>();
             }
 
-            outline.effectColor = _highlightColor;
-            outline.effectDistance = new Vector2(_highlightThickness, _highlightThickness);
-            outline.enabled = false;
+            highlight.color = _highlightColor;
+            highlight.Thickness = _highlightThickness;
+            highlight.enabled = false;
 
             AddClickHandler(tab.gameObject, tab);
 
@@ -90,10 +90,10 @@ namespace Oasis.LayoutEditor
         {
             if (_current != null)
             {
-                Outline currentOutline = _current.gameObject.GetComponent<Outline>();
-                if (currentOutline != null)
+                TabHighlight currentHighlight = _current.gameObject.GetComponent<TabHighlight>();
+                if (currentHighlight != null)
                 {
-                    currentOutline.enabled = false;
+                    currentHighlight.enabled = false;
                 }
             }
 
@@ -101,15 +101,15 @@ namespace Oasis.LayoutEditor
 
             if (_current != null)
             {
-                Outline newOutline = _current.gameObject.GetComponent<Outline>();
-                if (newOutline == null)
+                TabHighlight newHighlight = _current.gameObject.GetComponent<TabHighlight>();
+                if (newHighlight == null)
                 {
-                    newOutline = _current.gameObject.AddComponent<Outline>();
+                    newHighlight = _current.gameObject.AddComponent<TabHighlight>();
                 }
 
-                newOutline.effectColor = _highlightColor;
-                newOutline.effectDistance = new Vector2(_highlightThickness, _highlightThickness);
-                newOutline.enabled = true;
+                newHighlight.color = _highlightColor;
+                newHighlight.Thickness = _highlightThickness;
+                newHighlight.enabled = true;
             }
         }
 
@@ -117,10 +117,10 @@ namespace Oasis.LayoutEditor
         {
             if (_current == tab)
             {
-                Outline outline = tab.gameObject.GetComponent<Outline>();
-                if (outline != null)
+                TabHighlight highlight = tab.gameObject.GetComponent<TabHighlight>();
+                if (highlight != null)
                 {
-                    outline.enabled = false;
+                    highlight.enabled = false;
                 }
 
                 _current = null;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabHighlight.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabHighlight.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Oasis.LayoutEditor
+{
+    /// <summary>
+    /// Simple graphic that renders a line along the top edge of a rect transform.
+    /// </summary>
+    [RequireComponent(typeof(RectTransform))]
+    public class TabHighlight : MaskableGraphic
+    {
+        [SerializeField]
+        private float _thickness = 2f;
+
+        /// <summary>
+        /// Thickness of the top highlight line in pixels.
+        /// </summary>
+        public float Thickness
+        {
+            get => _thickness;
+            set
+            {
+                _thickness = value;
+                SetVerticesDirty();
+            }
+        }
+
+        protected override void OnPopulateMesh(VertexHelper vh)
+        {
+            vh.Clear();
+
+            Rect rect = GetPixelAdjustedRect();
+            float top = rect.yMax;
+            float bottom = top - _thickness;
+
+            vh.AddVert(new Vector3(rect.xMin, top), color, new Vector2(0f, 1f));
+            vh.AddVert(new Vector3(rect.xMax, top), color, new Vector2(1f, 1f));
+            vh.AddVert(new Vector3(rect.xMax, bottom), color, new Vector2(1f, 0f));
+            vh.AddVert(new Vector3(rect.xMin, bottom), color, new Vector2(0f, 0f));
+
+            vh.AddTriangle(0, 1, 2);
+            vh.AddTriangle(2, 3, 0);
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabHighlight.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabHighlight.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c043fa0fc8794825be1816f6b1c4b80d


### PR DESCRIPTION
## Summary
- introduce `TabHighlight` component rendering a line on a tab's top edge
- switch `GlobalActiveTabHighlighter` to use `TabHighlight` instead of Unity's `Outline`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c69b1c1f888327b4cce6d878994420