### PR TITLE
Add hierarchy panel scaffolding with Panel2D provider

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -27,6 +27,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly AssetBrowserViewModel _assetBrowser;
     private readonly OutputLogViewModel _outputLog;
     private readonly InspectorViewModel _inspector;
+    private readonly HierarchyViewModel _hierarchy;
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
 
@@ -75,6 +76,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => LoadedProject,
             _activeDocumentContext,
             ApplyInspectorSummary);
+        _hierarchy = new HierarchyViewModel(
+            () => SelectedDocument,
+            [new Panel2DHierarchyProvider()]);
 
         var preferences = _preferencesStore.Load();
         _selectedThemePreference = preferences.ThemePreference;
@@ -100,6 +104,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry($"Theme preference loaded: {_selectedThemePreference}", OutputLogStatus.Info);
 
         LoadStartupProject(startupProjectFilePath.Trim());
+        RefreshHierarchy();
     }
 
     public ICommand OpenUntitledDocumentCommand { get; }
@@ -189,6 +194,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 _activeDocumentContext.SetActiveDocument(value);
                 NotifyInspectorChanged();
                 NotifyDocumentCommands();
+                RefreshHierarchy();
             }
         }
     }
@@ -218,6 +224,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
 
     public bool CanEditInspectorSummary => _inspector.CanEditInspectorSummary;
+
+    public IReadOnlyList<HierarchyItemViewModel> HierarchyItems => _hierarchy.Items;
+
+    public bool HasHierarchyItems => _hierarchy.HasItems;
+
+    public string HierarchyEmptyStateMessage => _hierarchy.EmptyStateMessage;
 
     public string UndoMenuHeader
     {
@@ -670,12 +682,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         NotifyUndoRedoStateChanged();
         _assetBrowser.NotifyRefreshCommand();
+        RefreshHierarchy();
     }
 
     private void NotifyUndoRedoStateChanged()
     {
         OnPropertyChanged(nameof(UndoMenuHeader));
         OnPropertyChanged(nameof(RedoMenuHeader));
+        RefreshHierarchy();
         CommandManager.InvalidateRequerySuggested();
     }
 
@@ -688,6 +702,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(InspectorEditableSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
+    }
+
+    private void RefreshHierarchy()
+    {
+        _hierarchy.Refresh();
+        OnPropertyChanged(nameof(HierarchyItems));
+        OnPropertyChanged(nameof(HasHierarchyItems));
+        OnPropertyChanged(nameof(HierarchyEmptyStateMessage));
     }
 
     private DocumentTabViewModel? ApplyInspectorSummary(DocumentTabViewModel _, string summary)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+
