### PR TITLE
Add base document model for OasisEditor document tabs

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -1,0 +1,53 @@
+namespace OasisEditor;
+
+public enum EditorDocumentType
+{
+    Generic,
+    ProjectOverview,
+    Panel2D,
+    Cabinet3D,
+    Machine
+}
+
+public sealed class EditorDocument
+{
+    private EditorDocument(
+        string title,
+        EditorDocumentType documentType,
+        string filePath,
+        string contentSummary,
+        bool isUntitled)
+    {
+        Title = title;
+        DocumentType = documentType;
+        FilePath = filePath;
+        ContentSummary = contentSummary;
+        IsUntitled = isUntitled;
+    }
+
+    public string Title { get; }
+    public EditorDocumentType DocumentType { get; }
+    public string FilePath { get; }
+    public string ContentSummary { get; }
+    public bool IsUntitled { get; }
+
+    public static EditorDocument CreateUntitled(string title)
+    {
+        return new EditorDocument(
+            title,
+            EditorDocumentType.Generic,
+            "No file associated yet.",
+            "Create or open a project asset to begin editing.",
+            true);
+    }
+
+    public static EditorDocument CreateProjectOverview(EditorProject project)
+    {
+        return new EditorDocument(
+            "Project Overview",
+            EditorDocumentType.ProjectOverview,
+            project.ProjectFilePath,
+            $"Assets: {project.AssetsDirectory}\nMachines: {project.MachinesDirectory}\nGenerated: {project.GeneratedDirectory}",
+            false);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -305,10 +305,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var document = new DocumentTabViewModel(
-            $"Untitled {_untitledDocumentCounter++}",
-            "Document Type",
-            "No file associated yet.",
-            "Create or open a project asset to begin editing.");
+            EditorDocument.CreateUntitled($"Untitled {_untitledDocumentCounter++}"));
 
         OpenDocuments.Add(document);
         SelectedDocument = document;
@@ -426,11 +423,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         OpenDocuments.Clear();
-        var overviewDocument = new DocumentTabViewModel(
-            "Project Overview",
-            "Project",
-            LoadedProject.ProjectFilePath,
-            $"Assets: {LoadedProject.AssetsDirectory}\nMachines: {LoadedProject.MachinesDirectory}\nGenerated: {LoadedProject.GeneratedDirectory}");
+        var overviewDocument = new DocumentTabViewModel(EditorDocument.CreateProjectOverview(LoadedProject));
 
         OpenDocuments.Add(overviewDocument);
         SelectedDocument = overviewDocument;
@@ -603,18 +596,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
 public sealed class DocumentTabViewModel
 {
-    public DocumentTabViewModel(string title, string typeLabel, string filePath, string contentSummary)
+    public DocumentTabViewModel(EditorDocument document)
     {
-        Title = title;
-        TypeLabel = typeLabel;
-        FilePath = filePath;
-        ContentSummary = contentSummary;
+        Document = document;
     }
 
-    public string Title { get; }
-    public string TypeLabel { get; }
-    public string FilePath { get; }
-    public string ContentSummary { get; }
+    public EditorDocument Document { get; }
+    public string Title => Document.Title;
+    public string TypeLabel => Document.DocumentType switch
+    {
+        EditorDocumentType.ProjectOverview => "Project",
+        EditorDocumentType.Panel2D => "Panel 2D",
+        EditorDocumentType.Cabinet3D => "Cabinet 3D",
+        EditorDocumentType.Machine => "Machine",
+        _ => "Document Type"
+    };
+    public string FilePath => Document.FilePath;
+    public string ContentSummary => Document.ContentSummary;
 }
 
 public sealed class AssetBrowserItemViewModel

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -14,13 +14,13 @@
 - [x] Add toolbar
 - [x] Implement basic dock layout
 - [x] Implement document tab system
-- [ ] Add panels:
+- [x] Add panels:
   - [x] Asset browser
   - [x] Inspector
   - [x] Output/log
 
 ## Phase 3 — Document System
-- [ ] Define base document model
+- [x] Define base document model
 - [ ] Implement open/save document
 - [ ] Implement document dirty state
 - [ ] Implement document tabs integration


### PR DESCRIPTION
### Motivation
- Introduce a UI-agnostic document model so tab state and editor document metadata are decoupled from WPF view models to make it easier to add new document types and unit-test document logic.
- Prepare the codebase for future document features (open/save, dirty state, typed editors) by providing a canonical representation for documents.

### Description
- Added `EditorDocumentType` and `EditorDocument` with shared metadata and factory helpers in `OasisEditor/DocumentModel.cs` to represent untitled documents and project overview documents.
- Updated `DocumentTabViewModel` to wrap an `EditorDocument` and derive display properties (`Title`, `TypeLabel`, `FilePath`, `ContentSummary`) from the base model.
- Switched untitled tab creation and project overview creation in `MainWindowViewModel` to use `EditorDocument.CreateUntitled(...)` and `EditorDocument.CreateProjectOverview(...)` respectively.
- Updated `WindowsNetProjects/OasisEditor/TASKS.md` to mark the parent panels item and `Define base document model` task as complete.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment lacks the `dotnet` CLI (`dotnet: command not found`), so a build could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea2c8f409883279d7623831a7f3963)