### PR TITLE
Remove redundant Properties placeholder pane from EditorShellView

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -55,20 +55,6 @@
                                 </Border>
                             </layout:LayoutAnchorable>
 
-                            <layout:LayoutAnchorable Title="Properties Placeholder"
-                                                     ContentId="PropertiesPlaceholder">
-                                <Border Padding="12"
-                                        Background="{DynamicResource InspectorBackgroundBrush}">
-                                    <StackPanel>
-                                        <TextBlock FontWeight="SemiBold"
-                                                   Text="Properties" />
-                                        <TextBlock Margin="0,8,0,0"
-                                                   TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}"
-                                                   Text="Placeholder dock panel for future property grid content." />
-                                    </StackPanel>
-                                </Border>
-                            </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 


### PR DESCRIPTION
### Motivation
- The project already has a Unity-style `Inspector` pane, so the separate "Properties" placeholder dock panel in the main editor layout is redundant and should be removed to clean up the UI.

### Description
- Removed the `layout:LayoutAnchorable` block titled "Properties Placeholder" from `WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml`, deleting the placeholder text/content and leaving the existing `Inspector` pane unchanged.

### Testing
- Verified removal with a search for the placeholder strings using `rg` and confirmed no remaining occurrences in `EditorShellView.xaml`; the grep check succeeded. 
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` but the build could not run in this environment because the .NET SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eba5a9c5248327990a427f5a45561c)