### PR TITLE
Status-aware output log and status-bar sync (show last output with icon and color)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -91,9 +91,27 @@
                    Margin="0"
                    Background="{DynamicResource ToolBarBackgroundBrush}"
                    Foreground="{DynamicResource TextPrimaryBrush}">
-            <StatusBarItem Content="Ready" />
+            <StatusBarItem>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets"
+                               Text="{Binding StatusIconGlyph}"
+                               Foreground="{Binding StatusMessageBrush}" />
+                    <TextBlock Margin="6,0,0,0"
+                               Text="Status"
+                               Foreground="{Binding StatusMessageBrush}" />
+                </StackPanel>
+            </StatusBarItem>
             <Separator />
-            <StatusBarItem Content="Phase 3A: Theme Foundations" />
+            <StatusBarItem>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock FontFamily="Segoe MDL2 Assets"
+                               Text="{Binding StatusIconGlyph}"
+                               Foreground="{Binding StatusMessageBrush}" />
+                    <TextBlock Margin="8,0,0,0"
+                               Text="{Binding StatusMessage}"
+                               Foreground="{Binding StatusMessageBrush}" />
+                </StackPanel>
+            </StatusBarItem>
         </StatusBar>
     </Grid>
 </Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -96,17 +96,6 @@
                     <TextBlock FontFamily="Segoe MDL2 Assets"
                                Text="{Binding StatusIconGlyph}"
                                Foreground="{Binding StatusMessageBrush}" />
-                    <TextBlock Margin="6,0,0,0"
-                               Text="Status"
-                               Foreground="{Binding StatusMessageBrush}" />
-                </StackPanel>
-            </StatusBarItem>
-            <Separator />
-            <StatusBarItem>
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe MDL2 Assets"
-                               Text="{Binding StatusIconGlyph}"
-                               Foreground="{Binding StatusMessageBrush}" />
                     <TextBlock Margin="8,0,0,0"
                                Text="{Binding StatusMessage}"
                                Foreground="{Binding StatusMessageBrush}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using Microsoft.Win32;
 using EditorCommands = OasisEditor.Commands;
 
@@ -61,6 +62,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ExitCommand = new RelayCommand(ExitApplication);
 
         _outputLog = new OutputLogViewModel();
+        _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
         _activeDocumentContext = new ActiveDocumentContextService();
         _assetBrowser = new AssetBrowserViewModel(
             () => LoadedProject,
@@ -94,8 +96,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RefreshAssetBrowserCommand = _assetBrowser.RefreshAssetBrowserCommand;
         ClearOutputCommand = _outputLog.ClearOutputCommand;
         ApplyInspectorSummaryCommand = _inspector.ApplyInspectorSummaryCommand;
-        AddOutputEntry("Editor shell initialized.");
-        AddOutputEntry($"Theme preference loaded: {_selectedThemePreference}");
+        AddOutputEntry("Editor shell initialized.", OutputLogStatus.Info);
+        AddOutputEntry($"Theme preference loaded: {_selectedThemePreference}", OutputLogStatus.Info);
 
         LoadStartupProject(startupProjectFilePath.Trim());
     }
@@ -119,7 +121,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
-    public ObservableCollection<string> OutputEntries { get; }
+    public ObservableCollection<OutputLogEntry> OutputEntries { get; }
 
 
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
@@ -136,15 +138,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
             _applicationThemeService.ApplyTheme(Application.Current ?? throw new InvalidOperationException("Application is not initialized."), value);
             _preferencesStore.Save(new EditorPreferences { ThemePreference = value });
-            AddOutputEntry($"Theme preference changed: {value}");
+            AddOutputEntry($"Theme preference changed: {value}", OutputLogStatus.Info);
         }
     }
 
     public string StatusMessage
     {
-        get => _statusMessage;
+        get => LastOutputEntry?.Message ?? _statusMessage;
         private set => SetProperty(ref _statusMessage, value);
     }
