### PR TITLE
Fix extraction progress updates for MAME downloader

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/Download/MameDownloader.cs
@@ -110,12 +110,14 @@ namespace Oasis.Download
                 onExtractionProgress?.Invoke(clampedProgress);
 
                 int percentValue = Mathf.Clamp(Mathf.RoundToInt(clampedProgress * 100f), 0, 100);
+                float overallProgress = Mathf.Lerp(0.5f, 0.75f, clampedProgress);
+
                 NativeProgressWindow.UpdateContent(
                     "Extracting MAME...",
                     $"Extracting MAME... {percentValue}%",
-                    false);
+                    false,
+                    overallProgress);
 
-                float overallProgress = Mathf.Lerp(0.5f, 0.75f, clampedProgress);
                 NativeProgressWindow.UpdateProgress(overallProgress);
             };
 #else

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelEditorPreferencesMame.cs
@@ -123,13 +123,15 @@ namespace Oasis.LayoutEditor.Panels
                         float clamped = Mathf.Clamp01(progress);
                         int percentValue = Mathf.Clamp(Mathf.RoundToInt(clamped * 100f), 0, 100);
 
+                        float overallProgress = Mathf.Lerp(0.5f, 0.75f, clamped);
+
                         NativeProgressWindow.UpdateContent(
                             "Extracting MAME...",
                             $"Extracting MAME... {percentValue}%",
                             false,
-                            null);
+                            overallProgress);
 
-                        NativeProgressWindow.UpdateProgress(Mathf.Lerp(0.5f, 0.75f, clamped));
+                        NativeProgressWindow.UpdateProgress(overallProgress);
                     }
 #else
                     null,


### PR DESCRIPTION
## Summary
- prevent the native progress window from reverting to marquee mode during extraction updates
- ensure both the downloader and UI callbacks send the current progress value while updating extraction status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e11ebe7c5c8327b7d7115c8dffccb4