### PR TITLE
Add mouse-wheel zoom to Panel2D canvas

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -34,6 +34,10 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new PropertyMetadata(false));
 
+    private const double MinZoom = 0.25;
+    private const double MaxZoom = 4.0;
+    private const double ZoomStep = 1.1;
+
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
         return (bool)dependencyObject.GetValue(IsEnabledProperty);
@@ -54,10 +58,11 @@ public static class CanvasPanBehavior
         var isEnabled = (bool)eventArgs.NewValue;
         if (isEnabled)
         {
-            EnsureTranslateTransform(element);
+            EnsureTransformGroup(element);
             element.MouseDown += OnMouseDown;
             element.MouseMove += OnMouseMove;
             element.MouseUp += OnMouseUp;
+            element.MouseWheel += OnMouseWheel;
             element.LostMouseCapture += OnLostMouseCapture;
         }
         else
@@ -65,6 +70,7 @@ public static class CanvasPanBehavior
             element.MouseDown -= OnMouseDown;
             element.MouseMove -= OnMouseMove;
             element.MouseUp -= OnMouseUp;
+            element.MouseWheel -= OnMouseWheel;
             element.LostMouseCapture -= OnLostMouseCapture;
         }
     }
@@ -81,11 +87,10 @@ public static class CanvasPanBehavior
             return;
         }
 
-        EnsureTranslateTransform(element);
+        var (_, translate) = EnsureTransformGroup(element);
         var startPoint = eventArgs.GetPosition(element.Parent as IInputElement ?? element);
-        var transform = (TranslateTransform)element.RenderTransform;
         element.SetValue(StartPointProperty, startPoint);
-        element.SetValue(OriginProperty, new Point(transform.X, transform.Y));
+        element.SetValue(OriginProperty, new Point(translate.X, translate.Y));
         element.SetValue(IsPanningProperty, true);
         element.CaptureMouse();
         element.Cursor = Cursors.SizeAll;
@@ -103,9 +108,36 @@ public static class CanvasPanBehavior
         var origin = (Point)element.GetValue(OriginProperty);
         var currentPoint = eventArgs.GetPosition(element.Parent as IInputElement ?? element);
         var delta = currentPoint - startPoint;
-        var transform = (TranslateTransform)element.RenderTransform;
-        transform.X = origin.X + delta.X;
-        transform.Y = origin.Y + delta.Y;
+        var (_, translate) = EnsureTransformGroup(element);
+        translate.X = origin.X + delta.X;
+        translate.Y = origin.Y + delta.Y;
+    }
+
+    private static void OnMouseWheel(object sender, MouseWheelEventArgs eventArgs)
+    {
+        if (sender is not FrameworkElement element)
+        {
+            return;
+        }
+
+        var (scale, translate) = EnsureTransformGroup(element);
+        var parent = element.Parent as IInputElement ?? element;
+        var pivot = eventArgs.GetPosition(parent);
+        var zoomFactor = eventArgs.Delta > 0 ? ZoomStep : 1.0 / ZoomStep;
+        var newScale = Math.Clamp(scale.ScaleX * zoomFactor, MinZoom, MaxZoom);
+        if (Math.Abs(newScale - scale.ScaleX) < 0.0001)
+        {
+            return;
+        }
+
+        var worldX = (pivot.X - translate.X) / scale.ScaleX;
+        var worldY = (pivot.Y - translate.Y) / scale.ScaleY;
+
+        scale.ScaleX = newScale;
+        scale.ScaleY = newScale;
+        translate.X = pivot.X - (worldX * newScale);
+        translate.Y = pivot.Y - (worldY * newScale);
+        eventArgs.Handled = true;
     }
 
     private static void OnMouseUp(object sender, MouseButtonEventArgs eventArgs)
@@ -139,13 +171,21 @@ public static class CanvasPanBehavior
         element.Cursor = Cursors.Arrow;
     }
 
-    private static void EnsureTranslateTransform(FrameworkElement element)
+    private static (ScaleTransform Scale, TranslateTransform Translate) EnsureTransformGroup(FrameworkElement element)
     {
-        if (element.RenderTransform is TranslateTransform)
+        if (element.RenderTransform is TransformGroup existingGroup &&
+            existingGroup.Children.OfType<ScaleTransform>().FirstOrDefault() is { } existingScale &&
+            existingGroup.Children.OfType<TranslateTransform>().FirstOrDefault() is { } existingTranslate)
         {
-            return;
+            return (existingScale, existingTranslate);
         }
 
-        element.RenderTransform = new TranslateTransform();
+        var transformGroup = new TransformGroup();
+        var scale = new ScaleTransform(1, 1);
+        var translate = new TranslateTransform();
+        transformGroup.Children.Add(scale);
+        transformGroup.Children.Add(translate);
+        element.RenderTransform = transformGroup;
+        return (scale, translate);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -527,7 +527,7 @@
                                                                 <TextBlock Canvas.Left="136"
                                                                            Canvas.Top="132"
                                                                            Foreground="{DynamicResource TextSecondaryBrush}"
-                                                                           Text="Drag with middle mouse button to pan." />
+                                                                           Text="Drag with middle mouse to pan. Use mouse wheel to zoom." />
                                                             </Canvas>
                                                         </Border>
                                                     </Border>

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -72,7 +72,7 @@
 ## Phase 5 — Panel Editor (MVP)
 - [x] Render panel canvas
 - [x] Implement pan
-- [ ] Implement zoom
+- [x] Implement zoom
 - [ ] Implement selection
 - [ ] Add rectangle tool
 - [ ] Add image placement


### PR DESCRIPTION
### Motivation
- Complete the next item in the Panel Editor MVP by adding zoom support to the panel canvas as listed in `TASKS.md`.
- Provide a natural pan+zoom interaction where mouse-wheel zoom keeps the cursor-focus stable so users can zoom into a point of interest.

### Description
- Added zoom support to `CanvasPanBehavior.cs` and introduced `MinZoom`, `MaxZoom`, and `ZoomStep` constants to control bounds and step size.
- Replaced the single `TranslateTransform` with a `TransformGroup` containing a `ScaleTransform` and `TranslateTransform` so pan and zoom compose correctly, and preserved existing middle-mouse panning logic to work with the new transforms.
- Implemented `OnMouseWheel` to perform cursor-centered zooming and clamp scale changes, and wired/unwired `MouseWheel` handlers when the behavior is enabled/disabled.
- Updated the Panel2D canvas helper text in `MainWindow.xaml` to mention the new mouse-wheel zoom, and marked `Implement zoom` complete in `TASKS.md`.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not run in this environment because `dotnet` is not installed (build status unknown here).
- No automated unit tests were executed for this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea56151244832787130b713e076029)