+
+    public OutputLogEntry? LastOutputEntry => _outputLog.LastEntry;
+
+    public string StatusIconGlyph => LastOutputEntry?.IconGlyph ?? "\uE946";
+
+    public Brush StatusMessageBrush => LastOutputEntry?.StatusBrush ?? Brushes.White;
 
     public EditorProject? LoadedProject
     {
@@ -293,7 +301,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             var openedNewTab = _documentWorkspace.OpenOrSelectDocument(path, openData.Summary, openData.PanelLayoutJson);
             if (!openedNewTab)
             {
-                AddOutputEntry($"Switched to already open document tab for {path}");
+                AddOutputEntry($"Switched to already open document tab for {path}", OutputLogStatus.Info);
             }
 
             var selectedTitle = SelectedDocument?.Title ?? Path.GetFileName(path);
@@ -302,12 +310,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 : $"Activated open document tab: {selectedTitle}";
             AddOutputEntry(openedNewTab
                 ? $"Opened document file {path}"
-                : $"Activated existing document tab for {path}");
+                : $"Activated existing document tab for {path}",
+                OutputLogStatus.Info);
         }
         catch (Exception ex)
         {
             StatusMessage = ex.Message;
-            AddOutputEntry($"Open document failed: {ex.Message}");
+            AddOutputEntry($"Open document failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Open Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
     }
@@ -343,12 +352,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 current.CommandService);
             _documentWorkspace.ReplaceDocument(current, updatedDocument);
             StatusMessage = $"Saved document: {updatedDocument.Title}";
-            AddOutputEntry($"Saved document to {savePath}");
+            AddOutputEntry($"Saved document to {savePath}", OutputLogStatus.Info);
         }
         catch (Exception ex)
         {
             StatusMessage = ex.Message;
-            AddOutputEntry($"Save document failed: {ex.Message}");
+            AddOutputEntry($"Save document failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Save Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
     }
@@ -403,7 +412,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         _preferencesWindow.Closed += (_, _) => _preferencesWindow = null;
         _preferencesWindow.Show();
-        AddOutputEntry("Opened Preferences window.");
+        AddOutputEntry("Opened Preferences window.", OutputLogStatus.Info);
     }
 
     private void OpenProjectSettings()
@@ -422,7 +431,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         _projectSettingsWindow.Closed += (_, _) => _projectSettingsWindow = null;
         _projectSettingsWindow.Show();
-        AddOutputEntry("Opened Project Settings window.");
+        AddOutputEntry("Opened Project Settings window.", OutputLogStatus.Info);
     }
 
     private void ClosePreferences()
@@ -484,7 +493,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _documentWorkspace.EnsureProjectOverviewDocument();
         _assetBrowser.RefreshAssetBrowser();
         StatusMessage = $"Project opened: {project.Name} ({project.ProjectFilePath})";
-        AddOutputEntry($"Loaded startup project '{project.Name}' from {project.ProjectFilePath}");
+        AddOutputEntry($"Loaded startup project '{project.Name}' from {project.ProjectFilePath}", OutputLogStatus.Info);
     }
 
     private static EditorProject LoadProjectFromFile(string projectFilePath)
@@ -599,9 +608,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private void AddOutputEntry(string message)
+    private void AddOutputEntry(string message, OutputLogStatus status)
     {
-        _outputLog.AddOutputEntry(message);
+        _outputLog.AddOutputEntry(message, status);
+    }
+
+    private void OnOutputLogPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is not nameof(OutputLogViewModel.LastEntry))
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(LastOutputEntry));
+        OnPropertyChanged(nameof(StatusMessage));
+        OnPropertyChanged(nameof(StatusIconGlyph));
+        OnPropertyChanged(nameof(StatusMessageBrush));
     }
 
     private void NotifyDocumentCommands()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogEntry.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogEntry.cs
@@ -1,0 +1,33 @@
+using System.Windows.Media;
+
+namespace OasisEditor;
+
+public enum OutputLogStatus
+{
+    Info,
+    Warning,
+    Error
+}
+
+public sealed record OutputLogEntry(DateTime Timestamp, string Message, OutputLogStatus Status)
+{
+    private static readonly Brush InfoBrush = Brushes.White;
+    private static readonly Brush WarningBrush = Brushes.Gold;
+    private static readonly Brush ErrorBrush = Brushes.IndianRed;
+
+    public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss");
+
+    public string IconGlyph => Status switch
+    {
+        OutputLogStatus.Warning => "\uE7BA",
+        OutputLogStatus.Error => "\uEA39",
+        _ => "\uE946"
+    };
+
+    public Brush StatusBrush => Status switch
+    {
+        OutputLogStatus.Warning => WarningBrush,
+        OutputLogStatus.Error => ErrorBrush,
+        _ => InfoBrush
+    };
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -10,14 +10,14 @@ public sealed class AssetBrowserViewModel
     private readonly Func<EditorProject?> _loadedProjectAccessor;
     private readonly Action _selectionChanged;
     private readonly Action _notifyInspectorChanged;
-    private readonly Action<string> _addOutputEntry;
+    private readonly Action<string, OutputLogStatus> _addOutputEntry;
     private AssetBrowserItemViewModel? _selectedAsset;
 
     public AssetBrowserViewModel(
         Func<EditorProject?> loadedProjectAccessor,
         Action selectionChanged,
         Action notifyInspectorChanged,
-        Action<string> addOutputEntry)
+        Action<string, OutputLogStatus> addOutputEntry)
     {
         _loadedProjectAccessor = loadedProjectAccessor;
         _selectionChanged = selectionChanged;
@@ -61,7 +61,7 @@ public sealed class AssetBrowserViewModel
             AssetBrowserItems.Clear();
             SelectedAsset = null;
             _notifyInspectorChanged();
-            _addOutputEntry("Asset browser cleared (no project loaded).");
+            _addOutputEntry("Asset browser cleared (no project loaded).", OutputLogStatus.Info);
             return;
         }
 
