### PR TITLE
Add ROM path argument to MAME launch

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameRomDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameRomDownloader.cs
@@ -49,7 +49,7 @@ namespace Oasis.Download
             }
 
             var trimmedRomName = romName.Trim();
-            var downloadsRoot = Path.Combine(Application.persistentDataPath, "Downloads", "MAME", "ROMs");
+            var downloadsRoot = GetRomDownloadDirectory();
             Directory.CreateDirectory(downloadsRoot);
 
             var archiveFileName = string.Format("{0}.zip", trimmedRomName);
@@ -63,6 +63,11 @@ namespace Oasis.Download
 
             return archivePath;
 #endif
+        }
+
+        public static string GetRomDownloadDirectory()
+        {
+            return Path.Combine(Application.persistentDataPath, "Downloads", "MAME", "ROMs");
         }
     }
 }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.MAME/MameController.cs
@@ -1,4 +1,5 @@
 using MFMEExtract;
+using Oasis.Download;
 using Oasis.Layout;
 using Oasis.MFME;
 using System;
@@ -247,6 +248,10 @@ namespace Oasis.MAME
             {
                 additionalArgs += " " + kArgsForTestingWithVideo;
             }
+
+            string romDirectory = MameRomDownloader.GetRomDownloadDirectory();
+            string romDirectoryWindows = romDirectory.Replace("/", "\\");
+            additionalArgs += " -rompath \"" + romDirectoryWindows + "\"";
 
             if(loadState)
             {


### PR DESCRIPTION
## Summary
- centralize the MAME ROM download directory retrieval
- include the ROM download directory when launching MAME so downloaded ROMs are used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cde07549208327af689ee3bfcff26e