### PR TITLE
Implement Panel2D document save/load support

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -647,6 +647,10 @@ public static class CanvasPanBehavior
             }
 
             canvas.ClearValue(SelectedElementProperty);
+            if (canvas.DataContext is DocumentTabViewModel tab)
+            {
+                tab.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            }
         }
         finally
         {
@@ -694,7 +698,12 @@ public static class CanvasPanBehavior
             .Cast<PanelElementFile>()
             .ToArray();
 
-        canvas.SetCurrentValue(PanelLayoutJsonProperty, Panel2DDocumentStorage.SerializeLayout(elements));
+        var layoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        canvas.SetCurrentValue(PanelLayoutJsonProperty, layoutJson);
+        if (canvas.DataContext is DocumentTabViewModel tab)
+        {
+            tab.PanelLayoutJson = layoutJson;
+        }
     }
 
     private static PanelElementFile? CreateElementFromVisual(FrameworkElement child)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -69,12 +69,33 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new PropertyMetadata(false));
 
+    public static readonly DependencyProperty PanelLayoutJsonProperty =
+        DependencyProperty.RegisterAttached(
+            "PanelLayoutJson",
+            typeof(string),
+            typeof(CanvasPanBehavior),
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelLayoutJsonChanged));
+
     private static readonly DependencyProperty SelectedElementProperty =
         DependencyProperty.RegisterAttached(
             "SelectedElement",
             typeof(FrameworkElement),
             typeof(CanvasPanBehavior),
             new PropertyMetadata(null));
+
+    private static readonly DependencyProperty IsPersistedElementProperty =
+        DependencyProperty.RegisterAttached(
+            "IsPersistedElement",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false));
+
+    private static readonly DependencyProperty IsApplyingLayoutProperty =
+        DependencyProperty.RegisterAttached(
+            "IsApplyingLayout",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false));
 
     private static readonly DependencyProperty CommandServiceProperty =
         DependencyProperty.RegisterAttached(
@@ -153,6 +174,16 @@ public static class CanvasPanBehavior
     public static void SetIsImageToolActive(DependencyObject dependencyObject, bool value)
     {
         dependencyObject.SetValue(IsImageToolActiveProperty, value);
+    }
+
+    public static string? GetPanelLayoutJson(DependencyObject dependencyObject)
+    {
+        return (string?)dependencyObject.GetValue(PanelLayoutJsonProperty);
+    }
+
+    public static void SetPanelLayoutJson(DependencyObject dependencyObject, string? value)
+    {
+        dependencyObject.SetValue(PanelLayoutJsonProperty, value);
     }
 
     private static void OnIsEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
@@ -292,6 +323,7 @@ public static class CanvasPanBehavior
         };
         SetIsSelectable(rectangle, true);
         SetIsSelected(rectangle, true);
+        rectangle.SetValue(IsPersistedElementProperty, true);
 
         var x = Math.Max(0, canvasPoint.X - (NewRectangleWidth / 2));
         var y = Math.Max(0, canvasPoint.Y - (NewRectangleHeight / 2));
@@ -323,6 +355,7 @@ public static class CanvasPanBehavior
         };
         SetIsSelectable(image, true);
         SetIsSelected(image, true);
+        image.SetValue(IsPersistedElementProperty, true);
 
         var x = Math.Max(0, canvasPoint.X - (NewImageWidth / 2));
         var y = Math.Max(0, canvasPoint.Y - (NewImageHeight / 2));
@@ -504,6 +537,10 @@ public static class CanvasPanBehavior
     private static void ExecuteCanvasMutation(FrameworkElement canvas, Commands.ICommand command)
     {
         GetCommandService(canvas).Execute(command);
+        if (canvas is Canvas panelCanvas)
+        {
+            SyncPanelLayout(panelCanvas);
+        }
     }
 
     private static CommandService GetCommandService(FrameworkElement canvas)
@@ -560,6 +597,128 @@ public static class CanvasPanBehavior
             pixelWidth * bytesPerPixel);
         bitmap.Freeze();
         return bitmap;
