### PR TITLE
Add Hierarchy pane and move Assets to bottom dock group

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -24,12 +24,13 @@
                 <layout:LayoutPanel Orientation="Vertical">
                     <layout:LayoutPanel Orientation="Horizontal">
                         <layout:LayoutAnchorablePane DockWidth="240">
-                            <layout:LayoutAnchorable Title="Assets"
-                                                     ContentId="Assets"
+                            <layout:LayoutAnchorable Title="Hierarchy"
+                                                     ContentId="Hierarchy"
                                                      CanClose="False">
                                 <Border Padding="10"
                                         Background="{DynamicResource InspectorBackgroundBrush}">
-                                    <views:AssetBrowserView />
+                                    <TextBlock Text="Hierarchy placeholder"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
                                 </Border>
                             </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>
@@ -59,6 +60,15 @@
                     </layout:LayoutPanel>
 
                     <layout:LayoutAnchorablePane DockHeight="160">
+                        <layout:LayoutAnchorable Title="Assets"
+                                                 ContentId="Assets"
+                                                 CanClose="False">
+                            <Border Padding="10"
+                                    Background="{DynamicResource ToolBarBackgroundBrush}">
+                                <views:AssetBrowserView />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
                         <layout:LayoutAnchorable Title="Output"
                                                  ContentId="Output"
                                                  CanClose="False">


### PR DESCRIPTION
### Motivation
- Provide a left-side `Hierarchy` placeholder window in the editor layout and relocate the `Assets` tool to the bottom area so it shares a docked tab group with `Output`, matching the requested UI layout change.

### Description
- Replaced the left-side `Assets` `LayoutAnchorable` with a new `Hierarchy` `LayoutAnchorable` containing a placeholder `TextBlock` in `Views/EditorShellView.xaml`.
- Added an `Assets` `LayoutAnchorable` into the bottom `LayoutAnchorablePane` (the same pane that contains `Output`).
- Ensured the bottom pane lists `Assets` before `Output` so `Assets` is the first tab and `Output` is the second tab.
- No runtime logic changes were introduced; only the AvalonDock XAML layout in `OasisEditor/Views/EditorShellView.xaml` was modified.

### Testing
- Attempted to run `dotnet build OasisEditor/OasisEditor.csproj -v minimal` but the build could not run in this environment because `dotnet` is not installed (build failed for that reason).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec903fb9548327bae152a4bc2a1359)