### PR TITLE
Fix panel canvas undo/redo by preventing layout reapply loop

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -699,10 +699,18 @@ public static class CanvasPanBehavior
             .ToArray();
 
         var layoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
-        canvas.SetCurrentValue(PanelLayoutJsonProperty, layoutJson);
-        if (canvas.DataContext is DocumentTabViewModel tab)
+        canvas.SetValue(IsApplyingLayoutProperty, true);
+        try
         {
-            tab.PanelLayoutJson = layoutJson;
+            canvas.SetCurrentValue(PanelLayoutJsonProperty, layoutJson);
+            if (canvas.DataContext is DocumentTabViewModel tab)
+            {
+                tab.PanelLayoutJson = layoutJson;
+            }
+        }
+        finally
+        {
+            canvas.SetValue(IsApplyingLayoutProperty, false);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Undo/Redo stopped removing/adding rectangle visuals because `SyncPanelLayout` updated `PanelLayoutJson`, which immediately caused `ApplyPersistedLayout` to remove and recreate persisted visuals so command history operated on replaced instances instead of the originals.

### Description
- Guarded `SyncPanelLayout` updates by setting `IsApplyingLayoutProperty` while writing `PanelLayoutJson` and the bound `DocumentTabViewModel.PanelLayoutJson` to avoid re-triggering layout re-application; change made in `CanvasPanBehavior.cs` using `SetValue(IsApplyingLayoutProperty, true)` / `try` / `finally` to clear the flag and `SetCurrentValue` to update the attached property.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` in the container but the command failed because `dotnet` is not installed, so no automated build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eae5d48c6c8327924038530b4fdc57)