### PR TITLE
Ensure runtime hierarchy clicks update active tab highlight

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/GlobalActiveTabHighlighter.cs
@@ -47,28 +47,32 @@ namespace Oasis.LayoutEditor
 
             if (tab.Content != null)
             {
-                // Add handlers for all existing descendants of the tab content
+                // Add handlers for all existing descendants of the tab content and
+                // ensure that any future hierarchy changes also receive handlers.
                 AddClickHandlersRecursively(tab.Content, tab);
-
-                // Watch for future hierarchy changes so dynamically created children
-                // also receive click handlers
-                ContentHierarchyWatcher watcher = tab.Content.gameObject.GetComponent<ContentHierarchyWatcher>();
-                if (watcher == null)
-                {
-                    watcher = tab.Content.gameObject.AddComponent<ContentHierarchyWatcher>();
-                }
-                watcher.Initialize(this, tab);
             }
         }
 
         private void AddClickHandlersRecursively(Transform root, PanelTab tab)
         {
             AddClickHandler(root.gameObject, tab);
+            EnsureHierarchyWatcher(root, tab);
 
             foreach (Transform child in root)
             {
                 AddClickHandlersRecursively(child, tab);
             }
+        }
+
+        private void EnsureHierarchyWatcher(Transform target, PanelTab tab)
+        {
+            ContentHierarchyWatcher watcher = target.GetComponent<ContentHierarchyWatcher>();
+            if (watcher == null)
+            {
+                watcher = target.gameObject.AddComponent<ContentHierarchyWatcher>();
+            }
+
+            watcher.Initialize(this, tab);
         }
 
         private void AddClickHandler(GameObject target, PanelTab tab)


### PR DESCRIPTION
## Summary
- ensure the global active tab highlighter adds hierarchy watchers to every content transform so newly spawned UI elements get click handlers

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68e272ca5cec83279f22614b171abe00