### PR TITLE
Remove Tasks Placeholder panel from OasisEditor layout

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -68,20 +68,6 @@
                             </Border>
                         </layout:LayoutAnchorable>
 
-                        <layout:LayoutAnchorable Title="Tasks Placeholder"
-                                                 ContentId="TasksPlaceholder">
-                            <Border Padding="12"
-                                    Background="{DynamicResource ToolBarBackgroundBrush}">
-                                <StackPanel>
-                                    <TextBlock FontWeight="SemiBold"
-                                               Text="Tasks" />
-                                    <TextBlock Margin="0,8,0,0"
-                                               TextWrapping="Wrap"
-                                               Foreground="{DynamicResource TextSecondaryBrush}"
-                                               Text="Placeholder dock panel for validation, build, or import tasks." />
-                                </StackPanel>
-                            </Border>
-                        </layout:LayoutAnchorable>
                     </layout:LayoutAnchorablePane>
                 </layout:LayoutPanel>
             </layout:LayoutRoot>


### PR DESCRIPTION
### Motivation
- Remove an unneeded dock panel that served only as a placeholder in the editor layout so the UI is cleaner and doesn't show an unused "Tasks" panel.

### Description
- Deleted the `LayoutAnchorable` block titled "Tasks Placeholder" from `WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml`, leaving the bottom anchorable pane containing only the `Output` panel.

### Testing
- Attempted `dotnet build OasisEditor.sln`, which failed in this environment because `dotnet` is not installed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec8c1882908327859e485890888fca)