### PR TITLE
refactor: move project image assets into dedicated folder

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentBackground.cs
@@ -51,7 +51,7 @@ namespace Oasis.Layout
                         {
                             OasisImage = ImageOperations.LoadFromPng(
                                 Path.Combine(
-                                    Editor.Instance.ProjectsController.ProjectRootPath, 
+                                    Editor.Instance.ProjectsController.ProjectAssetsPath,
                                     (string)field.Value));
                         }
                         break;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentLamp.cs
@@ -96,7 +96,7 @@ namespace Oasis.Layout
                         {
                             OasisImage = ImageOperations.LoadFromPng(
                                 Path.Combine(
-                                    Editor.Instance.ProjectsController.ProjectRootPath,
+                                    Editor.Instance.ProjectsController.ProjectAssetsPath,
                                     (string)field.Value));
                         }
                         break;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Layout/Components/ComponentReel.cs
@@ -98,7 +98,7 @@ namespace Oasis.Layout
                         {
                             BandOasisImage = ImageOperations.LoadFromPng(
                                 Path.Combine(
-                                    Editor.Instance.ProjectsController.ProjectRootPath,
+                                    Editor.Instance.ProjectsController.ProjectAssetsPath,
                                     (string)field.Value));
                         }
                         break;
@@ -107,7 +107,7 @@ namespace Oasis.Layout
                         {
                             OverlayOasisImage = ImageOperations.LoadFromPng(
                                 Path.Combine(
-                                    Editor.Instance.ProjectsController.ProjectRootPath,
+                                    Editor.Instance.ProjectsController.ProjectAssetsPath,
                                     (string)field.Value));
                         }
                         break;

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Graphics/ImageOperations.cs
@@ -10,8 +10,10 @@ namespace Oasis.Graphics {
         {
             //JP TODO slightly less hardwiring, but we will prob want to pass in a path
             // to this generic SaveToPNG function:
+            string assetsPath = Editor.Instance.ProjectsController.ProjectAssetsPath;
+            Directory.CreateDirectory(assetsPath);
             string filePath = Path.Combine(
-                                  Editor.Instance.ProjectsController.ProjectRootPath,
+                                  assetsPath,
                                   fileUniqueName);
 
             File.WriteAllBytes(

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Projects/ProjectsController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Projects/ProjectsController.cs
@@ -8,11 +8,17 @@ namespace Oasis.Projects
     public class ProjectsController : MonoBehaviour
     {
         public const string kProjectJsonFilename = "project.json";
+        public const string kAssetsFolderName = "Assets";
          
         public string ProjectRootPath
         {
             get;
             set;
+        }
+
+        public string ProjectAssetsPath
+        {
+            get { return Path.Combine(ProjectRootPath, kAssetsFolderName); }
         }
 
         public ProjectsList ProjectsList
@@ -43,6 +49,7 @@ namespace Oasis.Projects
 
             // create project directory
             Directory.CreateDirectory(rootPath);
+            Directory.CreateDirectory(Path.Combine(rootPath, kAssetsFolderName));
 
             ProjectRootPath = rootPath;
 
@@ -74,6 +81,8 @@ namespace Oasis.Projects
             // TODO prob want to add some exception handling and return false for failed save
 
             ProjectRootPath = path;
+
+            Directory.CreateDirectory(ProjectAssetsPath);
 
             string projectJsonPath = Path.Combine(ProjectRootPath, kProjectJsonFilename);
 


### PR DESCRIPTION
## Summary
- create an `Assets` subfolder when creating or loading a project
- save and load image assets from the project's `Assets` directory

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c6a8871b948327aa6153bea1381650