### PR TITLE
Add Panel2D/Cabinet3D/Machine stub documents and UI commands

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -36,11 +36,51 @@ public sealed class EditorDocument
 
     public static EditorDocument CreateUntitled(string title)
     {
-        return new EditorDocument(
+        return CreateUntitledWithType(
             title,
             EditorDocumentType.Generic,
             "No file associated yet.",
-            "Create or open a project asset to begin editing.",
+            "Create or open a project asset to begin editing.");
+    }
+
+    public static EditorDocument CreatePanel2DStub(string title)
+    {
+        return CreateUntitledWithType(
+            title,
+            EditorDocumentType.Panel2D,
+            "Not saved yet (.panel2d)",
+            "Panel 2D stub:\n- Add panel bounds\n- Add placeholder layers\n- Configure control hit areas");
+    }
+
+    public static EditorDocument CreateCabinet3DStub(string title)
+    {
+        return CreateUntitledWithType(
+            title,
+            EditorDocumentType.Cabinet3D,
+            "Not saved yet (.cabinet3d)",
+            "Cabinet 3D stub:\n- Assign cabinet prefab reference\n- Configure screen anchor points\n- Map input regions");
+    }
+
+    public static EditorDocument CreateMachineStub(string title)
+    {
+        return CreateUntitledWithType(
+            title,
+            EditorDocumentType.Machine,
+            "Not saved yet (.machine)",
+            "Machine stub:\n- Reference panel and cabinet docs\n- Configure runtime metadata\n- Set default generated output targets");
+    }
+
+    private static EditorDocument CreateUntitledWithType(
+        string title,
+        EditorDocumentType documentType,
+        string filePath,
+        string contentSummary)
+    {
+        return new EditorDocument(
+            title,
+            documentType,
+            filePath,
+            contentSummary,
             true,
             true);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -28,6 +28,13 @@
                 <MenuItem Header="Open Selected _Recent"
                           Command="{Binding OpenRecentProjectCommand}" />
                 <Separator />
+                <MenuItem Header="New _Panel2D Stub"
+                          Command="{Binding OpenPanel2DStubCommand}" />
+                <MenuItem Header="New _Cabinet3D Stub"
+                          Command="{Binding OpenCabinet3DStubCommand}" />
+                <MenuItem Header="New _Machine Stub"
+                          Command="{Binding OpenMachineStubCommand}" />
+                <Separator />
                 <MenuItem Header="Open _Document"
                           Command="{Binding OpenDocumentCommand}" />
                 <MenuItem Header="_Save Document"
@@ -49,6 +56,13 @@
                         Content="Open Project" />
                 <Button Command="{Binding OpenRecentProjectCommand}"
                         Content="Open Recent" />
+                <Separator />
+                <Button Command="{Binding OpenPanel2DStubCommand}"
+                        Content="New Panel2D" />
+                <Button Command="{Binding OpenCabinet3DStubCommand}"
+                        Content="New Cabinet3D" />
+                <Button Command="{Binding OpenMachineStubCommand}"
+                        Content="New Machine" />
                 <Separator />
                 <Button Command="{Binding OpenDocumentCommand}"
                         Content="Open Document" />
@@ -280,6 +294,18 @@
                                                 Content="New Tab" />
                                         <Button Padding="10,4"
                                                 Margin="0,0,8,0"
+                                                Command="{Binding OpenPanel2DStubCommand}"
+                                                Content="New Panel2D" />
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
+                                                Command="{Binding OpenCabinet3DStubCommand}"
+                                                Content="New Cabinet3D" />
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
+                                                Command="{Binding OpenMachineStubCommand}"
+                                                Content="New Machine" />
+                                        <Button Padding="10,4"
+                                                Margin="0,0,8,0"
                                                 Command="{Binding OpenDocumentCommand}"
                                                 Content="Open..." />
                                         <Button Padding="10,4"
@@ -411,7 +437,7 @@
         <StatusBar Grid.Row="4" Margin="0,12,0,0">
             <StatusBarItem Content="Ready" />
             <Separator />
-            <StatusBarItem Content="Phase 2: Editor Shell" />
+            <StatusBarItem Content="Phase 3: Document System" />
         </StatusBar>
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -496,13 +496,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return null;
         }
 
+        var selectedDocument = SelectedDocument;
+        var defaultName = selectedDocument?.Document.Title ?? "Document";
+        var (defaultExtension, filter) = selectedDocument?.Document.DocumentType switch
+        {
+            EditorDocumentType.Cabinet3D => (".cabinet3d", "Cabinet 3D|*.cabinet3d|Panel 2D|*.panel2d|Machine|*.machine|All Files|*.*"),
+            EditorDocumentType.Machine => (".machine", "Machine|*.machine|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|All Files|*.*"),
+            _ => (".panel2d", "Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*")
+        };
+
         var dialog = new SaveFileDialog
         {
             Title = "Save Document",
             InitialDirectory = LoadedProject.AssetsDirectory,
-            FileName = $"{SelectedDocument?.Title ?? "Document"}.panel2d",
-            DefaultExt = ".panel2d",
-            Filter = "Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*"
+            FileName = $"{defaultName}{defaultExtension}",
+            DefaultExt = defaultExtension,
+            Filter = filter
         };
 
         return dialog.ShowDialog() == true ? dialog.FileName : null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -23,6 +23,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private DocumentTabViewModel? _selectedDocument;
     private AssetBrowserItemViewModel? _selectedAsset;
     private int _untitledDocumentCounter = 1;
+    private int _panelDocumentCounter = 1;
+    private int _cabinetDocumentCounter = 1;
+    private int _machineDocumentCounter = 1;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -32,6 +35,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
+        OpenPanel2DStubCommand = new RelayCommand(OpenPanel2DStubDocument, CanOpenUntitledDocument);
+        OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
+        OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
         SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
@@ -50,6 +56,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenProjectCommand { get; }
     public ICommand OpenRecentProjectCommand { get; }
     public ICommand OpenUntitledDocumentCommand { get; }
+    public ICommand OpenPanel2DStubCommand { get; }
+    public ICommand OpenCabinet3DStubCommand { get; }
+    public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
@@ -316,6 +325,54 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         SelectedDocument = document;
         StatusMessage = $"Opened document tab: {document.Title}";
         AddOutputEntry($"Opened document tab: {document.Title}");
+    }
+
+    private void OpenPanel2DStubDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreatePanel2DStub($"Panel {_panelDocumentCounter++}"));
+
+        OpenDocuments.Add(document);
+        SelectedDocument = document;
+        StatusMessage = $"Opened panel document stub: {document.Title}";
+        AddOutputEntry($"Opened panel document stub: {document.Title}");
+    }
+
+    private void OpenCabinet3DStubDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateCabinet3DStub($"Cabinet {_cabinetDocumentCounter++}"));
+
+        OpenDocuments.Add(document);
+        SelectedDocument = document;
+        StatusMessage = $"Opened cabinet document stub: {document.Title}";
+        AddOutputEntry($"Opened cabinet document stub: {document.Title}");
+    }
+
+    private void OpenMachineStubDocument()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateMachineStub($"Machine {_machineDocumentCounter++}"));
+
+        OpenDocuments.Add(document);
+        SelectedDocument = document;
+        StatusMessage = $"Opened machine document stub: {document.Title}";
+        AddOutputEntry($"Opened machine document stub: {document.Title}");
     }
 
     private bool CanCloseSelectedDocument()
