### PR TITLE
Add rectangle placement tool to panel canvas

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Shapes;
 
 namespace OasisEditor;
 
@@ -48,6 +49,13 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new PropertyMetadata(false));
 
+    public static readonly DependencyProperty IsRectangleToolActiveProperty =
+        DependencyProperty.RegisterAttached(
+            "IsRectangleToolActive",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false));
+
     private static readonly DependencyProperty SelectedElementProperty =
         DependencyProperty.RegisterAttached(
             "SelectedElement",
@@ -58,6 +66,8 @@ public static class CanvasPanBehavior
     private const double MinZoom = 0.25;
     private const double MaxZoom = 4.0;
     private const double ZoomStep = 1.1;
+    private const double NewRectangleWidth = 180;
+    private const double NewRectangleHeight = 120;
 
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
@@ -87,6 +97,16 @@ public static class CanvasPanBehavior
     public static void SetIsSelected(DependencyObject dependencyObject, bool value)
     {
         dependencyObject.SetValue(IsSelectedProperty, value);
+    }
+
+    public static bool GetIsRectangleToolActive(DependencyObject dependencyObject)
+    {
+        return (bool)dependencyObject.GetValue(IsRectangleToolActiveProperty);
+    }
+
+    public static void SetIsRectangleToolActive(DependencyObject dependencyObject, bool value)
+    {
+        dependencyObject.SetValue(IsRectangleToolActiveProperty, value);
     }
 
     private static void OnIsEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
@@ -164,6 +184,14 @@ public static class CanvasPanBehavior
         }
 
         var clickedElement = FindSelectableElement(eventArgs.OriginalSource as DependencyObject, canvas);
+
+        if (GetIsRectangleToolActive(canvas) && clickedElement is null)
+        {
+            AddRectangle(canvas, eventArgs);
+            eventArgs.Handled = true;
+            return;
+        }
+
         var selectedElement = (FrameworkElement?)canvas.GetValue(SelectedElementProperty);
 
         if (ReferenceEquals(clickedElement, selectedElement))
@@ -185,6 +213,42 @@ public static class CanvasPanBehavior
         SetIsSelected(clickedElement, true);
         canvas.SetValue(SelectedElementProperty, clickedElement);
         eventArgs.Handled = true;
+    }
+
+    private static void AddRectangle(FrameworkElement canvas, MouseButtonEventArgs eventArgs)
+    {
+        if (canvas is not System.Windows.Controls.Canvas panelCanvas)
+        {
+            return;
+        }
+
+        var clickPosition = eventArgs.GetPosition(panelCanvas.Parent as IInputElement ?? panelCanvas);
+        var (scale, translate) = EnsureTransformGroup(panelCanvas);
+        var canvasPoint = new Point(
+            (clickPosition.X - translate.X) / scale.ScaleX,
+            (clickPosition.Y - translate.Y) / scale.ScaleY);
+
+        var rectangle = new Rectangle
+        {
+            Width = NewRectangleWidth,
+            Height = NewRectangleHeight
+        };
+        SetIsSelectable(rectangle, true);
+        SetIsSelected(rectangle, true);
+
+        var x = Math.Max(0, canvasPoint.X - (NewRectangleWidth / 2));
+        var y = Math.Max(0, canvasPoint.Y - (NewRectangleHeight / 2));
+        System.Windows.Controls.Canvas.SetLeft(rectangle, x);
+        System.Windows.Controls.Canvas.SetTop(rectangle, y);
+        panelCanvas.Children.Add(rectangle);
+
+        var previousSelection = (FrameworkElement?)panelCanvas.GetValue(SelectedElementProperty);
+        if (previousSelection is not null)
+        {
+            SetIsSelected(previousSelection, false);
+        }
+
+        panelCanvas.SetValue(SelectedElementProperty, rectangle);
     }
 
     private static void OnMouseWheel(object sender, MouseWheelEventArgs eventArgs)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -461,6 +461,10 @@
                                                 Margin="0,0,8,0"
                                                 Command="{Binding SaveSelectedDocumentCommand}"
                                                 Content="Save" />
+                                        <ToggleButton x:Name="RectangleToolToggle"
+                                                      Padding="10,4"
+                                                      Margin="0,0,8,0"
+                                                      Content="Rectangle Tool" />
                                         <Button Padding="10,4"
                                                 Command="{Binding CloseSelectedDocumentCommand}"
                                                 Content="Close Tab" />
@@ -511,6 +515,7 @@
                                                                     Height="900"
                                                                     Cursor="SizeAll"
                                                                     local:CanvasPanBehavior.IsEnabled="True"
+                                                                    local:CanvasPanBehavior.IsRectangleToolActive="{Binding IsChecked, ElementName=RectangleToolToggle}"
                                                                     Background="{DynamicResource PanelBackgroundBrush}">
                                                                 <Canvas.Resources>
                                                                     <Style TargetType="Rectangle">
@@ -554,6 +559,10 @@
                                                                            Canvas.Top="156"
                                                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                                                            Text="Left-click a shape to select it." />
+                                                                <TextBlock Canvas.Left="136"
+                                                                           Canvas.Top="180"
+                                                                           Foreground="{DynamicResource TextSecondaryBrush}"
+                                                                           Text="Enable Rectangle Tool, then left-click empty canvas to place a rectangle." />
                                                             </Canvas>
                                                         </Border>
                                                     </Border>

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -74,7 +74,7 @@
 - [x] Implement pan
 - [x] Implement zoom
 - [x] Implement selection
-- [ ] Add rectangle tool
+- [x] Add rectangle tool
 - [ ] Add image placement
 - [ ] Add basic inspector editing
 - [ ] Save/load panel document


### PR DESCRIPTION
### Motivation
- Implement the next item from the Panel Editor MVP in `TASKS.md`: add a rectangle placement tool so designers can place rectangles onto the panel canvas. 
- Placement must respect the current pan/zoom transform and integrate with the existing selection/panning/zoom behaviors.

### Description
- Added a `Rectangle Tool` toggle to the document toolbar in the panel editor (`OasisEditor/MainWindow.xaml`) and a short help text explaining how to use it. 
- Introduced a new attached property `CanvasPanBehavior.IsRectangleToolActive` with getters/setters and a default size (`180x120`) in `OasisEditor/CanvasPanBehavior.cs`. 
- Implemented left-click handling so when the rectangle tool is active and the user clicks empty canvas space the behavior converts the click to canvas coordinates (accounting for scale/translate), creates a `Rectangle`, centers it on the click, clamps to non-negative coordinates, makes it selectable/selected, and adds it to the canvas while preserving existing pan/zoom/selection logic. 
- Marked the `Add rectangle tool` item complete in `TASKS.md`.

### Testing
- Attempted an automated build with `dotnet build OasisEditor.sln` in the environment, but the command failed because `dotnet` is not available (`dotnet: command not found`).
- No other automated tests were run in this environment due to the lack of .NET SDK; runtime/visual verification remains pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea5bc6694c83279b0d10e21f9795df)