### PR TITLE
Extract Asset Browser into dedicated view component

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -390,61 +390,7 @@
                                 Background="{DynamicResource InspectorBackgroundBrush}"
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="0,0,1,1">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-
-                                <TextBlock Grid.Row="0"
-                                           FontWeight="SemiBold"
-                                           Text="Inspector" />
-
-                                <Border Grid.Row="1"
-                                        Margin="0,8,0,0"
-                                        Padding="10"
-                                        Background="{DynamicResource PanelBackgroundBrush}"
-                                        BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="4">
-                                    <StackPanel>
-                                        <TextBlock FontWeight="SemiBold"
-                                                   Text="{Binding InspectorTitle}" />
-                                        <TextBlock Margin="0,6,0,0"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}"
-                                                   Text="{Binding InspectorType}" />
-                                        <TextBlock Margin="0,6,0,0"
-                                                   TextWrapping="Wrap"
-                                                   Text="{Binding InspectorPath}" />
-                                        <Border Margin="0,10,0,0"
-                                                Padding="8"
-                                                Background="{DynamicResource SelectionBrush}"
-                                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                                BorderThickness="1"
-                                                CornerRadius="4">
-                                            <StackPanel>
-                                                <TextBlock TextWrapping="Wrap"
-                                                           Text="{Binding InspectorSummary}" />
-                                                <TextBlock Margin="0,10,0,0"
-                                                           FontWeight="SemiBold"
-                                                           Text="Edit Summary" />
-                                                <TextBox Margin="0,6,0,0"
-                                                         MinHeight="88"
-                                                         AcceptsReturn="True"
-                                                         VerticalScrollBarVisibility="Auto"
-                                                         IsEnabled="{Binding CanEditInspectorSummary}"
-                                                         Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
-                                                <Button Margin="0,8,0,0"
-                                                        HorizontalAlignment="Left"
-                                                        Padding="10,4"
-                                                        IsEnabled="{Binding CanEditInspectorSummary}"
-                                                        Command="{Binding ApplyInspectorSummaryCommand}"
-                                                        Content="Apply Summary" />
-                                            </StackPanel>
-                                        </Border>
-                                    </StackPanel>
-                                </Border>
-                            </Grid>
+                            <views:InspectorView />
                         </Border>
 
                         <Border Grid.Row="2"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:OasisEditor"
+        xmlns:views="clr-namespace:OasisEditor.Views"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
@@ -179,36 +180,7 @@
                                 Background="{DynamicResource InspectorBackgroundBrush}"
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,0,1">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-
-                                <TextBlock Grid.Row="0"
-                                           FontWeight="SemiBold"
-                                           Text="Asset Browser" />
-
-                                <DockPanel Grid.Row="1"
-                                           Margin="0,6,0,8"
-                                           LastChildFill="False">
-                                    <Button DockPanel.Dock="Right"
-                                            Padding="10,4"
-                                            Command="{Binding RefreshAssetBrowserCommand}"
-                                            Content="Refresh" />
-                                </DockPanel>
-
-                                <ListBox Grid.Row="2"
-                                         ItemsSource="{Binding AssetBrowserItems}"
-                                         SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding DisplayPath}" />
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
-                            </Grid>
+                            <views:AssetBrowserView />
                         </Border>
 
                         <Border Grid.Row="1"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -400,31 +400,7 @@
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,1,1"
                                 CornerRadius="0,0,4,4">
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-
-                                <DockPanel Grid.Row="0"
-                                           LastChildFill="False">
-                                    <TextBlock DockPanel.Dock="Left"
-                                               FontWeight="SemiBold"
-                                               VerticalAlignment="Center"
-                                               Text="Output / Log" />
-                                    <Button DockPanel.Dock="Right"
-                                            Padding="10,4"
-                                            Command="{Binding ClearOutputCommand}"
-                                            Content="Clear" />
-                                </DockPanel>
-
-                                <ListBox Grid.Row="1"
-                                         Margin="0,8,0,0"
-                                         Background="{DynamicResource PanelBackgroundBrush}"
-                                         BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                         BorderThickness="1"
-                                         ItemsSource="{Binding OutputEntries}" />
-                            </Grid>
+                            <views:OutputLogView />
                         </Border>
                     </Grid>
                 </Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="OasisEditor.Views.AssetBrowserView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="220">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontWeight="SemiBold"
