### PR TITLE
Anchor new tabs to current panel

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -12,6 +12,7 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
     {
         var tab = GetComponent<PanelTab>();
         var maximiser = GetComponent<PanelTabMaximiser>();
+        Panel anchorPanel = tab ? tab.Panel : null;
 
         return new List<NativeContextMenuManager.MenuItemSpec>
         {
@@ -45,19 +46,19 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
                         "Hierarchy",
                         () =>
                         {
-                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Hierarchy);
+                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Hierarchy, anchorPanel);
                         }),
                     new NativeContextMenuManager.MenuItemSpec(
                         "Inspector",
                         () =>
                         {
-                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Inspector);
+                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Inspector, anchorPanel);
                         }),
                     new NativeContextMenuManager.MenuItemSpec(
                         "Project",
                         () =>
                         {
-                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Project);
+                            Editor.Instance.TabController.ShowTab(TabController.TabTypes.Project, anchorPanel);
                         }),
                 }
             },

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
@@ -69,7 +69,7 @@ namespace Oasis.LayoutEditor
             _storedPanels[id] = panel;
         }
 
-        public PanelTab ShowTab(TabTypes tabType)
+        public PanelTab ShowTab(TabTypes tabType, Panel anchorPanel = null)
         {
             if (tabType == TabTypes.CustomView)
             {
@@ -80,13 +80,24 @@ namespace Oasis.LayoutEditor
             if (_storedPanels.TryGetValue(tabType, out Panel storedPanel) && storedPanel != null)
             {
                 storedPanel.gameObject.SetActive(true);
-                PanelManager.Instance.AnchorPanel(storedPanel, storedPanel.Canvas, Direction.Right);
+                if (anchorPanel != null)
+                {
+                    PanelManager.Instance.AnchorPanel(storedPanel, anchorPanel, Direction.Right);
+                }
+                else
+                {
+                    PanelManager.Instance.AnchorPanel(storedPanel, storedPanel.Canvas, Direction.Right);
+                }
                 _storedPanels.Remove(tabType);
                 return storedPanel[0];
             }
 
             TabDefinition tabDefinition = TabDefinitions.Find(x => x.TypeID == tabType);
             PanelTab panelTab = CreatePanelTab(tabDefinition);
+            if (anchorPanel != null)
+            {
+                PanelManager.Instance.AnchorPanel(panelTab.Panel, anchorPanel, Direction.Right);
+            }
             return panelTab;
         }
 


### PR DESCRIPTION
## Summary
- Ensure TabController can anchor new tabs relative to an existing panel
- Use calling panel as anchor in tab header context menu when adding tabs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c711728a2883278e5dfa13fb358a05