### PR TITLE
Improve document-scoped undo/redo robustness

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -97,27 +97,6 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new PropertyMetadata(false));
 
-    private static readonly DependencyProperty CommandServiceProperty =
-        DependencyProperty.RegisterAttached(
-            "CommandService",
-            typeof(CommandService),
-            typeof(CanvasPanBehavior),
-            new PropertyMetadata(null));
-
-    private static readonly DependencyProperty UndoCommandBindingProperty =
-        DependencyProperty.RegisterAttached(
-            "UndoCommandBinding",
-            typeof(CommandBinding),
-            typeof(CanvasPanBehavior),
-            new PropertyMetadata(null));
-
-    private static readonly DependencyProperty RedoCommandBindingProperty =
-        DependencyProperty.RegisterAttached(
-            "RedoCommandBinding",
-            typeof(CommandBinding),
-            typeof(CanvasPanBehavior),
-            new PropertyMetadata(null));
-
     private const double MinZoom = 0.25;
     private const double MaxZoom = 4.0;
     private const double ZoomStep = 1.1;
@@ -197,7 +176,6 @@ public static class CanvasPanBehavior
         if (isEnabled)
         {
             EnsureTransformGroup(element);
-            EnsureCommandBindings(element);
             element.MouseDown += OnMouseDown;
             element.MouseLeftButtonDown += OnMouseLeftButtonDown;
             element.MouseMove += OnMouseMove;
@@ -207,7 +185,6 @@ public static class CanvasPanBehavior
         }
         else
         {
-            RemoveCommandBindings(element);
             element.MouseDown -= OnMouseDown;
             element.MouseLeftButtonDown -= OnMouseLeftButtonDown;
             element.MouseMove -= OnMouseMove;
@@ -330,7 +307,12 @@ public static class CanvasPanBehavior
         System.Windows.Controls.Canvas.SetLeft(rectangle, x);
         System.Windows.Controls.Canvas.SetTop(rectangle, y);
         var previousSelection = (FrameworkElement?)panelCanvas.GetValue(SelectedElementProperty);
-        ExecuteCanvasMutation(panelCanvas, new AddRectangleMutationCommand(panelCanvas, rectangle, previousSelection, x, y));
+        if (panelCanvas.DataContext is not DocumentTabViewModel tab)
+        {
+            return;
+        }
+
+        ExecuteCanvasMutation(panelCanvas, new AddRectangleMutationCommand(tab.DocumentId, panelCanvas, rectangle, previousSelection, x, y));
     }
 
     private static void AddImage(FrameworkElement canvas, MouseButtonEventArgs eventArgs)
@@ -363,7 +345,12 @@ public static class CanvasPanBehavior
         Canvas.SetTop(image, y);
 
         var previousSelection = (FrameworkElement?)panelCanvas.GetValue(SelectedElementProperty);
-        ExecuteCanvasMutation(panelCanvas, new AddImageMutationCommand(panelCanvas, image, previousSelection, x, y));
+        if (panelCanvas.DataContext is not DocumentTabViewModel tab)
+        {
+            return;
+        }
+
+        ExecuteCanvasMutation(panelCanvas, new AddImageMutationCommand(tab.DocumentId, panelCanvas, image, previousSelection, x, y));
     }
 
     private static void OnMouseWheel(object sender, MouseWheelEventArgs eventArgs)
@@ -463,96 +450,18 @@ public static class CanvasPanBehavior
         return null;
     }
 
