### PR TITLE
Use enum-based IDs for tab pooling

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Editor/TabPoolMenu.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 using Oasis;
+using Oasis.LayoutEditor;
 
 public static class TabPoolMenu
 {
@@ -11,7 +12,7 @@ public static class TabPoolMenu
         TabPool pool = Object.FindObjectOfType<TabPool>();
         if (pool != null)
         {
-            pool.ShowTab("Inspector");
+            pool.ShowTab(TabController.TabTypes.Inspector);
         }
         else
         {

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using DynamicPanels;
 using UnityEngine.UI;
+using UnityEngine.Serialization;
 using System;
 using System.Collections.Generic;
 
@@ -27,7 +28,8 @@ namespace Oasis.LayoutEditor
         public class TabDefinition
         {
             public string Label;
-            public TabTypes TabType;
+            [FormerlySerializedAs("TabType")]
+            public TabTypes TypeID;
             public Sprite Icon;
             public RectTransform RectTransform;
         }
@@ -43,7 +45,7 @@ namespace Oasis.LayoutEditor
                 return null;
             }
 
-            TabDefinition tabDefinition = TabDefinitions.Find(x => x.TabType == tabType);
+            TabDefinition tabDefinition = TabDefinitions.Find(x => x.TypeID == tabType);
             PanelTab panelTab = CreatePanelTab(tabDefinition);
             return panelTab;
         }
@@ -56,6 +58,7 @@ namespace Oasis.LayoutEditor
             PanelTab panelTab = panel[0];
             panelTab.Icon = tabDefinition.Icon;
             panelTab.Label = tabDefinition.Label;
+            panelTab.ID = tabDefinition.TypeID.ToString();
 
             return panelTab;
         }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/TabPool.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using DynamicPanels;
+using Oasis.LayoutEditor;
 
 namespace Oasis
 {
@@ -10,9 +11,9 @@ namespace Oasis
         private RectTransform _closedTabsRoot;
 
         [SerializeField]
-        private string[] _toolWindowIds;
+        private TabController.TabTypes[] _toolWindowIds;
 
-        private readonly Dictionary<string, Panel> _storedPanels = new Dictionary<string, Panel>();
+        private readonly Dictionary<TabController.TabTypes, Panel> _storedPanels = new Dictionary<TabController.TabTypes, Panel>();
 
         private void Awake()
         {
@@ -37,12 +38,17 @@ namespace Oasis
                 return;
             }
 
+            if (!System.Enum.TryParse<TabController.TabTypes>(id, out var tabType))
+            {
+                return;
+            }
+
             if (_toolWindowIds != null && _toolWindowIds.Length > 0)
             {
                 bool match = false;
                 for (int i = 0; i < _toolWindowIds.Length; i++)
                 {
-                    if (_toolWindowIds[i] == id)
+                    if (_toolWindowIds[i] == tabType)
                     {
                         match = true;
                         break;
@@ -67,16 +73,11 @@ namespace Oasis
             }
 
             panel.gameObject.SetActive(false);
-            _storedPanels[id] = panel;
+            _storedPanels[tabType] = panel;
         }
 
-        public void ShowTab(string id)
+        public void ShowTab(TabController.TabTypes id)
         {
-            if (string.IsNullOrEmpty(id))
-            {
-                return;
-            }
-
             Panel panel;
             if (!_storedPanels.TryGetValue(id, out panel) || panel == null)
             {
@@ -90,7 +91,7 @@ namespace Oasis
 
         public void ShowInspector()
         {
-            ShowTab("Inspector");
+            ShowTab(TabController.TabTypes.Inspector);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add stable `TypeID` field to `TabDefinition` and assign it to tab IDs
- Track pooled panels by `TabTypes` instead of strings and update API
- Adjust tooling menu to restore tabs using enum identifiers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6d5d115008327af5b771333db59ce