### PR TITLE
Implement Close Project flow to return to Launcher

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -175,6 +175,8 @@
                           Command="{Binding OpenDocumentCommand}" />
                 <MenuItem Header="_Save Document"
                           Command="{Binding SaveSelectedDocumentCommand}" />
+                <MenuItem Header="_Close Project"
+                          Command="{Binding CloseProjectCommand}" />
                 <Separator />
                 <MenuItem Header="E_xit"
                           Command="{Binding ExitCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -70,6 +70,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         ApplyInspectorSummaryCommand = new RelayCommand(ApplyInspectorSummary, CanApplyInspectorSummary);
+        CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
 
         var preferences = _preferencesStore.Load();
@@ -102,6 +103,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ClosePreferencesCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
+    public ICommand CloseProjectCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
@@ -631,6 +633,45 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _projectSettingsWindow?.Close();
     }
 
+    private bool CanCloseProject()
+    {
+        return LoadedProject is not null;
+    }
+
+    private void CloseProject()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        ClosePreferences();
+        CloseProjectSettings();
+        ClearProjectSessionState();
+
+        var launcherWindow = new LauncherWindow(_applicationThemeService, _preferencesStore);
+        launcherWindow.Show();
+
+        _ownerWindow.Close();
+        Application.Current.MainWindow = launcherWindow;
+        launcherWindow.Activate();
+        launcherWindow.Focus();
+    }
+
+    private void ClearProjectSessionState()
+    {
+        _documentCommandService.History.Clear();
+        OpenDocuments.Clear();
+        SelectedDocument = null;
+
+        AssetBrowserItems.Clear();
+        SelectedAsset = null;
+
+        LoadedProject = null;
+        ProjectFilePath = string.Empty;
+        StatusMessage = "Project closed. Returned to Launcher.";
+    }
+
     private static void ExitApplication()
     {
         Application.Current.Shutdown();
@@ -1115,6 +1156,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (CloseSelectedDocumentCommand is RelayCommand closeRelayCommand)
         {
             closeRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (CloseProjectCommand is RelayCommand closeProjectRelayCommand)
+        {
+            closeProjectRelayCommand.RaiseCanExecuteChanged();
         }
 
         NotifyAssetBrowserCommand();

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -23,10 +23,10 @@
 - [x] Prevent editor shell from opening when no active project exists
 
 ### Close Project Flow
-- [ ] Add File > Close Project action
-- [ ] Close editor shell and return to Launcher window
-- [ ] Ensure closing a project clears active document/session state
-- [ ] Ensure Launcher refreshes recent projects after returning from editor shell
+- [x] Add File > Close Project action
+- [x] Close editor shell and return to Launcher window
+- [x] Ensure closing a project clears active document/session state
+- [x] Ensure Launcher refreshes recent projects after returning from editor shell
 
 ### Verification
 - [ ] Verify New Project opens editor correctly


### PR DESCRIPTION
### Motivation
- Provide a way for users to close the active project from the editor and return to the Launcher while clearing editor session state.
- Ensure the editor shell enforces the invariant of having an active project and that returning to the Launcher refreshes recent projects.

### Description
- Added `CloseProjectCommand` to `MainWindowViewModel` with a `CanCloseProject` check and wired its `RaiseCanExecuteChanged` lifecycle. (modified `MainWindowViewModel.cs`).
- Implemented `CloseProject` which closes secondary windows, clears document/session state (including command history), creates and shows a new `LauncherWindow`, and closes the editor shell; session-clearing logic extracted to `ClearProjectSessionState`. (modified `MainWindowViewModel.cs`).
- Added a `File → Close Project` menu item bound to the new command in `MainWindow.xaml`.
- Updated `TASKS.md` to mark the Close Project Flow items as completed.

### Testing
- Attempted `dotnet build OasisEditor.sln` but the command failed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- Verified repository changes and committed the changes with `git` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eaef7e60608327ad7bfaf6edbf3d26)