+    }
+
+    private static void OnPanelLayoutJsonChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+    {
+        if (dependencyObject is not Canvas canvas)
+        {
+            return;
+        }
+
+        if ((bool)canvas.GetValue(IsApplyingLayoutProperty))
+        {
+            return;
+        }
+
+        ApplyPersistedLayout(canvas, eventArgs.NewValue as string);
+    }
+
+    private static void ApplyPersistedLayout(Canvas canvas, string? layoutJson)
+    {
+        canvas.SetValue(IsApplyingLayoutProperty, true);
+        try
+        {
+            var persistedChildren = canvas.Children
+                .OfType<FrameworkElement>()
+                .Where(child => (bool)child.GetValue(IsPersistedElementProperty))
+                .ToList();
+
+            foreach (var child in persistedChildren)
+            {
+                canvas.Children.Remove(child);
+            }
+
+            var elements = Panel2DDocumentStorage.DeserializeLayout(layoutJson);
+            foreach (var element in elements)
+            {
+                var visual = CreateVisualFromElement(element);
+                if (visual is null)
+                {
+                    continue;
+                }
+
+                visual.SetValue(IsPersistedElementProperty, true);
+                SetIsSelectable(visual, true);
+                SetIsSelected(visual, false);
+                Canvas.SetLeft(visual, Math.Max(0, element.X));
+                Canvas.SetTop(visual, Math.Max(0, element.Y));
+                canvas.Children.Add(visual);
+            }
+
+            canvas.ClearValue(SelectedElementProperty);
+        }
+        finally
+        {
+            canvas.SetValue(IsApplyingLayoutProperty, false);
+        }
+    }
+
+    private static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
+    {
+        if (string.Equals(element.Kind, "rectangle", StringComparison.OrdinalIgnoreCase))
+        {
+            return new Rectangle
+            {
+                Width = element.Width <= 0 ? NewRectangleWidth : element.Width,
+                Height = element.Height <= 0 ? NewRectangleHeight : element.Height
+            };
+        }
+
+        if (string.Equals(element.Kind, "image", StringComparison.OrdinalIgnoreCase))
+        {
+            return new Image
+            {
+                Width = element.Width <= 0 ? NewImageWidth : element.Width,
+                Height = element.Height <= 0 ? NewImageHeight : element.Height,
+                Stretch = Stretch.Fill,
+                Source = CreatePlaceholderImageSource()
+            };
+        }
+
+        return null;
+    }
+
+    private static void SyncPanelLayout(Canvas canvas)
+    {
+        if ((bool)canvas.GetValue(IsApplyingLayoutProperty))
+        {
+            return;
+        }
+
+        var elements = canvas.Children
+            .OfType<FrameworkElement>()
+            .Where(child => (bool)child.GetValue(IsPersistedElementProperty))
+            .Select(CreateElementFromVisual)
+            .Where(element => element is not null)
+            .Cast<PanelElementFile>()
+            .ToArray();
+
+        canvas.SetCurrentValue(PanelLayoutJsonProperty, Panel2DDocumentStorage.SerializeLayout(elements));
+    }
+
+    private static PanelElementFile? CreateElementFromVisual(FrameworkElement child)
+    {
+        var kind = child switch
+        {
+            Rectangle => "rectangle",
+            Image => "image",
+            _ => null
+        };
+
+        if (kind is null)
+        {
+            return null;
+        }
+
+        return new PanelElementFile
+        {
+            Kind = kind,
+            X = Canvas.GetLeft(child),
+            Y = Canvas.GetTop(child),
+            Width = child.Width,
+            Height = child.Height
+        };
     }
 
     private sealed class AddRectangleMutationCommand : Commands.ICommand

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -529,6 +529,7 @@
                                                                     local:CanvasPanBehavior.IsEnabled="True"
                                                                     local:CanvasPanBehavior.IsRectangleToolActive="{Binding IsChecked, ElementName=RectangleToolToggle}"
                                                                     local:CanvasPanBehavior.IsImageToolActive="{Binding IsChecked, ElementName=ImageToolToggle}"
