### PR TITLE
Add toolbar to Oasis Editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -32,7 +33,24 @@
             </MenuItem>
         </Menu>
 
-        <Border Grid.Row="1"
+        <ToolBarTray Grid.Row="1"
+                     Margin="0,0,0,12"
+                     Background="#FFF2F5FB">
+            <ToolBar Band="0"
+                     BandIndex="0">
+                <Button Command="{Binding CreateProjectCommand}"
+                        Content="Create Project" />
+                <Button Command="{Binding OpenProjectCommand}"
+                        Content="Open Project" />
+                <Button Command="{Binding OpenRecentProjectCommand}"
+                        Content="Open Recent" />
+                <Separator />
+                <Button Command="{Binding ExitCommand}"
+                        Content="Exit" />
+            </ToolBar>
+        </ToolBarTray>
+
+        <Border Grid.Row="2"
                 Padding="16"
                 Margin="0,0,0,12"
                 CornerRadius="6"
@@ -48,7 +66,7 @@
             </StackPanel>
         </Border>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="360" />
                 <ColumnDefinition Width="12" />
@@ -181,7 +199,7 @@
             </GroupBox>
         </Grid>
 
-        <StatusBar Grid.Row="3" Margin="0,12,0,0">
+        <StatusBar Grid.Row="4" Margin="0,12,0,0">
             <StatusBarItem Content="Ready" />
             <Separator />
             <StatusBarItem Content="Phase 2: Editor Shell" />

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -11,7 +11,7 @@
 ## Phase 2 — Editor Shell
 - [x] Create main window
 - [x] Add menu bar
-- [ ] Add toolbar
+- [x] Add toolbar
 - [ ] Implement basic dock layout
 - [ ] Implement document tab system
 - [ ] Add panels:


### PR DESCRIPTION
### Motivation
- Implement the next task from `TASKS.md` by adding a toolbar to the editor shell to expose core project actions directly in the UI.
- Improve usability by surfacing `Create`, `Open`, `Open Recent`, and `Exit` actions as toolbar buttons in addition to the menu.

### Description
- Added a `ToolBarTray` / `ToolBar` to `OasisEditor/MainWindow.xaml` with buttons bound to existing commands: `CreateProjectCommand`, `OpenProjectCommand`, `OpenRecentProjectCommand`, and `ExitCommand`.
- Adjusted the main window grid layout by adding a new row definition and updating `Grid.Row` indices so the header, toolbar, content, and `StatusBar` render correctly with the new toolbar row.
- Updated `TASKS.md` to mark the `Add toolbar` task as completed.

### Testing
- Attempted `dotnet build OasisEditor.sln`, but the build could not be run in this environment because the `dotnet` SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea22bedc448327a6ac02b77cb20615)