@@ -85,7 +85,7 @@ public sealed class AssetBrowserViewModel
 
         SelectedAsset = AssetBrowserItems.FirstOrDefault();
         _notifyInspectorChanged();
-        _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} files).");
+        _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} files).", OutputLogStatus.Info);
     }
 
     public void NotifyRefreshCommand()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -16,7 +16,7 @@ public sealed class DocumentWorkspaceViewModel
     private readonly Action<DocumentTabViewModel?> _setSelectedDocument;
     private readonly Action _notifyUndoRedoStateChanged;
     private readonly Action<string> _setStatusMessage;
-    private readonly Action<string> _addOutputEntry;
+    private readonly Action<string, OutputLogStatus> _addOutputEntry;
     private readonly Action<Guid> _onDocumentClosed;
 
     private int _untitledDocumentCounter = 1;
@@ -32,7 +32,7 @@ public sealed class DocumentWorkspaceViewModel
         Action<DocumentTabViewModel?> setSelectedDocument,
         Action notifyUndoRedoStateChanged,
         Action<string> setStatusMessage,
-        Action<string> addOutputEntry,
+        Action<string, OutputLogStatus> addOutputEntry,
         Action<Guid>? onDocumentClosed = null)
     {
         _getLoadedProject = getLoadedProject;
@@ -66,7 +66,7 @@ public sealed class DocumentWorkspaceViewModel
         var document = new DocumentTabViewModel(EditorDocument.CreateUntitled($"Untitled {_untitledDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened document tab: {document.Title}");
-        _addOutputEntry($"Opened document tab: {document.Title}");
+        _addOutputEntry($"Opened document tab: {document.Title}", OutputLogStatus.Info);
     }
 
     public void OpenPanel2DStubDocument()
@@ -82,7 +82,7 @@ public sealed class DocumentWorkspaceViewModel
 
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened panel document stub: {document.Title}");
-        _addOutputEntry($"Opened panel document stub: {document.Title}");
+        _addOutputEntry($"Opened panel document stub: {document.Title}", OutputLogStatus.Info);
     }
 
     public void OpenCabinet3DStubDocument()
@@ -95,7 +95,7 @@ public sealed class DocumentWorkspaceViewModel
         var document = new DocumentTabViewModel(EditorDocument.CreateCabinet3DStub($"Cabinet {_cabinetDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened cabinet document stub: {document.Title}");
-        _addOutputEntry($"Opened cabinet document stub: {document.Title}");
+        _addOutputEntry($"Opened cabinet document stub: {document.Title}", OutputLogStatus.Info);
     }
 
     public void OpenMachineStubDocument()
@@ -108,7 +108,7 @@ public sealed class DocumentWorkspaceViewModel
         var document = new DocumentTabViewModel(EditorDocument.CreateMachineStub($"Machine {_machineDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened machine document stub: {document.Title}");
-        _addOutputEntry($"Opened machine document stub: {document.Title}");
+        _addOutputEntry($"Opened machine document stub: {document.Title}", OutputLogStatus.Info);
     }
 
     public void CloseSelectedDocument()
@@ -121,7 +121,7 @@ public sealed class DocumentWorkspaceViewModel
 
         ExecuteDocumentMutation(new CloseDocumentTabMutationCommand(this, selectedDocument));
         _setStatusMessage($"Closed document tab: {selectedDocument.Title}");
