### PR TITLE
Add hierarchy-driven delete support for Panel2D elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -12,6 +12,11 @@ internal static class CanvasMutationCommands
         return new AddImageMutationCommand(documentId, document, element);
     }
 
+    public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
+    {
+        return new DeleteElementMutationCommand(documentId, document, selection);
+    }
+
     private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand
     {
         private readonly Guid _documentId;
@@ -144,6 +149,79 @@ internal static class CanvasMutationCommands
                 _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
             }
         }
+    }
+
+    private sealed class DeleteElementMutationCommand : Commands.IDocumentCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly PanelSelectionInfo _selection;
+        private PanelElementFile? _deletedElement;
+        private int? _deletedIndex;
+
+        public DeleteElementMutationCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
+        {
+            _documentId = documentId;
+            _document = document;
+            _selection = selection;
+        }
+
+        public Guid DocumentId => _documentId;
+
+        public string Description => "Delete element";
+
+        public void Execute()
+        {
+            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            if (!TryFindMatchingElementIndex(elements, _selection, out var index))
+            {
+                return;
+            }
+
+            _deletedElement = elements[index];
+            _deletedIndex = index;
+            elements.RemoveAt(index);
+            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        }
+
+        public void Undo()
+        {
+            if (_deletedElement is null || _deletedIndex is not int index)
+            {
+                return;
+            }
+
+            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var insertIndex = Math.Clamp(index, 0, elements.Count);
+            elements.Insert(insertIndex, _deletedElement);
+            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        }
+    }
+
+    private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementFile> elements, PanelSelectionInfo selection, out int index)
+    {
+        for (var i = 0; i < elements.Count; i++)
+        {
+            var element = elements[i];
+            if (!string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!element.X.Equals(selection.X)
+                || !element.Y.Equals(selection.Y)
+                || !element.Width.Equals(selection.Width)
+                || !element.Height.Equals(selection.Height))
+            {
+                continue;
+            }
+
+            index = i;
+            return true;
+        }
+
+        index = -1;
+        return false;
     }
 
     private static bool IsSameElement(PanelElementFile left, PanelElementFile right)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InverseBooleanToVisibilityConverter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InverseBooleanToVisibilityConverter.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace OasisEditor;
+
+public sealed class InverseBooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool boolValue)
+        {
+            return boolValue ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Visibility visibility)
+        {
+            return visibility != Visibility.Visible;
+        }
+
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -265,6 +265,41 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         SelectedDocument.HierarchySelectedPanelSelection = selection;
     }
 
