### PR TITLE
Add Inspector panel to editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -312,13 +312,44 @@
                                 Background="#FFF9FAFC"
                                 BorderBrush="#FFD9E0EE"
                                 BorderThickness="0,0,1,1">
-                            <StackPanel>
-                                <TextBlock FontWeight="SemiBold"
-                                           Text="Right Dock" />
-                                <TextBlock Margin="0,6,0,0"
-                                           Foreground="DimGray"
-                                           Text="Properties and inspectors." />
-                            </StackPanel>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0"
+                                           FontWeight="SemiBold"
+                                           Text="Inspector" />
+
+                                <Border Grid.Row="1"
+                                        Margin="0,8,0,0"
+                                        Padding="10"
+                                        Background="White"
+                                        BorderBrush="#FFD9E0EE"
+                                        BorderThickness="1"
+                                        CornerRadius="4">
+                                    <StackPanel>
+                                        <TextBlock FontWeight="SemiBold"
+                                                   Text="{Binding InspectorTitle}" />
+                                        <TextBlock Margin="0,6,0,0"
+                                                   Foreground="DimGray"
+                                                   Text="{Binding InspectorType}" />
+                                        <TextBlock Margin="0,6,0,0"
+                                                   TextWrapping="Wrap"
+                                                   Text="{Binding InspectorPath}" />
+                                        <Border Margin="0,10,0,0"
+                                                Padding="8"
+                                                Background="#FFF8FAFF"
+                                                BorderBrush="#FFD9E0EE"
+                                                BorderThickness="1"
+                                                CornerRadius="4">
+                                            <TextBlock TextWrapping="Wrap"
+                                                       Text="{Binding InspectorSummary}" />
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
+                            </Grid>
                         </Border>
 
                         <Border Grid.Row="2"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -89,6 +89,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _loadedProject, value))
             {
                 OnPropertyChanged(nameof(HasLoadedProject));
+                NotifyInspectorChanged();
                 NotifyDocumentCommands();
             }
         }
@@ -127,6 +128,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             if (SetProperty(ref _selectedDocument, value))
             {
+                NotifyInspectorChanged();
                 NotifyDocumentCommands();
             }
         }
@@ -139,8 +141,101 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             if (SetProperty(ref _selectedAsset, value))
             {
+                NotifyInspectorChanged();
                 NotifyAssetBrowserCommand();
             }
+        }
+    }
+
+    public string InspectorTitle
+    {
+        get
+        {
+            if (SelectedAsset is not null)
+            {
+                return $"Asset: {SelectedAsset.DisplayPath}";
+            }
+
+            if (SelectedDocument is not null)
+            {
+                return $"Document: {SelectedDocument.Title}";
+            }
+
+            if (LoadedProject is not null)
+            {
+                return $"Project: {LoadedProject.Name}";
+            }
+
+            return "No selection";
+        }
+    }
+
+    public string InspectorType
+    {
+        get
+        {
+            if (SelectedAsset is not null)
+            {
+                return "Asset File";
+            }
+
+            if (SelectedDocument is not null)
+            {
+                return SelectedDocument.TypeLabel;
+            }
+
+            if (LoadedProject is not null)
+            {
+                return "Editor Project";
+            }
+
+            return "None";
+        }
+    }
+
+    public string InspectorPath
+    {
+        get
+        {
+            if (SelectedAsset is not null)
+            {
+                return SelectedAsset.FullPath;
+            }
+
+            if (SelectedDocument is not null)
+            {
+                return SelectedDocument.FilePath;
+            }
+
+            if (LoadedProject is not null)
+            {
+                return LoadedProject.ProjectFilePath;
+            }
+
+            return "Select an asset or document to inspect details.";
+        }
+    }
+
+    public string InspectorSummary
+    {
+        get
+        {
+            if (SelectedAsset is not null)
+            {
+                return "Use this panel as the starting point for future property editing.";
+            }
+
+            if (SelectedDocument is not null)
+            {
+                return SelectedDocument.ContentSummary;
+            }
+
+            if (LoadedProject is not null)
+            {
+                return "Project loaded. Select a document tab or asset file to inspect it.";
+            }
+
+            return "Open or create a project to enable the inspector.";
         }
     }
 
@@ -373,6 +468,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             AssetBrowserItems.Clear();
             SelectedAsset = null;
+            NotifyInspectorChanged();
             return;
         }
 
@@ -389,6 +485,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         SelectedAsset = AssetBrowserItems.FirstOrDefault();
+        NotifyInspectorChanged();
     }
 
     private void NotifyCreateCommand()
@@ -436,6 +533,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             refreshRelayCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    private void NotifyInspectorChanged()
+    {
+        OnPropertyChanged(nameof(InspectorTitle));
+        OnPropertyChanged(nameof(InspectorType));
+        OnPropertyChanged(nameof(InspectorPath));
+        OnPropertyChanged(nameof(InspectorSummary));
     }
 
     private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -16,7 +16,7 @@
 - [x] Implement document tab system
 - [ ] Add panels:
   - [x] Asset browser
-  - [ ] Inspector
+  - [x] Inspector
   - [ ] Output/log
 
 ## Phase 3 — Document System


### PR DESCRIPTION
### Motivation
- Complete the Phase 2 editor shell by replacing the right-dock placeholder with an Inspector so users can view details for the selected project, document, or asset. 
- Expose inspector-facing state from the view model so the UI can display selection-aware metadata and summaries.

### Description
- Updated the right dock in `MainWindow.xaml` to render an Inspector card bound to `InspectorTitle`, `InspectorType`, `InspectorPath`, and `InspectorSummary`.
- Added computed inspector properties and change notifications to `MainWindowViewModel.cs`, including `InspectorTitle`, `InspectorType`, `InspectorPath`, `InspectorSummary`, and `NotifyInspectorChanged()`.
- Wired inspector updates to key state changes by invoking `NotifyInspectorChanged()` when `LoadedProject`, `SelectedDocument`, or `SelectedAsset` changes and after asset browser refresh.
- Marked the `Inspector` panel as complete in `WindowsNetProjects/OasisEditor/TASKS.md`.

### Testing
- Attempted to build the solution with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, which failed because `dotnet` is not available in this execution environment.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea29e9f9d88327a0e9d9bbfd806c1a)