-    private static void EnsureCommandBindings(FrameworkElement element)
-    {
-        if ((CommandService?)element.GetValue(CommandServiceProperty) is null)
-        {
-            element.SetValue(CommandServiceProperty, new CommandService());
-        }
-
-        if ((CommandBinding?)element.GetValue(UndoCommandBindingProperty) is null)
-        {
-            var undoBinding = new CommandBinding(UndoCommand, OnUndoExecuted, OnUndoCanExecute);
-            element.CommandBindings.Add(undoBinding);
-            element.SetValue(UndoCommandBindingProperty, undoBinding);
-        }
-
-        if ((CommandBinding?)element.GetValue(RedoCommandBindingProperty) is null)
-        {
-            var redoBinding = new CommandBinding(RedoCommand, OnRedoExecuted, OnRedoCanExecute);
-            element.CommandBindings.Add(redoBinding);
-            element.SetValue(RedoCommandBindingProperty, redoBinding);
-        }
-    }
-
-    private static void RemoveCommandBindings(FrameworkElement element)
-    {
-        if ((CommandBinding?)element.GetValue(UndoCommandBindingProperty) is { } undoBinding)
-        {
-            element.CommandBindings.Remove(undoBinding);
-            element.ClearValue(UndoCommandBindingProperty);
-        }
-
-        if ((CommandBinding?)element.GetValue(RedoCommandBindingProperty) is { } redoBinding)
-        {
-            element.CommandBindings.Remove(redoBinding);
-            element.ClearValue(RedoCommandBindingProperty);
-        }
-    }
-
-    private static void OnUndoCanExecute(object sender, CanExecuteRoutedEventArgs eventArgs)
-    {
-        eventArgs.CanExecute = sender is FrameworkElement element && GetCommandService(element).CanUndo;
-        eventArgs.Handled = true;
-    }
-
-    private static void OnRedoCanExecute(object sender, CanExecuteRoutedEventArgs eventArgs)
-    {
-        eventArgs.CanExecute = sender is FrameworkElement element && GetCommandService(element).CanRedo;
-        eventArgs.Handled = true;
-    }
-
-    private static void OnUndoExecuted(object sender, ExecutedRoutedEventArgs eventArgs)
-    {
-        if (sender is not FrameworkElement element)
-        {
-            return;
-        }
-
-        GetCommandService(element).TryUndo();
-        eventArgs.Handled = true;
-    }
-
-    private static void OnRedoExecuted(object sender, ExecutedRoutedEventArgs eventArgs)
-    {
-        if (sender is not FrameworkElement element)
-        {
-            return;
-        }
-
-        GetCommandService(element).TryRedo();
-        eventArgs.Handled = true;
-    }
-
     private static void ExecuteCanvasMutation(FrameworkElement canvas, Commands.ICommand command)
     {
-        GetCommandService(canvas).Execute(command);
+        if (canvas.DataContext is not DocumentTabViewModel tab)
+        {
+            return;
+        }
+
+        tab.CommandService.Execute(command);
         if (canvas is Canvas panelCanvas)
         {
             SyncPanelLayout(panelCanvas);
         }
-    }
-
-    private static CommandService GetCommandService(FrameworkElement canvas)
-    {
-        if ((CommandService?)canvas.GetValue(CommandServiceProperty) is { } existing)
-        {
-            return existing;
-        }
-
-        var created = new CommandService();
-        canvas.SetValue(CommandServiceProperty, created);
-        return created;
     }
 
     private static ImageSource CreatePlaceholderImageSource()
@@ -738,22 +647,26 @@ public static class CanvasPanBehavior
         };
     }
 
-    private sealed class AddRectangleMutationCommand : Commands.ICommand
+    private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand
     {
+        private readonly Guid _documentId;
         private readonly Canvas _canvas;
         private readonly Rectangle _rectangle;
         private readonly FrameworkElement? _previousSelection;
         private readonly double _x;
         private readonly double _y;
 
-        public AddRectangleMutationCommand(Canvas canvas, Rectangle rectangle, FrameworkElement? previousSelection, double x, double y)
+        public AddRectangleMutationCommand(Guid documentId, Canvas canvas, Rectangle rectangle, FrameworkElement? previousSelection, double x, double y)
         {
+            _documentId = documentId;
             _canvas = canvas;
             _rectangle = rectangle;
             _previousSelection = previousSelection;
             _x = x;
             _y = y;
         }
+
+        public Guid DocumentId => _documentId;
 
         public string Description => "Add rectangle";
 
@@ -773,6 +686,7 @@ public static class CanvasPanBehavior
 
             SetIsSelected(_rectangle, true);
             _canvas.SetValue(SelectedElementProperty, _rectangle);
+            SyncPanelLayout(_canvas);
         }
 
         public void Undo()
@@ -788,25 +702,30 @@ public static class CanvasPanBehavior
             }
 
             _canvas.ClearValue(SelectedElementProperty);
+            SyncPanelLayout(_canvas);
         }
     }
 
-    private sealed class AddImageMutationCommand : Commands.ICommand
+    private sealed class AddImageMutationCommand : Commands.IDocumentCommand
     {
+        private readonly Guid _documentId;
         private readonly Canvas _canvas;
         private readonly Image _image;
         private readonly FrameworkElement? _previousSelection;
         private readonly double _x;
         private readonly double _y;
 
-        public AddImageMutationCommand(Canvas canvas, Image image, FrameworkElement? previousSelection, double x, double y)
+        public AddImageMutationCommand(Guid documentId, Canvas canvas, Image image, FrameworkElement? previousSelection, double x, double y)
         {
+            _documentId = documentId;
             _canvas = canvas;
             _image = image;
             _previousSelection = previousSelection;
             _x = x;
             _y = y;
         }
+
+        public Guid DocumentId => _documentId;
 
         public string Description => "Add image";
 
@@ -826,6 +745,7 @@ public static class CanvasPanBehavior
 
             SetIsSelected(_image, true);
             _canvas.SetValue(SelectedElementProperty, _image);
+            SyncPanelLayout(_canvas);
         }
 
         public void Undo()
