### PR TITLE
Remove top quick toolbar and editor intro banner

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -24,7 +24,6 @@
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -70,31 +69,9 @@
             </MenuItem>
         </Menu>
 
-        <ToolBarTray Grid.Row="1"
-                     Margin="0,0,0,12"
-                     Background="{DynamicResource ToolBarBackgroundBrush}">
-            <ToolBar Band="0"
-                     BandIndex="0">
-                <Button Command="{Binding OpenPanel2DStubCommand}"
-                        Content="New Panel2D" />
-                <Button Command="{Binding OpenCabinet3DStubCommand}"
-                        Content="New Cabinet3D" />
-                <Button Command="{Binding OpenMachineStubCommand}"
-                        Content="New Machine" />
-                <Separator />
-                <Button Command="{Binding OpenDocumentCommand}"
-                        Content="Open Document" />
-                <Button Command="{Binding SaveSelectedDocumentCommand}"
-                        Content="Save Document" />
-                <Separator />
-                <Button Command="{Binding ExitCommand}"
-                        Content="Exit" />
-            </ToolBar>
-        </ToolBarTray>
+        <views:EditorShellView Grid.Row="1" />
 
-        <views:EditorShellView Grid.Row="2" />
-
-        <StatusBar Grid.Row="3"
+        <StatusBar Grid.Row="2"
                    Margin="0,12,0,0"
                    Background="{DynamicResource ToolBarBackgroundBrush}"
                    Foreground="{DynamicResource TextPrimaryBrush}">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -11,36 +11,7 @@
              d:DesignHeight="450"
              d:DesignWidth="900">
     <Grid Background="{DynamicResource EditorBackgroundBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <Border Grid.Row="0"
-                Padding="16"
-                Margin="0,0,0,12"
-                CornerRadius="6"
-                Background="{DynamicResource PanelBackgroundBrush}"
-                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                BorderThickness="1">
-            <StackPanel>
-                <TextBlock FontSize="22"
-                           FontWeight="SemiBold"
-                           Foreground="{DynamicResource TextPrimaryBrush}"
-                           Text="Oasis Editor" />
-                <TextBlock Margin="0,4,0,0"
-                           Foreground="{DynamicResource TextSecondaryBrush}"
-                           Text="Slot machine content authoring shell" />
-                <TextBlock Margin="0,8,0,0"
-                           Foreground="{DynamicResource TextSecondaryBrush}"
-                           Text="{Binding StatusMessage}" />
-                <TextBlock Margin="0,4,0,0"
-                           Foreground="{DynamicResource TextSecondaryBrush}"
-                           Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project to load the editor shell.}" />
-            </StackPanel>
-        </Border>
-
-        <avalonDock:DockingManager Grid.Row="1"
+        <avalonDock:DockingManager
                                    Background="{DynamicResource EditorBackgroundBrush}">
             <avalonDock:DockingManager.Resources>
                 <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />


### PR DESCRIPTION
### Motivation
- Declutter the main Editor window by removing the top quick-action toolbar and the intro/header banner so the docked editor workspace starts immediately under the menu.
- Match the provided screenshot by removing the two UI elements that occupy the top of the editor area and reflow the remaining layout.

### Description
- Removed the `ToolBarTray` (quick-action toolbar containing New/Open/Save/Exit buttons) from `MainWindow.xaml` and adjusted grid row assignments so the editor shell and status bar remain correctly placed.
- Removed the intro/header `Border` block (title, subtitle, status and project-path text) from `Views/EditorShellView.xaml` so the `avalonDock:DockingManager` begins at the top of the shell area.
- Updated XAML layout rows and bindings to keep the `views:EditorShellView` and `StatusBar` aligned after the removals.

### Testing
- Attempted to run an automated build with `dotnet build OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No other automated tests were run in this environment due to toolchain limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eba3f0b77c8327bec93c50bdd2254f)