-        _addOutputEntry($"Closed document tab: {selectedDocument.Title}");
+        _addOutputEntry($"Closed document tab: {selectedDocument.Title}", OutputLogStatus.Info);
     }
 
     public bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson)
@@ -232,7 +232,7 @@ public sealed class DocumentWorkspaceViewModel
 
         ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, selectedDocument, updated));
         _setStatusMessage($"Updated inspector summary for {updated.Title}");
-        _addOutputEntry($"Inspector summary updated for {updated.Title}");
+        _addOutputEntry($"Inspector summary updated for {updated.Title}", OutputLogStatus.Info);
         return updated;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -1,23 +1,45 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace OasisEditor;
 
-public sealed class OutputLogViewModel
+public sealed class OutputLogViewModel : INotifyPropertyChanged
 {
+    private OutputLogEntry? _lastEntry;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
     public OutputLogViewModel()
     {
-        OutputEntries = new ObservableCollection<string>();
+        OutputEntries = new ObservableCollection<OutputLogEntry>();
         ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
     }
 
-    public ObservableCollection<string> OutputEntries { get; }
+    public ObservableCollection<OutputLogEntry> OutputEntries { get; }
     public ICommand ClearOutputCommand { get; }
 
-    public void AddOutputEntry(string message)
+    public OutputLogEntry? LastEntry
     {
-        var timestamp = DateTime.Now.ToString("HH:mm:ss");
-        OutputEntries.Add($"[{timestamp}] {message}");
+        get => _lastEntry;
+        private set
+        {
+            if (ReferenceEquals(_lastEntry, value))
+            {
+                return;
+            }
+
+            _lastEntry = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public void AddOutputEntry(string message, OutputLogStatus status)
+    {
+        var entry = new OutputLogEntry(DateTime.Now, message, status);
+        OutputEntries.Add(entry);
+        LastEntry = entry;
         NotifyClearCommand();
     }
 
@@ -29,7 +51,8 @@ public sealed class OutputLogViewModel
     private void ClearOutput()
     {
         OutputEntries.Clear();
-        AddOutputEntry("Output log cleared.");
+        LastEntry = null;
+        AddOutputEntry("Output log cleared.", OutputLogStatus.Info);
     }
 
     public void NotifyClearCommand()
@@ -38,5 +61,10 @@ public sealed class OutputLogViewModel
         {
             clearRelayCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -23,6 +23,22 @@
         <ListBox Grid.Row="1"
                  Margin="0,8,0,0"
                  BorderThickness="0"
-                 ItemsSource="{Binding OutputEntries}" />
+                 ItemsSource="{Binding OutputEntries}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe MDL2 Assets"
+                                   Foreground="{Binding StatusBrush}"
+                                   Text="{Binding IconGlyph}" />
+                        <TextBlock Margin="8,0,0,0"
+                                   Foreground="{Binding StatusBrush}"
+                                   Text="{Binding FormattedTimestamp, StringFormat=[{0}]}" />
+                        <TextBlock Margin="8,0,0,0"
+                                   Foreground="{Binding StatusBrush}"
+                                   Text="{Binding Message}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Make the bottom status bar display the last message sent to the Output window (instead of placeholder text) and reflect that message's severity visually. 
- Require all output messages to include a status (`Info`, `Warning`, `Error`) so both the Console and status bar can render an icon and color consistently.

### Description
- Added a typed output entry model `OutputLogEntry` and `OutputLogStatus` enum with per-status icon glyph and `Brush` metadata for rendering colors (`White`, `Gold`, `IndianRed`) in `OutputLogEntry.cs`.
- Reworked `OutputLogViewModel` to hold `ObservableCollection<OutputLogEntry>`, track a `LastEntry`, and require `AddOutputEntry(string, OutputLogStatus)` so callers always pass a status.
- Updated producers to pass explicit statuses at call sites, including `DocumentWorkspaceViewModel` and `AssetBrowserViewModel`, and adjusted signatures where necessary to accept status-aware logging.
- Updated the Output tool view (`Views/OutputLogView.xaml`) to render icon + timestamp + message with status color, and replaced the bottom `MainWindow.xaml` status items to bind to `LastEntry` via `StatusIconGlyph`, `StatusMessage`, and `StatusMessageBrush` in `MainWindowViewModel` so the status bar mirrors the last output entry.

### Testing
- Attempted an automated build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj`, which failed in this environment because `dotnet` is not installed. 
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec965285d08327969a5e59fbfdef9c)