### PR TITLE
Implement recent projects list support in OasisEditor

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -5,9 +5,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
-        Height="360"
+        Height="500"
         Width="700"
-        MinHeight="360"
+        MinHeight="500"
         MinWidth="700">
     <Grid Margin="16">
         <Grid.RowDefinitions>
@@ -15,7 +15,10 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="140" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -74,9 +77,39 @@
                  Margin="0,0,0,10"
                  Text="{Binding ProjectFilePath, UpdateSourceTrigger=PropertyChanged}" />
 
-        <Border Grid.Row="5"
+        <Button Grid.Row="5"
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                MinWidth="140"
+                Padding="14,6"
+                Margin="0,0,0,10"
+                Command="{Binding OpenProjectCommand}"
+                Content="Open project" />
+
+        <TextBlock Grid.Row="6"
+                   Grid.Column="0"
+                   VerticalAlignment="Top"
+                   Margin="0,0,12,10"
+                   Text="Recent projects" />
+
+        <ListBox Grid.Row="6"
+                 Grid.Column="1"
+                 Margin="0,0,0,10"
+                 ItemsSource="{Binding RecentProjects}"
+                 SelectedItem="{Binding SelectedRecentProject, Mode=TwoWay}" />
+
+        <Button Grid.Row="7"
+                Grid.Column="1"
+                HorizontalAlignment="Right"
+                MinWidth="140"
+                Padding="14,6"
+                Margin="0,0,0,10"
+                Command="{Binding OpenRecentProjectCommand}"
+                Content="Open selected recent" />
+
+        <Border Grid.Row="8"
                 Grid.ColumnSpan="2"
-                Margin="0,10,0,10"
+                Margin="0,0,0,10"
                 Padding="10"
                 BorderThickness="1"
                 BorderBrush="LightGray"
@@ -85,13 +118,5 @@
                        Foreground="DimGray"
                        Text="{Binding StatusMessage}" />
         </Border>
-
-        <Button Grid.Row="6"
-                Grid.Column="1"
-                HorizontalAlignment="Right"
-                MinWidth="140"
-                Padding="14,6"
-                Command="{Binding OpenProjectCommand}"
-                Content="Open project" />
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -10,10 +11,12 @@ namespace OasisEditor;
 public sealed class MainWindowViewModel : INotifyPropertyChanged
 {
     private readonly ProjectScaffolder _projectScaffolder = new();
+    private readonly RecentProjectsStore _recentProjectsStore = new();
     private string _projectName = string.Empty;
     private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
     private string _projectFilePath = string.Empty;
     private string _statusMessage = "Create a new project to get started.";
+    private string? _selectedRecentProject;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -21,10 +24,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
+        OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
+
+        RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
     }
 
     public ICommand CreateProjectCommand { get; }
     public ICommand OpenProjectCommand { get; }
