### PR TITLE
Remove redundant inner headers and outer panel borders

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -9,16 +9,11 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0"
-                   FontWeight="SemiBold"
-                   Text="Asset Browser" />
-
-        <DockPanel Grid.Row="1"
-                   Margin="0,6,0,8"
+        <DockPanel Grid.Row="0"
+                   Margin="0,0,0,8"
                    LastChildFill="False">
             <Button DockPanel.Dock="Right"
                     Padding="10,4"
@@ -26,7 +21,7 @@
                     Content="Refresh" />
         </DockPanel>
 
-        <ListBox Grid.Row="2"
+        <ListBox Grid.Row="1"
                  ItemsSource="{Binding AssetBrowserItems}"
                  SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
             <ListBox.ItemTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -7,58 +7,41 @@
              d:DesignHeight="300"
              d:DesignWidth="260">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <TextBlock Grid.Row="0"
-                   FontWeight="SemiBold"
-                   Text="Inspector" />
-
-        <Border Grid.Row="1"
-                Margin="0,8,0,0"
-                Padding="10"
-                Background="{DynamicResource PanelBackgroundBrush}"
-                BorderBrush="{DynamicResource BorderSubtleBrush}"
-                BorderThickness="1"
-                CornerRadius="4">
-            <StackPanel>
-                <TextBlock FontWeight="SemiBold"
-                           Text="{Binding InspectorTitle}" />
-                <TextBlock Margin="0,6,0,0"
-                           Foreground="{DynamicResource TextSecondaryBrush}"
-                           Text="{Binding InspectorType}" />
-                <TextBlock Margin="0,6,0,0"
-                           TextWrapping="Wrap"
-                           Text="{Binding InspectorPath}" />
-                <Border Margin="0,10,0,0"
-                        Padding="8"
-                        Background="{DynamicResource SelectionBrush}"
-                        BorderBrush="{DynamicResource BorderSubtleBrush}"
-                        BorderThickness="1"
-                        CornerRadius="4">
-                    <StackPanel>
-                        <TextBlock TextWrapping="Wrap"
-                                   Text="{Binding InspectorSummary}" />
-                        <TextBlock Margin="0,10,0,0"
-                                   FontWeight="SemiBold"
-                                   Text="Edit Summary" />
-                        <TextBox Margin="0,6,0,0"
-                                 MinHeight="88"
-                                 AcceptsReturn="True"
-                                 VerticalScrollBarVisibility="Auto"
-                                 IsEnabled="{Binding CanEditInspectorSummary}"
-                                 Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
-                        <Button Margin="0,8,0,0"
-                                HorizontalAlignment="Left"
-                                Padding="10,4"
-                                IsEnabled="{Binding CanEditInspectorSummary}"
-                                Command="{Binding ApplyInspectorSummaryCommand}"
-                                Content="Apply Summary" />
-                    </StackPanel>
-                </Border>
-            </StackPanel>
-        </Border>
+        <StackPanel>
+            <TextBlock FontWeight="SemiBold"
+                       Text="{Binding InspectorTitle}" />
+            <TextBlock Margin="0,6,0,0"
+                       Foreground="{DynamicResource TextSecondaryBrush}"
+                       Text="{Binding InspectorType}" />
+            <TextBlock Margin="0,6,0,0"
+                       TextWrapping="Wrap"
+                       Text="{Binding InspectorPath}" />
+            <Border Margin="0,10,0,0"
+                    Padding="8"
+                    Background="{DynamicResource SelectionBrush}"
+                    BorderBrush="{DynamicResource BorderSubtleBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4">
+                <StackPanel>
+                    <TextBlock TextWrapping="Wrap"
+                               Text="{Binding InspectorSummary}" />
+                    <TextBlock Margin="0,10,0,0"
+                               FontWeight="SemiBold"
+                               Text="Edit Summary" />
+                    <TextBox Margin="0,6,0,0"
+                             MinHeight="88"
+                             AcceptsReturn="True"
+                             VerticalScrollBarVisibility="Auto"
+                             IsEnabled="{Binding CanEditInspectorSummary}"
+                             Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button Margin="0,8,0,0"
+                            HorizontalAlignment="Left"
+                            Padding="10,4"
+                            IsEnabled="{Binding CanEditInspectorSummary}"
+                            Command="{Binding ApplyInspectorSummaryCommand}"
+                            Content="Apply Summary" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -14,10 +14,6 @@
 
         <DockPanel Grid.Row="0"
                    LastChildFill="False">
-            <TextBlock DockPanel.Dock="Left"
-                       FontWeight="SemiBold"
-                       VerticalAlignment="Center"
-                       Text="Output / Log" />
             <Button DockPanel.Dock="Right"
                     Padding="10,4"
                     Command="{Binding ClearOutputCommand}"
@@ -26,9 +22,7 @@
 
         <ListBox Grid.Row="1"
                  Margin="0,8,0,0"
-                 Background="{DynamicResource PanelBackgroundBrush}"
-                 BorderBrush="{DynamicResource BorderSubtleBrush}"
-                 BorderThickness="1"
+                 BorderThickness="0"
                  ItemsSource="{Binding OutputEntries}" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- AvalonDock tab headers already present the panel titles, so embedded header text and duplicate top-level borders in the panel views were redundant and visually noisy.
- The dock window should act as the outer frame for panels, so inner base-level borders were removed to avoid double-framing while preserving control layout and functionality.

### Description
- Removed the inner `TextBlock` header and adjusted row layout in `WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml` so the `Refresh` button and list remain and the dock tab provides the title.
- Flattened the top-level container in `WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml` by removing the duplicate `Inspector` title and the outer `Border`, preserving inspector bindings and the summary edit controls.
- Removed the `Output / Log` header and disabled outer list border styling in `WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml` (set `BorderThickness="0"`), keeping the `Clear` action and `OutputEntries` binding intact.
- No behavioral changes to commands or view-model bindings were made; committed with message `Remove redundant panel headers and outer borders`.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec8ac845388327a98101ad0ff3eee2)