### PR TITLE
Add Output/Log panel to editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -359,13 +359,31 @@
                                 BorderBrush="#FFD9E0EE"
                                 BorderThickness="1,0,1,1"
                                 CornerRadius="0,0,4,4">
-                            <StackPanel>
-                                <TextBlock FontWeight="SemiBold"
-                                           Text="Bottom Dock" />
-                                <TextBlock Margin="0,6,0,0"
-                                           Foreground="DimGray"
-                                           Text="Output, logs, and diagnostics." />
-                            </StackPanel>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <DockPanel Grid.Row="0"
+                                           LastChildFill="False">
+                                    <TextBlock DockPanel.Dock="Left"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center"
+                                               Text="Output / Log" />
+                                    <Button DockPanel.Dock="Right"
+                                            Padding="10,4"
+                                            Command="{Binding ClearOutputCommand}"
+                                            Content="Clear" />
+                                </DockPanel>
+
+                                <ListBox Grid.Row="1"
+                                         Margin="0,8,0,0"
+                                         Background="White"
+                                         BorderBrush="#FFD9E0EE"
+                                         BorderThickness="1"
+                                         ItemsSource="{Binding OutputEntries}" />
+                            </Grid>
                         </Border>
                     </Grid>
                 </Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -33,11 +33,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
+        ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
         ExitCommand = new RelayCommand(ExitApplication);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
+        OutputEntries = new ObservableCollection<string>();
+        AddOutputEntry("Editor shell initialized.");
     }
 
     public ICommand CreateProjectCommand { get; }
@@ -46,10 +49,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenUntitledDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
+    public ICommand ClearOutputCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
+    public ObservableCollection<string> OutputEntries { get; }
 
     public string ProjectName
     {
@@ -247,10 +252,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             var projectFilePath = Path.Combine(projectPath, $"{ProjectName.Trim()}.oasisproj");
 
             OpenProjectFile(projectFilePath, $"Project created and loaded: {projectPath}");
+            AddOutputEntry($"Created project at {projectPath}");
         }
         catch (Exception ex)
         {
             StatusMessage = ex.Message;
+            AddOutputEntry($"Create project failed: {ex.Message}");
             MessageBox.Show(ex.Message, "Create Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
     }
@@ -306,6 +313,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenDocuments.Add(document);
         SelectedDocument = document;
         StatusMessage = $"Opened document tab: {document.Title}";
+        AddOutputEntry($"Opened document tab: {document.Title}");
     }
 
     private bool CanCloseSelectedDocument()
@@ -329,12 +337,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             SelectedDocument = null;
             StatusMessage = "Closed document tab.";
+            AddOutputEntry($"Closed document tab: {documentToClose.Title}");
             return;
         }
 
         var nextIndex = Math.Clamp(index, 0, OpenDocuments.Count - 1);
         SelectedDocument = OpenDocuments[nextIndex];
         StatusMessage = $"Closed document tab: {documentToClose.Title}";
+        AddOutputEntry($"Closed document tab: {documentToClose.Title}");
     }
 
     private static void ExitApplication()
@@ -398,10 +408,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             EnsureProjectOverviewDocument();
             RefreshAssetBrowser();
             StatusMessage = successMessage ?? $"Project opened: {openedProjectName} ({projectFile})";
+            AddOutputEntry($"Loaded project '{openedProjectName}' from {projectFile}");
         }
         catch (Exception ex)
         {
             StatusMessage = ex.Message;
+            AddOutputEntry($"Open project failed: {ex.Message}");
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
     }
@@ -469,6 +481,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AssetBrowserItems.Clear();
             SelectedAsset = null;
             NotifyInspectorChanged();
+            AddOutputEntry("Asset browser cleared (no project loaded).");
             return;
         }
 
@@ -486,6 +499,25 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         SelectedAsset = AssetBrowserItems.FirstOrDefault();
         NotifyInspectorChanged();
+        AddOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} files).");
+    }
+
+    private bool CanClearOutput()
+    {
+        return OutputEntries.Count > 0;
+    }
+
+    private void ClearOutput()
+    {
+        OutputEntries.Clear();
+        AddOutputEntry("Output log cleared.");
+    }
+
+    private void AddOutputEntry(string message)
+    {
+        var timestamp = DateTime.Now.ToString("HH:mm:ss");
+        OutputEntries.Add($"[{timestamp}] {message}");
+        NotifyOutputCommand();
     }
 
     private void NotifyCreateCommand()
@@ -532,6 +564,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (RefreshAssetBrowserCommand is RelayCommand refreshRelayCommand)
         {
             refreshRelayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private void NotifyOutputCommand()
+    {
+        if (ClearOutputCommand is RelayCommand clearRelayCommand)
+        {
+            clearRelayCommand.RaiseCanExecuteChanged();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -17,7 +17,7 @@
 - [ ] Add panels:
   - [x] Asset browser
   - [x] Inspector
-  - [ ] Output/log
+  - [x] Output/log
 
 ## Phase 3 — Document System
 - [ ] Define base document model


### PR DESCRIPTION
### Motivation
- Complete the Phase 2 requirement to provide an output/log panel in the editor shell and give users a simple runtime log for common shell actions and failures.
- Surface timestamped notifications for project/document/asset operations to aid debugging and UX feedback.

### Description
- Replaced the bottom dock placeholder with an "Output / Log" panel in `MainWindow.xaml` including a bound `ListBox` for `OutputEntries` and a `Clear` button bound to `ClearOutputCommand`.
- Extended `MainWindowViewModel` to add `OutputEntries` (`ObservableCollection<string>`), `ClearOutputCommand`, `AddOutputEntry(string)` helper, and `NotifyOutputCommand()`; added initial entry on construction and wired `AddOutputEntry` calls into project create/open, document open/close, asset refresh, and error paths.
- Updated `TASKS.md` to mark the Phase 2 `Output/log` task complete.
- Modified and committed the following files: `OasisEditor/MainWindow.xaml`, `OasisEditor/MainWindowViewModel.cs`, and `TASKS.md`.

### Testing
- Attempted to run an automated build with `dotnet build OasisEditor.sln` but the command could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea2b70dc10832797638b6f7bc3b14f)