+namespace OasisEditor;
+
+public sealed class HierarchyItemViewModel
+{
+    public HierarchyItemViewModel(string displayName, bool isGroup = false, IReadOnlyList<HierarchyItemViewModel>? children = null)
+    {
+        DisplayName = displayName;
+        IsGroup = isGroup;
+        Children = new ObservableCollection<HierarchyItemViewModel>(children ?? []);
+    }
+
+    public string DisplayName { get; }
+    public bool IsGroup { get; }
+    public ObservableCollection<HierarchyItemViewModel> Children { get; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
@@ -1,0 +1,75 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace OasisEditor;
+
+public sealed class HierarchyViewModel : INotifyPropertyChanged
+{
+    private readonly Func<DocumentTabViewModel?> _getSelectedDocument;
+    private readonly IReadOnlyList<IDocumentHierarchyProvider> _providers;
+    private string _emptyStateMessage = "No active document.";
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public HierarchyViewModel(
+        Func<DocumentTabViewModel?> getSelectedDocument,
+        IReadOnlyList<IDocumentHierarchyProvider> providers)
+    {
+        _getSelectedDocument = getSelectedDocument;
+        _providers = providers;
+    }
+
+    public ObservableCollection<HierarchyItemViewModel> Items { get; } = [];
+
+    public bool HasItems => Items.Count > 0;
+
+    public string EmptyStateMessage
+    {
+        get => _emptyStateMessage;
+        private set
+        {
+            if (string.Equals(_emptyStateMessage, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _emptyStateMessage = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(EmptyStateMessage)));
+        }
+    }
+
+    public void Refresh()
+    {
+        var selectedDocument = _getSelectedDocument();
+        var provider = _providers.FirstOrDefault(p => p.CanBuild(selectedDocument));
+
+        Items.Clear();
+
+        if (selectedDocument is null)
+        {
+            EmptyStateMessage = "No active document.";
+            NotifyCollectionStateChanged();
+            return;
+        }
+
+        if (provider is null)
+        {
+            EmptyStateMessage = $"Hierarchy is not available for {selectedDocument.TypeLabel}.";
+            NotifyCollectionStateChanged();
+            return;
+        }
+
+        foreach (var item in provider.Build(selectedDocument))
+        {
+            Items.Add(item);
+        }
+
+        EmptyStateMessage = Items.Count > 0 ? string.Empty : "This document has no hierarchy items yet.";
+        NotifyCollectionStateChanged();
+    }
+
+    private void NotifyCollectionStateChanged()
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasItems)));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/IDocumentHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/IDocumentHierarchyProvider.cs
@@ -1,0 +1,8 @@
+namespace OasisEditor;
+
+public interface IDocumentHierarchyProvider
+{
+    bool CanBuild(DocumentTabViewModel? document);
+
+    IReadOnlyList<HierarchyItemViewModel> Build(DocumentTabViewModel? document);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -1,0 +1,50 @@
+namespace OasisEditor;
+
+public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
+{
+    public bool CanBuild(DocumentTabViewModel? document)
+    {
+        return document?.Document.DocumentType == EditorDocumentType.Panel2D;
+    }
+
+    public IReadOnlyList<HierarchyItemViewModel> Build(DocumentTabViewModel? document)
+    {
+        if (!CanBuild(document))
+        {
+            return [];
+        }
+
+        var elements = Panel2DDocumentStorage.DeserializeLayout(document?.PanelLayoutJson);
+        var groups = new List<HierarchyItemViewModel>
+        {
+            BuildGroup("Images", elements, "image", "Image"),
+            BuildGroup("Rectangles", elements, "rectangle", "Rectangle"),
+            BuildGroup("Anchors", elements, "anchor", "Anchor"),
+            BuildGroup("Zones", elements, "zone", "Zone")
+        };
+
+        return groups;
+    }
+
+    private static HierarchyItemViewModel BuildGroup(
+        string groupName,
+        IReadOnlyList<PanelElementFile> elements,
+        string kind,
+        string itemPrefix)
+    {
+        var matches = elements
+            .Where(element => string.Equals(element.Kind, kind, StringComparison.OrdinalIgnoreCase))
+            .Select((element, index) =>
+            {
+                var x = Math.Round(element.X);
+                var y = Math.Round(element.Y);
+                var width = Math.Round(element.Width);
+                var height = Math.Round(element.Height);
+                return new HierarchyItemViewModel($"{itemPrefix} {index + 1} ({width}×{height} at {x}, {y})");
+            })
+            .ToArray();
+
+        var label = matches.Length > 0 ? $"{groupName} ({matches.Length})" : $"{groupName} (0)";
+        return new HierarchyItemViewModel(label, isGroup: true, children: matches);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -29,8 +29,7 @@
                                                      CanClose="False">
                                 <Border Padding="10"
                                         Background="{DynamicResource InspectorBackgroundBrush}">
-                                    <TextBlock Text="Hierarchy placeholder"
-                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <views:HierarchyView />
                                 </Border>
                             </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="OasisEditor.Views.HierarchyView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:OasisEditor"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="220">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TreeView Grid.Row="0"
+                  ItemsSource="{Binding HierarchyItems}"
+                  Visibility="{Binding HasHierarchyItems, Converter={StaticResource BoolToVisibility}}">
+            <TreeView.Resources>
+                <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"
+                                          ItemsSource="{Binding Children}">
+                    <TextBlock Text="{Binding DisplayName}" />
+                </HierarchicalDataTemplate>
+            </TreeView.Resources>
+        </TreeView>
+
+        <TextBlock Grid.Row="1"
+                   Margin="0,8,0,0"
+                   TextWrapping="Wrap"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="{Binding HierarchyEmptyStateMessage}" />
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class HierarchyView : UserControl
+{
+    public HierarchyView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -33,16 +33,16 @@
 - [x] Add safe empty states for no active document
 
 ### Hierarchy Panel
-- [ ] Rename or repurpose existing panel area as Hierarchy if needed
-- [ ] Create document-aware hierarchy provider interface
-- [ ] Add Panel2D hierarchy provider
-- [ ] Show Panel2D objects grouped by type:
-  - [ ] Images
-  - [ ] Rectangles
-  - [ ] Anchors
-  - [ ] Zones
-- [ ] Update hierarchy when active document changes
-- [ ] Update hierarchy when document content changes
+- [x] Rename or repurpose existing panel area as Hierarchy if needed
+- [x] Create document-aware hierarchy provider interface
+- [x] Add Panel2D hierarchy provider
+- [x] Show Panel2D objects grouped by type:
+  - [x] Images
+  - [x] Rectangles
+  - [x] Anchors
+  - [x] Zones
+- [x] Update hierarchy when active document changes
+- [x] Update hierarchy when document content changes
 - [ ] Selecting an item in hierarchy selects the object on the canvas
 - [ ] Selecting an object on the canvas selects the item in hierarchy
 - [ ] Support rename from hierarchy if object naming exists


### PR DESCRIPTION
### Motivation
- Provide a real, document-aware Hierarchy panel in the editor shell so Panel2D document contents can be surfaced and iterated in a dedicated tree view for future selection/rename/delete integration.
- Introduce a small provider abstraction to keep hierarchy population modular and allow adding providers for other document types later.

### Description
- Replaced the static hierarchy placeholder in `EditorShellView.xaml` with a `HierarchyView` user control bound to a view model for tree rendering.
- Added `HierarchyViewModel`, `HierarchyItemViewModel`, and `IDocumentHierarchyProvider` to manage hierarchy state and provider contracts, and hooked them into `MainWindowViewModel` (new fields, accessors, and `RefreshHierarchy` usage on document/context/command changes).
- Implemented `Panel2DHierarchyProvider` which groups `Panel2D` elements into Images, Rectangles, Anchors, and Zones and emits labeled tree nodes from the document layout JSON.
- Updated `TASKS.md` to mark the hierarchy scaffolding subtasks as completed.

### Testing
- Attempted to run a full solution build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment does not have the .NET CLI available (`/bin/bash: dotnet: command not found`), so no compile-time verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec99f138fc832780da26f1c929ea18)