### PR TITLE
Phase 1: Minimal AvalonDock integration in main editor shell

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:OasisEditor"
         xmlns:views="clr-namespace:OasisEditor.Views"
+        xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
@@ -92,7 +93,37 @@
             </ToolBar>
         </ToolBarTray>
 
-        <views:EditorShellView Grid.Row="2" />
+        <xcad:DockingManager Grid.Row="2">
+            <xcad:LayoutRoot>
+                <xcad:LayoutPanel Orientation="Horizontal">
+                    <xcad:LayoutDocumentPaneGroup>
+                        <xcad:LayoutDocumentPane>
+                            <xcad:LayoutDocument Title="Document"
+                                                 CanClose="False"
+                                                 CanFloat="False">
+                                <Border Padding="10"
+                                        Background="{DynamicResource PanelBackgroundBrush}">
+                                    <views:PanelCanvasView />
+                                </Border>
+                            </xcad:LayoutDocument>
+                        </xcad:LayoutDocumentPane>
+                    </xcad:LayoutDocumentPaneGroup>
+
+                    <xcad:LayoutAnchorablePane DockWidth="300">
+                        <xcad:LayoutAnchorable Title="Inspector"
+                                               CanAutoHide="False"
+                                               CanClose="False"
+                                               CanHide="False"
+                                               CanFloat="False">
+                            <Border Padding="10"
+                                    Background="{DynamicResource InspectorBackgroundBrush}">
+                                <views:InspectorView />
+                            </Border>
+                        </xcad:LayoutAnchorable>
+                    </xcad:LayoutAnchorablePane>
+                </xcad:LayoutPanel>
+            </xcad:LayoutRoot>
+        </xcad:DockingManager>
 
         <StatusBar Grid.Row="3"
                    Margin="0,12,0,0"
@@ -100,7 +131,7 @@
                    Foreground="{DynamicResource TextPrimaryBrush}">
             <StatusBarItem Content="Ready" />
             <Separator />
-            <StatusBarItem Content="Phase 3A: Theme Foundations" />
+            <StatusBarItem Content="Phase 1: AvalonDock minimal integration" />
         </StatusBar>
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:OasisEditor"
         xmlns:views="clr-namespace:OasisEditor.Views"
-        xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
+        xmlns:avalonDock="clr-namespace:AvalonDock;assembly=Dirkster.AvalonDock"
+        xmlns:avalonLayout="clr-namespace:AvalonDock.Layout;assembly=Dirkster.AvalonDock"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
@@ -93,24 +94,24 @@
             </ToolBar>
         </ToolBarTray>
 
-        <xcad:DockingManager Grid.Row="2">
-            <xcad:LayoutRoot>
-                <xcad:LayoutPanel Orientation="Horizontal">
-                    <xcad:LayoutDocumentPaneGroup>
-                        <xcad:LayoutDocumentPane>
-                            <xcad:LayoutDocument Title="Document"
+        <avalonDock:DockingManager Grid.Row="2">
+            <avalonLayout:LayoutRoot>
+                <avalonLayout:LayoutPanel Orientation="Horizontal">
+                    <avalonLayout:LayoutDocumentPaneGroup>
+                        <avalonLayout:LayoutDocumentPane>
+                            <avalonLayout:LayoutDocument Title="Document"
                                                  CanClose="False"
                                                  CanFloat="False">
                                 <Border Padding="10"
                                         Background="{DynamicResource PanelBackgroundBrush}">
                                     <views:PanelCanvasView />
                                 </Border>
-                            </xcad:LayoutDocument>
-                        </xcad:LayoutDocumentPane>
-                    </xcad:LayoutDocumentPaneGroup>
+                            </avalonLayout:LayoutDocument>
+                        </avalonLayout:LayoutDocumentPane>
+                    </avalonLayout:LayoutDocumentPaneGroup>
 
-                    <xcad:LayoutAnchorablePane DockWidth="300">
-                        <xcad:LayoutAnchorable Title="Inspector"
+                    <avalonLayout:LayoutAnchorablePane DockWidth="300">
+                        <avalonLayout:LayoutAnchorable Title="Inspector"
                                                CanAutoHide="False"
                                                CanClose="False"
                                                CanHide="False"
@@ -119,11 +120,11 @@
                                     Background="{DynamicResource InspectorBackgroundBrush}">
                                 <views:InspectorView />
                             </Border>
-                        </xcad:LayoutAnchorable>
-                    </xcad:LayoutAnchorablePane>
-                </xcad:LayoutPanel>
-            </xcad:LayoutRoot>
-        </xcad:DockingManager>
+                        </avalonLayout:LayoutAnchorable>
+                    </avalonLayout:LayoutAnchorablePane>
+                </avalonLayout:LayoutPanel>
+            </avalonLayout:LayoutRoot>
+        </avalonDock:DockingManager>
 
         <StatusBar Grid.Row="3"
                    Margin="0,12,0,0"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -4,8 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:OasisEditor"
         xmlns:views="clr-namespace:OasisEditor.Views"
