### PR TITLE
Implement document tab system in OasisEditor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -226,13 +226,61 @@
                                 Background="White"
                                 BorderBrush="#FFD9E0EE"
                                 BorderThickness="1,0,1,1">
-                            <StackPanel>
-                                <TextBlock FontWeight="SemiBold"
-                                           Text="Document Host" />
-                                <TextBlock Margin="0,6,0,0"
-                                           Foreground="DimGray"
-                                           Text="Center workspace for open editor documents." />
-                            </StackPanel>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <DockPanel Grid.Row="0"
+                                           LastChildFill="False"
+                                           Margin="0,0,0,8">
+                                    <TextBlock DockPanel.Dock="Left"
+                                               VerticalAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               Text="Document Host" />
+                                    <StackPanel DockPanel.Dock="Right"
+                                                Orientation="Horizontal">
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
+                                                Command="{Binding OpenUntitledDocumentCommand}"
+                                                Content="New Tab" />
+                                        <Button Padding="10,4"
+                                                Command="{Binding CloseSelectedDocumentCommand}"
+                                                Content="Close Tab" />
+                                    </StackPanel>
+                                </DockPanel>
+
+                                <TabControl Grid.Row="1"
+                                            ItemsSource="{Binding OpenDocuments}"
+                                            SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
+                                    <TabControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Title}" />
+                                        </DataTemplate>
+                                    </TabControl.ItemTemplate>
+                                    <TabControl.ContentTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Margin="4">
+                                                <TextBlock FontWeight="SemiBold"
+                                                           Text="{Binding TypeLabel}" />
+                                                <TextBlock Margin="0,6,0,0"
+                                                           Foreground="DimGray"
+                                                           Text="{Binding FilePath}" />
+                                                <Border Margin="0,10,0,0"
+                                                        Padding="10"
+                                                        CornerRadius="4"
+                                                        Background="#FFF8FAFF"
+                                                        BorderBrush="#FFD9E0EE"
+                                                        BorderThickness="1">
+                                                    <TextBlock TextWrapping="Wrap"
+                                                               Text="{Binding ContentSummary}" />
+                                                </Border>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </TabControl.ContentTemplate>
+                                </TabControl>
+                            </Grid>
                         </Border>
 
                         <Border Grid.Row="1"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -18,6 +18,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _statusMessage = "Create a new project to get started.";
     private string? _selectedRecentProject;
     private EditorProject? _loadedProject;
+    private DocumentTabViewModel? _selectedDocument;
+    private int _untitledDocumentCounter = 1;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -26,16 +28,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
+        OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
+        CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         ExitCommand = new RelayCommand(ExitApplication);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
+        OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
     }
 
     public ICommand CreateProjectCommand { get; }
     public ICommand OpenProjectCommand { get; }
     public ICommand OpenRecentProjectCommand { get; }
+    public ICommand OpenUntitledDocumentCommand { get; }
+    public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
+    public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
 
     public string ProjectName
     {
@@ -75,6 +83,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _loadedProject, value))
             {
                 OnPropertyChanged(nameof(HasLoadedProject));
+                NotifyDocumentCommands();
             }
         }
     }
@@ -101,6 +110,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _selectedRecentProject, value))
             {
                 NotifyOpenRecentCommand();
+            }
+        }
+    }
+
+    public DocumentTabViewModel? SelectedDocument
+    {
+        get => _selectedDocument;
+        set
+        {
+            if (SetProperty(ref _selectedDocument, value))
+            {
+                NotifyDocumentCommands();
             }
         }
     }
