### PR TITLE
Select hierarchy item on right-click before context menu

### DIFF
--- a/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelProject.cs
+++ b/UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/LayoutEditor/Panels/PanelProject.cs
@@ -627,6 +627,11 @@ namespace Oasis.LayoutEditor.Panels
                 return;
             }
 
+            if (_runtimeHierarchyFoldersTree != null)
+            {
+                _runtimeHierarchyFoldersTree.Select(boundTransform);
+            }
+
             ShowDirectoryContextMenu(metadata.DirectoryPath);
         }
 
@@ -655,6 +660,11 @@ namespace Oasis.LayoutEditor.Panels
 
             if (directoryMetadata != null && !string.IsNullOrEmpty(directoryMetadata.DirectoryPath))
             {
+                if (_runtimeHierarchyFilesAndFoldersList != null)
+                {
+                    _runtimeHierarchyFilesAndFoldersList.Select(boundTransform);
+                }
+
                 ShowDirectoryContextMenu(directoryMetadata.DirectoryPath);
                 return;
             }
@@ -664,6 +674,11 @@ namespace Oasis.LayoutEditor.Panels
             if (fileMetadata == null || string.IsNullOrEmpty(fileMetadata.FilePath))
             {
                 return;
+            }
+
+            if (_runtimeHierarchyFilesAndFoldersList != null)
+            {
+                _runtimeHierarchyFilesAndFoldersList.Select(boundTransform);
             }
 
             ShowFileContextMenu(fileMetadata.FilePath);


### PR DESCRIPTION
## Summary
- select the right-clicked folder entry in the tree before opening the context menu
- select folders and files in the list view before showing their context menus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2cb787cdc832786f58d1ad3c2115e