+                                                                    local:CanvasPanBehavior.PanelLayoutJson="{Binding PanelLayoutJson, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                                     Background="{DynamicResource PanelBackgroundBrush}">
                                                                 <Canvas.Resources>
                                                                     <Style TargetType="Rectangle">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -395,7 +395,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var document = new DocumentTabViewModel(
-            EditorDocument.CreatePanel2DStub($"Panel {_panelDocumentCounter++}"));
+            EditorDocument.CreatePanel2DStub($"Panel {_panelDocumentCounter++}"),
+            panelLayoutJson: Panel2DDocumentStorage.SerializeLayout([]));
 
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         StatusMessage = $"Opened panel document stub: {document.Title}";
@@ -466,9 +467,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             var path = dialog.FileName;
             var content = File.ReadAllText(path);
-            var summary = BuildDocumentSummary(path, content);
+            var openData = BuildOpenDocumentData(path, content);
 
-            var openedNewTab = OpenOrSelectDocument(path, summary);
+            var openedNewTab = OpenOrSelectDocument(path, openData.Summary, openData.PanelLayoutJson);
             if (!openedNewTab)
             {
                 AddOutputEntry($"Switched to already open document tab for {path}");
@@ -515,7 +516,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             File.WriteAllText(savePath, content);
 
             var updatedDocument = new DocumentTabViewModel(
-                current.Document.SaveAs(savePath, current.ContentSummary).MarkClean());
+                current.Document.SaveAs(savePath, current.ContentSummary).MarkClean(),
+                current.PanelLayoutJson);
             ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, current, updatedDocument));
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}");
@@ -700,7 +702,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ExecuteDocumentMutation(new ReplaceOpenDocumentsMutationCommand(this, [overviewDocument], overviewDocument));
     }
 
-    private bool OpenOrSelectDocument(string path, string summary)
+    private bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson)
     {
         var existing = OpenDocuments.FirstOrDefault(
             tab => string.Equals(tab.FilePath, path, StringComparison.OrdinalIgnoreCase));
@@ -710,7 +712,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary));
+        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary), panelLayoutJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         return true;
     }
@@ -720,28 +722,32 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _documentCommandService.Execute(command);
     }
 
-    private static string BuildDocumentSummary(string path, string content)
+    private static OpenDocumentData BuildOpenDocumentData(string path, string content)
     {
         if (string.Equals(Path.GetExtension(path), ".panel2d", StringComparison.OrdinalIgnoreCase)
-            && Panel2DDocumentStorage.TryCreateSummary(content, out var panelSummary))
+            && Panel2DDocumentStorage.TryRead(content, out var panelDocument))
         {
-            return panelSummary;
+            var summary = string.IsNullOrWhiteSpace(panelDocument.Summary)
+                ? "Panel document opened."
+                : panelDocument.Summary.Trim();
+            return new OpenDocumentData(summary, Panel2DDocumentStorage.SerializeLayout(panelDocument.Elements));
         }
 
         var preview = content.Length > 300 ? $"{content[..300]}..." : content;
         if (string.IsNullOrWhiteSpace(preview))
         {
-            return "Document opened (file is empty).";
+            preview = "Document opened (file is empty).";
         }
 
-        return preview;
+        return new OpenDocumentData(preview, null);
     }
 
     private static string BuildDocumentContent(DocumentTabViewModel document)
     {
         if (document.Document.DocumentType == EditorDocumentType.Panel2D)
         {
-            return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary);
+            var elements = Panel2DDocumentStorage.DeserializeLayout(document.PanelLayoutJson);
+            return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
         }
 
         var persisted = new
@@ -1135,7 +1141,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var updated = new DocumentTabViewModel(
-            SelectedDocument.Document.WithContentSummary(InspectorEditableSummary).MarkDirty());
+            SelectedDocument.Document.WithContentSummary(InspectorEditableSummary).MarkDirty(),
+            SelectedDocument.PanelLayoutJson);
 
         ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, SelectedDocument, updated));
         StatusMessage = $"Updated inspector summary for {updated.Title}";
@@ -1168,11 +1175,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
 }
 
