### PR TITLE
Implement document dirty state for OasisEditor documents

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -16,13 +16,15 @@ public sealed class EditorDocument
         EditorDocumentType documentType,
         string filePath,
         string contentSummary,
-        bool isUntitled)
+        bool isUntitled,
+        bool isDirty)
     {
         Title = title;
         DocumentType = documentType;
         FilePath = filePath;
         ContentSummary = contentSummary;
         IsUntitled = isUntitled;
+        IsDirty = isDirty;
     }
 
     public string Title { get; }
@@ -30,6 +32,7 @@ public sealed class EditorDocument
     public string FilePath { get; }
     public string ContentSummary { get; }
     public bool IsUntitled { get; }
+    public bool IsDirty { get; }
 
     public static EditorDocument CreateUntitled(string title)
     {
@@ -38,6 +41,7 @@ public sealed class EditorDocument
             EditorDocumentType.Generic,
             "No file associated yet.",
             "Create or open a project asset to begin editing.",
+            true,
             true);
     }
 
@@ -48,6 +52,7 @@ public sealed class EditorDocument
             EditorDocumentType.ProjectOverview,
             project.ProjectFilePath,
             $"Assets: {project.AssetsDirectory}\nMachines: {project.MachinesDirectory}\nGenerated: {project.GeneratedDirectory}",
+            false,
             false);
     }
 
@@ -79,11 +84,22 @@ public sealed class EditorDocument
             documentType,
             filePath,
             summary,
+            false,
             false);
     }
 
     public EditorDocument SaveAs(string filePath, string summary)
     {
         return CreateFromFile(filePath, summary);
+    }
+
+    public EditorDocument MarkDirty()
+    {
+        return new EditorDocument(Title, DocumentType, FilePath, ContentSummary, IsUntitled, true);
+    }
+
+    public EditorDocument MarkClean()
+    {
+        return new EditorDocument(Title, DocumentType, FilePath, ContentSummary, false, false);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -404,7 +404,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             var content = JsonSerializer.Serialize(persisted, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(savePath, content);
 
-            var updatedDocument = new DocumentTabViewModel(current.Document.SaveAs(savePath, current.ContentSummary));
+            var updatedDocument = new DocumentTabViewModel(
+                current.Document.SaveAs(savePath, current.ContentSummary).MarkClean());
             var index = OpenDocuments.IndexOf(current);
             if (index >= 0)
             {
@@ -736,7 +737,7 @@ public sealed class DocumentTabViewModel
     }
 
     public EditorDocument Document { get; }
-    public string Title => Document.Title;
+    public string Title => Document.IsDirty ? $"{Document.Title}*" : Document.Title;
     public string TypeLabel => Document.DocumentType switch
     {
         EditorDocumentType.ProjectOverview => "Project",
@@ -747,6 +748,7 @@ public sealed class DocumentTabViewModel
     };
     public string FilePath => Document.FilePath;
     public string ContentSummary => Document.ContentSummary;
+    public bool IsDirty => Document.IsDirty;
 }
 
 public sealed class AssetBrowserItemViewModel

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -22,7 +22,7 @@
 ## Phase 3 — Document System
 - [x] Define base document model
 - [x] Implement open/save document
-- [ ] Implement document dirty state
+- [x] Implement document dirty state
 - [ ] Implement document tabs integration
 - [ ] Stub document types:
   - [ ] .panel2d


### PR DESCRIPTION
### Motivation
- Provide a lightweight dirty-state mechanism so the editor can track unsaved changes on document tabs. 
- Surface unsaved changes in the UI so users can immediately see which tabs need saving.

### Description
- Added an `IsDirty` property to `EditorDocument` and updated its constructor and factory methods so untitled documents start dirty and loaded/project-overview documents start clean.
- Added `MarkDirty()` and `MarkClean()` helpers on `EditorDocument` to make future state transitions explicit.
- Updated the save flow in `MainWindowViewModel` to persist document content and then call `MarkClean()` on the saved document.
- Toggled tab titles in `DocumentTabViewModel` to append a trailing `*` when `IsDirty` is true, and checked off the corresponding task in `TASKS.md`.

### Testing
- Attempted to build with `dotnet build OasisEditor.sln`, but the build could not be run in this environment because `dotnet` is not installed, so no successful automated build verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea30a42d0483278ed0b550e405262a)