### PR TITLE
feat: add tab pooling for dynamic panels

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Editor.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7938d8b0deab476dbe73623796616976
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs
@@ -1,0 +1,22 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using Oasis;
+
+public static class TabPoolMenu
+{
+    [MenuItem("Window/Restore Tabs/Show Inspector")]
+    private static void ShowInspector()
+    {
+        TabPool pool = Object.FindObjectOfType<TabPool>();
+        if (pool != null)
+        {
+            pool.ShowTab("Inspector");
+        }
+        else
+        {
+            Debug.LogWarning("TabPool not found in the scene.");
+        }
+    }
+}
+#endif

--- a/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8c8daa0c22845ddbe7ecff635016dee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using UnityEngine;
+using DynamicPanels;
+
+namespace Oasis
+{
+    public class TabPool : MonoBehaviour
+    {
+        [SerializeField]
+        private RectTransform _closedTabsRoot;
+
+        [SerializeField]
+        private string[] _toolWindowIds;
+
+        private readonly Dictionary<string, Panel> _storedPanels = new Dictionary<string, Panel>();
+
+        private void Awake()
+        {
+            PanelNotificationCenter.OnTabClosed += HandleTabClosed;
+        }
+
+        private void OnDestroy()
+        {
+            PanelNotificationCenter.OnTabClosed -= HandleTabClosed;
+        }
+
+        private void HandleTabClosed(PanelTab tab)
+        {
+            if (tab == null)
+            {
+                return;
+            }
+
+            string id = tab.ID;
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            if (_toolWindowIds != null && _toolWindowIds.Length > 0)
+            {
+                bool match = false;
+                for (int i = 0; i < _toolWindowIds.Length; i++)
+                {
+                    if (_toolWindowIds[i] == id)
+                    {
+                        match = true;
+                        break;
+                    }
+                }
+
+                if (!match)
+                {
+                    return;
+                }
+            }
+
+            Panel panel = tab.Panel.DetachTab(tab);
+            if (panel == null)
+            {
+                return;
+            }
+
+            if (_closedTabsRoot != null)
+            {
+                panel.RectTransform.SetParent(_closedTabsRoot, false);
+            }
+
+            panel.gameObject.SetActive(false);
+            _storedPanels[id] = panel;
+        }
+
+        public void ShowTab(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return;
+            }
+
+            Panel panel;
+            if (!_storedPanels.TryGetValue(id, out panel) || panel == null)
+            {
+                return;
+            }
+
+            panel.gameObject.SetActive(true);
+            PanelManager.Instance.AnchorPanel(panel, panel.Canvas, Direction.Right);
+            _storedPanels.Remove(id);
+        }
+
+        public void ShowInspector()
+        {
+            ShowTab("Inspector");
+        }
+    }
+}
+

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df55425e0674418c94c11bffef913c59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add `TabPool` MonoBehaviour to pool closed tool tabs and restore them later
- add editor menu item to reopen pooled tabs like the Inspector

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c7d423648327844b8996ff10b28b