### PR TITLE
Add preference-managed MAME version and resolve exe path from downloads

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
@@ -1,7 +1,6 @@
 using MFMEExtract;
 using Oasis.Layout;
 using Oasis.MFME;
-using Oasis.Utility;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -181,7 +180,15 @@ namespace Oasis.MAME
         {
             get
             {
-                return Path.Combine(DataPathHelper.MAMERootPath);
+                int mameVersion = Preferences.kDefaultMameVersion;
+
+                if (Editor.Instance != null && Editor.Instance.Preferences != null)
+                {
+                    mameVersion = Editor.Instance.Preferences.MameVersion;
+                }
+
+                string versionFolder = $"mame{mameVersion.ToString("D4")}";
+                return Path.Combine(Application.persistentDataPath, "Downloads", "MAME", versionFolder);
             }
         }
 

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Preferences.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Preferences.cs
@@ -8,6 +8,9 @@ public class Preferences : MonoBehaviour
     public static string kPathProjectsFolderName = "Projects";
 
     public static string kKeyProjectsFolder = "ProjectsFolder";
+    public static string kKeyMameVersion = "MameVersion";
+
+    public const int kDefaultMameVersion = 239;
 
     public string ProjectsFolder
     {
@@ -25,6 +28,20 @@ public class Preferences : MonoBehaviour
         set
         {
             PlayerPrefs.SetString(kKeyProjectsFolder, value);
+        }
+    }
+
+    public int MameVersion
+    {
+        get
+        {
+            int storedVersion = PlayerPrefs.GetInt(kKeyMameVersion, kDefaultMameVersion);
+            return Mathf.Clamp(storedVersion, 0, 9999);
+        }
+        set
+        {
+            int sanitisedValue = Mathf.Clamp(value, 0, 9999);
+            PlayerPrefs.SetInt(kKeyMameVersion, sanitisedValue);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a saved MAME version preference with a default value
- resolve the MAME executable directory from the persistent downloads location using the stored version

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cc4a05fd648327974c881af213e32e