### PR TITLE
Ensure NativeProgressDialog RegisterClassEx uses Unicode

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs
@@ -1,0 +1,30 @@
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+using System;
+using System.Runtime.InteropServices;
+
+namespace Oasis.NativeWindows
+{
+    internal static class NativeProgressDialog
+    {
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "RegisterClassExW")]
+        private static extern ushort RegisterClassEx(ref WNDCLASSEX lpwcx);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WNDCLASSEX
+        {
+            public uint cbSize;
+            public uint style;
+            public IntPtr lpfnWndProc;
+            public int cbClsExtra;
+            public int cbWndExtra;
+            public IntPtr hInstance;
+            public IntPtr hIcon;
+            public IntPtr hCursor;
+            public IntPtr hbrBackground;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpszMenuName;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpszClassName;
+            public IntPtr hIconSm;
+        }
+    }
+}
+#endif

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 323e6d4f208f4c5db6f356443657e25b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a native progress dialog shim so RegisterClassEx explicitly targets the Unicode entry point
- retain the wide-string marshalling attributes on WNDCLASSEX string fields

## Testing
- not run (Windows-only Unity project; Windows build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d78f5d472c8327859924afa8d8a1b7