### PR TITLE
Enforce loaded-project startup contract for editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
@@ -144,7 +144,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
 
     private void OpenProject()
     {
-        OpenEditor(ProjectFilePath, requireLoadedProject: true);
+        OpenEditor(ProjectFilePath);
     }
 
     private bool CanOpenProject()
@@ -159,7 +159,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        OpenEditor(SelectedRecentProject, requireLoadedProject: true);
+        OpenEditor(SelectedRecentProject);
     }
 
     private bool CanOpenSelectedRecentProject()
@@ -167,7 +167,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
         return !string.IsNullOrWhiteSpace(SelectedRecentProject);
     }
 
-    private void OpenEditor(string projectFilePath, bool requireLoadedProject = false)
+    private void OpenEditor(string projectFilePath)
     {
         try
         {
@@ -175,11 +175,6 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
             ValidateProjectFile(trimmed);
 
             var mainWindow = new MainWindow(_applicationThemeService, _preferencesStore, trimmed);
-
-            if (requireLoadedProject)
-            {
-                EnsureProjectLoaded(mainWindow);
-            }
 
             mainWindow.Show();
             _launcherWindow.Close();
@@ -189,26 +184,6 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
             StatusMessage = ex.Message;
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
-    }
-
-    private static void EnsureProjectLoaded(Window mainWindow)
-    {
-        if (mainWindow.DataContext is not MainWindowViewModel viewModel)
-        {
-            mainWindow.Close();
-            throw new InvalidOperationException("Editor failed to initialize project context.");
-        }
-
-        if (viewModel.HasLoadedProject)
-        {
-            return;
-        }
-
-        var message = string.IsNullOrWhiteSpace(viewModel.StatusMessage)
-            ? "Project could not be loaded."
-            : viewModel.StatusMessage;
-        mainWindow.Close();
-        throw new InvalidOperationException(message);
     }
 
     private static void ValidateProjectFile(string projectFilePath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -164,13 +164,6 @@
                        BasedOn="{StaticResource EditorMenuItemStyle}" />
             </Menu.Resources>
             <MenuItem Header="_File">
-                <MenuItem Header="_Create Project"
-                          Command="{Binding CreateProjectCommand}" />
-                <MenuItem Header="_Open Project"
-                          Command="{Binding OpenProjectCommand}" />
-                <MenuItem Header="Open Selected _Recent"
-                          Command="{Binding OpenRecentProjectCommand}" />
-                <Separator />
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />
                 <MenuItem Header="New _Cabinet3D Stub"
@@ -206,13 +199,6 @@
                      Background="{DynamicResource ToolBarBackgroundBrush}">
             <ToolBar Band="0"
                      BandIndex="0">
-                <Button Command="{Binding CreateProjectCommand}"
-                        Content="Create Project" />
-                <Button Command="{Binding OpenProjectCommand}"
-                        Content="Open Project" />
-                <Button Command="{Binding OpenRecentProjectCommand}"
-                        Content="Open Recent" />
-                <Separator />
                 <Button Command="{Binding OpenPanel2DStubCommand}"
                         Content="New Panel2D" />
                 <Button Command="{Binding OpenCabinet3DStubCommand}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -7,8 +7,13 @@ public partial class MainWindow : Window
     public MainWindow(
         IApplicationThemeService applicationThemeService,
         EditorPreferencesStore preferencesStore,
-        string? startupProjectFilePath = null)
+        string startupProjectFilePath)
     {
+        if (string.IsNullOrWhiteSpace(startupProjectFilePath))
+        {
+            throw new InvalidOperationException("Editor shell requires an active loaded project.");
+        }
+
         InitializeComponent();
         EditorKeyboardShortcuts.RegisterWindowBindings(this);
         DataContext = new MainWindowViewModel(applicationThemeService, preferencesStore, this, startupProjectFilePath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -42,11 +42,16 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         IApplicationThemeService applicationThemeService,
         EditorPreferencesStore preferencesStore,
         Window ownerWindow,
-        string? startupProjectFilePath = null)
+        string startupProjectFilePath)
     {
         _applicationThemeService = applicationThemeService;
         _preferencesStore = preferencesStore;
         _ownerWindow = ownerWindow;
+
+        if (string.IsNullOrWhiteSpace(startupProjectFilePath))
+        {
+            throw new InvalidOperationException("Editor shell requires an active loaded project.");
+        }
 
         CreateProjectCommand = new RelayCommand(CreateProject, CanCreateProject);
         OpenProjectCommand = new RelayCommand(OpenProject, CanOpenProject);
@@ -77,10 +82,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry("Editor shell initialized.");
         AddOutputEntry($"Theme preference loaded: {_selectedThemePreference}");
 
-        if (!string.IsNullOrWhiteSpace(startupProjectFilePath))
-        {
-            OpenProjectFile(startupProjectFilePath, null);
-        }
+        LoadStartupProject(startupProjectFilePath.Trim());
     }
 
     public ICommand CreateProjectCommand { get; }
@@ -639,58 +641,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         try
         {
             var projectFile = projectFilePath.Trim();
-
-            if (!File.Exists(projectFile))
-            {
-                throw new FileNotFoundException("Project file was not found.", projectFile);
-            }
-
-            if (!string.Equals(Path.GetExtension(projectFile), ".oasisproj", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new InvalidOperationException("Project file must use the .oasisproj extension.");
-            }
-
-            using var projectStream = File.OpenRead(projectFile);
-            using var projectDocument = JsonDocument.Parse(projectStream);
-
-            if (!projectDocument.RootElement.TryGetProperty("name", out var projectNameElement))
-            {
-                throw new InvalidOperationException("Project metadata is missing required 'name' field.");
-            }
-
-            var openedProjectName = projectNameElement.GetString();
-            if (string.IsNullOrWhiteSpace(openedProjectName))
-            {
-                throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
-            }
-
-            var projectDirectory = Path.GetDirectoryName(projectFile);
-            if (string.IsNullOrWhiteSpace(projectDirectory))
-            {
-                throw new InvalidOperationException("Unable to determine project directory.");
-            }
-
-            var layoutElement = projectDocument.RootElement.GetProperty("layout");
-            var assetsDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "assets");
-            var machinesDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "machines");
-            var generatedDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "generated");
-
-            LoadedProject = new EditorProject
-            {
-                Name = openedProjectName,
-                ProjectFilePath = projectFile,
-                ProjectDirectory = projectDirectory,
-                AssetsDirectory = assetsDirectory,
-                MachinesDirectory = machinesDirectory,
-                GeneratedDirectory = generatedDirectory
-            };
+            var project = LoadProjectFromFile(projectFile);
+            LoadedProject = project;
 
             ProjectFilePath = projectFile;
             UpdateRecentProjects(projectFile);
             EnsureProjectOverviewDocument();
             RefreshAssetBrowser();
