### PR TITLE
Show byte progress during MAME download

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/DownloadUtility.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/DownloadUtility.cs
@@ -6,16 +6,30 @@ namespace Oasis.Download
 {
     public static class DownloadUtility
     {
-        public static async Task DownloadFileAsync(string url, string destinationPath)
+        public static async Task DownloadFileAsync(string url, string destinationPath, Action<long> onDownloadProgress = null)
         {
             using (var request = UnityWebRequest.Get(url))
             {
                 request.downloadHandler = new DownloadHandlerFile(destinationPath);
                 var operation = request.SendWebRequest();
 
+                long lastReportedBytes = -1;
                 while (!operation.isDone)
                 {
+                    long downloadedBytes = (long)request.downloadedBytes;
+                    if (downloadedBytes != lastReportedBytes)
+                    {
+                        lastReportedBytes = downloadedBytes;
+                        onDownloadProgress?.Invoke(downloadedBytes);
+                    }
+
                     await Task.Yield();
+                }
+
+                long finalDownloadedBytes = (long)request.downloadedBytes;
+                if (finalDownloadedBytes != lastReportedBytes)
+                {
+                    onDownloadProgress?.Invoke(finalDownloadedBytes);
                 }
 
 #if UNITY_2020_1_OR_NEWER

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
@@ -52,7 +52,7 @@ namespace Oasis.Download
             InstallingPlugins
         }
 
-        public async Task<string> DownloadAndExtractAsync(int versionNumber = kDefaultVersionNumber, Action<MameDownloadStage> onStageChanged = null)
+        public async Task<string> DownloadAndExtractAsync(int versionNumber = kDefaultVersionNumber, Action<MameDownloadStage> onStageChanged = null, Action<long> onDownloadProgress = null)
         {
 #if !UNITY_EDITOR_WIN && !UNITY_STANDALONE_WIN
             throw new PlatformNotSupportedException("MAME downloader currently supports only Windows builds.");
@@ -85,7 +85,11 @@ namespace Oasis.Download
             {
                 var downloadUrl = string.Format("{0}/{1}/{2}", DownloadRootUrl, versionFolder, archiveFileName);
                 UnityEngine.Debug.LogError("downloadUrl: " + downloadUrl);
-                await DownloadUtility.DownloadFileAsync(downloadUrl, archivePath);
+                await DownloadUtility.DownloadFileAsync(downloadUrl, archivePath, onDownloadProgress);
+            }
+            else
+            {
+                onDownloadProgress?.Invoke(new FileInfo(archivePath).Length);
             }
 
             Directory.CreateDirectory(extractPath);

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
@@ -84,7 +84,11 @@ namespace Oasis.LayoutEditor.Panels
                         switch (stage)
                         {
                             case MameDownloader.MameDownloadStage.Downloading:
-                                NativeProgressWindow.UpdateContent("Downloading MAME...", "Downloading MAME...", false, 0.25f);
+                                NativeProgressWindow.UpdateContent(
+                                    "Downloading MAME...",
+                                    FormatBytesDownloadedLabel(0),
+                                    false,
+                                    0.25f);
                                 break;
                             case MameDownloader.MameDownloadStage.Extracting:
                                 NativeProgressWindow.UpdateContent("Extracting MAME...", "Extracting MAME...", false, 0.5f);
@@ -94,7 +98,25 @@ namespace Oasis.LayoutEditor.Panels
                                 break;
                         }
 #endif
-                    });
+                    },
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+                    bytesDownloaded =>
+                    {
+                        if (!progressWindowCreated)
+                        {
+                            return;
+                        }
+
+                        NativeProgressWindow.UpdateContent(
+                            "Downloading MAME...",
+                            FormatBytesDownloadedLabel(bytesDownloaded),
+                            false,
+                            0.25f);
+                    }
+#else
+                    null
+#endif
+                    );
             }
             catch (Exception exception)
             {
@@ -110,6 +132,13 @@ namespace Oasis.LayoutEditor.Panels
 #endif
             }
         }
+
+#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
+        private static string FormatBytesDownloadedLabel(long bytesDownloaded)
+        {
+            return $"{bytesDownloaded:N0} bytes downloaded";
+        }
+#endif
     }
 
 }

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeProgress/NativeProgressWindow.cs
@@ -141,6 +141,7 @@ namespace Oasis.NativeProgress
                 return false;
             }
 
+            CenterWindowOnUnityWindow();
             ShowWindow(_windowHandle, SW_SHOWNORMAL);
             UpdateWindow(_windowHandle);
 
@@ -155,6 +156,30 @@ namespace Oasis.NativeProgress
 
             errorMessage = null;
             return true;
+        }
+
+        private static void CenterWindowOnUnityWindow()
+        {
+            if (_windowHandle == IntPtr.Zero || _unityWindowHandle == IntPtr.Zero) return;
+            if (!GetWindowRect(_unityWindowHandle, out RECT unityRect)) return;
+            if (!GetWindowRect(_windowHandle, out RECT windowRect)) return;
+
+            int unityWidth = unityRect.Right - unityRect.Left;
+            int unityHeight = unityRect.Bottom - unityRect.Top;
+            int windowWidth = windowRect.Right - windowRect.Left;
+            int windowHeight = windowRect.Bottom - windowRect.Top;
+
+            int x = unityRect.Left + ((unityWidth - windowWidth) / 2);
+            int y = unityRect.Top + ((unityHeight - windowHeight) / 2);
+
+            SetWindowPos(
+                _windowHandle,
+                IntPtr.Zero,
+                x,
+                y,
+                0,
+                0,
+                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
         }
 
         public static bool UpdateContent(string windowTitle, string statusText, bool cancelEnabled, float? progress = null)
@@ -517,6 +542,7 @@ namespace Oasis.NativeProgress
         [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
         [DllImport("user32.dll", SetLastError = true)] private static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
         [DllImport("user32.dll", SetLastError = true)] private static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+        [DllImport("user32.dll", SetLastError = true)] private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
         [DllImport("user32.dll", SetLastError = true)] private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
         [DllImport("user32.dll", SetLastError = true)] private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
         [DllImport("user32.dll", SetLastError = true)] private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);


### PR DESCRIPTION
## Summary
- add live download progress callbacks to the MAME downloader
- update the progress window text to display the downloaded byte count during the download stage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e10a5240dc83279cb4692bde9f8a08