### PR TITLE
Add rename support for Panel2D hierarchy items

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -17,6 +17,15 @@ internal static class CanvasMutationCommands
         return new DeleteElementMutationCommand(documentId, document, selection);
     }
 
+    public static Commands.ICommand CreateRenameElementCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelSelectionInfo selection,
+        string newName)
+    {
+        return new RenameElementMutationCommand(documentId, document, selection, newName);
+    }
+
     private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand
     {
         private readonly Guid _documentId;
@@ -198,6 +207,88 @@ internal static class CanvasMutationCommands
         }
     }
 
+    private sealed class RenameElementMutationCommand : Commands.IDocumentCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly PanelSelectionInfo _selection;
+        private readonly string _newName;
+        private int? _renamedIndex;
+        private string? _previousName;
+
+        public RenameElementMutationCommand(
+            Guid documentId,
+            DocumentTabViewModel document,
+            PanelSelectionInfo selection,
+            string newName)
+        {
+            _documentId = documentId;
+            _document = document;
+            _selection = selection;
+            _newName = newName;
+        }
+
+        public Guid DocumentId => _documentId;
+
+        public string Description => "Rename element";
+
+        public void Execute()
+        {
+            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            if (!TryFindMatchingElementIndex(elements, _selection, out var index))
+            {
+                return;
+            }
+
+            var existing = elements[index];
+            _renamedIndex = index;
+            _previousName = existing.Name;
+            elements[index] = new PanelElementFile
+            {
+                Name = _newName,
+                Kind = existing.Kind,
+                X = existing.X,
+                Y = existing.Y,
+                Width = existing.Width,
+                Height = existing.Height
+            };
+
+            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        }
+
+        public void Undo()
+        {
+            if (_renamedIndex is not int index)
+            {
+                return;
+            }
+
+            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            if (index < 0 || index >= elements.Count)
+            {
+                return;
+            }
+
+            if (!IsSelectionMatch(elements[index], _selection))
+            {
+                return;
+            }
+
+            var existing = elements[index];
+            elements[index] = new PanelElementFile
+            {
+                Name = _previousName ?? string.Empty,
+                Kind = existing.Kind,
+                X = existing.X,
+                Y = existing.Y,
+                Width = existing.Width,
+                Height = existing.Height
+            };
+
+            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        }
+    }
+
     private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementFile> elements, PanelSelectionInfo selection, out int index)
     {
         for (var i = 0; i < elements.Count; i++)
@@ -231,5 +322,14 @@ internal static class CanvasMutationCommands
             && left.Y.Equals(right.Y)
             && left.Width.Equals(right.Width)
             && left.Height.Equals(right.Height);
+    }
+
+    private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
+    {
+        return string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
+            && element.X.Equals(selection.X)
+            && element.Y.Equals(selection.Y)
+            && element.Width.Equals(selection.Width)
+            && element.Height.Equals(selection.Height);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -300,6 +300,75 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return wasDeleted;
     }
 
