### PR TITLE
Gray out Add Tab items for open tabs

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/ContextMenus/TabHeaderContextMenu.cs
@@ -14,6 +14,10 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
         var maximiser = GetComponent<PanelTabMaximiser>();
         Panel anchorPanel = tab ? tab.Panel : null;
 
+        bool hierarchyActive = Editor.Instance.TabController.IsTabActive(TabController.TabTypes.Hierarchy);
+        bool inspectorActive = Editor.Instance.TabController.IsTabActive(TabController.TabTypes.Inspector);
+        bool projectActive = Editor.Instance.TabController.IsTabActive(TabController.TabTypes.Project);
+
         return new List<NativeContextMenuManager.MenuItemSpec>
         {
             new NativeContextMenuManager.MenuItemSpec(
@@ -47,19 +51,22 @@ public sealed class TabHeaderContextMenu : NativeContextMenu
                         () =>
                         {
                             Editor.Instance.TabController.ShowTab(TabController.TabTypes.Hierarchy, anchorPanel);
-                        }),
+                        },
+                        !hierarchyActive),
                     new NativeContextMenuManager.MenuItemSpec(
                         "Inspector",
                         () =>
                         {
                             Editor.Instance.TabController.ShowTab(TabController.TabTypes.Inspector, anchorPanel);
-                        }),
+                        },
+                        !inspectorActive),
                     new NativeContextMenuManager.MenuItemSpec(
                         "Project",
                         () =>
                         {
                             Editor.Instance.TabController.ShowTab(TabController.TabTypes.Project, anchorPanel);
-                        }),
+                        },
+                        !projectActive),
                 }
             },
         };

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/TabController.cs
@@ -101,6 +101,21 @@ namespace Oasis.LayoutEditor
             return panelTab;
         }
 
+        public bool IsTabActive(TabTypes tabType)
+        {
+            if (_storedPanels.TryGetValue(tabType, out Panel storedPanel) && storedPanel != null)
+            {
+                return storedPanel.gameObject.activeSelf;
+            }
+
+            if (PanelNotificationCenter.TryGetTab(tabType.ToString(), out PanelTab tab))
+            {
+                return tab.Panel.gameObject.activeSelf;
+            }
+
+            return false;
+        }
+
         private PanelTab CreatePanelTab(TabDefinition tabDefinition)
         {
             DynamicPanelsCanvas dynamicPanelsCanvas = Editor.Instance.UIController.DynamicPanelsCanvas;


### PR DESCRIPTION
## Summary
- Detect active tabs through a new `TabController.IsTabActive` helper
- Gray out Add Tab menu entries when the corresponding tab is already visible

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c71714218883278aefffe6f52ee237