### PR TITLE
Add File menu and Exit command to editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -12,11 +12,27 @@
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0"
+        <Menu Grid.Row="0"
+              Margin="0,0,0,12">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Create Project"
+                          Command="{Binding CreateProjectCommand}" />
+                <MenuItem Header="_Open Project"
+                          Command="{Binding OpenProjectCommand}" />
+                <MenuItem Header="Open Selected _Recent"
+                          Command="{Binding OpenRecentProjectCommand}" />
+                <Separator />
+                <MenuItem Header="E_xit"
+                          Command="{Binding ExitCommand}" />
+            </MenuItem>
+        </Menu>
+
+        <Border Grid.Row="1"
                 Padding="16"
                 Margin="0,0,0,12"
                 CornerRadius="6"
@@ -32,7 +48,7 @@
             </StackPanel>
         </Border>
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="360" />
                 <ColumnDefinition Width="12" />
@@ -165,7 +181,7 @@
             </GroupBox>
         </Grid>
 
-        <StatusBar Grid.Row="2" Margin="0,12,0,0">
+        <StatusBar Grid.Row="3" Margin="0,12,0,0">
             <StatusBarItem Content="Ready" />
             <Separator />
             <StatusBarItem Content="Phase 2: Editor Shell" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -26,6 +26,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
+        ExitCommand = new RelayCommand(ExitApplication);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
     }
@@ -33,6 +34,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand CreateProjectCommand { get; }
     public ICommand OpenProjectCommand { get; }
     public ICommand OpenRecentProjectCommand { get; }
+    public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
 
     public string ProjectName
@@ -147,6 +149,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool CanOpenSelectedRecentProject()
     {
         return !string.IsNullOrWhiteSpace(SelectedRecentProject);
+    }
+
+    private static void ExitApplication()
+    {
+        Application.Current.Shutdown();
     }
 
     private void OpenProjectFile(string projectFilePath, string? successMessage)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -10,7 +10,7 @@
 
 ## Phase 2 — Editor Shell
 - [x] Create main window
-- [ ] Add menu bar
+- [x] Add menu bar
 - [ ] Add toolbar
 - [ ] Implement basic dock layout
 - [ ] Implement document tab system


### PR DESCRIPTION
### Motivation
- Implement the next Phase 2 task to add a menu bar to the editor shell and expose existing project actions from the UI.

### Description
- Added a top-level `Menu` with a `File` menu to `OasisEditor/MainWindow.xaml` and adjusted grid rows so layout remains correct.
- Bound menu items to existing commands: `CreateProjectCommand`, `OpenProjectCommand`, and `OpenRecentProjectCommand`, and added an `Exit` menu item bound to a new `ExitCommand`.
- Added `ExitCommand` and `ExitApplication()` (calls `Application.Current.Shutdown()`) to `OasisEditor/MainWindowViewModel.cs`, and initialized the command in the view model constructor.
- Marked the Phase 2 task `Add menu bar` as complete in `TASKS.md`.

### Testing
- Attempted to run `dotnet build OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not available (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea21d894f88327b173eec0e39b669a)