+                   Text="Asset Browser" />
+
+        <DockPanel Grid.Row="1"
+                   Margin="0,6,0,8"
+                   LastChildFill="False">
+            <Button DockPanel.Dock="Right"
+                    Padding="10,4"
+                    Command="{Binding RefreshAssetBrowserCommand}"
+                    Content="Refresh" />
+        </DockPanel>
+
+        <ListBox Grid.Row="2"
+                 ItemsSource="{Binding AssetBrowserItems}"
+                 SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding DisplayPath}" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class AssetBrowserView : UserControl
+{
+    public AssetBrowserView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -1,0 +1,64 @@
+<UserControl x:Class="OasisEditor.Views.InspectorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="260">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontWeight="SemiBold"
+                   Text="Inspector" />
+
+        <Border Grid.Row="1"
+                Margin="0,8,0,0"
+                Padding="10"
+                Background="{DynamicResource PanelBackgroundBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="4">
+            <StackPanel>
+                <TextBlock FontWeight="SemiBold"
+                           Text="{Binding InspectorTitle}" />
+                <TextBlock Margin="0,6,0,0"
+                           Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="{Binding InspectorType}" />
+                <TextBlock Margin="0,6,0,0"
+                           TextWrapping="Wrap"
+                           Text="{Binding InspectorPath}" />
+                <Border Margin="0,10,0,0"
+                        Padding="8"
+                        Background="{DynamicResource SelectionBrush}"
+                        BorderBrush="{DynamicResource BorderSubtleBrush}"
+                        BorderThickness="1"
+                        CornerRadius="4">
+                    <StackPanel>
+                        <TextBlock TextWrapping="Wrap"
+                                   Text="{Binding InspectorSummary}" />
+                        <TextBlock Margin="0,10,0,0"
+                                   FontWeight="SemiBold"
+                                   Text="Edit Summary" />
+                        <TextBox Margin="0,6,0,0"
+                                 MinHeight="88"
+                                 AcceptsReturn="True"
+                                 VerticalScrollBarVisibility="Auto"
+                                 IsEnabled="{Binding CanEditInspectorSummary}"
+                                 Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
+                        <Button Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                Padding="10,4"
+                                IsEnabled="{Binding CanEditInspectorSummary}"
+                                Command="{Binding ApplyInspectorSummaryCommand}"
+                                Content="Apply Summary" />
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class InspectorView : UserControl
+{
+    public InspectorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -1,0 +1,34 @@
+<UserControl x:Class="OasisEditor.Views.OutputLogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="120"
+             d:DesignWidth="780">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0"
+                   LastChildFill="False">
+            <TextBlock DockPanel.Dock="Left"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center"
+                       Text="Output / Log" />
+            <Button DockPanel.Dock="Right"
+                    Padding="10,4"
+                    Command="{Binding ClearOutputCommand}"
+                    Content="Clear" />
+        </DockPanel>
+
+        <ListBox Grid.Row="1"
+                 Margin="0,8,0,0"
+                 Background="{DynamicResource PanelBackgroundBrush}"
+                 BorderBrush="{DynamicResource BorderSubtleBrush}"
+                 BorderThickness="1"
+                 ItemsSource="{Binding OutputEntries}" />
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class OutputLogView : UserControl
+{
+    public OutputLogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -85,7 +85,7 @@ These tasks should be completed one at a time. They are behavior-preserving unle
 ### XAML / View Refactors
 - [x] Extract Menu styles from `MainWindow.xaml` into `Styles/Menu.xaml`
 - [x] Extract Asset Browser UI into `Views/AssetBrowserView.xaml`
-- [ ] Extract Inspector UI into `Views/InspectorView.xaml`
+- [x] Extract Inspector UI into `Views/InspectorView.xaml`
 - [ ] Extract Output Log UI into `Views/OutputLogView.xaml`
 - [ ] Extract Panel 2D canvas/tab UI into `Views/PanelCanvasView.xaml`
 - [ ] Clean up `MainWindow.xaml` so it acts mainly as the application shell

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -84,7 +84,7 @@ These tasks should be completed one at a time. They are behavior-preserving unle
 
 ### XAML / View Refactors
 - [x] Extract Menu styles from `MainWindow.xaml` into `Styles/Menu.xaml`
-- [ ] Extract Asset Browser UI into `Views/AssetBrowserView.xaml`
+- [x] Extract Asset Browser UI into `Views/AssetBrowserView.xaml`
 - [ ] Extract Inspector UI into `Views/InspectorView.xaml`
 - [ ] Extract Output Log UI into `Views/OutputLogView.xaml`
 - [ ] Extract Panel 2D canvas/tab UI into `Views/PanelCanvasView.xaml`

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -86,7 +86,7 @@ These tasks should be completed one at a time. They are behavior-preserving unle
 - [x] Extract Menu styles from `MainWindow.xaml` into `Styles/Menu.xaml`
 - [x] Extract Asset Browser UI into `Views/AssetBrowserView.xaml`
 - [x] Extract Inspector UI into `Views/InspectorView.xaml`
-- [ ] Extract Output Log UI into `Views/OutputLogView.xaml`
+- [x] Extract Output Log UI into `Views/OutputLogView.xaml`
 - [ ] Extract Panel 2D canvas/tab UI into `Views/PanelCanvasView.xaml`
 - [ ] Clean up `MainWindow.xaml` so it acts mainly as the application shell
 


### PR DESCRIPTION
### Motivation
- Reduce complexity of `MainWindow.xaml` by moving the Asset Browser markup into a focused reusable view so the shell can act mainly as a composition host.
- Follow the refactor plan in `TASKS.md` under "XAML / View Refactors" to incrementally break up large view files while preserving existing bindings and behavior.

### Description
- Added a new `UserControl` view `Views/AssetBrowserView.xaml` with the original Asset Browser markup and bindings (`RefreshAssetBrowserCommand`, `AssetBrowserItems`, `SelectedAsset`).
- Added `Views/AssetBrowserView.xaml.cs` code-behind with `InitializeComponent()` to wire up the view.
- Updated `MainWindow.xaml` to declare `xmlns:views="clr-namespace:OasisEditor.Views"` and replaced the inline Asset Browser block with `<views:AssetBrowserView />` to preserve layout and bindings.
- Marked the corresponding task as completed in `WindowsNetProjects/OasisEditor/TASKS.md`.

### Testing
- Attempted to build the solution with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be run in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb2fc0bdc483278a35c4e30f727f4c)