-            StatusMessage = successMessage ?? $"Project opened: {openedProjectName} ({projectFile})";
-            AddOutputEntry($"Loaded project '{openedProjectName}' from {projectFile}");
+            StatusMessage = successMessage ?? $"Project opened: {project.Name} ({projectFile})";
+            AddOutputEntry($"Loaded project '{project.Name}' from {projectFile}");
         }
         catch (Exception ex)
         {
@@ -698,6 +657,66 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Open project failed: {ex.Message}");
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private void LoadStartupProject(string startupProjectFilePath)
+    {
+        var project = LoadProjectFromFile(startupProjectFilePath);
+        LoadedProject = project;
+        ProjectFilePath = project.ProjectFilePath;
+        UpdateRecentProjects(project.ProjectFilePath);
+        EnsureProjectOverviewDocument();
+        RefreshAssetBrowser();
+        StatusMessage = $"Project opened: {project.Name} ({project.ProjectFilePath})";
+        AddOutputEntry($"Loaded startup project '{project.Name}' from {project.ProjectFilePath}");
+    }
+
+    private static EditorProject LoadProjectFromFile(string projectFilePath)
+    {
+        if (!File.Exists(projectFilePath))
+        {
+            throw new FileNotFoundException("Project file was not found.", projectFilePath);
+        }
+
+        if (!string.Equals(Path.GetExtension(projectFilePath), ".oasisproj", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Project file must use the .oasisproj extension.");
+        }
+
+        using var projectStream = File.OpenRead(projectFilePath);
+        using var projectDocument = JsonDocument.Parse(projectStream);
+
+        if (!projectDocument.RootElement.TryGetProperty("name", out var projectNameElement))
+        {
+            throw new InvalidOperationException("Project metadata is missing required 'name' field.");
+        }
+
+        var openedProjectName = projectNameElement.GetString();
+        if (string.IsNullOrWhiteSpace(openedProjectName))
+        {
+            throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
+        }
+
+        var projectDirectory = Path.GetDirectoryName(projectFilePath);
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+        {
+            throw new InvalidOperationException("Unable to determine project directory.");
+        }
+
+        var layoutElement = projectDocument.RootElement.GetProperty("layout");
+        var assetsDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "assets");
+        var machinesDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "machines");
+        var generatedDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "generated");
+
+        return new EditorProject
+        {
+            Name = openedProjectName,
+            ProjectFilePath = projectFilePath,
+            ProjectDirectory = projectDirectory,
+            AssetsDirectory = assetsDirectory,
+            MachinesDirectory = machinesDirectory,
+            GeneratedDirectory = generatedDirectory
+        };
     }
 
     private void EnsureProjectOverviewDocument()

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -18,9 +18,9 @@
 
 ### Editor Shell Separation
 - [x] Remove startup project-selection UI from editor shell