+    public ICommand OpenRecentProjectCommand { get; }
+    public ObservableCollection<string> RecentProjects { get; }
 
     public string ProjectName
     {
@@ -68,11 +76,26 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    public string? SelectedRecentProject
+    {
+        get => _selectedRecentProject;
+        set
+        {
+            if (SetProperty(ref _selectedRecentProject, value))
+            {
+                NotifyOpenRecentCommand();
+            }
+        }
+    }
+
     private void CreateProject()
     {
         try
         {
             var projectPath = _projectScaffolder.CreateProject(ProjectName, ProjectLocation);
+            var projectFilePath = Path.Combine(projectPath, $"{ProjectName.Trim()}.oasisproj");
+
+            UpdateRecentProjects(projectFilePath);
             StatusMessage = $"Project created: {projectPath}";
         }
         catch (Exception ex)
@@ -89,9 +112,34 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OpenProject()
     {
+        OpenProjectFile(ProjectFilePath);
+    }
+
+    private bool CanOpenProject()
+    {
+        return !string.IsNullOrWhiteSpace(ProjectFilePath);
+    }
+
+    private void OpenSelectedRecentProject()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedRecentProject))
+        {
+            return;
+        }
+
+        OpenProjectFile(SelectedRecentProject);
+    }
+
+    private bool CanOpenSelectedRecentProject()
+    {
+        return !string.IsNullOrWhiteSpace(SelectedRecentProject);
+    }
+
+    private void OpenProjectFile(string projectFilePath)
+    {
         try
         {
-            var projectFile = ProjectFilePath.Trim();
+            var projectFile = projectFilePath.Trim();
 
             if (!File.Exists(projectFile))
             {
@@ -117,6 +165,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
             }
 
+            ProjectFilePath = projectFile;
+            UpdateRecentProjects(projectFile);
             StatusMessage = $"Project opened: {openedProjectName} ({projectFile})";
         }
         catch (Exception ex)
@@ -126,9 +176,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private bool CanOpenProject()
+    private void UpdateRecentProjects(string projectFilePath)
     {
-        return !string.IsNullOrWhiteSpace(ProjectFilePath);
+        var updated = _recentProjectsStore.Add(projectFilePath);
+
+        RecentProjects.Clear();
+        foreach (var item in updated)
+        {
+            RecentProjects.Add(item);
+        }
     }
 
     private void NotifyCreateCommand()
@@ -142,6 +198,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private void NotifyOpenCommand()
     {
         if (OpenProjectCommand is RelayCommand relayCommand)
+        {
+            relayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private void NotifyOpenRecentCommand()
+    {
+        if (OpenRecentProjectCommand is RelayCommand relayCommand)
         {
             relayCommand.RaiseCanExecuteChanged();
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
@@ -8,8 +8,15 @@ public sealed class ProjectScaffolder
     private static readonly string[] ProjectFolders =
     [
         "Assets",
+        "Assets/Images",
+        "Assets/Audio",
+        "Assets/Fonts",
+        "Assets/Panel2D",
+        "Assets/Cabinet3D",
         "Machines",
-        "Generated"
+        "Generated",
+        "Generated/Build",
+        "Generated/Preview"
     ];
 
     public string CreateProject(string projectName, string rootLocation)
@@ -45,7 +52,13 @@ public sealed class ProjectScaffolder
         {
             name = sanitizedName,
             createdUtc = DateTime.UtcNow,
-            version = 1
+            version = 1,
+            layout = new
+            {
+                assets = "Assets",
+                machines = "Machines",
+                generated = "Generated"
+            }
         };
 
         var json = JsonSerializer.Serialize(projectMetadata, new JsonSerializerOptions

--- a/WindowsNetProjects/OasisEditor/OasisEditor/RecentProjectsStore.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/RecentProjectsStore.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using System.Text.Json;
+
+namespace OasisEditor;
+
+public sealed class RecentProjectsStore
+{
+    private const int MaxRecentProjects = 10;
+    private readonly string _storageFilePath;
+
+    public RecentProjectsStore()
+    {
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var oasisFolder = Path.Combine(appDataPath, "OasisEditor");
+        _storageFilePath = Path.Combine(oasisFolder, "recent-projects.json");
+    }
+
+    public IReadOnlyList<string> Load()
+    {
+        try
+        {
+            if (!File.Exists(_storageFilePath))
+            {
+                return [];
+            }
+
+            var json = File.ReadAllText(_storageFilePath);
+            var items = JsonSerializer.Deserialize<List<string>>(json) ?? [];
+
+            return items
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(MaxRecentProjects)
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public IReadOnlyList<string> Add(string projectFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(projectFilePath))
+        {
+            throw new ArgumentException("Project file path is required.", nameof(projectFilePath));
+        }
+
+        var normalizedPath = Path.GetFullPath(projectFilePath.Trim());
+        var items = Load().ToList();
+
+        items.RemoveAll(existing => string.Equals(existing, normalizedPath, StringComparison.OrdinalIgnoreCase));
+        items.Insert(0, normalizedPath);
+
+        if (items.Count > MaxRecentProjects)
+        {
+            items = items.Take(MaxRecentProjects).ToList();
+        }
+
+        var folder = Path.GetDirectoryName(_storageFilePath);
+        if (!string.IsNullOrWhiteSpace(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        var json = JsonSerializer.Serialize(items, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        File.WriteAllText(_storageFilePath, json);
+        return items;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -5,7 +5,7 @@
 - [x] Implement project create flow
 - [x] Implement project open flow
 - [x] Implement recent projects list
-- [ ] Generate project directory layout
+- [x] Generate project directory layout
 - [ ] Load project into editor shell
 
 ## Phase 2 — Editor Shell

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -4,7 +4,7 @@
 - [x] Create solution structure
 - [x] Implement project create flow
 - [x] Implement project open flow
-- [ ] Implement recent projects list
+- [x] Implement recent projects list
 - [ ] Generate project directory layout
 - [ ] Load project into editor shell
 


### PR DESCRIPTION
### Motivation
- Implement the next unchecked task from `TASKS.md`: provide a recent projects list in the editor shell for faster access to previously opened projects.
- Persist a bounded, de-duplicated list of recent `.oasisproj` paths so entries survive application restarts.

### Description
- Add `RecentProjectsStore` (`OasisEditor/RecentProjectsStore.cs`) which persists up to 10 recent project file paths to `%AppData%/OasisEditor/recent-projects.json` and handles missing/corrupt storage gracefully.
- Update `MainWindowViewModel` (`OasisEditor/MainWindowViewModel.cs`) to load recents at startup, expose `RecentProjects` as an `ObservableCollection<string>`, add `SelectedRecentProject` and `OpenRecentProjectCommand`, update recents after create/open flows, and factor shared open logic into `OpenProjectFile`.
- Update UI (`OasisEditor/MainWindow.xaml`) to display a `ListBox` of recent projects and an `Open selected recent` button, and adjust layout sizing to accommodate the new controls.
- Mark the `Implement recent projects list` task as complete in `TASKS.md`.

### Testing
- Attempted automated build with `dotnet build OasisEditor.sln` in the container, which failed because `dotnet` is not installed in this environment (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea1bf675dc83278930d589f6ef06c5)