### PR TITLE
Fix dark-theme contrast regressions for menus, tabs and combo boxes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -102,36 +102,47 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="ComboBox">
                             <Grid>
-                                <Border x:Name="ComboBorder"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="4">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="28" />
-                                        </Grid.ColumnDefinitions>
-                                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                <ToggleButton x:Name="DropDownToggleButton"
+                                              Focusable="False"
+                                              ClickMode="Press"
+                                              IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                                    <ToggleButton.Template>
+                                        <ControlTemplate TargetType="ToggleButton">
+                                            <Border x:Name="ComboBorder"
+                                                    Background="{Binding Background, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                    BorderBrush="{Binding BorderBrush, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="4">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="28" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <ContentPresenter Margin="{Binding Padding, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                                      VerticalAlignment="Center"
+                                                                      HorizontalAlignment="Left"
+                                                                      TextElement.Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                                      Content="{Binding SelectionBoxItem, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                                      ContentTemplate="{Binding SelectionBoxItemTemplate, RelativeSource={RelativeSource AncestorType=ComboBox}}"
+                                                                      ContentTemplateSelector="{Binding ItemTemplateSelector, RelativeSource={RelativeSource AncestorType=ComboBox}}" />
+                                                    <Path Grid.Column="1"
+                                                          Width="10"
+                                                          Height="6"
+                                                          Margin="0,0,8,0"
                                                           VerticalAlignment="Center"
-                                                          HorizontalAlignment="Left"
-                                                          Content="{TemplateBinding SelectionBoxItem}"
-                                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
-                                        <Path Grid.Column="1"
-                                              Width="10"
-                                              Height="6"
-                                              Margin="0,0,8,0"
-                                              VerticalAlignment="Center"
-                                              HorizontalAlignment="Right"
-                                              Fill="{DynamicResource TextSecondaryBrush}"
-                                              Data="M 0 0 L 10 0 L 5 6 Z" />
-                                    </Grid>
-                                </Border>
+                                                          HorizontalAlignment="Right"
+                                                          Fill="{DynamicResource TextSecondaryBrush}"
+                                                          Data="M 0 0 L 10 0 L 5 6 Z" />
+                                                </Grid>
+                                            </Border>
+                                        </ControlTemplate>
+                                    </ToggleButton.Template>
+                                </ToggleButton>
                                 <Popup Name="PART_Popup"
                                        AllowsTransparency="True"
                                        Focusable="False"
                                        IsOpen="{TemplateBinding IsDropDownOpen}"
+                                       PlacementTarget="{Binding ElementName=DropDownToggleButton}"
                                        Placement="Bottom"
                                        PopupAnimation="Fade">
                                     <Border Margin="0,4,0,0"
@@ -140,7 +151,8 @@
                                             BorderBrush="{DynamicResource BorderSubtleBrush}"
                                             BorderThickness="1"
                                             CornerRadius="4">
-                                        <ScrollViewer MaxHeight="280">
+                                        <ScrollViewer MaxHeight="280"
+                                                      CanContentScroll="True">
                                             <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
                                         </ScrollViewer>
                                     </Border>
@@ -148,10 +160,13 @@
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                                    <Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                    <Setter Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                    <Setter Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsDropDownOpen" Value="True">
+                                    <Setter Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter Property="Opacity" Value="0.65" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -97,11 +97,102 @@
                 <Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                <Setter Property="Padding" Value="8,4" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBox">
+                            <Grid>
+                                <Border x:Name="ComboBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="4">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="28" />
+                                        </Grid.ColumnDefinitions>
+                                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                          VerticalAlignment="Center"
+                                                          HorizontalAlignment="Left"
+                                                          Content="{TemplateBinding SelectionBoxItem}"
+                                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" />
+                                        <Path Grid.Column="1"
+                                              Width="10"
+                                              Height="6"
+                                              Margin="0,0,8,0"
+                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="Right"
+                                              Fill="{DynamicResource TextSecondaryBrush}"
+                                              Data="M 0 0 L 10 0 L 5 6 Z" />
+                                    </Grid>
+                                </Border>
+                                <Popup Name="PART_Popup"
+                                       AllowsTransparency="True"
+                                       Focusable="False"
+                                       IsOpen="{TemplateBinding IsDropDownOpen}"
+                                       Placement="Bottom"
+                                       PopupAnimation="Fade">
+                                    <Border Margin="0,4,0,0"
+                                            MinWidth="{TemplateBinding ActualWidth}"
+                                            Background="{DynamicResource PanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="4">
+                                        <ScrollViewer MaxHeight="280">
+                                            <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
+                                        </ScrollViewer>
+                                    </Border>
+                                </Popup>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                                    <Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.65" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
                 <Style.Triggers>
                     <Trigger Property="IsKeyboardFocusWithin" Value="True">
                         <Setter Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
                     </Trigger>
                 </Style.Triggers>
+            </Style>
+
+            <Style TargetType="ComboBoxItem">
+                <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Padding" Value="8,4" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBoxItem">
+                            <Border x:Name="ItemBorder"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="3">
+                                <ContentPresenter Margin="{TemplateBinding Padding}" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsHighlighted" Value="True">
+                                    <Setter TargetName="ItemBorder" Property="Background" Value="{DynamicResource InspectorBackgroundBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="ItemBorder" Property="Background" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.65" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
 
             <Style TargetType="TabControl">
@@ -114,6 +205,35 @@
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                 <Setter Property="Background" Value="{DynamicResource InspectorBackgroundBrush}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                <Setter Property="Padding" Value="10,5" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TabItem">
+                            <Border x:Name="TabBorder"
+                                    Margin="0,0,1,0"
+                                    Padding="{TemplateBinding Padding}"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="1,1,1,0"
+                                    CornerRadius="4,4,0,0">
+                                <ContentPresenter ContentSource="Header"
+                                                  RecognizesAccessKey="True" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="TabBorder" Property="Background" Value="{DynamicResource SelectionBrush}" />
+                                    <Setter TargetName="TabBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="TabBorder" Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter Property="Opacity" Value="0.65" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -114,8 +114,11 @@
                             </Trigger>
                             <Trigger Property="IsEnabled"
                                      Value="False">
-                                <Setter Property="Opacity"
-                                        Value="0.65" />
+                                <Setter Property="Foreground"
+                                        Value="{DynamicResource TextSecondaryBrush}" />
+                                <Setter TargetName="MenuItemBorder"
+                                        Property="Opacity"
+                                        Value="1" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -46,9 +46,10 @@
                                     Padding="{TemplateBinding Padding}"
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="0"
+                                    BorderThickness="1"
                                     CornerRadius="4">
-                                <DockPanel LastChildFill="True">
+                                <DockPanel LastChildFill="True"
+                                           TextElement.Foreground="{TemplateBinding Foreground}">
                                     <ContentPresenter x:Name="GlyphContent"
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0"
@@ -86,6 +87,9 @@
                                      Value="True">
                                 <Setter TargetName="MenuItemBorder"
                                         Property="Background"
+                                        Value="{DynamicResource ControlHoverBrush}" />
+                                <Setter TargetName="MenuItemBorder"
+                                        Property="BorderBrush"
                                         Value="{DynamicResource SelectionBrush}" />
                             </Trigger>
                             <Trigger Property="Role"
@@ -115,10 +119,10 @@
                             <Trigger Property="IsEnabled"
                                      Value="False">
                                 <Setter Property="Foreground"
-                                        Value="{DynamicResource TextSecondaryBrush}" />
+                                        Value="{DynamicResource TextPrimaryBrush}" />
                                 <Setter TargetName="MenuItemBorder"
                                         Property="Opacity"
-                                        Value="1" />
+                                        Value="0.72" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -158,6 +158,10 @@
               Style="{StaticResource EditorMenuStyle}"
               ItemContainerStyle="{StaticResource EditorMenuItemStyle}"
               Margin="0,0,0,12">
+            <Menu.Resources>
+                <Style TargetType="{x:Type MenuItem}"
+                       BasedOn="{StaticResource EditorMenuItemStyle}" />
+            </Menu.Resources>
             <MenuItem Header="_File">
                 <MenuItem Header="_Create Project"
                           Command="{Binding CreateProjectCommand}" />


### PR DESCRIPTION
### Motivation
- Dark theme UI surfaces (menus, tab headers, and combo box dropdowns) were rendering with bright/default visuals or low-contrast text, making text and controls hard to read in Dark mode. 
- Provide consistent semantic brush usage so the editor's custom UI doesn't fall back to Fluent defaults that are inappropriate for the app dark palette.

### Description
- Added a fully themed `ComboBox` control template and a matching `ComboBoxItem` style in `OasisEditor/App.xaml` so dropdown surfaces and selection text use the app's dark semantic brushes instead of bright defaults. 
- Implemented a custom `TabItem` control template in `OasisEditor/App.xaml` to keep selected tab headers consistent with the dark `SelectionBrush` and avoid bright header backgrounds. 
- Adjusted the `MenuItem` disabled-state behavior in `OasisEditor/MainWindow.xaml` to use `TextSecondaryBrush` for disabled text and keep the menu item border opacity at `1` so disabled items remain legible in Dark mode. 

### Testing
- Attempted `dotnet build OasisEditor.sln`, but the environment does not have the .NET SDK installed and the build could not be run (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea473b478883278cd59818f38ad46c)