### PR TITLE
Hide FilesAndFolders pseudo scene root in project panel

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelProject.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelProject.cs
@@ -16,7 +16,6 @@ namespace Oasis.LayoutEditor.Panels
     public class PanelProject : PanelBase
     {
         private const string kPseudoSceneName = "Assets";
-        private const string kFilesAndFoldersPseudoSceneName = "AssetsContents";
 
         [SerializeField] private RuntimeHierarchy _runtimeHierarchyFoldersTree = null;
         [SerializeField] private RuntimeHierarchy _runtimeHierarchyFilesAndFoldersList = null;
@@ -24,6 +23,7 @@ namespace Oasis.LayoutEditor.Panels
         private RuntimeHierarchyRightClickBroadcaster _hierarchyRightClickBroadcaster = null;
         private readonly List<Transform> _runtimeHierarchyAssetsRootTransforms = new List<Transform>();
         private readonly List<Transform> _runtimeHierarchyFilesAndFoldersTransforms = new List<Transform>();
+        private RuntimeHierarchyStandaloneTransformCollection _runtimeHierarchyFilesAndFoldersStandaloneCollection;
         private readonly Dictionary<string, Transform> _directoryTransformsByPath = new Dictionary<string, Transform>(StringComparer.OrdinalIgnoreCase);
         private FileSystemWatcher _assetsDirectoryWatcher;
         private string _watchedAssetsPath;
@@ -122,9 +122,10 @@ namespace Oasis.LayoutEditor.Panels
                 _runtimeHierarchyFoldersTree.CreatePseudoScene(kPseudoSceneName);
             }
 
-            if (_runtimeHierarchyFilesAndFoldersList != null)
+            if (_runtimeHierarchyFilesAndFoldersList != null && _runtimeHierarchyFilesAndFoldersStandaloneCollection == null)
             {
-                _runtimeHierarchyFilesAndFoldersList.CreatePseudoScene(kFilesAndFoldersPseudoSceneName);
+                _runtimeHierarchyFilesAndFoldersStandaloneCollection = new RuntimeHierarchyStandaloneTransformCollection(
+                    _runtimeHierarchyFilesAndFoldersList);
             }
 
 
@@ -350,7 +351,7 @@ namespace Oasis.LayoutEditor.Panels
 
                 Transform directoryTransform = CreateDirectoryTransform(directoryName, null, subDirectory, false);
 
-                _runtimeHierarchyFilesAndFoldersList.AddToPseudoScene(kFilesAndFoldersPseudoSceneName, directoryTransform);
+                _runtimeHierarchyFilesAndFoldersStandaloneCollection?.Add(directoryTransform);
                 _runtimeHierarchyFilesAndFoldersTransforms.Add(directoryTransform);
             }
 
@@ -373,7 +374,7 @@ namespace Oasis.LayoutEditor.Panels
 
                 Transform fileTransform = CreateFileTransform(fileName, filePath);
 
-                _runtimeHierarchyFilesAndFoldersList.AddToPseudoScene(kFilesAndFoldersPseudoSceneName, fileTransform);
+                _runtimeHierarchyFilesAndFoldersStandaloneCollection?.Add(fileTransform);
                 _runtimeHierarchyFilesAndFoldersTransforms.Add(fileTransform);
             }
         }
@@ -437,16 +438,10 @@ namespace Oasis.LayoutEditor.Panels
 
         private void ClearFilesAndFoldersPseudoScene()
         {
+            _runtimeHierarchyFilesAndFoldersStandaloneCollection?.Clear();
+
             if (_runtimeHierarchyFilesAndFoldersTransforms.Count > 0)
             {
-                if (_runtimeHierarchyFilesAndFoldersList != null)
-                {
-                    foreach (Transform entryTransform in _runtimeHierarchyFilesAndFoldersTransforms)
-                    {
-                        _runtimeHierarchyFilesAndFoldersList.RemoveFromPseudoScene(kFilesAndFoldersPseudoSceneName, entryTransform, false);
-                    }
-                }
-
                 foreach (Transform entryTransform in _runtimeHierarchyFilesAndFoldersTransforms)
                 {
                     DestroyTransform(entryTransform);

--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/RuntimeHierarchy/RuntimeHierarchyStandaloneTransformCollection.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/RuntimeHierarchy/RuntimeHierarchyStandaloneTransformCollection.cs
@@ -161,6 +161,7 @@ namespace Oasis.LayoutEditor.RuntimeHierarchyIntegration
                 : base(hierarchy, string.Empty)
             {
                 _transform = transform;
+                m_depth = 1;
             }
 
             public override string Name => _transform ? _transform.name : "<missing>";
@@ -177,7 +178,7 @@ namespace Oasis.LayoutEditor.RuntimeHierarchyIntegration
 
             public override bool Refresh()
             {
-                m_depth = 0;
+                m_depth = 1;
 
                 bool changed = base.Refresh();
 


### PR DESCRIPTION
## Summary
- use a standalone transform collection for the FilesAndFolders list hierarchy
- populate and clear the collection when refreshing the project file list so only entries are shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2b0bd0b6c8327ba4258c4467edfb2