@@ -691,6 +748,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (OpenUntitledDocumentCommand is RelayCommand openRelayCommand)
         {
             openRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (OpenPanel2DStubCommand is RelayCommand openPanelRelayCommand)
+        {
+            openPanelRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (OpenCabinet3DStubCommand is RelayCommand openCabinetRelayCommand)
+        {
+            openCabinetRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (OpenMachineStubCommand is RelayCommand openMachineRelayCommand)
+        {
+            openMachineRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (OpenDocumentCommand is RelayCommand openDocumentRelayCommand)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -23,11 +23,11 @@
 - [x] Define base document model
 - [x] Implement open/save document
 - [x] Implement document dirty state
-- [ ] Implement document tabs integration
-- [ ] Stub document types:
-  - [ ] .panel2d
-  - [ ] .cabinet3d
-  - [ ] .machine
+- [x] Implement document tabs integration
+- [x] Stub document types:
+  - [x] .panel2d
+  - [x] .cabinet3d
+  - [x] .machine
 
 ## Phase 4 — Command System
 - [ ] Define ICommand interface


### PR DESCRIPTION
### Motivation
- Provide initial stub document types for editor workflows so users can create unsaved Panel2D, Cabinet3D, and Machine documents from the UI. 
- Surface commands and controls in the shell to create these stubs and track document phase progress in the task list.

### Description
- Added factory helpers to `EditorDocument` to create untitled stubs: `CreatePanel2DStub`, `CreateCabinet3DStub`, `CreateMachineStub`, and consolidated common logic into `CreateUntitledWithType` (file `DocumentModel.cs`).
- Introduced new commands, counters, and handlers in `MainWindowViewModel` for opening the three stub types (`OpenPanel2DStubCommand`, `OpenCabinet3DStubCommand`, `OpenMachineStubCommand`) and implemented the corresponding `Open*Document` methods to add tabs and log output.
- Updated `MainWindow.xaml` to add menu items, toolbar buttons, and document host buttons for creating the new stubs, and updated the status bar text to "Phase 3: Document System".
- Marked the document tabs integration and stub document tasks complete in `TASKS.md`.

### Testing
- Ran a solution build with `dotnet build` and the project compiled successfully.
- There are no unit tests added or modified for these UI/document changes, so no test suite changes were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea32b150a08327949ec7841a559689)