+    public bool DeleteSelectedHierarchyItem()
+    {
+        if (SelectedDocument is null || SelectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        var selection = SelectedDocument.HierarchySelectedPanelSelection;
+        if (selection is null)
+        {
+            return false;
+        }
+
+        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(SelectedDocument.PanelLayoutJson)
+            .Any(element =>
+                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
+                && element.X.Equals(selection.X)
+                && element.Y.Equals(selection.Y)
+                && element.Width.Equals(selection.Width)
+                && element.Height.Equals(selection.Height));
+        if (!hasMatchingElement)
+        {
+            return false;
+        }
+
+        var command = CanvasMutationCommands.CreateDeleteElementCommand(SelectedDocument.DocumentId, SelectedDocument, selection);
+        var wasDeleted = ExecuteDocumentCanvasCommand(SelectedDocument.DocumentId, command);
+        if (wasDeleted)
+        {
+            UpdateDocumentPanelSelection(SelectedDocument.DocumentId, null);
+        }
+
+        return wasDeleted;
+    }
+
     private bool CanOpenUntitledDocument()
     {
         return _documentWorkspace.CanOpenUntitledDocument();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -267,18 +267,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public bool DeleteSelectedHierarchyItem()
     {
-        if (SelectedDocument is null || SelectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
         {
             return false;
         }
 
-        var selection = SelectedDocument.HierarchySelectedPanelSelection;
-        if (selection is null)
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
         {
             return false;
         }
 
-        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(SelectedDocument.PanelLayoutJson)
+        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
             .Any(element =>
                 string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
                 && element.X.Equals(selection.X)
@@ -290,11 +290,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var command = CanvasMutationCommands.CreateDeleteElementCommand(SelectedDocument.DocumentId, SelectedDocument, selection);
-        var wasDeleted = ExecuteDocumentCanvasCommand(SelectedDocument.DocumentId, command);
+        var command = CanvasMutationCommands.CreateDeleteElementCommand(selectedDocument.DocumentId, selectedDocument, selection);
+        var wasDeleted = ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
         if (wasDeleted)
         {
-            UpdateDocumentPanelSelection(SelectedDocument.DocumentId, null);
+            UpdateDocumentPanelSelection(selectedDocument.DocumentId, null);
         }
 
         return wasDeleted;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -9,15 +9,11 @@
              d:DesignWidth="220">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <local:InverseBooleanToVisibilityConverter x:Key="InverseBoolToVisibility" />
     </UserControl.Resources>
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <TreeView Grid.Row="0"
+        <TreeView
                   ItemsSource="{Binding HierarchyItems}"
                   SelectedItemChanged="OnTreeViewSelectedItemChanged"
                   PreviewKeyDown="OnTreeViewPreviewKeyDown"
@@ -40,9 +36,12 @@
             </TreeView.Resources>
         </TreeView>
 
-        <TextBlock Grid.Row="1"
-                   Margin="0,8,0,0"
+        <TextBlock Margin="12"
+                   VerticalAlignment="Center"
+                   HorizontalAlignment="Center"
                    TextWrapping="Wrap"
+                   TextAlignment="Center"
+                   Visibility="{Binding HasHierarchyItems, Converter={StaticResource InverseBoolToVisibility}}"
                    Foreground="{DynamicResource TextSecondaryBrush}"
                    Text="{Binding HierarchyEmptyStateMessage}" />
     </Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -20,6 +20,7 @@
         <TreeView Grid.Row="0"
                   ItemsSource="{Binding HierarchyItems}"
                   SelectedItemChanged="OnTreeViewSelectedItemChanged"
+                  PreviewKeyDown="OnTreeViewPreviewKeyDown"
                   Visibility="{Binding HasHierarchyItems, Converter={StaticResource BoolToVisibility}}"
                   Foreground="{DynamicResource TextPrimaryBrush}"
                   Background="{DynamicResource PanelBackgroundBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Controls;
 using System.Windows;
+using System.Windows.Input;
 
 namespace OasisEditor.Views;
 
@@ -18,5 +19,23 @@ public partial class HierarchyView : UserControl
         }
 
         viewModel.SelectHierarchyItem(eventArgs.NewValue as HierarchyItemViewModel);
+    }
+
+    private void OnTreeViewPreviewKeyDown(object sender, KeyEventArgs eventArgs)
+    {
+        if (eventArgs.Key != Key.Delete)
+        {
+            return;
+        }
+
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        if (viewModel.DeleteSelectedHierarchyItem())
+        {
+            eventArgs.Handled = true;
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -47,7 +47,7 @@
 - [x] Selecting an object on the canvas selects the item in hierarchy
 - [ ] Support rename from hierarchy if object naming exists
 - [x] Support delete selected hierarchy item through command system
-- [ ] Add empty hierarchy state for unsupported document types
+- [x] Add empty hierarchy state for unsupported document types
 
 ### Panel Editor Object Model Cleanup
 - [ ] Ensure every editable panel object has a stable object ID

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -46,7 +46,7 @@
 - [x] Selecting an item in hierarchy selects the object on the canvas
 - [x] Selecting an object on the canvas selects the item in hierarchy
 - [ ] Support rename from hierarchy if object naming exists
-- [ ] Support delete selected hierarchy item through command system
+- [x] Support delete selected hierarchy item through command system
 - [ ] Add empty hierarchy state for unsupported document types
 
 ### Panel Editor Object Model Cleanup


### PR DESCRIPTION
### Motivation
- Provide users a way to delete Panel2D elements from the Hierarchy and ensure deletes go through the document-scoped command pipeline so undo/redo and document ownership semantics are preserved.
- Keep the behavior consistent with existing canvas mutation commands and the refactor goal of routing document mutations through `CommandService`/`CommandHistory`.

### Description
- Add `CreateDeleteElementCommand(...)` and a document-scoped `DeleteElementMutationCommand` in `CanvasMutationCommands.cs` that finds the matching element, removes it from the `PanelLayoutJson`, and records the deleted element and index so `Undo()` reinserts it at the original index.
- Add `MainWindowViewModel.DeleteSelectedHierarchyItem()` which validates the active `Panel2D` document, checks for a matching element via `Panel2DDocumentStorage.DeserializeLayout(...)`, executes the delete through `ExecuteDocumentCanvasCommand(...)`, and clears the panel selection on success.
- Wire the hierarchy `TreeView` to handle the `Delete` key by adding `PreviewKeyDown=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eca200f100832782989b048a0ddc2d)