### PR TITLE
Theme preferences, semantic brushes, and Preferences/Project Settings UI (Phase 3A)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -7,14 +7,14 @@
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <SolidColorBrush x:Key="EditorBackgroundBrush" Color="#FFF4F7FC" />
-            <SolidColorBrush x:Key="PanelBackgroundBrush" Color="White" />
-            <SolidColorBrush x:Key="InspectorBackgroundBrush" Color="#FFF9FAFC" />
-            <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#FFF2F5FB" />
-            <SolidColorBrush x:Key="TextPrimaryBrush" Color="#FF20242C" />
-            <SolidColorBrush x:Key="TextSecondaryBrush" Color="#FF626A78" />
-            <SolidColorBrush x:Key="BorderSubtleBrush" Color="#FFD9E0EE" />
-            <SolidColorBrush x:Key="SelectionBrush" Color="#FFCCE0FF" />
+            <SolidColorBrush x:Key="EditorBackgroundBrush" Color="#FF151A22" />
+            <SolidColorBrush x:Key="PanelBackgroundBrush" Color="#FF1C2535" />
+            <SolidColorBrush x:Key="InspectorBackgroundBrush" Color="#FF18202E" />
+            <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#FF202B3C" />
+            <SolidColorBrush x:Key="TextPrimaryBrush" Color="#FFF2F5FB" />
+            <SolidColorBrush x:Key="TextSecondaryBrush" Color="#FFC2CBDA" />
+            <SolidColorBrush x:Key="BorderSubtleBrush" Color="#FF334156" />
+            <SolidColorBrush x:Key="SelectionBrush" Color="#FF2C4F7E" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -6,6 +6,15 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <SolidColorBrush x:Key="EditorBackgroundBrush" Color="#FFF4F7FC" />
+            <SolidColorBrush x:Key="PanelBackgroundBrush" Color="White" />
+            <SolidColorBrush x:Key="InspectorBackgroundBrush" Color="#FFF9FAFC" />
+            <SolidColorBrush x:Key="ToolBarBackgroundBrush" Color="#FFF2F5FB" />
+            <SolidColorBrush x:Key="TextPrimaryBrush" Color="#FF20242C" />
+            <SolidColorBrush x:Key="TextSecondaryBrush" Color="#FF626A78" />
+            <SolidColorBrush x:Key="BorderSubtleBrush" Color="#FFD9E0EE" />
+            <SolidColorBrush x:Key="SelectionBrush" Color="#FFCCE0FF" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml.cs
@@ -5,13 +5,18 @@ namespace OasisEditor;
 public partial class App : Application
 {
     private readonly IApplicationThemeService _applicationThemeService = new ApplicationThemeService();
+    private readonly EditorPreferencesStore _preferencesStore = new();
 
     protected override void OnStartup(StartupEventArgs e)
     {
         _applicationThemeService.EnsureFluentThemeResources(this);
+
+        var preferences = _preferencesStore.Load();
+        _applicationThemeService.ApplyTheme(this, preferences.ThemePreference);
+
         base.OnStartup(e);
 
-        var mainWindow = new MainWindow();
+        var mainWindow = new MainWindow(_applicationThemeService, _preferencesStore);
         mainWindow.Show();
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Media;
+using Microsoft.Win32;
 
 namespace OasisEditor;
 
@@ -25,5 +28,70 @@ public sealed class ApplicationThemeService : IApplicationThemeService
         {
             Source = FluentThemeDictionaryUri
         });
+    }
+
+    public void ApplyTheme(Application application, ThemePreference preference)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        var effectiveTheme = ResolveEffectiveTheme(preference);
+        var palette = effectiveTheme == ThemePreference.Dark ? BuildDarkPalette() : BuildLightPalette();
+
+        foreach (var (key, color) in palette)
+        {
+            application.Resources[key] = new SolidColorBrush(color);
+        }
+    }
+
+    private static ThemePreference ResolveEffectiveTheme(ThemePreference preference)
+    {
+        if (preference is not ThemePreference.System)
+        {
+            return preference;
+        }
+
+        const string personalizeKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+        const string appsUseLightTheme = "AppsUseLightTheme";
+
+        try
+        {
+            var value = Registry.GetValue($@"HKEY_CURRENT_USER\{personalizeKeyPath}", appsUseLightTheme, 1);
+            var isLight = value is int intValue ? intValue != 0 : true;
+            return isLight ? ThemePreference.Light : ThemePreference.Dark;
+        }
+        catch
+        {
+            return ThemePreference.Light;
+        }
+    }
+
+    private static Dictionary<string, Color> BuildLightPalette()
+    {
+        return new Dictionary<string, Color>
+        {
+            ["EditorBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FFF4F7FC"),
+            ["PanelBackgroundBrush"] = Colors.White,
+            ["InspectorBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FFF9FAFC"),
+            ["ToolBarBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FFF2F5FB"),
+            ["TextPrimaryBrush"] = (Color)ColorConverter.ConvertFromString("#FF20242C"),
+            ["TextSecondaryBrush"] = (Color)ColorConverter.ConvertFromString("#FF626A78"),
+            ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FFD9E0EE"),
+            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FFCCE0FF")
+        };
+    }
+
+    private static Dictionary<string, Color> BuildDarkPalette()
+    {
+        return new Dictionary<string, Color>
+        {
+            ["EditorBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FF151A22"),
+            ["PanelBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FF1C2535"),
+            ["InspectorBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FF18202E"),
+            ["ToolBarBackgroundBrush"] = (Color)ColorConverter.ConvertFromString("#FF202B3C"),
+            ["TextPrimaryBrush"] = (Color)ColorConverter.ConvertFromString("#FFF2F5FB"),
+            ["TextSecondaryBrush"] = (Color)ColorConverter.ConvertFromString("#FFC2CBDA"),
+            ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FF334156"),
+            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF2C4F7E")
+        };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -1,0 +1,6 @@
+namespace OasisEditor;
+
+public sealed class EditorPreferences
+{
+    public ThemePreference ThemePreference { get; init; } = ThemePreference.System;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -2,5 +2,5 @@ namespace OasisEditor;
 
 public sealed class EditorPreferences
 {
-    public ThemePreference ThemePreference { get; init; } = ThemePreference.System;
+    public ThemePreference ThemePreference { get; init; } = ThemePreference.Dark;
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferencesStore.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferencesStore.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Text.Json;
+
+namespace OasisEditor;
+
+public sealed class EditorPreferencesStore
+{
+    private readonly string _storageFilePath;
+
+    public EditorPreferencesStore()
+    {
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var oasisFolder = Path.Combine(appDataPath, "OasisEditor");
+        _storageFilePath = Path.Combine(oasisFolder, "editor-preferences.json");
+    }
+
+    public EditorPreferences Load()
+    {
+        try
+        {
+            if (!File.Exists(_storageFilePath))
+            {
+                return new EditorPreferences();
+            }
+
+            var json = File.ReadAllText(_storageFilePath);
+            return JsonSerializer.Deserialize<EditorPreferences>(json) ?? new EditorPreferences();
+        }
+        catch
+        {
+            return new EditorPreferences();
+        }
+    }
+
+    public void Save(EditorPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        var folder = Path.GetDirectoryName(_storageFilePath);
+        if (!string.IsNullOrWhiteSpace(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        var json = JsonSerializer.Serialize(preferences, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        File.WriteAllText(_storageFilePath, json);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/IApplicationThemeService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/IApplicationThemeService.cs
@@ -5,4 +5,5 @@ namespace OasisEditor;
 public interface IApplicationThemeService
 {
     void EnsureFluentThemeResources(Application application);
+    void ApplyTheme(Application application, ThemePreference preference);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -8,7 +8,9 @@
         Height="780"
         Width="1200"
         MinHeight="620"
-        MinWidth="900">
+        MinWidth="900"
+        Background="{DynamicResource EditorBackgroundBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}">
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -43,11 +45,17 @@
                 <MenuItem Header="E_xit"
                           Command="{Binding ExitCommand}" />
             </MenuItem>
+            <MenuItem Header="_Edit">
+                <MenuItem Header="_Preferences"
+                          Command="{Binding OpenPreferencesCommand}" />
+                <MenuItem Header="_Project Settings"
+                          Command="{Binding OpenProjectSettingsCommand}" />
+            </MenuItem>
         </Menu>
 
         <ToolBarTray Grid.Row="1"
                      Margin="0,0,0,12"
-                     Background="#FFF2F5FB">
+                     Background="{DynamicResource ToolBarBackgroundBrush}">
             <ToolBar Band="0"
                      BandIndex="0">
                 <Button Command="{Binding CreateProjectCommand}"
@@ -78,14 +86,14 @@
                 Padding="16"
                 Margin="0,0,0,12"
                 CornerRadius="6"
-                Background="#FF1C2535">
+                Background="{DynamicResource PanelBackgroundBrush}">
             <StackPanel>
                 <TextBlock FontSize="22"
                            FontWeight="SemiBold"
-                           Foreground="White"
+                           Foreground="{DynamicResource TextPrimaryBrush}"
                            Text="Oasis Editor" />
                 <TextBlock Margin="0,4,0,0"
-                           Foreground="#FFE3E8F0"
+                           Foreground="{DynamicResource TextSecondaryBrush}"
                            Text="Slot machine content authoring shell" />
             </StackPanel>
         </Border>
@@ -181,17 +189,17 @@
                             Padding="10"
                             Margin="0,0,0,10"
                             BorderThickness="1"
-                            BorderBrush="LightGray"
+                            BorderBrush="{DynamicResource BorderSubtleBrush}"
                             CornerRadius="4">
                         <TextBlock TextWrapping="Wrap"
-                                   Foreground="DimGray"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
                                    Text="{Binding StatusMessage}" />
                     </Border>
 
                     <Border Grid.Row="1"
                             Padding="10"
                             BorderThickness="1"
-                            BorderBrush="LightGray"
+                            BorderBrush="{DynamicResource BorderSubtleBrush}"
                             CornerRadius="4">
                         <StackPanel>
                             <TextBlock FontWeight="SemiBold"
@@ -199,7 +207,7 @@
                             <TextBlock Margin="0,4,0,0"
                                        Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded.}" />
                             <TextBlock Margin="0,2,0,0"
-                                       Foreground="DimGray"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                        Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project to load the editor shell.}" />
                         </StackPanel>
                     </Border>
@@ -220,8 +228,8 @@
                         <Border Grid.Row="0"
                                 Grid.ColumnSpan="3"
                                 Padding="10,6"
-                                Background="#FFF3F6FC"
-                                BorderBrush="#FFD9E0EE"
+                                Background="{DynamicResource ToolBarBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1"
                                 CornerRadius="4,4,0,0">
                             <TextBlock VerticalAlignment="Center"
@@ -232,8 +240,8 @@
                         <Border Grid.Row="1"
                                 Grid.Column="0"
                                 Padding="10"
-                                Background="#FFF9FAFC"
-                                BorderBrush="#FFD9E0EE"
+                                Background="{DynamicResource InspectorBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,0,1">
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -270,8 +278,8 @@
                         <Border Grid.Row="1"
                                 Grid.Column="1"
                                 Padding="10"
-                                Background="White"
-                                BorderBrush="#FFD9E0EE"
+                                Background="{DynamicResource PanelBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,1,1">
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -332,13 +340,13 @@
                                                 <TextBlock FontWeight="SemiBold"
                                                            Text="{Binding TypeLabel}" />
                                                 <TextBlock Margin="0,6,0,0"
-                                                           Foreground="DimGray"
+                                                           Foreground="{DynamicResource TextSecondaryBrush}"
                                                            Text="{Binding FilePath}" />
                                                 <Border Margin="0,10,0,0"
                                                         Padding="10"
                                                         CornerRadius="4"
-                                                        Background="#FFF8FAFF"
-                                                        BorderBrush="#FFD9E0EE"
+                                                        Background="{DynamicResource SelectionBrush}"
+                                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
                                                         BorderThickness="1">
                                                     <TextBlock TextWrapping="Wrap"
                                                                Text="{Binding ContentSummary}" />
@@ -353,8 +361,8 @@
                         <Border Grid.Row="1"
                                 Grid.Column="2"
                                 Padding="10"
-                                Background="#FFF9FAFC"
-                                BorderBrush="#FFD9E0EE"
+                                Background="{DynamicResource InspectorBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="0,0,1,1">
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -369,23 +377,23 @@
                                 <Border Grid.Row="1"
                                         Margin="0,8,0,0"
                                         Padding="10"
-                                        Background="White"
-                                        BorderBrush="#FFD9E0EE"
+                                        Background="{DynamicResource PanelBackgroundBrush}"
+                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
                                         BorderThickness="1"
                                         CornerRadius="4">
                                     <StackPanel>
                                         <TextBlock FontWeight="SemiBold"
                                                    Text="{Binding InspectorTitle}" />
                                         <TextBlock Margin="0,6,0,0"
-                                                   Foreground="DimGray"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
                                                    Text="{Binding InspectorType}" />
                                         <TextBlock Margin="0,6,0,0"
                                                    TextWrapping="Wrap"
                                                    Text="{Binding InspectorPath}" />
                                         <Border Margin="0,10,0,0"
                                                 Padding="8"
-                                                Background="#FFF8FAFF"
-                                                BorderBrush="#FFD9E0EE"
+                                                Background="{DynamicResource SelectionBrush}"
+                                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                                 BorderThickness="1"
                                                 CornerRadius="4">
                                             <TextBlock TextWrapping="Wrap"
@@ -399,8 +407,8 @@
                         <Border Grid.Row="2"
                                 Grid.ColumnSpan="3"
                                 Padding="10"
-                                Background="#FFF5F8FF"
-                                BorderBrush="#FFD9E0EE"
+                                Background="{DynamicResource ToolBarBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,1,1"
                                 CornerRadius="0,0,4,4">
                             <Grid>
@@ -423,8 +431,8 @@
 
                                 <ListBox Grid.Row="1"
                                          Margin="0,8,0,0"
-                                         Background="White"
-                                         BorderBrush="#FFD9E0EE"
+                                         Background="{DynamicResource PanelBackgroundBrush}"
+                                         BorderBrush="{DynamicResource BorderSubtleBrush}"
                                          BorderThickness="1"
                                          ItemsSource="{Binding OutputEntries}" />
                             </Grid>
@@ -437,7 +445,7 @@
         <StatusBar Grid.Row="4" Margin="0,12,0,0">
             <StatusBarItem Content="Ready" />
             <Separator />
-            <StatusBarItem Content="Phase 3: Document System" />
+            <StatusBarItem Content="Phase 3A: Theme Foundations" />
         </StatusBar>
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -4,9 +4,9 @@ namespace OasisEditor;
 
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    public MainWindow(IApplicationThemeService applicationThemeService, EditorPreferencesStore preferencesStore)
     {
         InitializeComponent();
-        DataContext = new MainWindowViewModel();
+        DataContext = new MainWindowViewModel(applicationThemeService, preferencesStore, this);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -14,6 +14,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 {
     private readonly ProjectScaffolder _projectScaffolder = new();
     private readonly RecentProjectsStore _recentProjectsStore = new();
+    private readonly IApplicationThemeService _applicationThemeService;
+    private readonly EditorPreferencesStore _preferencesStore;
+    private readonly Window _ownerWindow;
     private string _projectName = string.Empty;
     private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
     private string _projectFilePath = string.Empty;
@@ -26,11 +29,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private int _panelDocumentCounter = 1;
     private int _cabinetDocumentCounter = 1;
     private int _machineDocumentCounter = 1;
+    private ThemePreference _selectedThemePreference;
+    private PreferencesWindow? _preferencesWindow;
+    private ProjectSettingsWindow? _projectSettingsWindow;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public MainWindowViewModel()
+    public MainWindowViewModel(IApplicationThemeService applicationThemeService, EditorPreferencesStore preferencesStore, Window ownerWindow)
     {
+        _applicationThemeService = applicationThemeService;
+        _preferencesStore = preferencesStore;
+        _ownerWindow = ownerWindow;
+
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
         OpenRecentProjectCommand = new RelayCommand(OpenSelectedRecentProject, CanOpenSelectedRecentProject);
@@ -43,13 +53,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
+        OpenPreferencesCommand = new RelayCommand(OpenPreferences);
+        OpenProjectSettingsCommand = new RelayCommand(OpenProjectSettings);
+        ClosePreferencesCommand = new RelayCommand(ClosePreferences);
+        CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         ExitCommand = new RelayCommand(ExitApplication);
+
+        var preferences = _preferencesStore.Load();
+        _selectedThemePreference = preferences.ThemePreference;
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
         OutputEntries = new ObservableCollection<string>();
         AddOutputEntry("Editor shell initialized.");
+        AddOutputEntry($"Theme preference loaded: {_selectedThemePreference}");
     }
 
     public ICommand CreateProjectCommand { get; }
@@ -64,11 +82,34 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand ClearOutputCommand { get; }
+    public ICommand OpenPreferencesCommand { get; }
+    public ICommand OpenProjectSettingsCommand { get; }
+    public ICommand ClosePreferencesCommand { get; }
+    public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
     public ObservableCollection<string> OutputEntries { get; }
+
+
+    public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
+
+    public ThemePreference SelectedThemePreference
+    {
+        get => _selectedThemePreference;
+        set
+        {
+            if (!SetProperty(ref _selectedThemePreference, value))
+            {
+                return;
+            }
+
+            _applicationThemeService.ApplyTheme(Application.Current ?? throw new InvalidOperationException("Application is not initialized."), value);
+            _preferencesStore.Save(new EditorPreferences { ThemePreference = value });
+            AddOutputEntry($"Theme preference changed: {value}");
+        }
+    }
 
     public string ProjectName
     {
@@ -541,6 +582,55 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         SelectedDocument = OpenDocuments[nextIndex];
         StatusMessage = $"Closed document tab: {documentToClose.Title}";
         AddOutputEntry($"Closed document tab: {documentToClose.Title}");
+    }
+
+
+    private void OpenPreferences()
+    {
+        if (_preferencesWindow is { IsLoaded: true })
+        {
+            _preferencesWindow.Activate();
+            return;
+        }
+
+        _preferencesWindow = new PreferencesWindow
+        {
+            Owner = _ownerWindow,
+            DataContext = this
+        };
+
+        _preferencesWindow.Closed += (_, _) => _preferencesWindow = null;
+        _preferencesWindow.Show();
+        AddOutputEntry("Opened Preferences window.");
+    }
+
+    private void OpenProjectSettings()
+    {
+        if (_projectSettingsWindow is { IsLoaded: true })
+        {
+            _projectSettingsWindow.Activate();
+            return;
+        }
+
+        _projectSettingsWindow = new ProjectSettingsWindow
+        {
+            Owner = _ownerWindow,
+            DataContext = this
+        };
+
+        _projectSettingsWindow.Closed += (_, _) => _projectSettingsWindow = null;
+        _projectSettingsWindow.Show();
+        AddOutputEntry("Opened Project Settings window.");
+    }
+
+    private void ClosePreferences()
+    {
+        _preferencesWindow?.Close();
+    }
+
+    private void CloseProjectSettings()
+    {
+        _projectSettingsWindow?.Close();
     }
 
     private static void ExitApplication()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
@@ -1,0 +1,46 @@
+<Window x:Class="OasisEditor.PreferencesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Preferences"
+        Width="420"
+        Height="220"
+        MinWidth="380"
+        MinHeight="200"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource PanelBackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Foreground="{DynamicResource TextPrimaryBrush}"
+                   Text="Editor Preferences" />
+
+        <TextBlock Grid.Row="1"
+                   Margin="0,16,0,6"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="Theme" />
+
+        <ComboBox Grid.Row="2"
+                  Width="180"
+                  HorizontalAlignment="Left"
+                  ItemsSource="{Binding ThemePreferences}"
+                  SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <StackPanel Grid.Row="3"
+                    Margin="0,16,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button MinWidth="96"
+                    Padding="12,6"
+                    Command="{Binding ClosePreferencesCommand}"
+                    Content="Close" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+public partial class PreferencesWindow : Window
+{
+    public PreferencesWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml
@@ -1,0 +1,48 @@
+<Window x:Class="OasisEditor.ProjectSettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Project Settings"
+        Width="560"
+        Height="340"
+        MinWidth="500"
+        MinHeight="320"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource PanelBackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Foreground="{DynamicResource TextPrimaryBrush}"
+                   Text="Project Settings" />
+
+        <TextBlock Grid.Row="1" Margin="0,14,0,4" Text="Project" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="2" Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded}" />
+
+        <TextBlock Grid.Row="3" Margin="0,12,0,4" Text="Project file" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="4" TextWrapping="Wrap" Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project first.}" />
+
+        <TextBlock Grid.Row="5" Margin="0,12,0,4" Text="Assets folder" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="6" TextWrapping="Wrap" Text="{Binding LoadedProject.AssetsDirectory, TargetNullValue=Open or create a project first.}" />
+
+        <StackPanel Grid.Row="7"
+                    Margin="0,16,0,0"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button MinWidth="96"
+                    Padding="12,6"
+                    Command="{Binding CloseProjectSettingsCommand}"
+                    Content="Close" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+public partial class ProjectSettingsWindow : Window
+{
+    public ProjectSettingsWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ThemePreference.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ThemePreference.cs
@@ -1,0 +1,8 @@
+namespace OasisEditor;
+
+public enum ThemePreference
+{
+    System,
+    Light,
+    Dark
+}

--- a/WindowsNetProjects/OasisEditor/SMOKE_TEST_CHECKLIST.md
+++ b/WindowsNetProjects/OasisEditor/SMOKE_TEST_CHECKLIST.md
@@ -1,0 +1,19 @@
+# Theme Smoke Test Checklist
+
+## System Theme
+- [ ] Set **Edit > Preferences > Theme** to **System**.
+- [ ] Restart Oasis Editor.
+- [ ] Confirm main window shell surfaces (menu, toolbar, document tabs, panels) use the OS theme tone.
+
+## Light Theme
+- [ ] Set **Edit > Preferences > Theme** to **Light**.
+- [ ] Confirm menu, toolbar, document tabs, and shell panels update immediately to light semantic colors.
+
+## Dark Theme
+- [ ] Set **Edit > Preferences > Theme** to **Dark**.
+- [ ] Confirm menu, toolbar, document tabs, and shell panels update immediately to dark semantic colors.
+
+## Theme Persistence After Restart
+- [ ] Choose **Light** or **Dark** in Preferences.
+- [ ] Close Oasis Editor.
+- [ ] Re-open Oasis Editor and verify the selected theme remains applied.

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -34,33 +34,33 @@
 - [x] Verify solution builds and runs cleanly in Visual Studio 2022
 - [x] Add built-in WPF Fluent theme resources
 - [x] Define application theme service
-- [ ] Define theme preference enum:
-  - [ ] System
-  - [ ] Light
-  - [ ] Dark
-- [ ] Persist editor theme preference
-- [ ] Apply theme preference on startup
-- [ ] Add Edit > Preferences menu item
-- [ ] Add Edit > Project Settings menu item
-- [ ] Create non-modal Preferences window
-- [ ] Create non-modal Project Settings window
-- [ ] Add theme selector to Preferences window
-- [ ] Define semantic editor brushes:
-  - [ ] EditorBackgroundBrush
-  - [ ] PanelBackgroundBrush
-  - [ ] InspectorBackgroundBrush
-  - [ ] ToolBarBackgroundBrush
-  - [ ] TextPrimaryBrush
-  - [ ] TextSecondaryBrush
-  - [ ] BorderSubtleBrush
-  - [ ] SelectionBrush
-- [ ] Replace shell-level hard-coded colors with semantic theme resources
-- [ ] Ensure main window, menu, toolbar, document tabs, and panels respond to theme changes
-- [ ] Add smoke test checklist for:
-  - [ ] System theme
-  - [ ] Light theme
-  - [ ] Dark theme
-  - [ ] Theme persistence after restart
+- [x] Define theme preference enum:
+  - [x] System
+  - [x] Light
+  - [x] Dark
+- [x] Persist editor theme preference
+- [x] Apply theme preference on startup
+- [x] Add Edit > Preferences menu item
+- [x] Add Edit > Project Settings menu item
+- [x] Create non-modal Preferences window
+- [x] Create non-modal Project Settings window
+- [x] Add theme selector to Preferences window
+- [x] Define semantic editor brushes:
+  - [x] EditorBackgroundBrush
+  - [x] PanelBackgroundBrush
+  - [x] InspectorBackgroundBrush
+  - [x] ToolBarBackgroundBrush
+  - [x] TextPrimaryBrush
+  - [x] TextSecondaryBrush
+  - [x] BorderSubtleBrush
+  - [x] SelectionBrush
+- [x] Replace shell-level hard-coded colors with semantic theme resources
+- [x] Ensure main window, menu, toolbar, document tabs, and panels respond to theme changes
+- [x] Add smoke test checklist for:
+  - [x] System theme
+  - [x] Light theme
+  - [x] Dark theme
+  - [x] Theme persistence after restart
 
 ## Phase 4 — Command System
 - [ ] Define ICommand interface


### PR DESCRIPTION
### Motivation
- Finish Phase 3A by providing a persistent editor theme preference and making the shell respond to theme changes instead of using hard-coded colors.
- Surface lightweight preferences and project settings UI so users can change theme and inspect project metadata without blocking the main window.
- Provide a simple application theme service to apply light/dark palettes and resolve the OS theme when `System` is chosen.

### Description
- Added a theme model and persistence: `ThemePreference`, `EditorPreferences`, and `EditorPreferencesStore` which saves to `%APPDATA%/OasisEditor/editor-preferences.json` and loads on startup.
- Implemented runtime theming in `IApplicationThemeService`/`ApplicationThemeService` with `ApplyTheme`, system theme resolution via the Windows `AppsUseLightTheme` registry key, and light/dark color palettes applied as semantic brushes.
- Wire-up and UI updates: `App` loads persisted preferences and calls `ApplyTheme`, `MainWindow` and `MainWindowViewModel` accept the theme service and prefs store, and `MainWindowViewModel` exposes `SelectedThemePreference` and commands to open non-modal `PreferencesWindow` and `ProjectSettingsWindow`.
- Replaced shell hard-coded colors with semantic dynamic resources defined in `App.xaml`, added `PreferencesWindow` (with a theme selector bound to `SelectedThemePreference`), `ProjectSettingsWindow`, and `SMOKE_TEST_CHECKLIST.md`, and marked Phase 3A items complete in `TASKS.md`.

### Testing
- Attempted `dotnet build OasisEditor.sln`, which failed in this environment because `dotnet` is not installed (build could not be executed here).
- Ran `git diff --check` to validate whitespace/diff issues, which returned clean (no problems reported).
- Checked repository status with `git status --short`, which completed successfully (changes staged/committed in the working tree).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea3cc3fa408327bc4cdbe71ff84bc1)