### PR TITLE
Remove outer margins for editor workspace and status bar

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -112,7 +112,7 @@
                 <Setter Property="Background" Value="{DynamicResource ToolBarBackgroundBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
-                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="BorderThickness" Value="0,1,0,0" />
             </Style>
         </ResourceDictionary>
     </Application.Resources>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -85,10 +85,10 @@
         </Menu>
 
         <views:EditorShellView Grid.Row="1"
-                               Margin="16,12,16,0" />
+                               Margin="0" />
 
         <StatusBar Grid.Row="2"
-                   Margin="16,12,16,16"
+                   Margin="0"
                    Background="{DynamicResource ToolBarBackgroundBrush}"
                    Foreground="{DynamicResource TextPrimaryBrush}">
             <StatusBarItem Content="Ready" />


### PR DESCRIPTION
### Motivation
- The main editor docking surface and the bottom status bar had unnecessary outer margins which created unwanted padding around the UI content.  
- The status bar also appeared visually boxed by a full border, so a subtler separator is preferred while keeping it flush to the window edges.

### Description
- Changed `EditorShellView` in `MainWindow.xaml` to use `Margin="0"` so the AvalonDock workspace fills the available area.  
- Changed the bottom `StatusBar` in `MainWindow.xaml` to use `Margin="0"` so it sits flush with the left, right, and bottom edges of the window.  
- Updated the global `StatusBar` style in `App.xaml` to set `BorderThickness="0,1,0,0"` to remove the boxed border while preserving a subtle top separator.

### Testing
- Attempted to run `dotnet build OasisEditor.sln`, but the build could not be executed because `dotnet` is not available in the current environment.  
- Verified the XAML file diffs show the intended changes to `MainWindow.xaml` and `App.xaml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec8e35b3a48327ae18252b9b9d9b4e)