### PR TITLE
Add extraction progress reporting for MAME downloads

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
@@ -91,7 +91,7 @@ namespace Oasis.LayoutEditor.Panels
                                     0.25f);
                                 break;
                             case MameDownloader.MameDownloadStage.Extracting:
-                                NativeProgressWindow.UpdateContent("Extracting MAME...", "Extracting MAME...", false, 0.5f);
+                                NativeProgressWindow.UpdateContent("Extracting MAME...", "Extracting MAME... 0%", false, 0.5f);
                                 break;
                             case MameDownloader.MameDownloadStage.InstallingPlugins:
                                 NativeProgressWindow.UpdateContent("Copying Oasis Plugin...", "Install plugins...", false, 0.75f);
@@ -112,8 +112,25 @@ namespace Oasis.LayoutEditor.Panels
                             FormatBytesDownloadedLabel(bytesDownloaded),
                             false,
                             0.25f);
+                    },
+                    progress =>
+                    {
+                        if (!progressWindowCreated)
+                        {
+                            return;
+                        }
+
+                        float clamped = Mathf.Clamp01(progress);
+                        int percentValue = Mathf.Clamp(Mathf.RoundToInt(clamped * 100f), 0, 100);
+
+                        NativeProgressWindow.UpdateContent(
+                            "Extracting MAME...",
+                            $"Extracting MAME... {percentValue}%",
+                            false,
+                            null);
                     }
 #else
+                    null,
                     null
 #endif
                     );

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
@@ -128,6 +128,8 @@ namespace Oasis.LayoutEditor.Panels
                             $"Extracting MAME... {percentValue}%",
                             false,
                             null);
+
+                        NativeProgressWindow.UpdateProgress(Mathf.Lerp(0.5f, 0.75f, clamped));
                     }
 #else
                     null,


### PR DESCRIPTION
## Summary
- add an extraction progress callback to the MAME downloader and forward it to the native progress window
- extend the archive extraction routine to stream 7-Zip progress output and report normalized values
- update the MAME preferences panel to surface extraction percentages in the native progress UI

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68e10fceba208327bbc1b61fcc1b5f80