### PR TITLE
Wire hierarchy selection to Panel2D canvas

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Linq;
 using OasisEditor.Commands;
 
 namespace OasisEditor;
@@ -37,6 +38,13 @@ public static class CanvasPanBehavior
             typeof(string),
             typeof(CanvasPanBehavior),
             new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelLayoutJsonChanged));
+
+    public static readonly DependencyProperty SelectedPanelSelectionProperty =
+        DependencyProperty.RegisterAttached(
+            "SelectedPanelSelection",
+            typeof(PanelSelectionInfo?),
+            typeof(CanvasPanBehavior),
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedPanelSelectionChanged));
 
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
@@ -76,6 +84,16 @@ public static class CanvasPanBehavior
     public static void SetPanelLayoutJson(DependencyObject dependencyObject, string? value)
     {
         dependencyObject.SetValue(PanelLayoutJsonProperty, value);
+    }
+
+    public static PanelSelectionInfo? GetSelectedPanelSelection(DependencyObject dependencyObject)
+    {
+        return (PanelSelectionInfo?)dependencyObject.GetValue(SelectedPanelSelectionProperty);
+    }
+
+    public static void SetSelectedPanelSelection(DependencyObject dependencyObject, PanelSelectionInfo? value)
+    {
+        dependencyObject.SetValue(SelectedPanelSelectionProperty, value);
     }
 
     private static void OnIsEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
@@ -274,6 +292,52 @@ public static class CanvasPanBehavior
         }
 
         PanelLayoutMapper.ApplyPersistedLayout(canvas, eventArgs.NewValue as string);
