### PR TITLE
Add Asset Browser panel to editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -211,13 +211,36 @@
                                 Background="#FFF9FAFC"
                                 BorderBrush="#FFD9E0EE"
                                 BorderThickness="1,0,0,1">
-                            <StackPanel>
-                                <TextBlock FontWeight="SemiBold"
-                                           Text="Left Dock" />
-                                <TextBlock Margin="0,6,0,0"
-                                           Foreground="DimGray"
-                                           Text="Tool windows and navigation." />
-                            </StackPanel>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0"
+                                           FontWeight="SemiBold"
+                                           Text="Asset Browser" />
+
+                                <DockPanel Grid.Row="1"
+                                           Margin="0,6,0,8"
+                                           LastChildFill="False">
+                                    <Button DockPanel.Dock="Right"
+                                            Padding="10,4"
+                                            Command="{Binding RefreshAssetBrowserCommand}"
+                                            Content="Refresh" />
+                                </DockPanel>
+
+                                <ListBox Grid.Row="2"
+                                         ItemsSource="{Binding AssetBrowserItems}"
+                                         SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding DisplayPath}" />
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </Grid>
                         </Border>
 
                         <Border Grid.Row="1"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
@@ -19,6 +20,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string? _selectedRecentProject;
     private EditorProject? _loadedProject;
     private DocumentTabViewModel? _selectedDocument;
+    private AssetBrowserItemViewModel? _selectedAsset;
     private int _untitledDocumentCounter = 1;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -30,10 +32,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
+        RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         ExitCommand = new RelayCommand(ExitApplication);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
+        AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
     }
 
     public ICommand CreateProjectCommand { get; }
@@ -41,9 +45,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenRecentProjectCommand { get; }
     public ICommand OpenUntitledDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
+    public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
+    public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
 
     public string ProjectName
     {
@@ -122,6 +128,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _selectedDocument, value))
             {
                 NotifyDocumentCommands();
+            }
+        }
+    }
+
+    public AssetBrowserItemViewModel? SelectedAsset
+    {
+        get => _selectedAsset;
+        set
+        {
+            if (SetProperty(ref _selectedAsset, value))
+            {
+                NotifyAssetBrowserCommand();
             }
         }
     }
@@ -283,6 +301,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             ProjectFilePath = projectFile;
             UpdateRecentProjects(projectFile);
             EnsureProjectOverviewDocument();
+            RefreshAssetBrowser();
             StatusMessage = successMessage ?? $"Project opened: {openedProjectName} ({projectFile})";
         }
         catch (Exception ex)
@@ -343,6 +362,35 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    private bool CanRefreshAssetBrowser()
+    {
+        return LoadedProject is not null;
+    }
+
+    private void RefreshAssetBrowser()
+    {
+        if (LoadedProject is null)
+        {
+            AssetBrowserItems.Clear();
+            SelectedAsset = null;
+            return;
+        }
+
+        var assetsRoot = LoadedProject.AssetsDirectory;
+        var assetFiles = Directory.EnumerateFiles(assetsRoot, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        AssetBrowserItems.Clear();
+        foreach (var file in assetFiles)
+        {
+            var relativePath = Path.GetRelativePath(assetsRoot, file);
+            AssetBrowserItems.Add(new AssetBrowserItemViewModel(relativePath, file));
+        }
+
+        SelectedAsset = AssetBrowserItems.FirstOrDefault();
+    }
+
     private void NotifyCreateCommand()
     {
         if (CreateProjectCommand is RelayCommand relayCommand)
@@ -378,6 +426,16 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             closeRelayCommand.RaiseCanExecuteChanged();
         }
+
+        NotifyAssetBrowserCommand();
+    }
+
+    private void NotifyAssetBrowserCommand()
+    {
+        if (RefreshAssetBrowserCommand is RelayCommand refreshRelayCommand)
+        {
+            refreshRelayCommand.RaiseCanExecuteChanged();
+        }
     }
 
     private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
@@ -412,4 +470,16 @@ public sealed class DocumentTabViewModel
     public string TypeLabel { get; }
     public string FilePath { get; }
     public string ContentSummary { get; }
+}
+
+public sealed class AssetBrowserItemViewModel
+{
+    public AssetBrowserItemViewModel(string displayPath, string fullPath)
+    {
+        DisplayPath = displayPath;
+        FullPath = fullPath;
+    }
+
+    public string DisplayPath { get; }
+    public string FullPath { get; }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -15,7 +15,7 @@
 - [x] Implement basic dock layout
 - [x] Implement document tab system
 - [ ] Add panels:
-  - [ ] Asset browser
+  - [x] Asset browser
   - [ ] Inspector
   - [ ] Output/log
 


### PR DESCRIPTION
### Motivation
- Implement the next Phase 2 task by adding an in-editor Asset Browser so users can view project assets from the editor shell.
- Provide a simple list view and a manual refresh action to inspect files under a project's `AssetsDirectory`.
- Wire the UI to view-model state so the asset list updates when a project is opened.

### Description
- Replaced the left-dock placeholder with an `Asset Browser` panel in `MainWindow.xaml` that includes a `ListBox` bound to `AssetBrowserItems` and a `Refresh` button bound to `RefreshAssetBrowserCommand`.
- Extended `MainWindowViewModel` with `AssetBrowserItems`, `SelectedAsset`, `RefreshAssetBrowserCommand`, `RefreshAssetBrowser()` logic, and `AssetBrowserItemViewModel` for list entries; the asset list is auto-populated when a project is opened.
- Added `using System.Linq;` and simple file enumeration to gather asset paths under the project's assets root and populate the `AssetBrowserItems` collection.
- Marked the `Asset browser` item complete in `TASKS.md` to reflect the implemented Phase 2 task.

### Testing
- Attempted to build the solution with `dotnet build OasisEditor.sln`, which could not run in this environment because `dotnet` is not installed (build not validated).
- No automated unit tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea287d4bc4832785623dbbcec5d6e8)