@@ -841,6 +761,7 @@ public static class CanvasPanBehavior
             }
 
             _canvas.ClearValue(SelectedElementProperty);
+            SyncPanelLayout(_canvas);
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Commands/CommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Commands/CommandService.cs
@@ -6,15 +6,17 @@ namespace OasisEditor.Commands;
 public sealed class CommandService
 {
     private readonly CommandHistory _history;
+    private readonly Guid? _documentId;
 
     public CommandService()
-        : this(new CommandHistory())
+        : this(new CommandHistory(), null)
     {
     }
 
-    public CommandService(CommandHistory history)
+    public CommandService(CommandHistory history, Guid? documentId = null)
     {
         _history = history ?? throw new ArgumentNullException(nameof(history));
+        _documentId = documentId;
     }
 
     public CommandHistory History => _history;
@@ -26,6 +28,7 @@ public sealed class CommandService
     public void Execute(ICommand command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        ValidateDocumentOwnership(command);
 
         command.Execute();
         _history.RecordExecuted(command);
@@ -39,6 +42,7 @@ public sealed class CommandService
         }
 
         var command = _history.GetUndoCandidate();
+        ValidateDocumentOwnership(command);
         command.Undo();
         _history.MarkUndone();
         return true;
@@ -52,8 +56,22 @@ public sealed class CommandService
         }
 
         var command = _history.GetRedoCandidate();
+        ValidateDocumentOwnership(command);
         command.Execute();
         _history.MarkRedone();
         return true;
+    }
+
+    private void ValidateDocumentOwnership(ICommand command)
+    {
+        if (_documentId is null || command is not IDocumentCommand documentCommand)
+        {
+            return;
+        }
+
+        if (documentCommand.DocumentId != _documentId.Value)
+        {
+            throw new InvalidOperationException("Command document does not match this command history.");
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Commands/ICommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Commands/ICommand.cs
@@ -20,3 +20,11 @@ public interface ICommand
     /// </summary>
     void Undo();
 }
+
+/// <summary>
+/// Represents a command scoped to a specific document.
+/// </summary>
+public interface IDocumentCommand : ICommand
+{
+    Guid DocumentId { get; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Input;
 
 namespace OasisEditor;
 
@@ -16,6 +17,27 @@ public partial class MainWindow : Window
 
         InitializeComponent();
         EditorKeyboardShortcuts.RegisterWindowBindings(this);
-        DataContext = new MainWindowViewModel(applicationThemeService, preferencesStore, this, startupProjectFilePath);
+        var viewModel = new MainWindowViewModel(applicationThemeService, preferencesStore, this, startupProjectFilePath);
+        DataContext = viewModel;
+
+        CommandBindings.Add(new CommandBinding(CanvasPanBehavior.UndoCommand, (_, args) =>
+        {
+            viewModel.UndoActiveDocument();
+            args.Handled = true;
+        }, (_, args) =>
+        {
+            args.CanExecute = viewModel.CanUndoActiveDocument();
+            args.Handled = true;
+        }));
+
+        CommandBindings.Add(new CommandBinding(CanvasPanBehavior.RedoCommand, (_, args) =>
+        {
+            viewModel.RedoActiveDocument();
+            args.Handled = true;
+        }, (_, args) =>
+        {
+            args.CanExecute = viewModel.CanRedoActiveDocument();
+            args.Handled = true;
+        }));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -17,7 +17,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly RecentProjectsStore _recentProjectsStore = new();
     private readonly IApplicationThemeService _applicationThemeService;
     private readonly EditorPreferencesStore _preferencesStore;
-    private readonly EditorCommands.CommandService _documentCommandService = new();
+    private readonly EditorCommands.CommandService _shellCommandService = new();
     private readonly Window _ownerWindow;
     private string _projectName = string.Empty;
     private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
@@ -530,7 +530,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
             var updatedDocument = new DocumentTabViewModel(
                 current.Document.SaveAs(savePath, current.ContentSummary).MarkClean(),
-                current.PanelLayoutJson);
+                current.PanelLayoutJson,
+                current.DocumentId,
+                current.CommandService);
             ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, current, updatedDocument));
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}");
@@ -660,7 +662,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void ClearProjectSessionState()
     {
-        _documentCommandService.History.Clear();
+        _shellCommandService.History.Clear();
         OpenDocuments.Clear();
         SelectedDocument = null;
 
@@ -788,7 +790,27 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void ExecuteDocumentMutation(EditorCommands.ICommand command)
     {
-        _documentCommandService.Execute(command);
+        _shellCommandService.Execute(command);
+    }
+
+    public bool CanUndoActiveDocument()
+    {
+        return SelectedDocument?.CommandService.CanUndo ?? false;
+    }
+
+    public bool CanRedoActiveDocument()
+    {
+        return SelectedDocument?.CommandService.CanRedo ?? false;
+    }
+
+    public bool UndoActiveDocument()
+    {
+        return SelectedDocument?.CommandService.TryUndo() ?? false;
+    }
+
+    public bool RedoActiveDocument()
+    {
+        return SelectedDocument?.CommandService.TryRedo() ?? false;
     }
 
     private static OpenDocumentData BuildOpenDocumentData(string path, string content)
@@ -1216,7 +1238,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         var updated = new DocumentTabViewModel(
             SelectedDocument.Document.WithContentSummary(InspectorEditableSummary).MarkDirty(),
-            SelectedDocument.PanelLayoutJson);
+            SelectedDocument.PanelLayoutJson,
+            SelectedDocument.DocumentId,
+            SelectedDocument.CommandService);
 
         ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, SelectedDocument, updated));
         StatusMessage = $"Updated inspector summary for {updated.Title}";
