### PR TITLE
Add MAME ROM downloader and shared download helper

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/DownloadUtility.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/DownloadUtility.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using UnityEngine.Networking;
+
+namespace Oasis.Download
+{
+    public static class DownloadUtility
+    {
+        public static async Task DownloadFileAsync(string url, string destinationPath)
+        {
+            using (var request = UnityWebRequest.Get(url))
+            {
+                request.downloadHandler = new DownloadHandlerFile(destinationPath);
+                var operation = request.SendWebRequest();
+
+                while (!operation.isDone)
+                {
+                    await Task.Yield();
+                }
+
+#if UNITY_2020_1_OR_NEWER
+                if (request.result != UnityWebRequest.Result.Success)
+#else
+                if (request.isNetworkError || request.isHttpError)
+#endif
+                {
+                    throw new InvalidOperationException(string.Format("Failed to download file from '{0}': {1}", url, request.error));
+                }
+            }
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.Networking;
 using Oasis.Utility;
 
 namespace Oasis.Download
@@ -66,7 +65,7 @@ namespace Oasis.Download
             if (!File.Exists(archivePath))
             {
                 var downloadUrl = string.Format("{0}/{1}/{2}", DownloadRootUrl, versionFolder, archiveFileName);
-                await DownloadFileAsync(downloadUrl, archivePath);
+                await DownloadUtility.DownloadFileAsync(downloadUrl, archivePath);
             }
 
             Directory.CreateDirectory(extractPath);
@@ -119,27 +118,5 @@ namespace Oasis.Download
             });
         }
 
-        private static async Task DownloadFileAsync(string url, string destinationPath)
-        {
-            using (var request = UnityWebRequest.Get(url))
-            {
-                request.downloadHandler = new DownloadHandlerFile(destinationPath);
-                var operation = request.SendWebRequest();
-
-                while (!operation.isDone)
-                {
-                    await Task.Yield();
-                }
-
-#if UNITY_2020_1_OR_NEWER
-                if (request.result != UnityWebRequest.Result.Success)
-#else
-                if (request.isNetworkError || request.isHttpError)
-#endif
-                {
-                    throw new InvalidOperationException(string.Format("Failed to download MAME from '{0}': {1}", url, request.error));
-                }
-            }
-        }
     }
 }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameRomDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameRomDownloader.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Oasis.Download
+{
+    public class MameRomDownloader : MonoBehaviour
+    {
+        private const string DownloadRootUrl = "https://archive.org/download/CentralArquivistaArcade/";
+
+        private static MameRomDownloader _instance;
+
+        public static MameRomDownloader Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    var existing = FindObjectOfType<MameRomDownloader>();
+                    if (existing != null)
+                    {
+                        _instance = existing;
+                    }
+                    else
+                    {
+                        var gameObject = new GameObject(nameof(MameRomDownloader));
+                        _instance = gameObject.AddComponent<MameRomDownloader>();
+                    }
+
+                    if (_instance != null)
+                    {
+                        DontDestroyOnLoad(_instance.gameObject);
+                    }
+                }
+
+                return _instance;
+            }
+        }
+
+        public async Task<string> DownloadRomAsync(string romName)
+        {
+#if !UNITY_EDITOR_WIN && !UNITY_STANDALONE_WIN
+            throw new PlatformNotSupportedException("MAME ROM downloader currently supports only Windows builds.");
+#else
+            if (string.IsNullOrWhiteSpace(romName))
+            {
+                throw new ArgumentException("ROM name must be provided.", nameof(romName));
+            }
+
+            var trimmedRomName = romName.Trim();
+            var downloadsRoot = Path.Combine(Application.persistentDataPath, "Downloads", "MAME", "ROMs");
+            Directory.CreateDirectory(downloadsRoot);
+
+            var archiveFileName = string.Format("{0}.zip", trimmedRomName);
+            var archivePath = Path.Combine(downloadsRoot, archiveFileName);
+
+            if (!File.Exists(archivePath))
+            {
+                var downloadUrl = string.Format("{0}{1}", DownloadRootUrl, archiveFileName);
+                await DownloadUtility.DownloadFileAsync(downloadUrl, archivePath);
+            }
+
+            return archivePath;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared download helper so multiple downloaders can reuse UnityWebRequest logic
- update the existing MAME downloader to use the shared helper
- implement a new MAME ROM downloader that saves downloaded archives into persistent storage

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68cc41067c908327b954ebb50249ca6b