### PR TITLE
Use standard OS-style top bar menu in OasisEditor

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -34,8 +34,6 @@
                                  Value="TopLevelHeader">
                             <Setter Property="Padding"
                                     Value="6,0" />
-                            <Setter Property="Height"
-                                    Value="22" />
                             <Setter Property="MinWidth"
                                     Value="0" />
                             <Setter Property="Margin"
@@ -45,8 +43,6 @@
                                  Value="TopLevelItem">
                             <Setter Property="Padding"
                                     Value="6,0" />
-                            <Setter Property="Height"
-                                    Value="22" />
                             <Setter Property="MinWidth"
                                     Value="0" />
                             <Setter Property="Margin"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -21,18 +21,27 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
-              MinHeight="28"
               Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
               Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               BorderThickness="0,0,0,1"
               Padding="0">
-            <Menu.ItemContainerStyle>
+            <Menu.Resources>
                 <Style TargetType="{x:Type MenuItem}">
-                    <Setter Property="Padding"
-                            Value="8,4" />
+                    <Style.Triggers>
+                        <Trigger Property="Role"
+                                 Value="TopLevelHeader">
+                            <Setter Property="Padding"
+                                    Value="4,1" />
+                        </Trigger>
+                        <Trigger Property="Role"
+                                 Value="TopLevelItem">
+                            <Setter Property="Padding"
+                                    Value="4,1" />
+                        </Trigger>
+                    </Style.Triggers>
                 </Style>
-            </Menu.ItemContainerStyle>
+            </Menu.Resources>
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -13,14 +13,6 @@
         MinWidth="900"
         Background="{DynamicResource EditorBackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}">
-    <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Styles/Menu.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Window.Resources>
-
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -29,13 +21,7 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
-              Style="{StaticResource EditorMenuStyle}"
-              ItemContainerStyle="{StaticResource EditorMenuItemStyle}"
               Margin="0,0,0,12">
-            <Menu.Resources>
-                <Style TargetType="{x:Type MenuItem}"
-                       BasedOn="{StaticResource EditorMenuItemStyle}" />
-            </Menu.Resources>
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -13,7 +13,7 @@
         MinWidth="900"
         Background="{DynamicResource EditorBackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}">
-    <Grid Margin="16">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -21,7 +21,11 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
-              Margin="0,0,0,12">
+              Background="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"
+              Foreground="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}"
+              BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+              BorderThickness="0,0,0,1"
+              Padding="0">
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />
@@ -55,10 +59,11 @@
             </MenuItem>
         </Menu>
 
-        <views:EditorShellView Grid.Row="1" />
+        <views:EditorShellView Grid.Row="1"
+                               Margin="16,12,16,0" />
 
         <StatusBar Grid.Row="2"
-                   Margin="0,12,0,0"
+                   Margin="16,12,16,16"
                    Background="{DynamicResource ToolBarBackgroundBrush}"
                    Foreground="{DynamicResource TextPrimaryBrush}">
             <StatusBarItem Content="Ready" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -21,11 +21,13 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
+              Height="{x:Static SystemParameters.MenuHeight}"
               Background="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"
               Foreground="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}"
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               BorderThickness="0,0,0,1"
-              Padding="0">
+              Padding="0"
+              VerticalContentAlignment="Center">
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -21,6 +21,7 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
+              Height="24"
               Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
               Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
@@ -32,12 +33,24 @@
                         <Trigger Property="Role"
                                  Value="TopLevelHeader">
                             <Setter Property="Padding"
-                                    Value="4,1" />
+                                    Value="6,0" />
+                            <Setter Property="Height"
+                                    Value="22" />
+                            <Setter Property="MinWidth"
+                                    Value="0" />
+                            <Setter Property="Margin"
+                                    Value="0" />
                         </Trigger>
                         <Trigger Property="Role"
                                  Value="TopLevelItem">
                             <Setter Property="Padding"
-                                    Value="4,1" />
+                                    Value="6,0" />
+                            <Setter Property="Height"
+                                    Value="22" />
+                            <Setter Property="MinWidth"
+                                    Value="0" />
+                            <Setter Property="Margin"
+                                    Value="0" />
                         </Trigger>
                     </Style.Triggers>
                 </Style>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -21,9 +21,9 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
-              Height="24"
+              MinHeight="24"
               Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+              Foreground="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}"
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               BorderThickness="0,0,0,1"
               Padding="0">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -21,13 +21,18 @@
         </Grid.RowDefinitions>
 
         <Menu Grid.Row="0"
-              Height="{x:Static SystemParameters.MenuHeight}"
-              Background="{DynamicResource {x:Static SystemColors.MenuBrushKey}}"
-              Foreground="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}"
+              MinHeight="28"
+              Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
               BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               BorderThickness="0,0,0,1"
-              Padding="0"
-              VerticalContentAlignment="Center">
+              Padding="0">
+            <Menu.ItemContainerStyle>
+                <Style TargetType="{x:Type MenuItem}">
+                    <Setter Property="Padding"
+                            Value="8,4" />
+                </Style>
+            </Menu.ItemContainerStyle>
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />


### PR DESCRIPTION
### Motivation
- Replace the custom-styled top menu chrome with the standard WPF/OS menu rendering so the File and Edit items appear and behave like a normal desktop app menu bar.

### Description
- Removed the `Window.Resources` merge of `Styles/Menu.xaml` and the custom `Style`/`ItemContainerStyle` and `Menu.Resources` overrides from `MainWindow.xaml`, while keeping the existing `MenuItem` hierarchy, commands, and bindings unchanged.

### Testing
- Ran `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, which failed because `dotnet` is not installed in the execution environment (`dotnet: command not found`), so no build verification completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec80be787483278770cc6552de96cd)