### PR TITLE
OasisEditor: Add project creation UI and scaffolder

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -1,12 +1,74 @@
-﻿<Window x:Class="OasisEditor.MainWindow"
+<Window x:Class="OasisEditor.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:OasisEditor"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
+        Title="Oasis Editor"
+        Height="320"
+        Width="700"
+        MinHeight="320"
+        MinWidth="700">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="170" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
+        <TextBlock Grid.Row="0"
+                   Grid.ColumnSpan="2"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,14"
+                   Text="Create Project" />
+
+        <TextBlock Grid.Row="1"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="0,0,12,10"
+                   Text="Project name" />
+
+        <TextBox Grid.Row="1"
+                 Grid.Column="1"
+                 Margin="0,0,0,10"
+                 Text="{Binding ProjectName, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Grid.Row="2"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="0,0,12,10"
+                   Text="Project location" />
+
+        <TextBox Grid.Row="2"
+                 Grid.Column="1"
+                 Margin="0,0,0,10"
+                 Text="{Binding ProjectLocation, UpdateSourceTrigger=PropertyChanged}" />
+
+        <Border Grid.Row="3"
+                Grid.ColumnSpan="2"
+                Margin="0,10,0,10"
+                Padding="10"
+                BorderThickness="1"
+                BorderBrush="LightGray"
+                CornerRadius="4">
+            <TextBlock TextWrapping="Wrap"
+                       Foreground="DimGray"
+                       Text="{Binding StatusMessage}" />
+        </Border>
+
+        <Button Grid.Row="4"
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                MinWidth="140"
+                Padding="14,6"
+                Command="{Binding CreateProjectCommand}"
+                Content="Create project" />
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -1,24 +1,12 @@
-﻿using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace OasisEditor
+namespace OasisEditor;
+
+public partial class MainWindow : Window
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
-    public partial class MainWindow : Window
+    public MainWindow()
     {
-        public MainWindow()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
+        DataContext = new MainWindowViewModel();
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Input;
+
+namespace OasisEditor;
+
+public sealed class MainWindowViewModel : INotifyPropertyChanged
+{
+    private readonly ProjectScaffolder _projectScaffolder = new();
+    private string _projectName = string.Empty;
+    private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+    private string _statusMessage = "Create a new project to get started.";
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public MainWindowViewModel()
+    {
+        CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
+    }
+
+    public ICommand CreateProjectCommand { get; }
+
+    public string ProjectName
+    {
+        get => _projectName;
+        set
+        {
+            if (SetProperty(ref _projectName, value))
+            {
+                NotifyCreateCommand();
+            }
+        }
+    }
+
+    public string ProjectLocation
+    {
+        get => _projectLocation;
+        set
+        {
+            if (SetProperty(ref _projectLocation, value))
+            {
+                NotifyCreateCommand();
+            }
+        }
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetProperty(ref _statusMessage, value);
+    }
+
+    private void CreateProject()
+    {
+        try
+        {
+            var projectPath = _projectScaffolder.CreateProject(ProjectName, ProjectLocation);
+            StatusMessage = $"Project created: {projectPath}";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            MessageBox.Show(ex.Message, "Create Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private bool CanCreateProject()
+    {
+        return !string.IsNullOrWhiteSpace(ProjectName) && !string.IsNullOrWhiteSpace(ProjectLocation);
+    }
+
+    private void NotifyCreateCommand()
+    {
+        if (CreateProjectCommand is RelayCommand relayCommand)
+        {
+            relayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+
+namespace OasisEditor;
+
+public sealed class ProjectScaffolder
+{
+    private static readonly string[] ProjectFolders =
+    [
+        "Assets",
+        "Machines",
+        "Generated"
+    ];
+
+    public string CreateProject(string projectName, string rootLocation)
+    {
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            throw new ArgumentException("Project name is required.", nameof(projectName));
+        }
+
+        if (string.IsNullOrWhiteSpace(rootLocation))
+        {
+            throw new ArgumentException("Project location is required.", nameof(rootLocation));
+        }
+
+        var sanitizedName = projectName.Trim();
+        var baseLocation = Path.GetFullPath(rootLocation.Trim());
+        var projectDirectory = Path.Combine(baseLocation, sanitizedName);
+
+        if (Directory.Exists(projectDirectory))
+        {
+            throw new InvalidOperationException($"Project folder already exists: {projectDirectory}");
+        }
+
+        Directory.CreateDirectory(projectDirectory);
+
+        foreach (var folder in ProjectFolders)
+        {
+            Directory.CreateDirectory(Path.Combine(projectDirectory, folder));
+        }
+
+        var projectFilePath = Path.Combine(projectDirectory, $"{sanitizedName}.oasisproj");
+        var projectMetadata = new
+        {
+            name = sanitizedName,
+            createdUtc = DateTime.UtcNow,
+            version = 1
+        };
+
+        var json = JsonSerializer.Serialize(projectMetadata, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        File.WriteAllText(projectFilePath, json);
+
+        return projectDirectory;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json;
 
 namespace OasisEditor;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/RelayCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/RelayCommand.cs
@@ -1,0 +1,23 @@
+using System.Windows.Input;
+
+namespace OasisEditor;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -2,7 +2,7 @@
 
 ## Phase 1 — Project System
 - [x] Create solution structure
-- [ ] Implement project create flow
+- [x] Implement project create flow
 - [ ] Implement project open flow
 - [ ] Implement recent projects list
 - [ ] Generate project directory layout


### PR DESCRIPTION
### Motivation
- Implement the next actionable item from `TASKS.md` by providing a minimal project creation flow so users can create new editor projects. 
- Keep UI logic separated from business logic and follow the repository principle of using commands for mutations. 
- Provide a simple, testable service to scaffold project folders and a metadata file so downstream features (open/load) have a stable on-disk format.

### Description
- Add `ProjectScaffolder` which validates inputs, creates the project directory, scaffolds `Assets/`, `Machines/`, and `Generated/`, and writes a `{name}.oasisproj` JSON metadata file. 
- Add `RelayCommand` and `MainWindowViewModel` with a `CreateProjectCommand` and properties `ProjectName`, `ProjectLocation`, and `StatusMessage` to host the creation logic and command wiring. 
- Replace the empty shell `MainWindow.xaml` with a simple Create Project UI and set `DataContext` to `MainWindowViewModel` in `MainWindow.xaml.cs`. 
- Update `WindowsNetProjects/OasisEditor/TASKS.md` to mark `Implement project create flow` as completed.

### Testing
- Attempted an automated build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but it failed in this environment due to `dotnet: command not found`. 
- No other automated tests (unit or integration) were present or executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea1831e870832780e1df91a28eca9d)