### PR TITLE
Implement project open flow and update main window UI

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -5,16 +5,18 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
-        Height="320"
+        Height="360"
         Width="700"
-        MinHeight="320"
+        MinHeight="360"
         MinWidth="700">
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -27,7 +29,7 @@
                    FontSize="18"
                    FontWeight="SemiBold"
                    Margin="0,0,0,14"
-                   Text="Create Project" />
+                   Text="Project Setup" />
 
         <TextBlock Grid.Row="1"
                    Grid.Column="0"
@@ -52,6 +54,27 @@
                  Text="{Binding ProjectLocation, UpdateSourceTrigger=PropertyChanged}" />
 
         <Border Grid.Row="3"
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                Margin="0,0,0,10">
+            <Button MinWidth="140"
+                    Padding="14,6"
+                    Command="{Binding CreateProjectCommand}"
+                    Content="Create project" />
+        </Border>
+
+        <TextBlock Grid.Row="4"
+                   Grid.Column="0"
+                   VerticalAlignment="Center"
+                   Margin="0,0,12,10"
+                   Text="Project file" />
+
+        <TextBox Grid.Row="4"
+                 Grid.Column="1"
+                 Margin="0,0,0,10"
+                 Text="{Binding ProjectFilePath, UpdateSourceTrigger=PropertyChanged}" />
+
+        <Border Grid.Row="5"
                 Grid.ColumnSpan="2"
                 Margin="0,10,0,10"
                 Padding="10"
@@ -63,12 +86,12 @@
                        Text="{Binding StatusMessage}" />
         </Border>
 
-        <Button Grid.Row="4"
+        <Button Grid.Row="6"
                 Grid.Column="1"
                 HorizontalAlignment="Right"
                 MinWidth="140"
                 Padding="14,6"
-                Command="{Binding CreateProjectCommand}"
-                Content="Create project" />
+                Command="{Binding OpenProjectCommand}"
+                Content="Open project" />
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
 
@@ -10,6 +11,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly ProjectScaffolder _projectScaffolder = new();
     private string _projectName = string.Empty;
     private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+    private string _projectFilePath = string.Empty;
     private string _statusMessage = "Create a new project to get started.";
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -17,9 +19,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public MainWindowViewModel()
     {
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
+        OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
     }
 
     public ICommand CreateProjectCommand { get; }
+    public ICommand OpenProjectCommand { get; }
 
     public string ProjectName
     {
@@ -51,6 +55,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         private set => SetProperty(ref _statusMessage, value);
     }
 
+    public string ProjectFilePath
+    {
+        get => _projectFilePath;
+        set
+        {
+            if (SetProperty(ref _projectFilePath, value))
+            {
+                NotifyOpenCommand();
+            }
+        }
+    }
+
     private void CreateProject()
     {
         try
@@ -70,9 +86,61 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return !string.IsNullOrWhiteSpace(ProjectName) && !string.IsNullOrWhiteSpace(ProjectLocation);
     }
 
+    private void OpenProject()
+    {
+        try
+        {
+            var projectFile = ProjectFilePath.Trim();
+
+            if (!File.Exists(projectFile))
+            {
+                throw new FileNotFoundException("Project file was not found.", projectFile);
+            }
+
+            if (!string.Equals(Path.GetExtension(projectFile), ".oasisproj", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Project file must use the .oasisproj extension.");
+            }
+
+            using var projectStream = File.OpenRead(projectFile);
+            using var projectDocument = JsonDocument.Parse(projectStream);
+
+            if (!projectDocument.RootElement.TryGetProperty("name", out var projectNameElement))
+            {
+                throw new InvalidOperationException("Project metadata is missing required 'name' field.");
+            }
+
+            var openedProjectName = projectNameElement.GetString();
+            if (string.IsNullOrWhiteSpace(openedProjectName))
+            {
+                throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
+            }
+
+            StatusMessage = $"Project opened: {openedProjectName} ({projectFile})";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private bool CanOpenProject()
+    {
+        return !string.IsNullOrWhiteSpace(ProjectFilePath);
+    }
+
     private void NotifyCreateCommand()
     {
         if (CreateProjectCommand is RelayCommand relayCommand)
+        {
+            relayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private void NotifyOpenCommand()
+    {
+        if (OpenProjectCommand is RelayCommand relayCommand)
         {
             relayCommand.RaiseCanExecuteChanged();
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -3,7 +3,7 @@
 ## Phase 1 — Project System
 - [x] Create solution structure
 - [x] Implement project create flow
-- [ ] Implement project open flow
+- [x] Implement project open flow
 - [ ] Implement recent projects list
 - [ ] Generate project directory layout
 - [ ] Load project into editor shell


### PR DESCRIPTION
### Motivation
- Provide a way for users to open existing editor projects from the main window so the app can load projects created outside the current session.

### Description
- Add an `OpenProjectCommand`, `ProjectFilePath` property and `OpenProject()` method to `MainWindowViewModel` to drive the open-project flow and command state.
- Implement validation in `OpenProject()` to ensure the file exists, has the `.oasisproj` extension, and contains a non-empty `name` field in the JSON metadata using `System.Text.Json`.
- Update `MainWindow.xaml` to include inputs for `ProjectFilePath`, separate create/open buttons, adjusted layout rows and increased window height, and update the status area to reflect open/create results.
- Mark the `Implement project open flow` task as complete in `TASKS.md`.

### Testing
- Attempted to build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the step failed in this environment because `dotnet` is not installed, so no automated build/test completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea1a651d7483278d112ff87ac3837c)