### PR TITLE
Add tab hiding mechanism

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMiddleClickCloser.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/PanelTabMiddleClickCloser.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 using DynamicPanels;
+using Oasis;
 
 // Closes a tab when it is middle-clicked.
 public sealed class PanelTabMiddleClickCloser : MonoBehaviour, IPointerClickHandler
@@ -12,7 +13,7 @@ public sealed class PanelTabMiddleClickCloser : MonoBehaviour, IPointerClickHand
             var tab = GetComponent<PanelTab>();
             if (tab)
             {
-                tab.Destroy();
+                Editor.Instance.TabController.HideTab(tab);
             }
         }
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -32,7 +32,7 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
                 {
                     if (tab)
                     {
-                        tab.Destroy();
+                        Editor.Instance.TabController.HideTab(tab);
                     }
                 }),
             NativeContextMenuManager.MenuItemSpec.Sep(),

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
@@ -53,6 +53,11 @@ namespace Oasis.LayoutEditor
 
         private void HandleTabClosed(PanelTab tab)
         {
+            HideTab(tab);
+        }
+
+        public void HideTab(PanelTab tab)
+        {
             if (tab == null)
             {
                 return;


### PR DESCRIPTION
## Summary
- Allow TabController to hide and restore tabs instead of destroying them
- Update tab header context menu to hide tabs
- Middle-click closer now hides tabs via TabController

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c70ab1b0d48327b115219c7b77e9b2