### PR TITLE
Enable native progress window in editor

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5ec13f9a5344d199468ad9274afcf6f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressBootstrap.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressBootstrap.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace Oasis.NativeProgress
+{
+    [DisallowMultipleComponent]
+    public sealed class NativeProgressBootstrap : MonoBehaviour
+    {
+        private bool _windowCreated;
+
+        private void Awake()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+            if (!NativeProgressWindow.EnsureWindowCreated(out string errorMessage))
+            {
+                Debug.LogError($"Failed to create native progress window: {errorMessage}");
+                return;
+            }
+
+            _windowCreated = true;
+#else
+            Debug.Log("Native progress window bootstrap is only active on Windows platforms.");
+#endif
+        }
+
+        private void OnDestroy()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+            if (_windowCreated)
+            {
+                NativeProgressWindow.CloseWindow();
+                _windowCreated = false;
+            }
+#endif
+        }
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressBootstrap.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d4c57f83a0940d79f8a1e1643b91c7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Runtime.InteropServices;
+namespace Oasis.NativeProgress
+{
+    internal static class NativeProgressWindow
+    {
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+        private const string WindowClassName = "OasisNativeProgressWindow";
+        private const int CS_HREDRAW = 0x0002;
+        private const int CS_VREDRAW = 0x0001;
+        private const int WS_OVERLAPPEDWINDOW = 0x00CF0000;
+        private const int WS_VISIBLE = 0x10000000;
+        private const int CW_USEDEFAULT = unchecked((int)0x80000000);
+        private const int SW_SHOWNORMAL = 1;
+        private const int IDC_ARROW = 32512;
+        private const int COLOR_WINDOW = 5;
+
+        private static ushort _classAtom;
+        private static IntPtr _instanceHandle = IntPtr.Zero;
+        private static IntPtr _windowHandle = IntPtr.Zero;
+        private static WndProc _wndProc;
+
+        public static bool EnsureWindowCreated(out string errorMessage)
+        {
+            if (_windowHandle != IntPtr.Zero)
+            {
+                errorMessage = null;
+                return true;
+            }
+
+            _instanceHandle = GetModuleHandle(null);
+            if (_instanceHandle == IntPtr.Zero)
+            {
+                errorMessage = $"GetModuleHandle failed with error {Marshal.GetLastWin32Error()}";
+                return false;
+            }
+
+            _wndProc = WindowProcedure;
+
+            var windowClass = new WNDCLASSEX
+            {
+                cbSize = (uint)Marshal.SizeOf(typeof(WNDCLASSEX)),
+                style = CS_HREDRAW | CS_VREDRAW,
+                lpfnWndProc = _wndProc,
+                cbClsExtra = 0,
+                cbWndExtra = 0,
+                hInstance = _instanceHandle,
+                hIcon = IntPtr.Zero,
+                hCursor = LoadCursor(IntPtr.Zero, new IntPtr(IDC_ARROW)),
+                hbrBackground = new IntPtr(COLOR_WINDOW + 1),
+                lpszMenuName = null,
+                lpszClassName = WindowClassName,
+                hIconSm = IntPtr.Zero
+            };
+
+            _classAtom = RegisterClassEx(ref windowClass);
+            if (_classAtom == 0)
+            {
+                errorMessage = $"RegisterClassEx failed with error {Marshal.GetLastWin32Error()}";
+                _wndProc = null;
+                return false;
+            }
+
+            _windowHandle = CreateWindowEx(
+                0,
+                WindowClassName,
+                "Oasis Progress",
+                WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                480,
+                120,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                _instanceHandle,
+                IntPtr.Zero);
+
+            if (_windowHandle == IntPtr.Zero)
+            {
+                int lastError = Marshal.GetLastWin32Error();
+                UnregisterWindowClass();
+                errorMessage = $"CreateWindowEx failed with error {lastError}";
+                return false;
+            }
+
+            ShowWindow(_windowHandle, SW_SHOWNORMAL);
+            UpdateWindow(_windowHandle);
+
+            errorMessage = null;
+            return true;
+        }
+
+        public static void CloseWindow()
+        {
+            if (_windowHandle != IntPtr.Zero)
+            {
+                DestroyWindowNative(_windowHandle);
+                _windowHandle = IntPtr.Zero;
+            }
+
+            UnregisterWindowClass();
+            _wndProc = null;
+            _instanceHandle = IntPtr.Zero;
+        }
+
+        private static void UnregisterWindowClass()
+        {
+            if (_classAtom != 0 && _instanceHandle != IntPtr.Zero)
+            {
+                UnregisterClass(WindowClassName, _instanceHandle);
+                _classAtom = 0;
+            }
+        }
+
+        private static IntPtr WindowProcedure(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            return DefWindowProc(hWnd, msg, wParam, lParam);
+        }
+
+        private delegate IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WNDCLASSEX
+        {
+            public uint cbSize;
+            public uint style;
+            public WndProc lpfnWndProc;
+            public int cbClsExtra;
+            public int cbWndExtra;
+            public IntPtr hInstance;
+            public IntPtr hIcon;
+            public IntPtr hCursor;
+            public IntPtr hbrBackground;
+            public string lpszMenuName;
+            public string lpszClassName;
+            public IntPtr hIconSm;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern ushort RegisterClassEx(ref WNDCLASSEX lpwcx);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool UnregisterClass(string lpClassName, IntPtr hInstance);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateWindowEx(
+            int dwExStyle,
+            string lpClassName,
+            string lpWindowName,
+            int dwStyle,
+            int X,
+            int Y,
+            int nWidth,
+            int nHeight,
+            IntPtr hWndParent,
+            IntPtr hMenu,
+            IntPtr hInstance,
+            IntPtr lpParam);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyWindowNative(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr DefWindowProc(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        private static extern bool UpdateWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr LoadCursor(IntPtr hInstance, IntPtr lpCursorName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+#else
+        public static bool EnsureWindowCreated(out string errorMessage)
+        {
+            errorMessage = "Native progress window is only supported on Windows.";
+            return false;
+        }
+
+        public static void CloseWindow()
+        {
+        }
+#endif
+    }
+}

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs.meta
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f1dbb0ba8b441b2b9d6c6b2f3e6578e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- allow the native progress bootstrap to run on Windows in both standalone builds and the Unity editor
- expose the Win32 window implementation to UNITY_EDITOR_WIN so the editor session can create and tear down the OS window

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d79ba214a88327b9f3932826f8729d