### PR TITLE
Refactor MainWindow into a lean shell and extract EditorShellView

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -25,7 +25,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -93,129 +92,9 @@
             </ToolBar>
         </ToolBarTray>
 
-        <Border Grid.Row="2"
-                Padding="16"
-                Margin="0,0,0,12"
-                CornerRadius="6"
-                Background="{DynamicResource PanelBackgroundBrush}">
-            <StackPanel>
-                <TextBlock FontSize="22"
-                           FontWeight="SemiBold"
-                           Foreground="{DynamicResource TextPrimaryBrush}"
-                           Text="Oasis Editor" />
-                <TextBlock Margin="0,4,0,0"
-                           Foreground="{DynamicResource TextSecondaryBrush}"
-                           Text="Slot machine content authoring shell" />
-            </StackPanel>
-        </Border>
+        <views:EditorShellView Grid.Row="2" />
 
-        <Grid Grid.Row="3">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <GroupBox Grid.Column="0" Header="Editor Shell" Padding="10">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-
-                    <Border Grid.Row="0"
-                            Padding="10"
-                            Margin="0,0,0,10"
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource BorderSubtleBrush}"
-                            CornerRadius="4">
-                        <TextBlock TextWrapping="Wrap"
-                                   Foreground="{DynamicResource TextSecondaryBrush}"
-                                   Text="{Binding StatusMessage}" />
-                    </Border>
-
-                    <Border Grid.Row="1"
-                            Padding="10"
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource BorderSubtleBrush}"
-                            CornerRadius="4">
-                        <StackPanel>
-                            <TextBlock FontWeight="SemiBold"
-                                       Text="Loaded project" />
-                            <TextBlock Margin="0,4,0,0"
-                                       Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded.}" />
-                            <TextBlock Margin="0,2,0,0"
-                                       Foreground="{DynamicResource TextSecondaryBrush}"
-                                       Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project to load the editor shell.}" />
-                        </StackPanel>
-                    </Border>
-
-                    <Grid Grid.Row="2"
-                          Margin="0,10,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="36" />
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="120" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="220" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="260" />
-                        </Grid.ColumnDefinitions>
-
-                        <Border Grid.Row="0"
-                                Grid.ColumnSpan="3"
-                                Padding="10,6"
-                                Background="{DynamicResource ToolBarBackgroundBrush}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4,4,0,0">
-                            <TextBlock VerticalAlignment="Center"
-                                       FontWeight="SemiBold"
-                                       Text="Dock Layout (Phase 2 MVP)" />
-                        </Border>
-
-                        <Border Grid.Row="1"
-                                Grid.Column="0"
-                                Padding="10"
-                                Background="{DynamicResource InspectorBackgroundBrush}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="1,0,0,1">
-                            <views:AssetBrowserView />
-                        </Border>
-
-                        <Border Grid.Row="1"
-                                Grid.Column="1"
-                                Padding="10"
-                                Background="{DynamicResource PanelBackgroundBrush}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="1,0,1,1">
-                            <views:PanelCanvasView />
-                        </Border>
-
-                        <Border Grid.Row="1"
-                                Grid.Column="2"
-                                Padding="10"
-                                Background="{DynamicResource InspectorBackgroundBrush}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="0,0,1,1">
-                            <views:InspectorView />
-                        </Border>
-
-                        <Border Grid.Row="2"
-                                Grid.ColumnSpan="3"
-                                Padding="10"
-                                Background="{DynamicResource ToolBarBackgroundBrush}"
-                                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                                BorderThickness="1,0,1,1"
-                                CornerRadius="0,0,4,4">
-                            <views:OutputLogView />
-                        </Border>
-                    </Grid>
-                </Grid>
-            </GroupBox>
-        </Grid>
-
-        <StatusBar Grid.Row="4"
+        <StatusBar Grid.Row="3"
                    Margin="0,12,0,0"
                    Background="{DynamicResource ToolBarBackgroundBrush}"
                    Foreground="{DynamicResource TextPrimaryBrush}">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -1,0 +1,139 @@
