### PR TITLE
Remove legacy MAME plugin fallback path

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
@@ -180,25 +180,15 @@ namespace Oasis.Download
 
         private static string GetPluginSourceDirectory()
         {
-            string projectRootPath = DataPathHelper.ProjectRootPath;
+            string externalAssetsDirectory = ExternalExecutableUtility.GetExternalAssetsDirectory();
 
-            string[] candidatePaths = new[]
+            if (string.IsNullOrEmpty(externalAssetsDirectory))
             {
-                Path.Combine(projectRootPath, "MameLuaPlugins", "oasis"),
-                Path.Combine(projectRootPath, "..", "MameLuaPlugins", "oasis"),
-                Path.Combine(projectRootPath, "..", "..", "MameLuaPlugins", "oasis")
-            };
-
-            foreach (string candidatePath in candidatePaths)
-            {
-                string fullPath = Path.GetFullPath(candidatePath);
-                if (Directory.Exists(fullPath))
-                {
-                    return fullPath;
-                }
+                UnityEngine.Debug.LogWarning("External assets directory is not configured. MAME plugins will not be copied.");
+                return string.Empty;
             }
 
-            return Path.GetFullPath(candidatePaths[candidatePaths.Length - 1]);
+            return Path.Combine(externalAssetsDirectory, "MameLuaPlugins", "oasis");
         }
 
     }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Utility/ExternalExecutableUtility.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Oasis.Utility/ExternalExecutableUtility.cs
@@ -57,6 +57,11 @@ namespace Oasis.Utility
             return Path.Combine(executableDirectory, executableFileName);
         }
 
+        public static string GetExternalAssetsDirectory()
+        {
+            return GetExecutableDirectory();
+        }
+
         public static bool HasEditorExecutables()
         {
 #if UNITY_EDITOR
@@ -130,7 +135,48 @@ namespace Oasis.Utility
                 File.Copy(sourceFilePath, destinationFilePath, true);
             }
 
+            foreach (string sourceSubDirectory in Directory.GetDirectories(sourceDirectory))
+            {
+                string directoryName = Path.GetFileName(sourceSubDirectory);
+                if (string.IsNullOrEmpty(directoryName))
+                {
+                    continue;
+                }
+
+                string destinationSubDirectory = Path.Combine(destinationDirectory, directoryName);
+                CopyDirectoryRecursive(sourceSubDirectory, destinationSubDirectory);
+            }
+
             Debug.Log($"Copied external executables to '{destinationDirectory}'.");
+        }
+
+        private static void CopyDirectoryRecursive(string sourceDirectory, string destinationDirectory)
+        {
+            Directory.CreateDirectory(destinationDirectory);
+
+            foreach (string filePath in Directory.GetFiles(sourceDirectory))
+            {
+                string fileName = Path.GetFileName(filePath);
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    continue;
+                }
+
+                string destinationFilePath = Path.Combine(destinationDirectory, fileName);
+                File.Copy(filePath, destinationFilePath, true);
+            }
+
+            foreach (string subDirectory in Directory.GetDirectories(sourceDirectory))
+            {
+                string directoryName = Path.GetFileName(subDirectory);
+                if (string.IsNullOrEmpty(directoryName))
+                {
+                    continue;
+                }
+
+                string destinationSubDirectory = Path.Combine(destinationDirectory, directoryName);
+                CopyDirectoryRecursive(subDirectory, destinationSubDirectory);
+            }
         }
 #endif
     }


### PR DESCRIPTION
## Summary
- simplify the MAME downloader plugin lookup to use only the external assets directory
- warn when the external assets directory is missing so the copy step is skipped cleanly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d7daca56f483278139c952b250c622