-        xmlns:avalonDock="clr-namespace:AvalonDock;assembly=Dirkster.AvalonDock"
-        xmlns:avalonLayout="clr-namespace:AvalonDock.Layout;assembly=Dirkster.AvalonDock"
+        xmlns:xcad="clr-namespace:Xceed.Wpf.AvalonDock;assembly=Xceed.Wpf.AvalonDock"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"
@@ -94,24 +93,24 @@
             </ToolBar>
         </ToolBarTray>
 
-        <avalonDock:DockingManager Grid.Row="2">
-            <avalonLayout:LayoutRoot>
-                <avalonLayout:LayoutPanel Orientation="Horizontal">
-                    <avalonLayout:LayoutDocumentPaneGroup>
-                        <avalonLayout:LayoutDocumentPane>
-                            <avalonLayout:LayoutDocument Title="Document"
+        <xcad:DockingManager Grid.Row="2">
+            <xcad:LayoutRoot>
+                <xcad:LayoutPanel Orientation="Horizontal">
+                    <xcad:LayoutDocumentPaneGroup>
+                        <xcad:LayoutDocumentPane>
+                            <xcad:LayoutDocument Title="Document"
                                                  CanClose="False"
                                                  CanFloat="False">
                                 <Border Padding="10"
                                         Background="{DynamicResource PanelBackgroundBrush}">
                                     <views:PanelCanvasView />
                                 </Border>
-                            </avalonLayout:LayoutDocument>
-                        </avalonLayout:LayoutDocumentPane>
-                    </avalonLayout:LayoutDocumentPaneGroup>
+                            </xcad:LayoutDocument>
+                        </xcad:LayoutDocumentPane>
+                    </xcad:LayoutDocumentPaneGroup>
 
-                    <avalonLayout:LayoutAnchorablePane DockWidth="300">
-                        <avalonLayout:LayoutAnchorable Title="Inspector"
+                    <xcad:LayoutAnchorablePane DockWidth="300">
+                        <xcad:LayoutAnchorable Title="Inspector"
                                                CanAutoHide="False"
                                                CanClose="False"
                                                CanHide="False"
@@ -120,11 +119,11 @@
                                     Background="{DynamicResource InspectorBackgroundBrush}">
                                 <views:InspectorView />
                             </Border>
-                        </avalonLayout:LayoutAnchorable>
-                    </avalonLayout:LayoutAnchorablePane>
-                </avalonLayout:LayoutPanel>
-            </avalonLayout:LayoutRoot>
-        </avalonDock:DockingManager>
+                        </xcad:LayoutAnchorable>
+                    </xcad:LayoutAnchorablePane>
+                </xcad:LayoutPanel>
+            </xcad:LayoutRoot>
+        </xcad:DockingManager>
 
         <StatusBar Grid.Row="3"
                    Margin="0,12,0,0"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:local="clr-namespace:OasisEditor"
         xmlns:views="clr-namespace:OasisEditor.Views"
-        xmlns:xcad="clr-namespace:Xceed.Wpf.AvalonDock;assembly=Xceed.Wpf.AvalonDock"
+        xmlns:xcad="https://github.com/Dirkster99/AvalonDock"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         Title="Oasis Editor"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -8,4 +8,9 @@
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
+
+  <ItemGroup>
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
+  </ItemGroup>
+
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.74.0" />
   </ItemGroup>
 
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Dirkster.AvalonDock" Version="4.74.0" />
+    <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
   </ItemGroup>
 
 </Project>

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -5,10 +5,10 @@
 ### Docking Framework Integration (AvalonDock)
 
 #### Phase 1 — Minimal Integration
-- [ ] Add AvalonDock via NuGet
-- [ ] Replace main window layout with DockingManager
-- [ ] Create central document pane
-- [ ] Add one tool window (Inspector) docked to the right
+- [x] Add AvalonDock via NuGet
+- [x] Replace main window layout with DockingManager
+- [x] Create central document pane
+- [x] Add one tool window (Inspector) docked to the right
 - [ ] Ensure app builds and runs
 
 #### Phase 2 — Tool Window Expansion


### PR DESCRIPTION
### Motivation
- Integrate a minimal docking framework into the editor shell per `TASKS.md` Phase 1 to provide a central document area and a single tool window while keeping the change surface small. 
- Keep docking framework usage isolated to the WPF shell and avoid refactoring unrelated subsystems. 

### Description
- Added a `PackageReference` for `Dirkster.AvalonDock` to `OasisEditor/OasisEditor.csproj`. 
- Replaced the previous editor shell content in `MainWindow.xaml` with a `DockingManager` and `LayoutRoot`, adding a `LayoutDocumentPane` hosting `PanelCanvasView` as the central document area. 
- Added a right-docked `LayoutAnchorable` titled `Inspector` hosting `InspectorView` and set docking flags to prevent float/close/hide for this minimal phase. 
- Updated `TASKS.md` to mark the Phase 1 checklist items completed and kept other UI and project structure unchanged. 

### Testing
- Attempted to add the NuGet package with `dotnet add OasisEditor/OasisEditor.csproj package Dirkster.AvalonDock`, but the `dotnet` CLI is not available in this environment so the command failed. 
- Attempted to build with `dotnet build OasisEditor.sln`, but the `dotnet` CLI is not available so the build could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb542857d883279cae4f412b8acc2c)