@@ -1253,17 +1277,26 @@ internal readonly record struct OpenDocumentData(string Summary, string? PanelLa
 
 public sealed class DocumentTabViewModel : INotifyPropertyChanged
 {
+    private readonly EditorCommands.CommandService _commandService;
     private string? _panelLayoutJson;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public DocumentTabViewModel(EditorDocument document, string? panelLayoutJson = null)
+    public DocumentTabViewModel(
+        EditorDocument document,
+        string? panelLayoutJson = null,
+        Guid? documentId = null,
+        EditorCommands.CommandService? commandService = null)
     {
         Document = document;
+        DocumentId = documentId ?? Guid.NewGuid();
+        _commandService = commandService ?? new EditorCommands.CommandService(new EditorCommands.CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
     }
 
     public EditorDocument Document { get; }
+    public Guid DocumentId { get; }
+    public EditorCommands.CommandService CommandService => _commandService;
     public string Title => Document.IsDirty ? $"{Document.Title}*" : Document.Title;
     public string TypeLabel => Document.DocumentType switch
     {

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -3,11 +3,11 @@
 ## Current Focus — Editor Stability and Document Context
 
 ### Undo/Redo Robustness
-- [ ] Audit current command history ownership
-- [ ] Ensure each open document has its own command history
-- [ ] Ensure commands are bound to the document they were created for
-- [ ] Ensure undo only affects the active document
-- [ ] Ensure redo only affects the active document
+- [x] Audit current command history ownership
+- [x] Ensure each open document has its own command history
+- [x] Ensure commands are bound to the document they were created for
+- [x] Ensure undo only affects the active document
+- [x] Ensure redo only affects the active document
 - [ ] Clear redo stack only for the affected document when a new command is executed
 - [ ] Prevent commands from applying to a different active document after tab switching
 - [ ] Add document identity checks before command execute/undo/redo


### PR DESCRIPTION
### Motivation
- Fix undo/redo correctness by ensuring command history is owned per-open document so tab mutations and document edits do not share a single history. 
- Prevent commands created for one document from applying to a different document after tab switching. 
- Route global Undo/Redo input to the active document only while keeping shell-level tab mutation history separate.

### Description
- Introduce `IDocumentCommand` and extend the command contract to carry a `DocumentId`. 
- Add document ownership validation in `CommandService` so `Execute`, `TryUndo`, and `TryRedo` reject commands that do not match the service's `documentId`. 
- Give each `DocumentTabViewModel` a stable `DocumentId` and its own `CommandService` instance, and preserve those when replacing a tab's view-model. 
- Update `CanvasPanBehavior` to create `AddRectangle` / `AddImage` commands carrying the originating `DocumentId` and to execute mutations via the associated tab's `CommandService`. 
- Route the Undo/Redo routed commands at `MainWindow` to `MainWindowViewModel` helpers that operate on the `SelectedDocument`'s `CommandService`, and mark the first five tasks in `TASKS.md` as completed.

### Testing
- Attempted to run `dotnet build OasisEditor.sln` to validate compilation, but the environment lacks the .NET SDK and the build could not be executed (`dotnet: command not found`).
- No automated unit/integration tests were available or executed in this environment; changes are limited and focused to command history and canvas mutation wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eaf4a303ac8327a4508b730c66b824)