### PR TITLE
Add basic inspector editing support for document summaries

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -142,4 +142,9 @@ public sealed class EditorDocument
     {
         return new EditorDocument(Title, DocumentType, FilePath, ContentSummary, false, false);
     }
+
+    public EditorDocument WithContentSummary(string contentSummary)
+    {
+        return new EditorDocument(Title, DocumentType, FilePath, contentSummary, IsUntitled, IsDirty);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -661,8 +661,25 @@
                                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                                 BorderThickness="1"
                                                 CornerRadius="4">
-                                            <TextBlock TextWrapping="Wrap"
-                                                       Text="{Binding InspectorSummary}" />
+                                            <StackPanel>
+                                                <TextBlock TextWrapping="Wrap"
+                                                           Text="{Binding InspectorSummary}" />
+                                                <TextBlock Margin="0,10,0,0"
+                                                           FontWeight="SemiBold"
+                                                           Text="Edit Summary" />
+                                                <TextBox Margin="0,6,0,0"
+                                                         MinHeight="88"
+                                                         AcceptsReturn="True"
+                                                         VerticalScrollBarVisibility="Auto"
+                                                         IsEnabled="{Binding CanEditInspectorSummary}"
+                                                         Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
+                                                <Button Margin="0,8,0,0"
+                                                        HorizontalAlignment="Left"
+                                                        Padding="10,4"
+                                                        IsEnabled="{Binding CanEditInspectorSummary}"
+                                                        Command="{Binding ApplyInspectorSummaryCommand}"
+                                                        Content="Apply Summary" />
+                                            </StackPanel>
                                         </Border>
                                     </StackPanel>
                                 </Border>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -34,6 +34,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private ThemePreference _selectedThemePreference;
     private PreferencesWindow? _preferencesWindow;
     private ProjectSettingsWindow? _projectSettingsWindow;
+    private string _inspectorEditableSummary = string.Empty;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -59,6 +60,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenProjectSettingsCommand = new RelayCommand(OpenProjectSettings);
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
+        ApplyInspectorSummaryCommand = new RelayCommand(ApplyInspectorSummary, CanApplyInspectorSummary);
         ExitCommand = new RelayCommand(ExitApplication);
 
         var preferences = _preferencesStore.Load();
@@ -88,6 +90,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenProjectSettingsCommand { get; }
     public ICommand ClosePreferencesCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
+    public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
@@ -300,6 +303,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return "Open or create a project to enable the inspector.";
         }
     }
+
+    public string InspectorEditableSummary
+    {
+        get => _inspectorEditableSummary;
+        set
+        {
+            if (SetProperty(ref _inspectorEditableSummary, value))
+            {
+                NotifyInspectorEditCommand();
+            }
+        }
+    }
+
+    public bool CanEditInspectorSummary => SelectedDocument is not null
+        && SelectedDocument.Document.DocumentType != EditorDocumentType.ProjectOverview;
 
     private void CreateProject()
     {
@@ -1067,6 +1085,46 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorType));
         OnPropertyChanged(nameof(InspectorPath));
         OnPropertyChanged(nameof(InspectorSummary));
+        OnPropertyChanged(nameof(CanEditInspectorSummary));
+
+        InspectorEditableSummary = SelectedDocument?.ContentSummary ?? string.Empty;
+        NotifyInspectorEditCommand();
+    }
+
+    private bool CanApplyInspectorSummary()
+    {
+        if (!CanEditInspectorSummary || SelectedDocument is null)
+        {
+            return false;
+        }
+
+        return !string.Equals(
+            SelectedDocument.ContentSummary,
+            InspectorEditableSummary,
+            StringComparison.Ordinal);
+    }
+
+    private void ApplyInspectorSummary()
+    {
+        if (SelectedDocument is null || !CanEditInspectorSummary)
+        {
+            return;
+        }
+
+        var updated = new DocumentTabViewModel(
+            SelectedDocument.Document.WithContentSummary(InspectorEditableSummary).MarkDirty());
+
+        ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, SelectedDocument, updated));
+        StatusMessage = $"Updated inspector summary for {updated.Title}";
+        AddOutputEntry($"Inspector summary updated for {updated.Title}");
+    }
+
+    private void NotifyInspectorEditCommand()
+    {
+        if (ApplyInspectorSummaryCommand is RelayCommand relayCommand)
+        {
+            relayCommand.RaiseCanExecuteChanged();
+        }
     }
 
     private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -71,5 +71,5 @@
 - [x] Implement selection
 - [x] Add rectangle tool
 - [x] Add image placement
-- [ ] Add basic inspector editing
+- [x] Add basic inspector editing
 - [ ] Save/load panel document


### PR DESCRIPTION
### Motivation
- Complete the next Phase 5 task by enabling basic inspector editing so users can edit a document's summary from the Inspector panel. 
- Keep the domain model immutable and route UI changes through the existing command/mutation system to preserve undo/redo semantics.

### Description
- Add `EditorDocument.WithContentSummary(string)` to support creating an updated immutable `EditorDocument` with a new `ContentSummary`.
- Add inspector edit state and command handling in `MainWindowViewModel`: introduced `InspectorEditableSummary`, `ApplyInspectorSummaryCommand`, `CanEditInspectorSummary`, `CanApplyInspectorSummary`, `ApplyInspectorSummary()`, selection-sync logic, and wiring to use `ReplaceDocumentTabMutationCommand` and `MarkDirty()` when applying edits.
- Update `MainWindow.xaml` Inspector UI to show an editable `TextBox` and `Apply Summary` `Button` bound to the new view-model properties/command and disabled for project-overview documents.
- Marked the `Add basic inspector editing` item complete in `TASKS.md`.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the `dotnet` CLI is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea6a8083a48327adb22c701c5768e6)