### PR TITLE
Implement document open/save workflow (model, VM, and UI)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -50,4 +50,28 @@ public sealed class EditorDocument
             $"Assets: {project.AssetsDirectory}\nMachines: {project.MachinesDirectory}\nGenerated: {project.GeneratedDirectory}",
             false);
     }
+
+    public static EditorDocument CreateFromFile(string filePath, string summary)
+    {
+        var extension = Path.GetExtension(filePath);
+        var documentType = extension.ToLowerInvariant() switch
+        {
+            ".panel2d" => EditorDocumentType.Panel2D,
+            ".cabinet3d" => EditorDocumentType.Cabinet3D,
+            ".machine" => EditorDocumentType.Machine,
+            _ => EditorDocumentType.Generic
+        };
+
+        return new EditorDocument(
+            Path.GetFileName(filePath),
+            documentType,
+            filePath,
+            summary,
+            false);
+    }
+
+    public EditorDocument SaveAs(string filePath, string summary)
+    {
+        return CreateFromFile(filePath, summary);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -53,17 +53,29 @@ public sealed class EditorDocument
 
     public static EditorDocument CreateFromFile(string filePath, string summary)
     {
-        var extension = Path.GetExtension(filePath);
-        var documentType = extension.ToLowerInvariant() switch
+        var extension = System.IO.Path.GetExtension(filePath);
+        var normalizedExtension = extension.ToLowerInvariant();
+
+        EditorDocumentType documentType;
+        if (normalizedExtension == ".panel2d")
         {
-            ".panel2d" => EditorDocumentType.Panel2D,
-            ".cabinet3d" => EditorDocumentType.Cabinet3D,
-            ".machine" => EditorDocumentType.Machine,
-            _ => EditorDocumentType.Generic
-        };
+            documentType = EditorDocumentType.Panel2D;
+        }
+        else if (normalizedExtension == ".cabinet3d")
+        {
+            documentType = EditorDocumentType.Cabinet3D;
+        }
+        else if (normalizedExtension == ".machine")
+        {
+            documentType = EditorDocumentType.Machine;
+        }
+        else
+        {
+            documentType = EditorDocumentType.Generic;
+        }
 
         return new EditorDocument(
-            Path.GetFileName(filePath),
+            System.IO.Path.GetFileName(filePath),
             documentType,
             filePath,
             summary,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -28,6 +28,11 @@
                 <MenuItem Header="Open Selected _Recent"
                           Command="{Binding OpenRecentProjectCommand}" />
                 <Separator />
+                <MenuItem Header="Open _Document"
+                          Command="{Binding OpenDocumentCommand}" />
+                <MenuItem Header="_Save Document"
+                          Command="{Binding SaveSelectedDocumentCommand}" />
+                <Separator />
                 <MenuItem Header="E_xit"
                           Command="{Binding ExitCommand}" />
             </MenuItem>
@@ -44,6 +49,11 @@
                         Content="Open Project" />
                 <Button Command="{Binding OpenRecentProjectCommand}"
                         Content="Open Recent" />
+                <Separator />
+                <Button Command="{Binding OpenDocumentCommand}"
+                        Content="Open Document" />
+                <Button Command="{Binding SaveSelectedDocumentCommand}"
+                        Content="Save Document" />
                 <Separator />
                 <Button Command="{Binding ExitCommand}"
                         Content="Exit" />
@@ -268,6 +278,14 @@
                                                 Margin="0,0,8,0"
                                                 Command="{Binding OpenUntitledDocumentCommand}"
                                                 Content="New Tab" />
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
+                                                Command="{Binding OpenDocumentCommand}"
+                                                Content="Open..." />
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
+                                                Command="{Binding SaveSelectedDocumentCommand}"
+                                                Content="Save" />
                                         <Button Padding="10,4"
                                                 Command="{Binding CloseSelectedDocumentCommand}"
                                                 Content="Close Tab" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
+using Microsoft.Win32;
 
 namespace OasisEditor;
 
@@ -31,6 +32,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
+        OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
+        SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
@@ -47,6 +50,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenProjectCommand { get; }
     public ICommand OpenRecentProjectCommand { get; }
     public ICommand OpenUntitledDocumentCommand { get; }
+    public ICommand OpenDocumentCommand { get; }
+    public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand ClearOutputCommand { get; }
@@ -318,6 +323,125 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return SelectedDocument is not null;
     }
 
+    private bool CanOpenDocument()
+    {
+        return LoadedProject is not null;
+    }
+
+    private void OpenDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        var dialog = new OpenFileDialog
+        {
+            Title = "Open Document",
+            Filter = "Editor Documents|*.panel2d;*.cabinet3d;*.machine|All Files|*.*",
+            InitialDirectory = LoadedProject.ProjectDirectory,
+            CheckFileExists = true
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        try
+        {
+            var path = dialog.FileName;
+            var preview = File.ReadAllText(path);
+            var summary = preview.Length > 300 ? $"{preview[..300]}..." : preview;
+            if (string.IsNullOrWhiteSpace(summary))
+            {
+                summary = "Document opened (file is empty).";
+            }
+
+            var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary));
+            OpenDocuments.Add(document);
+            SelectedDocument = document;
+            StatusMessage = $"Opened document: {document.Title}";
+            AddOutputEntry($"Opened document file {path}");
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            AddOutputEntry($"Open document failed: {ex.Message}");
+            MessageBox.Show(ex.Message, "Open Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private bool CanSaveSelectedDocument()
+    {
+        return SelectedDocument is not null && SelectedDocument.Document.DocumentType != EditorDocumentType.ProjectOverview;
+    }
+
+    private void SaveSelectedDocument()
+    {
+        if (SelectedDocument is null)
+        {
+            return;
+        }
+
+        var current = SelectedDocument;
+        var savePath = current.Document.IsUntitled ? PromptSavePath() : current.FilePath;
+        if (string.IsNullOrWhiteSpace(savePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var persisted = new
+            {
+                title = current.Title,
+                type = current.Document.DocumentType.ToString(),
+                summary = current.ContentSummary,
+                savedAtUtc = DateTime.UtcNow
+            };
+
+            var content = JsonSerializer.Serialize(persisted, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(savePath, content);
+
+            var updatedDocument = new DocumentTabViewModel(current.Document.SaveAs(savePath, current.ContentSummary));
+            var index = OpenDocuments.IndexOf(current);
+            if (index >= 0)
+            {
+                OpenDocuments[index] = updatedDocument;
+            }
+
+            SelectedDocument = updatedDocument;
+            StatusMessage = $"Saved document: {updatedDocument.Title}";
+            AddOutputEntry($"Saved document to {savePath}");
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            AddOutputEntry($"Save document failed: {ex.Message}");
+            MessageBox.Show(ex.Message, "Save Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private string? PromptSavePath()
+    {
+        if (LoadedProject is null)
+        {
+            return null;
+        }
+
+        var dialog = new SaveFileDialog
+        {
+            Title = "Save Document",
+            InitialDirectory = LoadedProject.AssetsDirectory,
+            FileName = $"{SelectedDocument?.Title ?? "Document"}.panel2d",
+            DefaultExt = ".panel2d",
+            Filter = "Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*"
+        };
+
+        return dialog.ShowDialog() == true ? dialog.FileName : null;
+    }
+
     private void CloseSelectedDocument()
     {
         if (SelectedDocument is null)
@@ -542,6 +666,16 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (OpenUntitledDocumentCommand is RelayCommand openRelayCommand)
         {
             openRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (OpenDocumentCommand is RelayCommand openDocumentRelayCommand)
+        {
+            openDocumentRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (SaveSelectedDocumentCommand is RelayCommand saveRelayCommand)
+        {
+            saveRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (CloseSelectedDocumentCommand is RelayCommand closeRelayCommand)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -21,7 +21,7 @@
 
 ## Phase 3 — Document System
 - [x] Define base document model
-- [ ] Implement open/save document
+- [x] Implement open/save document
 - [ ] Implement document dirty state
 - [ ] Implement document tabs integration
 - [ ] Stub document types:


### PR DESCRIPTION
### Motivation
- Provide a basic document open and save UX so users can open editor documents into tabs and persist them to disk as part of Phase 3 work on the Document System.

### Description
- Add file-backed document support in `EditorDocument` via `CreateFromFile(...)` with file extension → `EditorDocumentType` mapping and a `SaveAs(...)` helper in `OasisEditor/DocumentModel.cs`.
- Add `OpenDocumentCommand` and `SaveSelectedDocumentCommand` in `MainWindowViewModel`, implementing open flow with `OpenFileDialog` (file preview/summary) and save flow with `SaveFileDialog` plus JSON persistence in `OasisEditor/MainWindowViewModel.cs`.
- Wire the new commands into the UI (File menu, toolbar, and document host buttons) in `OasisEditor/MainWindow.xaml` so open/save controls are available in the shell.
- Mark the Phase 3 task `Implement open/save document` complete in `TASKS.md`.

### Testing
- Attempted `dotnet build OasisEditor.sln`, which could not run in this environment because the `dotnet` SDK is not installed (build unavailable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea2dcfd8bc8327878a8017a42ee36f)