@@ -149,6 +170,58 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool CanOpenSelectedRecentProject()
     {
         return !string.IsNullOrWhiteSpace(SelectedRecentProject);
+    }
+
+    private bool CanOpenUntitledDocument()
+    {
+        return LoadedProject is not null;
+    }
+
+    private void OpenUntitledDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        var document = new DocumentTabViewModel(
+            $"Untitled {_untitledDocumentCounter++}",
+            "Document Type",
+            "No file associated yet.",
+            "Create or open a project asset to begin editing.");
+
+        OpenDocuments.Add(document);
+        SelectedDocument = document;
+        StatusMessage = $"Opened document tab: {document.Title}";
+    }
+
+    private bool CanCloseSelectedDocument()
+    {
+        return SelectedDocument is not null;
+    }
+
+    private void CloseSelectedDocument()
+    {
+        if (SelectedDocument is null)
+        {
+            return;
+        }
+
+        var documentToClose = SelectedDocument;
+        var index = OpenDocuments.IndexOf(documentToClose);
+
+        OpenDocuments.Remove(documentToClose);
+
+        if (OpenDocuments.Count == 0)
+        {
+            SelectedDocument = null;
+            StatusMessage = "Closed document tab.";
+            return;
+        }
+
+        var nextIndex = Math.Clamp(index, 0, OpenDocuments.Count - 1);
+        SelectedDocument = OpenDocuments[nextIndex];
+        StatusMessage = $"Closed document tab: {documentToClose.Title}";
     }
 
     private static void ExitApplication()
@@ -209,6 +282,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
             ProjectFilePath = projectFile;
             UpdateRecentProjects(projectFile);
+            EnsureProjectOverviewDocument();
             StatusMessage = successMessage ?? $"Project opened: {openedProjectName} ({projectFile})";
         }
         catch (Exception ex)
@@ -216,6 +290,24 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             StatusMessage = ex.Message;
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private void EnsureProjectOverviewDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        OpenDocuments.Clear();
+        var overviewDocument = new DocumentTabViewModel(
+            "Project Overview",
+            "Project",
+            LoadedProject.ProjectFilePath,
+            $"Assets: {LoadedProject.AssetsDirectory}\nMachines: {LoadedProject.MachinesDirectory}\nGenerated: {LoadedProject.GeneratedDirectory}");
+
+        OpenDocuments.Add(overviewDocument);
+        SelectedDocument = overviewDocument;
     }
 
     private static string ResolveProjectDirectory(string projectDirectory, JsonElement layoutElement, string propertyName)
@@ -275,14 +367,27 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    private void NotifyDocumentCommands()
     {
-        if (EqualityComparer<T>.Default.Equals(storage, value))
+        if (OpenUntitledDocumentCommand is RelayCommand openRelayCommand)
+        {
+            openRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (CloseSelectedDocumentCommand is RelayCommand closeRelayCommand)
+        {
+            closeRelayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
         {
             return false;
         }
 
-        storage = value;
+        field = value;
         OnPropertyChanged(propertyName);
         return true;
     }
@@ -291,4 +396,20 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
+}
+
+public sealed class DocumentTabViewModel
+{
+    public DocumentTabViewModel(string title, string typeLabel, string filePath, string contentSummary)
+    {
+        Title = title;
+        TypeLabel = typeLabel;
+        FilePath = filePath;
+        ContentSummary = contentSummary;
+    }
+
+    public string Title { get; }
+    public string TypeLabel { get; }
+    public string FilePath { get; }
+    public string ContentSummary { get; }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -13,7 +13,7 @@
 - [x] Add menu bar
 - [x] Add toolbar
 - [x] Implement basic dock layout
-- [ ] Implement document tab system
+- [x] Implement document tab system
 - [ ] Add panels:
   - [ ] Asset browser
   - [ ] Inspector


### PR DESCRIPTION
### Motivation
- Implement the next Phase 2 item from `TASKS.md`: a minimal document tab system for the editor shell. 
- Provide a small, testable tab model so the UI can host multiple documents and the project overview when a project is opened. 
- Add basic UI controls for opening/closing tabs to make later document system work (Phase 3) easier to integrate.

### Description
- Added tab state and commands to `MainWindowViewModel` including `OpenDocuments`, `SelectedDocument`, `OpenUntitledDocumentCommand`, and `CloseSelectedDocumentCommand`, plus an `EnsureProjectOverviewDocument()` helper (file: `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).
- Introduced a lightweight `DocumentTabViewModel` to represent tabs and their display metadata (same file as above).
- Updated `MainWindow.xaml` to replace the placeholder center pane with a `TabControl` and added `New Tab` / `Close Tab` buttons bound to the new commands (file: `WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml`).
- Marked the `Implement document tab system` item as complete in `TASKS.md` (file: `WindowsNetProjects/OasisEditor/TASKS.md`).

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found` so no build completed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea256a770c832795c69be015b0fbd3)