### PR TITLE
Load project metadata into editor shell state

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -1,0 +1,11 @@
+namespace OasisEditor;
+
+public sealed class EditorProject
+{
+    public required string Name { get; init; }
+    public required string ProjectFilePath { get; init; }
+    public required string ProjectDirectory { get; init; }
+    public required string AssetsDirectory { get; init; }
+    public required string MachinesDirectory { get; init; }
+    public required string GeneratedDirectory { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="140" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -117,6 +118,23 @@
             <TextBlock TextWrapping="Wrap"
                        Foreground="DimGray"
                        Text="{Binding StatusMessage}" />
+        </Border>
+
+        <Border Grid.Row="9"
+                Grid.ColumnSpan="2"
+                Padding="10"
+                BorderThickness="1"
+                BorderBrush="LightGray"
+                CornerRadius="4">
+            <StackPanel>
+                <TextBlock FontWeight="SemiBold"
+                           Text="Loaded project" />
+                <TextBlock Margin="0,4,0,0"
+                           Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded.}" />
+                <TextBlock Margin="0,2,0,0"
+                           Foreground="DimGray"
+                           Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project to load the editor shell.}" />
+            </StackPanel>
         </Border>
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -17,6 +17,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _projectFilePath = string.Empty;
     private string _statusMessage = "Create a new project to get started.";
     private string? _selectedRecentProject;
+    private EditorProject? _loadedProject;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -64,6 +65,20 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         private set => SetProperty(ref _statusMessage, value);
     }
 
+    public EditorProject? LoadedProject
+    {
+        get => _loadedProject;
+        private set
+        {
+            if (SetProperty(ref _loadedProject, value))
+            {
+                OnPropertyChanged(nameof(HasLoadedProject));
+            }
+        }
+    }
+
+    public bool HasLoadedProject => LoadedProject is not null;
+
     public string ProjectFilePath
     {
         get => _projectFilePath;
@@ -95,8 +110,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             var projectPath = _projectScaffolder.CreateProject(ProjectName, ProjectLocation);
             var projectFilePath = Path.Combine(projectPath, $"{ProjectName.Trim()}.oasisproj");
 
-            UpdateRecentProjects(projectFilePath);
-            StatusMessage = $"Project created: {projectPath}";
+            OpenProjectFile(projectFilePath, $"Project created and loaded: {projectPath}");
         }
         catch (Exception ex)
         {
@@ -112,7 +126,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OpenProject()
     {
-        OpenProjectFile(ProjectFilePath);
+        OpenProjectFile(ProjectFilePath, null);
     }
 
     private bool CanOpenProject()
@@ -127,7 +141,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        OpenProjectFile(SelectedRecentProject);
+        OpenProjectFile(SelectedRecentProject, null);
     }
 
     private bool CanOpenSelectedRecentProject()
@@ -135,7 +149,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return !string.IsNullOrWhiteSpace(SelectedRecentProject);
     }
 
-    private void OpenProjectFile(string projectFilePath)
+    private void OpenProjectFile(string projectFilePath, string? successMessage)
     {
         try
         {
@@ -165,15 +179,58 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
             }
 
+            var projectDirectory = Path.GetDirectoryName(projectFile);
+            if (string.IsNullOrWhiteSpace(projectDirectory))
+            {
+                throw new InvalidOperationException("Unable to determine project directory.");
+            }
+
+            var layoutElement = projectDocument.RootElement.GetProperty("layout");
+            var assetsDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "assets");
+            var machinesDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "machines");
+            var generatedDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "generated");
+
+            LoadedProject = new EditorProject
+            {
+                Name = openedProjectName,
+                ProjectFilePath = projectFile,
+                ProjectDirectory = projectDirectory,
+                AssetsDirectory = assetsDirectory,
+                MachinesDirectory = machinesDirectory,
+                GeneratedDirectory = generatedDirectory
+            };
+
             ProjectFilePath = projectFile;
             UpdateRecentProjects(projectFile);
-            StatusMessage = $"Project opened: {openedProjectName} ({projectFile})";
+            StatusMessage = successMessage ?? $"Project opened: {openedProjectName} ({projectFile})";
         }
         catch (Exception ex)
         {
             StatusMessage = ex.Message;
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private static string ResolveProjectDirectory(string projectDirectory, JsonElement layoutElement, string propertyName)
+    {
+        if (!layoutElement.TryGetProperty(propertyName, out var directoryElement))
+        {
+            throw new InvalidOperationException($"Project metadata is missing required layout '{propertyName}' field.");
+        }
+
+        var relativePath = directoryElement.GetString();
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new InvalidOperationException($"Project metadata layout '{propertyName}' field is empty.");
+        }
+
+        var fullPath = Path.GetFullPath(Path.Combine(projectDirectory, relativePath));
+        if (!Directory.Exists(fullPath))
+        {
+            throw new DirectoryNotFoundException($"Project layout folder was not found: {fullPath}");
+        }
+
+        return fullPath;
     }
 
     private void UpdateRecentProjects(string projectFilePath)
@@ -219,7 +276,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         storage = value;
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        OnPropertyChanged(propertyName);
         return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -6,7 +6,7 @@
 - [x] Implement project open flow
 - [x] Implement recent projects list
 - [x] Generate project directory layout
-- [ ] Load project into editor shell
+- [x] Load project into editor shell
 
 ## Phase 2 — Editor Shell
 - [ ] Create main window


### PR DESCRIPTION
### Motivation
- Ensure the editor shell holds a strongly-typed representation of the currently opened project so UI and features can reference project directories. 
- Validate project metadata and layout when opening or creating a project to surface missing fields or folders early. 
- Automatically load newly created projects into the shell to streamline the user flow.

### Description
- Add `EditorProject` model to represent the loaded project identity and resolved layout directories (`Assets`, `Machines`, `Generated`).
- Update `MainWindowViewModel` to parse and validate `.oasisproj` metadata, resolve layout paths via a new `ResolveProjectDirectory` helper, and populate `LoadedProject`; the open/create flows now call `OpenProjectFile(string, string?)` so create auto-loads the project.
- Expose `LoadedProject` and `HasLoadedProject` on the view model and add `OnPropertyChanged` helper to centralize notifications.
- Update `MainWindow.xaml` to show a small "Loaded project" section and mark the `Load project into editor shell` task as complete in `TASKS.md`.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, which failed in this environment because `dotnet` is not installed. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea1def9b4483279fb291a3e999ced5)