+    }
+
+    private static void OnSelectedPanelSelectionChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+    {
+        if (dependencyObject is not Canvas canvas)
+        {
+            return;
+        }
+
+        if (eventArgs.NewValue is not PanelSelectionInfo selection)
+        {
+            CanvasSelectionBehavior.ClearSelection(canvas);
+            NotifyActiveDocumentSelection(canvas, null);
+            return;
+        }
+
+        var matchedElement = canvas.Children
+            .OfType<FrameworkElement>()
+            .FirstOrDefault(element => IsSelectionMatch(element, selection));
+        CanvasSelectionBehavior.SelectElement(canvas, matchedElement);
+        NotifyActiveDocumentSelection(canvas, matchedElement);
+    }
+
+    private static bool IsSelectionMatch(FrameworkElement element, PanelSelectionInfo selection)
+    {
+        var kind = element switch
+        {
+            System.Windows.Shapes.Rectangle => "rectangle",
+            Image => "image",
+            _ => string.Empty
+        };
+
+        if (!string.Equals(kind, selection.Kind, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return AreClose(Canvas.GetLeft(element), selection.X)
+            && AreClose(Canvas.GetTop(element), selection.Y)
+            && AreClose(element.Width, selection.Width)
+            && AreClose(element.Height, selection.Height);
+    }
+
+    private static bool AreClose(double left, double right)
+    {
+        return Math.Abs(left - right) < 0.01d;
     }
 
     private static void NotifyActiveDocumentSelection(FrameworkElement canvas, FrameworkElement? selectedElement)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasSelectionBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasSelectionBehavior.cs
@@ -82,6 +82,29 @@ public static class CanvasSelectionBehavior
         canvas.ClearValue(SelectedElementProperty);
     }
 
+    public static void SelectElement(FrameworkElement canvas, FrameworkElement? element)
+    {
+        var selectedElement = (FrameworkElement?)canvas.GetValue(SelectedElementProperty);
+        if (ReferenceEquals(selectedElement, element))
+        {
+            return;
+        }
+
+        if (selectedElement is not null)
+        {
+            SetIsSelected(selectedElement, false);
+        }
+
+        if (element is null)
+        {
+            canvas.ClearValue(SelectedElementProperty);
+            return;
+        }
+
+        SetIsSelected(element, true);
+        canvas.SetValue(SelectedElementProperty, element);
+    }
+
     public static FrameworkElement? FindSelectableElement(DependencyObject? source, FrameworkElement canvas)
     {
         var current = source;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -249,6 +249,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    public void SelectHierarchyItem(HierarchyItemViewModel? hierarchyItem)
+    {
+        if (SelectedDocument is null || SelectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        if (hierarchyItem is null || hierarchyItem.IsGroup || hierarchyItem.PanelSelection is not PanelSelectionInfo selection)
+        {
+            return;
+        }
+
+        SelectedDocument.HierarchySelectedPanelSelection = selection;
+    }
+
     private bool CanOpenUntitledDocument()
     {
         return _documentWorkspace.CanOpenUntitledDocument();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -7,6 +7,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 {
     private readonly CommandService _commandService;
     private string? _panelLayoutJson;
+    private PanelSelectionInfo? _hierarchySelectedPanelSelection;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -50,6 +51,21 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
             _panelLayoutJson = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
+        }
+    }
+
+    public PanelSelectionInfo? HierarchySelectedPanelSelection
+    {
+        get => _hierarchySelectedPanelSelection;
+        set
+        {
+            if (_hierarchySelectedPanelSelection == value)
+            {
+                return;
+            }
+
+            _hierarchySelectedPanelSelection = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HierarchySelectedPanelSelection)));
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
@@ -4,14 +4,20 @@ namespace OasisEditor;
 
 public sealed class HierarchyItemViewModel
 {
-    public HierarchyItemViewModel(string displayName, bool isGroup = false, IReadOnlyList<HierarchyItemViewModel>? children = null)
+    public HierarchyItemViewModel(
+        string displayName,
+        bool isGroup = false,
+        IReadOnlyList<HierarchyItemViewModel>? children = null,
+        PanelSelectionInfo? panelSelection = null)
     {
         DisplayName = displayName;
         IsGroup = isGroup;
         Children = new ObservableCollection<HierarchyItemViewModel>(children ?? []);
+        PanelSelection = panelSelection;
     }
 
     public string DisplayName { get; }
     public bool IsGroup { get; }
     public ObservableCollection<HierarchyItemViewModel> Children { get; }
+    public PanelSelectionInfo? PanelSelection { get; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -40,7 +40,14 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
                 var y = Math.Round(element.Y);
                 var width = Math.Round(element.Width);
                 var height = Math.Round(element.Height);
-                return new HierarchyItemViewModel($"{itemPrefix} {index + 1} ({width}×{height} at {x}, {y})");
+                return new HierarchyItemViewModel(
+                    $"{itemPrefix} {index + 1} ({width}×{height} at {x}, {y})",
+                    panelSelection: new PanelSelectionInfo(
+                        kind,
+                        element.X,
+                        element.Y,
+                        element.Width,
+                        element.Height));
             })
             .ToArray();
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -19,6 +19,7 @@
 
         <TreeView Grid.Row="0"
                   ItemsSource="{Binding HierarchyItems}"
+                  SelectedItemChanged="OnTreeViewSelectedItemChanged"
                   Visibility="{Binding HasHierarchyItems, Converter={StaticResource BoolToVisibility}}">
             <TreeView.Resources>
                 <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows.Controls;
+using System.Windows;
 
 namespace OasisEditor.Views;
 
@@ -7,5 +8,15 @@ public partial class HierarchyView : UserControl
     public HierarchyView()
     {
         InitializeComponent();
+    }
+
+    private void OnTreeViewSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> eventArgs)
+    {
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        viewModel.SelectHierarchyItem(eventArgs.NewValue as HierarchyItemViewModel);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
@@ -108,6 +108,7 @@
                                             local:CanvasPanBehavior.IsRectangleToolActive="{Binding IsChecked, ElementName=RectangleToolToggle}"
                                             local:CanvasPanBehavior.IsImageToolActive="{Binding IsChecked, ElementName=ImageToolToggle}"
                                             local:CanvasPanBehavior.PanelLayoutJson="{Binding PanelLayoutJson, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            local:CanvasPanBehavior.SelectedPanelSelection="{Binding HierarchySelectedPanelSelection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             Background="{DynamicResource PanelBackgroundBrush}">
                                         <Canvas.Resources>
                                             <Style TargetType="Rectangle">

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -43,7 +43,7 @@
   - [x] Zones
 - [x] Update hierarchy when active document changes
 - [x] Update hierarchy when document content changes
-- [ ] Selecting an item in hierarchy selects the object on the canvas
+- [x] Selecting an item in hierarchy selects the object on the canvas
 - [ ] Selecting an object on the canvas selects the item in hierarchy
 - [ ] Support rename from hierarchy if object naming exists
 - [ ] Support delete selected hierarchy item through command system


### PR DESCRIPTION
### Motivation
- Enable users to select an item in the Hierarchy and have the corresponding visual element on the Panel2D canvas become selected so the hierarchy and canvas interact as expected. 

### Description
- Added leaf selection metadata by extending `HierarchyItemViewModel` to carry a `PanelSelectionInfo` and populated it in `Panel2DHierarchyProvider` so leaves encode element kind/position/size. 
- Added a document-scoped `HierarchySelectedPanelSelection` property to `DocumentTabViewModel` and bound it from the `PanelCanvasView` into a new `CanvasPanBehavior.SelectedPanelSelection` attached property. 
- Wired `HierarchyView` selection events to `MainWindowViewModel.SelectHierarchyItem`, which sets the active document’s `HierarchySelectedPanelSelection`. 
- Extended canvas behaviors so `CanvasPanBehavior` responds to `SelectedPanelSelection` by locating the matching visual and selecting it (using a new `CanvasSelectionBehavior.SelectElement` helper) and by notifying the active document selection; also added tolerant geometry matching (`AreClose`) to account for floating point differences. 
- Marked the hierarchy-selection task as completed in `TASKS.md`.

### Testing
- Attempted `dotnet build OasisEditor.sln` in this environment, but the command failed due to the environment missing the `dotnet` tool. 
- Verified repository state and that the code changes were staged/committed locally in the workspace (no runtime/unit tests executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec9ba09a388327b4b22fe63998fecc)