### PR TITLE
Expand window native menu tab options

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenu/Editor/NativeMenuEditorMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenu/Editor/NativeMenuEditorMenu.cs
@@ -262,10 +262,25 @@ namespace Oasis.NativeMenu.Editor
         [MenuItem(MenuPrefix + "/Background/Global Normalise", true, 168)]
         private static bool BackgroundGlobalNormaliseValidate() => Validate("Background/Global Normalise");
 
-        [MenuItem(MenuPrefix + "/Window/Project", priority = 169)]
+        [MenuItem(MenuPrefix + "/Window/Hierarchy", priority = 169)]
+        private static void WindowHierarchy() => Execute("Window/Hierarchy");
+        [MenuItem(MenuPrefix + "/Window/Hierarchy", true, 169)]
+        private static bool WindowHierarchyValidate() => Validate("Window/Hierarchy");
+
+        [MenuItem(MenuPrefix + "/Window/Inspector", priority = 170)]
+        private static void WindowInspector() => Execute("Window/Inspector");
+        [MenuItem(MenuPrefix + "/Window/Inspector", true, 170)]
+        private static bool WindowInspectorValidate() => Validate("Window/Inspector");
+
+        [MenuItem(MenuPrefix + "/Window/Project", priority = 171)]
         private static void WindowProject() => Execute("Window/Project");
-        [MenuItem(MenuPrefix + "/Window/Project", true, 169)]
+        [MenuItem(MenuPrefix + "/Window/Project", true, 171)]
         private static bool WindowProjectValidate() => Validate("Window/Project");
+
+        [MenuItem(MenuPrefix + "/Window/Base View", priority = 172)]
+        private static void WindowBaseView() => Execute("Window/Base View");
+        [MenuItem(MenuPrefix + "/Window/Base View", true, 172)]
+        private static bool WindowBaseViewValidate() => Validate("Window/Base View");
 
         [MenuItem(MenuPrefix + "/Help/Context Help", priority = 170)]
         private static void HelpContextHelp() => Execute("Help/Context Help");

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenu/NativeMenuDefinition.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenu/NativeMenuDefinition.cs
@@ -71,7 +71,10 @@ namespace Oasis.NativeMenu
                 Item("Background/Local Normalise", 167, handler.OnBackgroundLocalNormalise),
                 Item("Background/Global Normalise", 168, handler.OnBackgroundGlobalNormalise),
 
-                Item("Window/Project", 169, null, Disabled),
+                Item("Window/Hierarchy", 169, handler.OnWindowShowHierarchy, handler.CanShowWindowHierarchy),
+                Item("Window/Inspector", 170, handler.OnWindowShowInspector, handler.CanShowWindowInspector),
+                Item("Window/Project", 171, handler.OnWindowShowProject, handler.CanShowWindowProject),
+                Item("Window/Base View", 172, handler.OnWindowShowBaseView, handler.CanShowWindowBaseView),
 
                 Item("Help/Context Help", 170, null, Disabled),
                 Item("Help/Manual", 171, null, Disabled),

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenus/SelectionHandler.Window.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenus/SelectionHandler.Window.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using Oasis;
+using Oasis.LayoutEditor;
+
+namespace Oasis.NativeMenus
+{
+    public partial class SelectionHandler : MonoBehaviour
+    {
+        public void OnWindowShowHierarchy()
+        {
+            ShowWindowTab(TabController.TabTypes.Hierarchy);
+        }
+
+        public void OnWindowShowInspector()
+        {
+            ShowWindowTab(TabController.TabTypes.Inspector);
+        }
+
+        public void OnWindowShowProject()
+        {
+            ShowWindowTab(TabController.TabTypes.Project);
+        }
+
+        public void OnWindowShowBaseView()
+        {
+            ShowWindowTab(TabController.TabTypes.BaseView);
+        }
+
+        public bool CanShowWindowHierarchy()
+        {
+            return CanShowWindowTab(TabController.TabTypes.Hierarchy);
+        }
+
+        public bool CanShowWindowInspector()
+        {
+            return CanShowWindowTab(TabController.TabTypes.Inspector);
+        }
+
+        public bool CanShowWindowProject()
+        {
+            return CanShowWindowTab(TabController.TabTypes.Project);
+        }
+
+        public bool CanShowWindowBaseView()
+        {
+            return CanShowWindowTab(TabController.TabTypes.BaseView);
+        }
+
+        private void ShowWindowTab(TabController.TabTypes tabType)
+        {
+            Editor.Instance.TabController.ShowTab(tabType);
+        }
+
+        private bool CanShowWindowTab(TabController.TabTypes tabType)
+        {
+            return !Editor.Instance.TabController.IsTabActive(tabType);
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenus/SelectionHandler.Window.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenus/SelectionHandler.Window.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fd1318c0dc54888965d9228dbba839a


### PR DESCRIPTION
## Summary
- replace the single Window/Project native menu item with Hierarchy, Inspector, Project, and Base View entries
- add SelectionHandler logic to show the requested tab and disable menu items when the tab is already active

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68c9ce10f2f4832792f7927ec8cfacb6