-public sealed class DocumentTabViewModel
+internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson);
+
+public sealed class DocumentTabViewModel : INotifyPropertyChanged
 {
-    public DocumentTabViewModel(EditorDocument document)
+    private string? _panelLayoutJson;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public DocumentTabViewModel(EditorDocument document, string? panelLayoutJson = null)
     {
         Document = document;
+        _panelLayoutJson = panelLayoutJson;
     }
 
     public EditorDocument Document { get; }
@@ -1188,6 +1202,21 @@ public sealed class DocumentTabViewModel
     public string FilePath => Document.FilePath;
     public string ContentSummary => Document.ContentSummary;
     public bool IsDirty => Document.IsDirty;
+
+    public string? PanelLayoutJson
+    {
+        get => _panelLayoutJson;
+        set
+        {
+            if (string.Equals(_panelLayoutJson, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _panelLayoutJson = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
+        }
+    }
 }
 
 public sealed class AssetBrowserItemViewModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -465,12 +465,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         try
         {
             var path = dialog.FileName;
-            var preview = File.ReadAllText(path);
-            var summary = preview.Length > 300 ? $"{preview[..300]}..." : preview;
-            if (string.IsNullOrWhiteSpace(summary))
-            {
-                summary = "Document opened (file is empty).";
-            }
+            var content = File.ReadAllText(path);
+            var summary = BuildDocumentSummary(path, content);
 
             var openedNewTab = OpenOrSelectDocument(path, summary);
             if (!openedNewTab)
@@ -515,15 +511,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         try
         {
-            var persisted = new
-            {
-                title = current.Title,
-                type = current.Document.DocumentType.ToString(),
-                summary = current.ContentSummary,
-                savedAtUtc = DateTime.UtcNow
-            };
-
-            var content = JsonSerializer.Serialize(persisted, new JsonSerializerOptions { WriteIndented = true });
+            var content = BuildDocumentContent(current);
             File.WriteAllText(savePath, content);
 
             var updatedDocument = new DocumentTabViewModel(
@@ -730,6 +718,41 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private void ExecuteDocumentMutation(EditorCommands.ICommand command)
     {
         _documentCommandService.Execute(command);
+    }
+
+    private static string BuildDocumentSummary(string path, string content)
+    {
+        if (string.Equals(Path.GetExtension(path), ".panel2d", StringComparison.OrdinalIgnoreCase)
+            && Panel2DDocumentStorage.TryCreateSummary(content, out var panelSummary))
+        {
+            return panelSummary;
+        }
+
+        var preview = content.Length > 300 ? $"{content[..300]}..." : content;
+        if (string.IsNullOrWhiteSpace(preview))
+        {
+            return "Document opened (file is empty).";
+        }
+
+        return preview;
+    }
+
+    private static string BuildDocumentContent(DocumentTabViewModel document)
+    {
+        if (document.Document.DocumentType == EditorDocumentType.Panel2D)
+        {
+            return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary);
+        }
+
+        var persisted = new
+        {
+            title = document.Title,
+            type = document.Document.DocumentType.ToString(),
+            summary = document.ContentSummary,
+            savedAtUtc = DateTime.UtcNow
+        };
+
+        return JsonSerializer.Serialize(persisted, new JsonSerializerOptions { WriteIndented = true });
     }
 
     private sealed class OpenDocumentTabMutationCommand : EditorCommands.ICommand

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+
+namespace OasisEditor;
+
+internal static class Panel2DDocumentStorage
+{
+    public static string Serialize(string title, string summary)
+    {
+        var payload = new Panel2DDocumentFile
+        {
+            SchemaVersion = 1,
+            Title = title,
+            Summary = summary,
+            SavedAtUtc = DateTime.UtcNow
+        };
+
+        return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public static bool TryCreateSummary(string content, out string summary)
+    {
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<Panel2DDocumentFile>(content);
+            if (parsed is null)
+            {
+                summary = "Panel document opened (file is empty).";
+                return true;
+            }
+
+            summary = string.IsNullOrWhiteSpace(parsed.Summary)
+                ? "Panel document opened."
+                : parsed.Summary.Trim();
+            return true;
+        }
+        catch (JsonException)
+        {
+            summary = string.Empty;
+            return false;
+        }
+    }
+}
+
+internal sealed class Panel2DDocumentFile
+{
+    public int SchemaVersion { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Summary { get; init; } = string.Empty;
+    public DateTime SavedAtUtc { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -4,14 +4,15 @@ namespace OasisEditor;
 
 internal static class Panel2DDocumentStorage
 {
-    public static string Serialize(string title, string summary)
+    public static string Serialize(string title, string summary, IReadOnlyList<PanelElementFile> elements)
     {
         var payload = new Panel2DDocumentFile
         {
             SchemaVersion = 1,
             Title = title,
             Summary = summary,
-            SavedAtUtc = DateTime.UtcNow
+            SavedAtUtc = DateTime.UtcNow,
+            Elements = elements.ToArray()
         };
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
@@ -19,24 +20,51 @@ internal static class Panel2DDocumentStorage
 
     public static bool TryCreateSummary(string content, out string summary)
     {
+        if (!TryRead(content, out var document))
+        {
+            summary = string.Empty;
+            return false;
+        }
+
+        summary = string.IsNullOrWhiteSpace(document.Summary)
+            ? "Panel document opened."
+            : document.Summary.Trim();
+        return true;
+    }
+
+    public static bool TryRead(string content, out Panel2DDocumentFile document)
+    {
         try
         {
-            var parsed = JsonSerializer.Deserialize<Panel2DDocumentFile>(content);
-            if (parsed is null)
-            {
-                summary = "Panel document opened (file is empty).";
-                return true;
-            }
-
-            summary = string.IsNullOrWhiteSpace(parsed.Summary)
-                ? "Panel document opened."
-                : parsed.Summary.Trim();
+            document = JsonSerializer.Deserialize<Panel2DDocumentFile>(content) ?? new Panel2DDocumentFile();
             return true;
         }
         catch (JsonException)
         {
-            summary = string.Empty;
+            document = new Panel2DDocumentFile();
             return false;
+        }
+    }
+
+    public static string SerializeLayout(IReadOnlyList<PanelElementFile> elements)
+    {
+        return JsonSerializer.Serialize(elements);
+    }
+
+    public static IReadOnlyList<PanelElementFile> DeserializeLayout(string? layoutJson)
+    {
+        if (string.IsNullOrWhiteSpace(layoutJson))
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<PanelElementFile>>(layoutJson) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
         }
     }
 }
@@ -47,4 +75,14 @@ internal sealed class Panel2DDocumentFile
     public string Title { get; init; } = string.Empty;
     public string Summary { get; init; } = string.Empty;
     public DateTime SavedAtUtc { get; init; }
+    public PanelElementFile[] Elements { get; init; } = [];
+}
+
+internal sealed class PanelElementFile
+{
+    public string Kind { get; init; } = string.Empty;
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -72,4 +72,4 @@
 - [x] Add rectangle tool
 - [x] Add image placement
 - [x] Add basic inspector editing
-- [ ] Save/load panel document
+- [x] Save/load panel document


### PR DESCRIPTION
### Motivation
- Provide structured save/load support for `.panel2d` documents so panel assets can be persisted and reopened with a reliable summary extraction flow.

### Description
- Add `Panel2DDocumentStorage.cs` which defines `Panel2DDocumentFile` and exposes `Serialize` and `TryCreateSummary` for panel-specific JSON persistence and safe summary extraction.
- Update `MainWindowViewModel` to use `BuildDocumentSummary` when opening files and `BuildDocumentContent` when saving files so `.panel2d` files use the new storage format while other document types fall back to the existing preview-based JSON.
- Mark the Phase 5 checklist item `Save/load panel document` as completed in `TASKS.md`.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj` which failed in this environment because `dotnet` is not installed.
- No automated unit tests were executed in this environment; changes were limited to adding the storage helper and wiring open/save flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea6cfe894883278e2ef23762ea9457)