### PR TITLE
Add ability to add existing projects via hub

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/ProjectsHub/HubMenu.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/ProjectsHub/HubMenu.cs
@@ -1,6 +1,8 @@
 using Oasis.Projects;
+using SFB;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -75,9 +77,38 @@ namespace Oasis.LayoutEditor.ProjectsHub
 
         private void OnAddProjectButtonClick()
         {
-            Debug.LogError("TODO OnAddProjectButtonClick");
+            string defaultPath = null;
 
-            //Editor.Instance.Preferences.ProjectsFolder
+            if (Editor.Instance?.Preferences != null)
+            {
+                defaultPath = Editor.Instance.Preferences.ProjectsFolder;
+            }
+
+            if (string.IsNullOrEmpty(defaultPath) || !Directory.Exists(defaultPath))
+            {
+                defaultPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            }
+
+            string[] paths = StandaloneFileBrowser.OpenFolderPanel("Select Project Folder", defaultPath, false);
+
+            if (paths == null || paths.Length == 0)
+            {
+                return;
+            }
+
+            string selectedPath = paths[0];
+
+            if (string.IsNullOrEmpty(selectedPath))
+            {
+                return;
+            }
+
+            bool projectAdded = Editor.Instance.ProjectsController.TryAddExistingProject(selectedPath);
+
+            if (!projectAdded)
+            {
+                Debug.LogWarning($"Unable to add project at path '{selectedPath}'.");
+            }
         }
 
         private void OnListModified()


### PR DESCRIPTION
## Summary
- open a native folder picker when the Add Project button is pressed in the hub menu
- validate the selected folder contains a project.json file and add it to the tracked projects list with normalised paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cc37ceba18832784c5269ce8e9191b