### PR TITLE
Use async MAME archive extraction

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
@@ -68,7 +68,7 @@ namespace Oasis.Download
             }
 
             Directory.CreateDirectory(extractPath);
-            LazyExtractor.Extract(extractPath, archivePath);
+            await LazyExtractor.ExtractAsync(extractPath, archivePath);
 
             return extractPath;
 #endif


### PR DESCRIPTION
## Summary
- switch the MAME archive extraction call to the asynchronous API to avoid blocking the Unity main thread

## Testing
- not run (Unity editor/build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68cb101cf29c8327b6e3761d2611a860