### PR TITLE
Add initial Panel2D canvas rendering in document host

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -1,0 +1,141 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace OasisEditor;
+
+public static class CanvasPanBehavior
+{
+    public static readonly DependencyProperty IsEnabledProperty =
+        DependencyProperty.RegisterAttached(
+            "IsEnabled",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false, OnIsEnabledChanged));
+
+    private static readonly DependencyProperty StartPointProperty =
+        DependencyProperty.RegisterAttached(
+            "StartPoint",
+            typeof(Point),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(default(Point)));
+
+    private static readonly DependencyProperty OriginProperty =
+        DependencyProperty.RegisterAttached(
+            "Origin",
+            typeof(Point),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(default(Point)));
+
+    private static readonly DependencyProperty IsPanningProperty =
+        DependencyProperty.RegisterAttached(
+            "IsPanning",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false));
+
+    public static bool GetIsEnabled(DependencyObject dependencyObject)
+    {
+        return (bool)dependencyObject.GetValue(IsEnabledProperty);
+    }
+
+    public static void SetIsEnabled(DependencyObject dependencyObject, bool value)
+    {
+        dependencyObject.SetValue(IsEnabledProperty, value);
+    }
+
+    private static void OnIsEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+    {
+        if (dependencyObject is not FrameworkElement element)
+        {
+            return;
+        }
+
+        var isEnabled = (bool)eventArgs.NewValue;
+        if (isEnabled)
+        {
+            EnsureTranslateTransform(element);
+            element.MouseLeftButtonDown += OnMouseLeftButtonDown;
+            element.MouseMove += OnMouseMove;
+            element.MouseLeftButtonUp += OnMouseLeftButtonUp;
+            element.LostMouseCapture += OnLostMouseCapture;
+        }
+        else
+        {
+            element.MouseLeftButtonDown -= OnMouseLeftButtonDown;
+            element.MouseMove -= OnMouseMove;
+            element.MouseLeftButtonUp -= OnMouseLeftButtonUp;
+            element.LostMouseCapture -= OnLostMouseCapture;
+        }
+    }
+
+    private static void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs eventArgs)
+    {
+        if (sender is not FrameworkElement element)
+        {
+            return;
+        }
+
+        EnsureTranslateTransform(element);
+        var startPoint = eventArgs.GetPosition(element.Parent as IInputElement ?? element);
+        var transform = (TranslateTransform)element.RenderTransform;
+        element.SetValue(StartPointProperty, startPoint);
+        element.SetValue(OriginProperty, new Point(transform.X, transform.Y));
+        element.SetValue(IsPanningProperty, true);
+        element.CaptureMouse();
+        element.Cursor = Cursors.SizeAll;
+        eventArgs.Handled = true;
+    }
+
+    private static void OnMouseMove(object sender, MouseEventArgs eventArgs)
+    {
+        if (sender is not FrameworkElement element || !(bool)element.GetValue(IsPanningProperty))
+        {
+            return;
+        }
+
+        var startPoint = (Point)element.GetValue(StartPointProperty);
+        var origin = (Point)element.GetValue(OriginProperty);
+        var currentPoint = eventArgs.GetPosition(element.Parent as IInputElement ?? element);
+        var delta = currentPoint - startPoint;
+        var transform = (TranslateTransform)element.RenderTransform;
+        transform.X = origin.X + delta.X;
+        transform.Y = origin.Y + delta.Y;
+    }
+
+    private static void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs eventArgs)
+    {
+        EndPan(sender as FrameworkElement);
+    }
+
+    private static void OnLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    {
+        EndPan(sender as FrameworkElement);
+    }
+
+    private static void EndPan(FrameworkElement? element)
+    {
+        if (element is null)
+        {
+            return;
+        }
+
+        element.SetValue(IsPanningProperty, false);
+        if (element.IsMouseCaptured)
+        {
+            element.ReleaseMouseCapture();
+        }
+
+        element.Cursor = Cursors.Arrow;
+    }
+
+    private static void EnsureTranslateTransform(FrameworkElement element)
+    {
+        if (element.RenderTransform is TranslateTransform)
+        {
+            return;
+        }
+
+        element.RenderTransform = new TranslateTransform();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -55,23 +55,28 @@ public static class CanvasPanBehavior
         if (isEnabled)
         {
             EnsureTranslateTransform(element);
-            element.MouseLeftButtonDown += OnMouseLeftButtonDown;
+            element.MouseDown += OnMouseDown;
             element.MouseMove += OnMouseMove;
-            element.MouseLeftButtonUp += OnMouseLeftButtonUp;
+            element.MouseUp += OnMouseUp;
             element.LostMouseCapture += OnLostMouseCapture;
         }
         else
         {
-            element.MouseLeftButtonDown -= OnMouseLeftButtonDown;
+            element.MouseDown -= OnMouseDown;
             element.MouseMove -= OnMouseMove;
-            element.MouseLeftButtonUp -= OnMouseLeftButtonUp;
+            element.MouseUp -= OnMouseUp;
             element.LostMouseCapture -= OnLostMouseCapture;
         }
     }
 
