### PR TITLE
Use bundled 7z extractor for MAME archives

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/TestExtract.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/TestExtract.cs
@@ -1,4 +1,3 @@
-using LazyJedi.SevenZip;
 using UnityEngine;
 
 namespace Oasis.Download


### PR DESCRIPTION
## Summary
- replace the LazyExtractor dependency in `MameDownloader` with a direct invocation of the bundled `7z.exe`
- add process-based extraction logic that runs in both the Unity Editor and Windows builds
- remove the leftover LazyExtractor using directive from the test harness script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc2577a24c832794ba085f69e23a9b