+    public bool TryGetSelectedHierarchyItemName(out string currentName)
+    {
+        currentName = string.Empty;
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
+        {
+            return false;
+        }
+
+        var matchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
+            .FirstOrDefault(element =>
+                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
+                && element.X.Equals(selection.X)
+                && element.Y.Equals(selection.Y)
+                && element.Width.Equals(selection.Width)
+                && element.Height.Equals(selection.Height));
+        if (matchingElement is null)
+        {
+            return false;
+        }
+
+        currentName = matchingElement.Name ?? string.Empty;
+        return true;
+    }
+
+    public bool RenameSelectedHierarchyItem(string newName)
+    {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
+        {
+            return false;
+        }
+
+        var normalizedName = newName?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName))
+        {
+            return false;
+        }
+
+        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
+            .Any(element =>
+                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
+                && element.X.Equals(selection.X)
+                && element.Y.Equals(selection.Y)
+                && element.Width.Equals(selection.Width)
+                && element.Height.Equals(selection.Height));
+        if (!hasMatchingElement)
+        {
+            return false;
+        }
+
+        var command = CanvasMutationCommands.CreateRenameElementCommand(
+            selectedDocument.DocumentId,
+            selectedDocument,
+            selection,
+            normalizedName);
+        return ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
+    }
+
     private bool CanOpenUntitledDocument()
     {
         return _documentWorkspace.CanOpenUntitledDocument();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -80,6 +80,7 @@ internal sealed class Panel2DDocumentFile
 
 internal sealed class PanelElementFile
 {
+    public string Name { get; init; } = string.Empty;
     public string Kind { get; init; } = string.Empty;
     public double X { get; init; }
     public double Y { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -40,8 +40,11 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
                 var y = Math.Round(element.Y);
                 var width = Math.Round(element.Width);
                 var height = Math.Round(element.Height);
+                var displayName = string.IsNullOrWhiteSpace(element.Name)
+                    ? $"{itemPrefix} {index + 1} ({width}×{height} at {x}, {y})"
+                    : element.Name.Trim();
                 return new HierarchyItemViewModel(
-                    $"{itemPrefix} {index + 1} ({width}×{height} at {x}, {y})",
+                    displayName,
                     $"{kind}:{element.X:0.###}:{element.Y:0.###}:{element.Width:0.###}:{element.Height:0.###}",
                     panelSelection: new PanelSelectionInfo(
                         kind,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Input;
+using Microsoft.VisualBasic;
 
 namespace OasisEditor.Views;
 
@@ -23,17 +24,41 @@ public partial class HierarchyView : UserControl
 
     private void OnTreeViewPreviewKeyDown(object sender, KeyEventArgs eventArgs)
     {
-        if (eventArgs.Key != Key.Delete)
-        {
-            return;
-        }
-
         if (DataContext is not MainWindowViewModel viewModel)
         {
             return;
         }
 
-        if (viewModel.DeleteSelectedHierarchyItem())
+        if (eventArgs.Key == Key.Delete)
+        {
+            if (viewModel.DeleteSelectedHierarchyItem())
+            {
+                eventArgs.Handled = true;
+            }
+
+            return;
+        }
+
+        if (eventArgs.Key != Key.F2)
+        {
+            return;
+        }
+
+        if (!viewModel.TryGetSelectedHierarchyItemName(out var currentName))
+        {
+            return;
+        }
+
+        var renamed = Interaction.InputBox(
+            "Enter a new name for the selected hierarchy object:",
+            "Rename Hierarchy Item",
+            currentName);
+        if (string.IsNullOrWhiteSpace(renamed))
+        {
+            return;
+        }
+
+        if (viewModel.RenameSelectedHierarchyItem(renamed))
         {
             eventArgs.Handled = true;
         }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -45,7 +45,7 @@
 - [x] Update hierarchy when document content changes
 - [x] Selecting an item in hierarchy selects the object on the canvas
 - [x] Selecting an object on the canvas selects the item in hierarchy
-- [ ] Support rename from hierarchy if object naming exists
+- [x] Support rename from hierarchy if object naming exists
 - [x] Support delete selected hierarchy item through command system
 - [x] Add empty hierarchy state for unsupported document types
 


### PR DESCRIPTION
### Motivation
- Allow authors to give persistent, human-friendly names to Panel2D elements and surface those names in the Hierarchy view.
- Provide an undoable rename flow so renames are routed through the existing document-aware command system and respect per-document command history.

### Description
- Add a `Name` property to `PanelElementFile` so element names are persisted in layout JSON and round-tripped via `Panel2DDocumentStorage`.
- Update `Panel2DHierarchyProvider` to prefer `element.Name` for the hierarchy label and fall back to the existing geometry-based label when no name is set.
- Add an undoable `Rename element` command via `CanvasMutationCommands.CreateRenameElementCommand` with a `RenameElementMutationCommand` implementation that updates element `Name` and supports `Undo`/`Redo`.
- Wire rename UI and view-model flows by adding `TryGetSelectedHierarchyItemName` and `RenameSelectedHierarchyItem` to `MainWindowViewModel`, handling `F2` in `HierarchyView.xaml.cs` to prompt for a name, and preserve existing Delete-key behavior; also mark the TASKS item as completed.

### Testing
- Attempted automated build with `dotnet build OasisEditor.sln`, but the environment lacks `dotnet` so the build could not be run (`/bin/bash: line 1: dotnet: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eca6d79154832798a6c7abcb9cee38)