-    private static void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs eventArgs)
+    private static void OnMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
         if (sender is not FrameworkElement element)
+        {
+            return;
+        }
+
+        if (eventArgs.ChangedButton != MouseButton.Middle)
         {
             return;
         }
@@ -103,8 +108,13 @@ public static class CanvasPanBehavior
         transform.Y = origin.Y + delta.Y;
     }
 
-    private static void OnMouseLeftButtonUp(object sender, MouseButtonEventArgs eventArgs)
+    private static void OnMouseUp(object sender, MouseButtonEventArgs eventArgs)
     {
+        if (eventArgs.ChangedButton != MouseButton.Middle)
+        {
+            return;
+        }
+
         EndPan(sender as FrameworkElement);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:OasisEditor"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
@@ -476,22 +477,76 @@
                                     </TabControl.ItemTemplate>
                                     <TabControl.ContentTemplate>
                                         <DataTemplate>
-                                            <StackPanel Margin="4">
-                                                <TextBlock FontWeight="SemiBold"
+                                            <Grid Margin="4">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="*" />
+                                                </Grid.RowDefinitions>
+
+                                                <TextBlock Grid.Row="0"
+                                                           FontWeight="SemiBold"
                                                            Text="{Binding TypeLabel}" />
-                                                <TextBlock Margin="0,6,0,0"
+
+                                                <TextBlock Grid.Row="1"
+                                                           Margin="0,6,0,0"
                                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                                            Text="{Binding FilePath}" />
-                                                <Border Margin="0,10,0,0"
-                                                        Padding="10"
-                                                        CornerRadius="4"
-                                                        Background="{DynamicResource SelectionBrush}"
-                                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                                        BorderThickness="1">
-                                                    <TextBlock TextWrapping="Wrap"
-                                                               Text="{Binding ContentSummary}" />
-                                                </Border>
-                                            </StackPanel>
+
+                                                <Grid Grid.Row="2"
+                                                      Margin="0,10,0,0">
+                                                    <Border x:Name="PanelCanvasContainer"
+                                                            Padding="12"
+                                                            Background="{DynamicResource EditorBackgroundBrush}"
+                                                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                                            BorderThickness="1"
+                                                            CornerRadius="4"
+                                                            Visibility="Collapsed">
+                                                        <Grid>
+                                                            <Canvas MinHeight="280"
+                                                                    Background="{DynamicResource PanelBackgroundBrush}">
+                                                                <Rectangle Width="540"
+                                                                           Height="300"
+                                                                           Stroke="{DynamicResource SelectionBrush}"
+                                                                           StrokeThickness="2"
+                                                                           Fill="{DynamicResource ToolBarBackgroundBrush}"
+                                                                           Canvas.Left="24"
+                                                                           Canvas.Top="24" />
+                                                                <TextBlock Canvas.Left="40"
+                                                                           Canvas.Top="40"
+                                                                           FontWeight="SemiBold"
+                                                                           Text="Panel Canvas (MVP)"
+                                                                           Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                                <TextBlock Canvas.Left="40"
+                                                                           Canvas.Top="66"
+                                                                           Foreground="{DynamicResource TextSecondaryBrush}"
+                                                                           Text="Viewport, pan, and zoom will be added in follow-up tasks." />
+                                                            </Canvas>
+                                                        </Grid>
+                                                    </Border>
+
+                                                    <Border x:Name="DefaultSummaryContainer"
+                                                            Padding="10"
+                                                            CornerRadius="4"
+                                                            Background="{DynamicResource SelectionBrush}"
+                                                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                                            BorderThickness="1">
+                                                        <TextBlock TextWrapping="Wrap"
+                                                                   Text="{Binding ContentSummary}" />
+                                                    </Border>
+                                                </Grid>
+                                            </Grid>
+                                            <DataTemplate.Triggers>
+                                                <DataTrigger Binding="{Binding Document.DocumentType}"
+                                                             Value="{x:Static local:EditorDocumentType.Panel2D}">
+                                                    <Setter TargetName="PanelCanvasContainer"
+                                                            Property="Visibility"
+                                                            Value="Visible" />
+                                                    <Setter TargetName="DefaultSummaryContainer"
+                                                            Property="Visibility"
+                                                            Value="Collapsed" />
+                                                </DataTrigger>
+                                            </DataTemplate.Triggers>
                                         </DataTemplate>
                                     </TabControl.ContentTemplate>
                                 </TabControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -502,27 +502,34 @@
                                                             BorderThickness="1"
                                                             CornerRadius="4"
                                                             Visibility="Collapsed">
-                                                        <Grid>
-                                                            <Canvas MinHeight="280"
+                                                        <Border MinHeight="280"
+                                                                ClipToBounds="True"
+                                                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                                                BorderThickness="1"
+                                                                Background="{DynamicResource PanelBackgroundBrush}">
+                                                            <Canvas Width="1400"
+                                                                    Height="900"
+                                                                    Cursor="SizeAll"
+                                                                    local:CanvasPanBehavior.IsEnabled="True"
                                                                     Background="{DynamicResource PanelBackgroundBrush}">
                                                                 <Rectangle Width="540"
                                                                            Height="300"
                                                                            Stroke="{DynamicResource SelectionBrush}"
                                                                            StrokeThickness="2"
                                                                            Fill="{DynamicResource ToolBarBackgroundBrush}"
-                                                                           Canvas.Left="24"
-                                                                           Canvas.Top="24" />
-                                                                <TextBlock Canvas.Left="40"
-                                                                           Canvas.Top="40"
+                                                                           Canvas.Left="120"
+                                                                           Canvas.Top="90" />
+                                                                <TextBlock Canvas.Left="136"
+                                                                           Canvas.Top="106"
                                                                            FontWeight="SemiBold"
                                                                            Text="Panel Canvas (MVP)"
                                                                            Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                                <TextBlock Canvas.Left="40"
-                                                                           Canvas.Top="66"
+                                                                <TextBlock Canvas.Left="136"
+                                                                           Canvas.Top="132"
                                                                            Foreground="{DynamicResource TextSecondaryBrush}"
-                                                                           Text="Viewport, pan, and zoom will be added in follow-up tasks." />
+                                                                           Text="Drag with left mouse button to pan." />
                                                             </Canvas>
-                                                        </Grid>
+                                                        </Border>
                                                     </Border>
 
                                                     <Border x:Name="DefaultSummaryContainer"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -527,7 +527,7 @@
                                                                 <TextBlock Canvas.Left="136"
                                                                            Canvas.Top="132"
                                                                            Foreground="{DynamicResource TextSecondaryBrush}"
-                                                                           Text="Drag with left mouse button to pan." />
+                                                                           Text="Drag with middle mouse button to pan." />
                                                             </Canvas>
                                                         </Border>
                                                     </Border>

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -70,7 +70,7 @@
 - [x] Ensure documents update via commands only
 
 ## Phase 5 — Panel Editor (MVP)
-- [ ] Render panel canvas
+- [x] Render panel canvas
 - [ ] Implement pan
 - [ ] Implement zoom
 - [ ] Implement selection
@@ -78,4 +78,3 @@
 - [ ] Add image placement
 - [ ] Add basic inspector editing
 - [ ] Save/load panel document
-

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -71,7 +71,7 @@
 
 ## Phase 5 — Panel Editor (MVP)
 - [x] Render panel canvas
-- [ ] Implement pan
+- [x] Implement pan
 - [ ] Implement zoom
 - [ ] Implement selection
 - [ ] Add rectangle tool


### PR DESCRIPTION
### Motivation
- Begin the Panel Editor MVP by rendering a visual canvas for Panel2D documents inside the main document host so users can see an initial surface during subsequent feature work. 
- Preserve the existing summary view for non-Panel2D documents so behavior for other document types remains unchanged. 
- Keep project task tracking accurate by marking the first Panel Editor milestone complete in `TASKS.md`.

### Description
- Added `xmlns:local="clr-namespace:OasisEditor"` to `MainWindow.xaml` and refactored the `TabControl.ContentTemplate` to a `Grid` layout for richer content placement. 
- Introduced two containers in the document content area: `PanelCanvasContainer` that hosts a placeholder `Canvas` with a bounds `Rectangle` and helper `TextBlock`s, and `DefaultSummaryContainer` that preserves the existing summary view. 
- Added a `DataTrigger` that toggles visibility based on `Document.DocumentType == local:EditorDocumentType.Panel2D` so only Panel2D tabs show the canvas placeholder. 
- Updated `TASKS.md` to mark the Phase 5 task `Render panel canvas` as completed.

### Testing
- Attempted to run `dotnet build OasisEditor.sln` in the environment but `dotnet` is not available so the build could not be executed. 
- No automated tests were run as a result of the unavailable `dotnet` tool in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea527e6efc8327b5eba46a0d54c8ef)