### PR TITLE
Add semantic theme styling for MainWindow menu and submenus

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -11,6 +11,133 @@
         MinWidth="900"
         Background="{DynamicResource EditorBackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}">
+    <Window.Resources>
+        <Style x:Key="EditorMenuStyle"
+               TargetType="{x:Type Menu}">
+            <Setter Property="Background"
+                    Value="{DynamicResource ToolBarBackgroundBrush}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource TextPrimaryBrush}" />
+            <Setter Property="BorderBrush"
+                    Value="{DynamicResource BorderSubtleBrush}" />
+            <Setter Property="BorderThickness"
+                    Value="1" />
+            <Setter Property="Padding"
+                    Value="2" />
+        </Style>
+
+        <Style x:Key="EditorMenuItemStyle"
+               TargetType="{x:Type MenuItem}">
+            <Setter Property="Foreground"
+                    Value="{DynamicResource TextPrimaryBrush}" />
+            <Setter Property="Background"
+                    Value="{DynamicResource ToolBarBackgroundBrush}" />
+            <Setter Property="BorderBrush"
+                    Value="{DynamicResource BorderSubtleBrush}" />
+            <Setter Property="BorderThickness"
+                    Value="1" />
+            <Setter Property="Padding"
+                    Value="8,4" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type MenuItem}">
+                        <Grid SnapsToDevicePixels="True">
+                            <Border x:Name="MenuItemBorder"
+                                    Padding="{TemplateBinding Padding}"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="0"
+                                    CornerRadius="4">
+                                <DockPanel LastChildFill="True">
+                                    <ContentPresenter x:Name="GlyphContent"
+                                                      VerticalAlignment="Center"
+                                                      Margin="0,0,8,0"
+                                                      ContentSource="Icon" />
+                                    <ContentPresenter x:Name="HeaderContent"
+                                                      VerticalAlignment="Center"
+                                                      ContentSource="Header"
+                                                      RecognizesAccessKey="True" />
+                                </DockPanel>
+                            </Border>
+                            <Popup x:Name="SubMenuPopup"
+                                   AllowsTransparency="True"
+                                   Focusable="False"
+                                   IsOpen="{TemplateBinding IsSubmenuOpen}"
+                                   Placement="Bottom"
+                                   PopupAnimation="Fade">
+                                <Border Padding="4"
+                                        Background="{DynamicResource ToolBarBackgroundBrush}"
+                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="4">
+                                    <StackPanel KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                IsItemsHost="True" />
+                                </Border>
+                            </Popup>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="Icon"
+                                     Value="{x:Null}">
+                                <Setter TargetName="GlyphContent"
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="IsHighlighted"
+                                     Value="True">
+                                <Setter TargetName="MenuItemBorder"
+                                        Property="Background"
+                                        Value="{DynamicResource SelectionBrush}" />
+                            </Trigger>
+                            <Trigger Property="Role"
+                                     Value="TopLevelHeader">
+                                <Setter TargetName="SubMenuPopup"
+                                        Property="Placement"
+                                        Value="Bottom" />
+                            </Trigger>
+                            <Trigger Property="Role"
+                                     Value="SubmenuHeader">
+                                <Setter TargetName="SubMenuPopup"
+                                        Property="Placement"
+                                        Value="Right" />
+                            </Trigger>
+                            <Trigger Property="Role"
+                                     Value="TopLevelItem">
+                                <Setter TargetName="SubMenuPopup"
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="Role"
+                                     Value="SubmenuItem">
+                                <Setter TargetName="SubMenuPopup"
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled"
+                                     Value="False">
+                                <Setter Property="Opacity"
+                                        Value="0.65" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsHighlighted"
+                         Value="True">
+                    <Setter Property="Background"
+                            Value="{DynamicResource SelectionBrush}" />
+                    <Setter Property="Foreground"
+                            Value="{DynamicResource TextPrimaryBrush}" />
+                </Trigger>
+                <Trigger Property="IsSubmenuOpen"
+                         Value="True">
+                    <Setter Property="Background"
+                            Value="{DynamicResource SelectionBrush}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -21,6 +148,8 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
+              Style="{StaticResource EditorMenuStyle}"
+              ItemContainerStyle="{StaticResource EditorMenuItemStyle}"
               Margin="0,0,0,12">
             <MenuItem Header="_File">
                 <MenuItem Header="_Create Project"


### PR DESCRIPTION
### Motivation
- Ensure the top menu and its submenus use app-defined semantic brushes instead of default Fluent colors so the UI is dark/light theme compatible.
- Provide explicit hover/pressed visuals that work with the editor's dark surface colors and avoid hard-coded hex values in XAML controls.
- Make submenu popup surfaces use the same semantic brushes so nested menus do not revert to Fluent defaults.

### Description
- Added an `EditorMenuStyle` in `MainWindow.xaml` `Window.Resources` that sets `Background`, `Foreground`, and `BorderBrush` to semantic brushes (`ToolBarBackgroundBrush`, `TextPrimaryBrush`, `BorderSubtleBrush`) and includes basic padding/border thickness.
- Added an `EditorMenuItemStyle` that sets `Foreground`, `Background`, `BorderBrush`, `Padding`, highlight/submenu triggers using `SelectionBrush`, and an explicit `ControlTemplate` for `MenuItem` to control visuals.
- The `MenuItem` template includes a themed `Popup` for submenus whose `Border` and background use `ToolBarBackgroundBrush` and `BorderSubtleBrush`, ensuring submenu hosts are dark-compatible.
- Applied the new styles to the main `Menu` via `Style` and `ItemContainerStyle` so top-level and nested items use the theme-aware styling.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment does not have `dotnet` installed so the build could not be executed (`/bin/bash: dotnet: command not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea4356c0408327a55018d6046b3d26)