### PR TITLE
Add stable ObjectId for panel editor elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ActiveDocumentContextService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ActiveDocumentContextService.cs
@@ -47,6 +47,7 @@ public sealed class ActiveDocumentContextService
 }
 
 public readonly record struct PanelSelectionInfo(
+    string ObjectId,
     string Kind,
     double X,
     double Y,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -245,6 +245,7 @@ internal static class CanvasMutationCommands
             _previousName = existing.Name;
             elements[index] = new PanelElementFile
             {
+                ObjectId = existing.ObjectId,
                 Name = _newName,
                 Kind = existing.Kind,
                 X = existing.X,
@@ -277,6 +278,7 @@ internal static class CanvasMutationCommands
             var existing = elements[index];
             elements[index] = new PanelElementFile
             {
+                ObjectId = existing.ObjectId,
                 Name = _previousName ?? string.Empty,
                 Kind = existing.Kind,
                 X = existing.X,
@@ -291,6 +293,18 @@ internal static class CanvasMutationCommands
 
     private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementFile> elements, PanelSelectionInfo selection, out int index)
     {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId))
+        {
+            for (var i = 0; i < elements.Count; i++)
+            {
+                if (string.Equals(elements[i].ObjectId, selection.ObjectId, StringComparison.Ordinal))
+                {
+                    index = i;
+                    return true;
+                }
+            }
+        }
+
         for (var i = 0; i < elements.Count; i++)
         {
             var element = elements[i];
@@ -317,6 +331,12 @@ internal static class CanvasMutationCommands
 
     private static bool IsSameElement(PanelElementFile left, PanelElementFile right)
     {
+        if (!string.IsNullOrWhiteSpace(left.ObjectId)
+            && !string.IsNullOrWhiteSpace(right.ObjectId))
+        {
+            return string.Equals(left.ObjectId, right.ObjectId, StringComparison.Ordinal);
+        }
+
         return string.Equals(left.Kind, right.Kind, StringComparison.OrdinalIgnoreCase)
             && left.X.Equals(right.X)
             && left.Y.Equals(right.Y)
@@ -326,6 +346,12 @@ internal static class CanvasMutationCommands
 
     private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
     {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
+            && !string.IsNullOrWhiteSpace(element.ObjectId))
+        {
+            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
+        }
+
         return string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
             && element.X.Equals(selection.X)
             && element.Y.Equals(selection.Y)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -317,6 +317,13 @@ public static class CanvasPanBehavior
 
     private static bool IsSelectionMatch(FrameworkElement element, PanelSelectionInfo selection)
     {
+        var elementObjectId = element.Uid?.Trim() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
+            && !string.IsNullOrWhiteSpace(elementObjectId))
+        {
+            return string.Equals(elementObjectId, selection.ObjectId, StringComparison.Ordinal);
+        }
+
         var kind = element switch
         {
             System.Windows.Shapes.Rectangle => "rectangle",
@@ -366,6 +373,7 @@ public static class CanvasPanBehavior
         };
 
         var selection = new PanelSelectionInfo(
+            selectedElement.Uid?.Trim() ?? string.Empty,
             kind,
             Canvas.GetLeft(selectedElement),
             Canvas.GetTop(selectedElement),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -279,12 +279,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .Any(element =>
-                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
-                && element.X.Equals(selection.X)
-                && element.Y.Equals(selection.Y)
-                && element.Width.Equals(selection.Width)
-                && element.Height.Equals(selection.Height));
+            .Any(element => IsSelectionMatch(element, selection));
         if (!hasMatchingElement)
         {
             return false;
@@ -315,12 +310,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var matchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .FirstOrDefault(element =>
-                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
-                && element.X.Equals(selection.X)
-                && element.Y.Equals(selection.Y)
-                && element.Width.Equals(selection.Width)
-                && element.Height.Equals(selection.Height));
+            .FirstOrDefault(element => IsSelectionMatch(element, selection));
         if (matchingElement is null)
         {
             return false;
@@ -350,12 +340,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .Any(element =>
-                string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
-                && element.X.Equals(selection.X)
-                && element.Y.Equals(selection.Y)
-                && element.Width.Equals(selection.Width)
-                && element.Height.Equals(selection.Height));
+            .Any(element => IsSelectionMatch(element, selection));
         if (!hasMatchingElement)
         {
             return false;
@@ -859,6 +844,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
+    {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
+            && !string.IsNullOrWhiteSpace(element.ObjectId))
+        {
+            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
+        }
+
+        return string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
+            && element.X.Equals(selection.X)
+            && element.Y.Equals(selection.Y)
+            && element.Width.Equals(selection.Width)
+            && element.Height.Equals(selection.Height);
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -60,12 +60,23 @@ internal static class Panel2DDocumentStorage
 
         try
         {
-            return JsonSerializer.Deserialize<List<PanelElementFile>>(layoutJson) ?? [];
+            var elements = JsonSerializer.Deserialize<List<PanelElementFile>>(layoutJson) ?? [];
+            return elements.Select(NormalizeElement).ToArray();
         }
         catch (JsonException)
         {
             return [];
         }
+    }
+
+    private static PanelElementFile NormalizeElement(PanelElementFile element)
+    {
+        return element with
+        {
+            ObjectId = string.IsNullOrWhiteSpace(element.ObjectId)
+                ? Guid.NewGuid().ToString("N")
+                : element.ObjectId.Trim()
+        };
     }
 }
 
@@ -78,8 +89,9 @@ internal sealed class Panel2DDocumentFile
     public PanelElementFile[] Elements { get; init; } = [];
 }
 
-internal sealed class PanelElementFile
+internal sealed record PanelElementFile
 {
+    public string ObjectId { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;
     public string Kind { get; init; } = string.Empty;
     public double X { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -19,6 +19,7 @@ internal static class PanelElementFactory
         var y = Math.Max(0, canvasPoint.Y - (NewRectangleHeight / 2));
         return new PanelElementFile
         {
+            ObjectId = Guid.NewGuid().ToString("N"),
             Kind = "rectangle",
             X = x,
             Y = y,
@@ -33,6 +34,7 @@ internal static class PanelElementFactory
         var y = Math.Max(0, canvasPoint.Y - (NewImageHeight / 2));
         return new PanelElementFile
         {
+            ObjectId = Guid.NewGuid().ToString("N"),
             Kind = "image",
             X = x,
             Y = y,
@@ -47,6 +49,7 @@ internal static class PanelElementFactory
         {
             return new Rectangle
             {
+                Uid = element.ObjectId,
                 Width = element.Width <= 0 ? NewRectangleWidth : element.Width,
                 Height = element.Height <= 0 ? NewRectangleHeight : element.Height
             };
@@ -56,6 +59,7 @@ internal static class PanelElementFactory
         {
             return new Image
             {
+                Uid = element.ObjectId,
                 Width = element.Width <= 0 ? NewImageWidth : element.Width,
                 Height = element.Height <= 0 ? NewImageHeight : element.Height,
                 Stretch = Stretch.Fill,
@@ -82,6 +86,7 @@ internal static class PanelElementFactory
 
         return new PanelElementFile
         {
+            ObjectId = string.IsNullOrWhiteSpace(child.Uid) ? Guid.NewGuid().ToString("N") : child.Uid.Trim(),
             Kind = kind,
             X = Canvas.GetLeft(child),
             Y = Canvas.GetTop(child),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -45,8 +45,9 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
                     : element.Name.Trim();
                 return new HierarchyItemViewModel(
                     displayName,
-                    $"{kind}:{element.X:0.###}:{element.Y:0.###}:{element.Width:0.###}:{element.Height:0.###}",
+                    $"{kind}:{element.ObjectId}",
                     panelSelection: new PanelSelectionInfo(
+                        element.ObjectId,
                         kind,
                         element.X,
                         element.Y,

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -50,7 +50,7 @@
 - [x] Add empty hierarchy state for unsupported document types
 
 ### Panel Editor Object Model Cleanup
-- [ ] Ensure every editable panel object has a stable object ID
+- [x] Ensure every editable panel object has a stable object ID
 - [ ] Ensure every editable panel object has a display name
 - [ ] Ensure object type is explicit and queryable
 - [ ] Ensure image and rectangle objects share common selectable-object contract


### PR DESCRIPTION
### Motivation
- Provide stable identity for panel editor elements so hierarchy, selection, and undo/redo can target elements reliably even when geometry is identical or changes.
- Make legacy layouts compatible by ensuring loaded elements without IDs get normalized to a stable `ObjectId` so downstream logic can assume IDs exist.

### Description
- Added an `ObjectId` field to `PanelElementFile` and return a normalized list from `DeserializeLayout` where missing IDs are assigned using `Guid.NewGuid().ToString("N")` (in `Panel2DDocumentStorage`).
- Assign `ObjectId` for newly-created elements in `PanelElementFactory` and set visual elements' `Uid` to the element `ObjectId` so IDs round-trip through visuals.
- Extended `PanelSelectionInfo` to carry `ObjectId` and updated hierarchy provider to emit selections keyed by object ID (in `Panel2DHierarchyProvider`).
- Updated selection matching and mutation command logic (`CanvasPanBehavior`, `CanvasMutationCommands`, `MainWindowViewModel`) to prefer `ObjectId` equality when present and fall back to geometry-based matching for compatibility with older layouts.
- Marked the corresponding task complete in `TASKS.md`.

### Testing
- Attempted to run an automated build with `dotnet build OasisEditor.sln` but it could not be executed in this environment because the `dotnet` SDK is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eca83c61448327bbf46f8ad60bd6ce)