-- [ ] Ensure editor shell requires a valid loaded project at construction/open time
-- [ ] Ensure editor shell initializes correctly from an already-loaded project
-- [ ] Prevent editor shell from opening when no active project exists
+- [x] Ensure editor shell requires a valid loaded project at construction/open time
+- [x] Ensure editor shell initializes correctly from an already-loaded project
+- [x] Prevent editor shell from opening when no active project exists
 
 ### Close Project Flow
 - [ ] Add File > Close Project action


### PR DESCRIPTION
### Motivation
- Guarantee the editor shell is always launched with an active project so UI and domain code can assume a valid project context.  
- Move project create/open responsibilities fully into the `Launcher` to preserve the startup-flow separation.  
- Simplify error handling by failing early when the shell is constructed without a valid startup project rather than checking after construction.

### Description
- Require a non-empty startup project path in `MainWindow` by changing the constructor to `string startupProjectFilePath` and throwing when it is null/whitespace (`OasisEditor/MainWindow.xaml.cs`).  
- Require a non-empty startup project path in `MainWindowViewModel`, and immediately load and initialize shell state from that path via `LoadStartupProject(...)` (`OasisEditor/MainWindowViewModel.cs`).  
- Centralize project parsing/validation into `LoadProjectFromFile(...)` and reuse it from both startup loading and in-shell open logic (`OasisEditor/MainWindowViewModel.cs`).  
- Simplify launcher flow by removing the post-construction "ensure loaded" check and by invoking `MainWindow` with the validated project path, and remove project-create/open UI from the shell XAML so those actions remain in the `Launcher` (`OasisEditor/LauncherWindowViewModel.cs`, `OasisEditor/MainWindow.xaml`).  
- Update `TASKS.md` to mark the Editor Shell Separation checklist items as completed (`TASKS.md`).

### Testing
- Attempted to build with `dotnet build OasisEditor.sln` in the container, but the build could not run here because `dotnet` is not installed (error: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eaed5109208327b1edceb8acc86387)