### PR TITLE
Harden NativeProgressDialog class registration

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs
@@ -1,0 +1,140 @@
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Oasis.NativeWindows
+{
+    internal static class NativeProgressDialog
+    {
+        private const string WindowClassName = "Oasis.NativeProgressDialog";
+
+        private static readonly object s_classRegistrationLock = new object();
+        private static bool s_isClassRegistered;
+        private static readonly WndProc s_wndProc = WindowProc;
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "RegisterClassExW")]
+        private static extern ushort RegisterClassEx(ref WNDCLASSEX lpwcx);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateWindowEx(
+            uint dwExStyle,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpClassName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpWindowName,
+            uint dwStyle,
+            int x,
+            int y,
+            int nWidth,
+            int nHeight,
+            IntPtr hWndParent,
+            IntPtr hMenu,
+            IntPtr hInstance,
+            IntPtr lpParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "GetModuleHandleW")]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        private delegate IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        /// <summary>
+        /// Ensures the hidden progress dialog host window class is registered and returns a freshly created window handle.
+        /// </summary>
+        /// <param name="windowName">Optional title for diagnostic purposes.</param>
+        /// <returns>The handle to the created window.</returns>
+        public static IntPtr CreateHostWindow(string windowName = "")
+        {
+            EnsureClassRegistered();
+
+            IntPtr hwnd = CreateWindowEx(
+                0,
+                WindowClassName,
+                windowName ?? string.Empty,
+                0,
+                0,
+                0,
+                0,
+                0,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                GetModuleHandle(null),
+                IntPtr.Zero);
+
+            if (hwnd == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to create native progress dialog host window.");
+            }
+
+            return hwnd;
+        }
+
+        private static void EnsureClassRegistered()
+        {
+            if (s_isClassRegistered)
+            {
+                return;
+            }
+
+            lock (s_classRegistrationLock)
+            {
+                if (s_isClassRegistered)
+                {
+                    return;
+                }
+
+                var windowClass = new WNDCLASSEX
+                {
+                    cbSize = (uint)Marshal.SizeOf<WNDCLASSEX>(),
+                    style = 0,
+                    lpfnWndProc = Marshal.GetFunctionPointerForDelegate(s_wndProc),
+                    hInstance = GetModuleHandle(null),
+                    hIcon = IntPtr.Zero,
+                    hCursor = IntPtr.Zero,
+                    hbrBackground = IntPtr.Zero,
+                    lpszMenuName = null,
+                    lpszClassName = WindowClassName,
+                    hIconSm = IntPtr.Zero,
+                };
+
+                ushort atom = RegisterClassEx(ref windowClass);
+                if (atom == 0)
+                {
+                    int error = Marshal.GetLastWin32Error();
+
+                    // ERROR_CLASS_ALREADY_EXISTS (1410) is benign when multiple threads race to register.
+                    if (error != 1410)
+                    {
+                        throw new Win32Exception(error, "Failed to register native progress dialog window class.");
+                    }
+                }
+
+                s_isClassRegistered = true;
+            }
+        }
+
+        private static IntPtr WindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            return DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WNDCLASSEX
+        {
+            public uint cbSize;
+            public uint style;
+            public IntPtr lpfnWndProc;
+            public int cbClsExtra;
+            public int cbWndExtra;
+            public IntPtr hInstance;
+            public IntPtr hIcon;
+            public IntPtr hCursor;
+            public IntPtr hbrBackground;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpszMenuName;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpszClassName;
+            public IntPtr hIconSm;
+        }
+    }
+}
+#endif

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeWindows/NativeProgressDialog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 323e6d4f208f4c5db6f356443657e25b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add CreateHostWindow helper that registers the native window class once and creates the host window with consistent parameters
- guard class registration with proper callbacks, module handle resolution, and Win32 error handling

## Testing
- not run (Windows-only Unity workflow not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d78f5d472c8327859924afa8d8a1b7