+<UserControl x:Class="OasisEditor.Views.EditorShellView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="900">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Padding="16"
+                Margin="0,0,0,12"
+                CornerRadius="6"
+                Background="{DynamicResource PanelBackgroundBrush}">
+            <StackPanel>
+                <TextBlock FontSize="22"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource TextPrimaryBrush}"
+                           Text="Oasis Editor" />
+                <TextBlock Margin="0,4,0,0"
+                           Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="Slot machine content authoring shell" />
+            </StackPanel>
+        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <GroupBox Grid.Column="0"
+                      Header="Editor Shell"
+                      Padding="10">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Border Grid.Row="0"
+                            Padding="10"
+                            Margin="0,0,0,10"
+                            BorderThickness="1"
+                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                            CornerRadius="4">
+                        <TextBlock TextWrapping="Wrap"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   Text="{Binding StatusMessage}" />
+                    </Border>
+
+                    <Border Grid.Row="1"
+                            Padding="10"
+                            BorderThickness="1"
+                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                            CornerRadius="4">
+                        <StackPanel>
+                            <TextBlock FontWeight="SemiBold"
+                                       Text="Loaded project" />
+                            <TextBlock Margin="0,4,0,0"
+                                       Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded.}" />
+                            <TextBlock Margin="0,2,0,0"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project to load the editor shell.}" />
+                        </StackPanel>
+                    </Border>
+
+                    <Grid Grid.Row="2"
+                          Margin="0,10,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="36" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="120" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="220" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="260" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border Grid.Row="0"
+                                Grid.ColumnSpan="3"
+                                Padding="10,6"
+                                Background="{DynamicResource ToolBarBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4,4,0,0">
+                            <TextBlock VerticalAlignment="Center"
+                                       FontWeight="SemiBold"
+                                       Text="Dock Layout (Phase 2 MVP)" />
+                        </Border>
+
+                        <Border Grid.Row="1"
+                                Grid.Column="0"
+                                Padding="10"
+                                Background="{DynamicResource InspectorBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                BorderThickness="1,0,0,1">
+                            <AssetBrowserView />
+                        </Border>
+
+                        <Border Grid.Row="1"
+                                Grid.Column="1"
+                                Padding="10"
+                                Background="{DynamicResource PanelBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                BorderThickness="1,0,1,1">
+                            <PanelCanvasView />
+                        </Border>
+
+                        <Border Grid.Row="1"
+                                Grid.Column="2"
+                                Padding="10"
+                                Background="{DynamicResource InspectorBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                BorderThickness="0,0,1,1">
+                            <InspectorView />
+                        </Border>
+
+                        <Border Grid.Row="2"
+                                Grid.ColumnSpan="3"
+                                Padding="10"
+                                Background="{DynamicResource ToolBarBackgroundBrush}"
+                                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                BorderThickness="1,0,1,1"
+                                CornerRadius="0,0,4,4">
+                            <OutputLogView />
+                        </Border>
+                    </Grid>
+                </Grid>
+            </GroupBox>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:views="clr-namespace:OasisEditor.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="450"
@@ -101,7 +102,7 @@
                                 Background="{DynamicResource InspectorBackgroundBrush}"
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,0,1">
-                            <AssetBrowserView />
+                            <views:AssetBrowserView />
                         </Border>
 
                         <Border Grid.Row="1"
@@ -110,7 +111,7 @@
                                 Background="{DynamicResource PanelBackgroundBrush}"
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,1,1">
-                            <PanelCanvasView />
+                            <views:PanelCanvasView />
                         </Border>
 
                         <Border Grid.Row="1"
@@ -119,7 +120,7 @@
                                 Background="{DynamicResource InspectorBackgroundBrush}"
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="0,0,1,1">
-                            <InspectorView />
+                            <views:InspectorView />
                         </Border>
 
                         <Border Grid.Row="2"
@@ -129,7 +130,7 @@
                                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                                 BorderThickness="1,0,1,1"
                                 CornerRadius="0,0,4,4">
-                            <OutputLogView />
+                            <views:OutputLogView />
                         </Border>
                     </Grid>
                 </Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class EditorShellView : UserControl
+{
+    public EditorShellView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -88,7 +88,7 @@ These tasks should be completed one at a time. They are behavior-preserving unle
 - [x] Extract Inspector UI into `Views/InspectorView.xaml`
 - [x] Extract Output Log UI into `Views/OutputLogView.xaml`
 - [x] Extract Panel 2D canvas/tab UI into `Views/PanelCanvasView.xaml`
-- [ ] Clean up `MainWindow.xaml` so it acts mainly as the application shell
+- [x] Clean up `MainWindow.xaml` so it acts mainly as the application shell
 
 ### ViewModel Refactors
 - [ ] Move `DocumentTabViewModel` into `ViewModels/DocumentTabViewModel.cs`


### PR DESCRIPTION
### Motivation
- Reduce the responsibility of `MainWindow.xaml` so it acts primarily as the application shell per the XAML/View Refactors checklist. 
- Improve maintainability by extracting a cohesive editor content region into a reusable UserControl to enable future view and ViewModel splits. 

### Description
- Added `Views/EditorShellView.xaml` and `Views/EditorShellView.xaml.cs` and moved the editor body (branding banner, status/loaded project block, dock layout and Asset/Canvas/Inspector/Output regions) from `MainWindow.xaml` into this new UserControl. 
- Updated `MainWindow.xaml` to host the extracted view via `<views:EditorShellView />` and adjusted its grid rows so `MainWindow` retains menu, toolbar, and status bar only. 
- Preserved existing bindings and child view usage (`AssetBrowserView`, `PanelCanvasView`, `InspectorView`, `OutputLogView`) so behavior and layout remain unchanged. 
- Marked the TASKS.md item for cleaning up `MainWindow.xaml` as complete. 

### Testing
- Attempted to build the solution with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the command failed in this environment because `dotnet` is not available (`bash: command not found: dotnet`). 
- No other automated test suites were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb3abe93e8832788e3a7d29ec895dd)