### PR TITLE
Reuse existing document tabs when opening files

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -358,11 +358,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 summary = "Document opened (file is empty).";
             }
 
-            var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary));
-            OpenDocuments.Add(document);
-            SelectedDocument = document;
-            StatusMessage = $"Opened document: {document.Title}";
-            AddOutputEntry($"Opened document file {path}");
+            var openedNewTab = OpenOrSelectDocument(path, summary);
+            if (!openedNewTab)
+            {
+                AddOutputEntry($"Switched to already open document tab for {path}");
+            }
+
+            var selectedTitle = SelectedDocument?.Title ?? Path.GetFileName(path);
+            StatusMessage = openedNewTab
+                ? $"Opened document: {selectedTitle}"
+                : $"Activated open document tab: {selectedTitle}";
+            AddOutputEntry(openedNewTab
+                ? $"Opened document file {path}"
+                : $"Activated existing document tab for {path}");
         }
         catch (Exception ex)
         {
@@ -552,6 +560,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         OpenDocuments.Add(overviewDocument);
         SelectedDocument = overviewDocument;
+    }
+
+    private bool OpenOrSelectDocument(string path, string summary)
+    {
+        var existing = OpenDocuments.FirstOrDefault(
+            tab => string.Equals(tab.FilePath, path, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+        {
+            SelectedDocument = existing;
+            return false;
+        }
+
+        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary));
+        OpenDocuments.Add(document);
+        SelectedDocument = document;
+        return true;
     }
 
     private static string ResolveProjectDirectory(string projectDirectory, JsonElement layoutElement, string propertyName)


### PR DESCRIPTION
### Motivation
- Prevent duplicate tabs for the same file path and make the document host behave like a typical editor by switching to an already-open tab when the user opens a file that's already open.
- Improve clarity of status and output messages so the user can see whether a file was opened in a new tab or an existing tab was activated.

### Description
- Added a new helper `OpenOrSelectDocument(string path, string summary)` that selects an existing `DocumentTabViewModel` for `path` if present, or creates and selects a new tab otherwise.
- Updated the `OpenDocument` flow to call `OpenOrSelectDocument` and to set `StatusMessage` and `OutputEntries` differently depending on whether a new tab was created or an existing tab was activated.
- Kept existing document save/close behavior intact and preserved the `DocumentTabViewModel`/`EditorDocument` models.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` to validate the change, but the `dotnet` SDK is not installed in the environment so the build could not be executed.
- No other automated tests were available or executed in this environment, changes were compiled locally not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea319e206c8327a0bb63e9ab289723)