### PR TITLE
Add default display names for Panel2D elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -65,7 +65,7 @@ internal static class CanvasMutationCommands
             if (_insertIndex is int index
                 && index >= 0
                 && index < elements.Count
-                && IsSameElement(elements[index], _element))
+                && PanelSelectionContract.IsSame(elements[index], _element))
             {
                 elements.RemoveAt(index);
                 removed = true;
@@ -75,7 +75,7 @@ internal static class CanvasMutationCommands
             {
                 for (var i = elements.Count - 1; i >= 0; i--)
                 {
-                    if (!IsSameElement(elements[i], _element))
+                    if (!PanelSelectionContract.IsSame(elements[i], _element))
                     {
                         continue;
                     }
@@ -132,7 +132,7 @@ internal static class CanvasMutationCommands
             if (_insertIndex is int index
                 && index >= 0
                 && index < elements.Count
-                && IsSameElement(elements[index], _element))
+                && PanelSelectionContract.IsSame(elements[index], _element))
             {
                 elements.RemoveAt(index);
                 removed = true;
@@ -142,7 +142,7 @@ internal static class CanvasMutationCommands
             {
                 for (var i = elements.Count - 1; i >= 0; i--)
                 {
-                    if (!IsSameElement(elements[i], _element))
+                    if (!PanelSelectionContract.IsSame(elements[i], _element))
                     {
                         continue;
                     }
@@ -270,7 +270,7 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            if (!IsSelectionMatch(elements[index], _selection))
+            if (!PanelSelectionContract.IsMatch(elements[index], _selection))
             {
                 return;
             }
@@ -308,15 +308,7 @@ internal static class CanvasMutationCommands
         for (var i = 0; i < elements.Count; i++)
         {
             var element = elements[i];
-            if (!string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            if (!element.X.Equals(selection.X)
-                || !element.Y.Equals(selection.Y)
-                || !element.Width.Equals(selection.Width)
-                || !element.Height.Equals(selection.Height))
+            if (!PanelSelectionContract.IsMatch(element, selection))
             {
                 continue;
             }
@@ -327,35 +319,5 @@ internal static class CanvasMutationCommands
 
         index = -1;
         return false;
-    }
-
-    private static bool IsSameElement(PanelElementFile left, PanelElementFile right)
-    {
-        if (!string.IsNullOrWhiteSpace(left.ObjectId)
-            && !string.IsNullOrWhiteSpace(right.ObjectId))
-        {
-            return string.Equals(left.ObjectId, right.ObjectId, StringComparison.Ordinal);
-        }
-
-        return string.Equals(left.Kind, right.Kind, StringComparison.OrdinalIgnoreCase)
-            && left.X.Equals(right.X)
-            && left.Y.Equals(right.Y)
-            && left.Width.Equals(right.Width)
-            && left.Height.Equals(right.Height);
-    }
-
-    private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
-    {
-        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
-            && !string.IsNullOrWhiteSpace(element.ObjectId))
-        {
-            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
-        }
-
-        return string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
-            && element.X.Equals(selection.X)
-            && element.Y.Equals(selection.Y)
-            && element.Width.Equals(selection.Width)
-            && element.Height.Equals(selection.Height);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -317,34 +317,12 @@ public static class CanvasPanBehavior
 
     private static bool IsSelectionMatch(FrameworkElement element, PanelSelectionInfo selection)
     {
-        var elementObjectId = element.Uid?.Trim() ?? string.Empty;
-        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
-            && !string.IsNullOrWhiteSpace(elementObjectId))
-        {
-            return string.Equals(elementObjectId, selection.ObjectId, StringComparison.Ordinal);
-        }
-
-        var kind = element switch
-        {
-            System.Windows.Shapes.Rectangle => "rectangle",
-            Image => "image",
-            _ => string.Empty
-        };
-
-        if (!string.Equals(kind, selection.Kind, StringComparison.OrdinalIgnoreCase))
+        if (!PanelSelectionContract.TryCreateFromVisual(element, out var selectable))
         {
             return false;
         }
 
-        return AreClose(Canvas.GetLeft(element), selection.X)
-            && AreClose(Canvas.GetTop(element), selection.Y)
-            && AreClose(element.Width, selection.Width)
-            && AreClose(element.Height, selection.Height);
-    }
-
-    private static bool AreClose(double left, double right)
-    {
-        return Math.Abs(left - right) < 0.01d;
+        return PanelSelectionContract.IsMatch(selectable, selection);
     }
 
     private static void NotifyActiveDocumentSelection(FrameworkElement canvas, FrameworkElement? selectedElement)
@@ -365,20 +343,19 @@ public static class CanvasPanBehavior
             return;
         }
 
-        var kind = selectedElement switch
+        if (!PanelSelectionContract.TryCreateFromVisual(selectedElement, out var selectable))
         {
-            System.Windows.Shapes.Rectangle => "rectangle",
-            Image => "image",
-            _ => selectedElement.GetType().Name
-        };
+            var fallbackSelection = new PanelSelectionInfo(
+                selectedElement.Uid?.Trim() ?? string.Empty,
+                selectedElement.GetType().Name,
+                Canvas.GetLeft(selectedElement),
+                Canvas.GetTop(selectedElement),
+                selectedElement.Width,
+                selectedElement.Height);
+            shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, fallbackSelection);
+            return;
+        }
 
-        var selection = new PanelSelectionInfo(
-            selectedElement.Uid?.Trim() ?? string.Empty,
-            kind,
-            Canvas.GetLeft(selectedElement),
-            Canvas.GetTop(selectedElement),
-            selectedElement.Width,
-            selectedElement.Height);
-        shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, selection);
+        shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, PanelSelectionContract.ToSelectionInfo(selectable));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -848,17 +848,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
     {
-        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
-            && !string.IsNullOrWhiteSpace(element.ObjectId))
-        {
-            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
-        }
-
-        return string.Equals(element.Kind, selection.Kind, StringComparison.OrdinalIgnoreCase)
-            && element.X.Equals(selection.X)
-            && element.Y.Equals(selection.Y)
-            && element.Width.Equals(selection.Width)
-            && element.Height.Equals(selection.Height);
+        return PanelSelectionContract.IsMatch(element, selection);
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -1,9 +1,47 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace OasisEditor;
 
 internal static class Panel2DDocumentStorage
 {
+    internal static PanelElementKind ParseElementKind(string? kind)
+    {
+        if (string.Equals(kind, "rectangle", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.Rectangle;
+        }
+
+        if (string.Equals(kind, "image", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.Image;
+        }
+
+        if (string.Equals(kind, "anchor", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.Anchor;
+        }
+
+        if (string.Equals(kind, "zone", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.Zone;
+        }
+
+        return PanelElementKind.Unknown;
+    }
+
+    internal static string SerializeElementKind(PanelElementKind kind)
+    {
+        return kind switch
+        {
+            PanelElementKind.Rectangle => "rectangle",
+            PanelElementKind.Image => "image",
+            PanelElementKind.Anchor => "anchor",
+            PanelElementKind.Zone => "zone",
+            _ => string.Empty
+        };
+    }
+
     public static string Serialize(string title, string summary, IReadOnlyList<PanelElementFile> elements)
     {
         var payload = new Panel2DDocumentFile
@@ -74,18 +112,24 @@ internal static class Panel2DDocumentStorage
         var normalizedObjectId = string.IsNullOrWhiteSpace(element.ObjectId)
             ? Guid.NewGuid().ToString("N")
             : element.ObjectId.Trim();
+        var normalizedKind = ParseElementKind(element.Kind);
 
         return element with
         {
             ObjectId = normalizedObjectId,
-            Name = NormalizeElementName(element.Name, element.Kind, normalizedObjectId),
-            Kind = element.Kind?.Trim() ?? string.Empty
+            Name = NormalizeElementName(element.Name, normalizedKind, normalizedObjectId),
+            Kind = SerializeElementKind(normalizedKind)
         };
     }
 
     internal static string CreateDefaultElementName(string? kind, string? objectId)
     {
-        var prefix = string.Equals(kind, "image", StringComparison.OrdinalIgnoreCase)
+        return CreateDefaultElementName(ParseElementKind(kind), objectId);
+    }
+
+    internal static string CreateDefaultElementName(PanelElementKind kind, string? objectId)
+    {
+        var prefix = kind == PanelElementKind.Image
             ? "Image"
             : "Rectangle";
 
@@ -100,12 +144,21 @@ internal static class Panel2DDocumentStorage
         return $"{prefix} {suffix}";
     }
 
-    private static string NormalizeElementName(string? name, string? kind, string objectId)
+    private static string NormalizeElementName(string? name, PanelElementKind kind, string objectId)
     {
         return string.IsNullOrWhiteSpace(name)
             ? CreateDefaultElementName(kind, objectId)
             : name.Trim();
     }
+}
+
+internal enum PanelElementKind
+{
+    Unknown = 0,
+    Rectangle,
+    Image,
+    Anchor,
+    Zone
 }
 
 internal sealed class Panel2DDocumentFile
@@ -126,4 +179,7 @@ internal sealed record PanelElementFile
     public double Y { get; init; }
     public double Width { get; init; }
     public double Height { get; init; }
+
+    [JsonIgnore]
+    public PanelElementKind ElementKind => Panel2DDocumentStorage.ParseElementKind(Kind);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -71,12 +71,40 @@ internal static class Panel2DDocumentStorage
 
     private static PanelElementFile NormalizeElement(PanelElementFile element)
     {
+        var normalizedObjectId = string.IsNullOrWhiteSpace(element.ObjectId)
+            ? Guid.NewGuid().ToString("N")
+            : element.ObjectId.Trim();
+
         return element with
         {
-            ObjectId = string.IsNullOrWhiteSpace(element.ObjectId)
-                ? Guid.NewGuid().ToString("N")
-                : element.ObjectId.Trim()
+            ObjectId = normalizedObjectId,
+            Name = NormalizeElementName(element.Name, element.Kind, normalizedObjectId),
+            Kind = element.Kind?.Trim() ?? string.Empty
         };
+    }
+
+    internal static string CreateDefaultElementName(string? kind, string? objectId)
+    {
+        var prefix = string.Equals(kind, "image", StringComparison.OrdinalIgnoreCase)
+            ? "Image"
+            : "Rectangle";
+
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return prefix;
+        }
+
+        var trimmedObjectId = objectId.Trim();
+        var suffixLength = Math.Min(6, trimmedObjectId.Length);
+        var suffix = trimmedObjectId[..suffixLength].ToUpperInvariant();
+        return $"{prefix} {suffix}";
+    }
+
+    private static string NormalizeElementName(string? name, string? kind, string objectId)
+    {
+        return string.IsNullOrWhiteSpace(name)
+            ? CreateDefaultElementName(kind, objectId)
+            : name.Trim();
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -170,7 +170,7 @@ internal sealed class Panel2DDocumentFile
     public PanelElementFile[] Elements { get; init; } = [];
 }
 
-internal sealed record PanelElementFile
+internal sealed record PanelElementFile : IPanelSelectableObject
 {
     public string ObjectId { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -21,8 +21,8 @@ internal static class PanelElementFactory
         return new PanelElementFile
         {
             ObjectId = objectId,
-            Name = Panel2DDocumentStorage.CreateDefaultElementName("rectangle", objectId),
-            Kind = "rectangle",
+            Name = Panel2DDocumentStorage.CreateDefaultElementName(PanelElementKind.Rectangle, objectId),
+            Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Rectangle),
             X = x,
             Y = y,
             Width = NewRectangleWidth,
@@ -38,8 +38,8 @@ internal static class PanelElementFactory
         return new PanelElementFile
         {
             ObjectId = objectId,
-            Name = Panel2DDocumentStorage.CreateDefaultElementName("image", objectId),
-            Kind = "image",
+            Name = Panel2DDocumentStorage.CreateDefaultElementName(PanelElementKind.Image, objectId),
+            Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Image),
             X = x,
             Y = y,
             Width = NewImageWidth,
@@ -49,7 +49,7 @@ internal static class PanelElementFactory
 
     public static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
     {
-        if (string.Equals(element.Kind, "rectangle", StringComparison.OrdinalIgnoreCase))
+        if (element.ElementKind == PanelElementKind.Rectangle)
         {
             return new Rectangle
             {
@@ -59,7 +59,7 @@ internal static class PanelElementFactory
             };
         }
 
-        if (string.Equals(element.Kind, "image", StringComparison.OrdinalIgnoreCase))
+        if (element.ElementKind == PanelElementKind.Image)
         {
             return new Image
             {
@@ -78,12 +78,12 @@ internal static class PanelElementFactory
     {
         var kind = child switch
         {
-            Rectangle => "rectangle",
-            Image => "image",
-            _ => null
+            Rectangle => PanelElementKind.Rectangle,
+            Image => PanelElementKind.Image,
+            _ => PanelElementKind.Unknown
         };
 
-        if (kind is null)
+        if (kind == PanelElementKind.Unknown)
         {
             return null;
         }
@@ -93,7 +93,7 @@ internal static class PanelElementFactory
         {
             ObjectId = objectId,
             Name = Panel2DDocumentStorage.CreateDefaultElementName(kind, objectId),
-            Kind = kind,
+            Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
             X = Canvas.GetLeft(child),
             Y = Canvas.GetTop(child),
             Width = child.Width,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -8,6 +8,13 @@ namespace OasisEditor;
 
 internal static class PanelElementFactory
 {
+    public static readonly DependencyProperty ElementNameProperty =
+        DependencyProperty.RegisterAttached(
+            "ElementName",
+            typeof(string),
+            typeof(PanelElementFactory),
+            new PropertyMetadata(string.Empty));
+
     public const double NewRectangleWidth = 180;
     public const double NewRectangleHeight = 120;
     public const double NewImageWidth = 220;
@@ -51,17 +58,20 @@ internal static class PanelElementFactory
     {
         if (element.ElementKind == PanelElementKind.Rectangle)
         {
-            return new Rectangle
+            var rectangle = new Rectangle
             {
                 Uid = element.ObjectId,
                 Width = element.Width <= 0 ? NewRectangleWidth : element.Width,
                 Height = element.Height <= 0 ? NewRectangleHeight : element.Height
             };
+
+            SetElementName(rectangle, element.Name);
+            return rectangle;
         }
 
         if (element.ElementKind == PanelElementKind.Image)
         {
-            return new Image
+            var image = new Image
             {
                 Uid = element.ObjectId,
                 Width = element.Width <= 0 ? NewImageWidth : element.Width,
@@ -69,6 +79,9 @@ internal static class PanelElementFactory
                 Stretch = Stretch.Fill,
                 Source = CreatePlaceholderImageSource()
             };
+
+            SetElementName(image, element.Name);
+            return image;
         }
 
         return null;
@@ -89,16 +102,29 @@ internal static class PanelElementFactory
         }
 
         var objectId = string.IsNullOrWhiteSpace(child.Uid) ? Guid.NewGuid().ToString("N") : child.Uid.Trim();
+        var elementName = GetElementName(child);
         return new PanelElementFile
         {
             ObjectId = objectId,
-            Name = Panel2DDocumentStorage.CreateDefaultElementName(kind, objectId),
+            Name = string.IsNullOrWhiteSpace(elementName)
+                ? Panel2DDocumentStorage.CreateDefaultElementName(kind, objectId)
+                : elementName.Trim(),
             Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
             X = Canvas.GetLeft(child),
             Y = Canvas.GetTop(child),
             Width = child.Width,
             Height = child.Height
         };
+    }
+
+    public static string GetElementName(DependencyObject dependencyObject)
+    {
+        return (string)dependencyObject.GetValue(ElementNameProperty);
+    }
+
+    public static void SetElementName(DependencyObject dependencyObject, string value)
+    {
+        dependencyObject.SetValue(ElementNameProperty, value);
     }
 
     private static ImageSource CreatePlaceholderImageSource()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -17,9 +17,11 @@ internal static class PanelElementFactory
     {
         var x = Math.Max(0, canvasPoint.X - (NewRectangleWidth / 2));
         var y = Math.Max(0, canvasPoint.Y - (NewRectangleHeight / 2));
+        var objectId = Guid.NewGuid().ToString("N");
         return new PanelElementFile
         {
-            ObjectId = Guid.NewGuid().ToString("N"),
+            ObjectId = objectId,
+            Name = Panel2DDocumentStorage.CreateDefaultElementName("rectangle", objectId),
             Kind = "rectangle",
             X = x,
             Y = y,
@@ -32,9 +34,11 @@ internal static class PanelElementFactory
     {
         var x = Math.Max(0, canvasPoint.X - (NewImageWidth / 2));
         var y = Math.Max(0, canvasPoint.Y - (NewImageHeight / 2));
+        var objectId = Guid.NewGuid().ToString("N");
         return new PanelElementFile
         {
-            ObjectId = Guid.NewGuid().ToString("N"),
+            ObjectId = objectId,
+            Name = Panel2DDocumentStorage.CreateDefaultElementName("image", objectId),
             Kind = "image",
             X = x,
             Y = y,
@@ -84,9 +88,11 @@ internal static class PanelElementFactory
             return null;
         }
 
+        var objectId = string.IsNullOrWhiteSpace(child.Uid) ? Guid.NewGuid().ToString("N") : child.Uid.Trim();
         return new PanelElementFile
         {
-            ObjectId = string.IsNullOrWhiteSpace(child.Uid) ? Guid.NewGuid().ToString("N") : child.Uid.Trim(),
+            ObjectId = objectId,
+            Name = Panel2DDocumentStorage.CreateDefaultElementName(kind, objectId),
             Kind = kind,
             X = Canvas.GetLeft(child),
             Y = Canvas.GetTop(child),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelSelectionContracts.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelSelectionContracts.cs
@@ -1,0 +1,105 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Shapes;
+
+namespace OasisEditor;
+
+internal interface IPanelSelectableObject
+{
+    string ObjectId { get; }
+    PanelElementKind ElementKind { get; }
+    double X { get; }
+    double Y { get; }
+    double Width { get; }
+    double Height { get; }
+}
+
+internal static class PanelSelectionContract
+{
+    public static PanelSelectionInfo ToSelectionInfo(IPanelSelectableObject selectable)
+    {
+        return new PanelSelectionInfo(
+            selectable.ObjectId,
+            Panel2DDocumentStorage.SerializeElementKind(selectable.ElementKind),
+            selectable.X,
+            selectable.Y,
+            selectable.Width,
+            selectable.Height);
+    }
+
+    public static bool IsMatch(IPanelSelectableObject selectable, PanelSelectionInfo selection)
+    {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
+            && !string.IsNullOrWhiteSpace(selectable.ObjectId))
+        {
+            if (string.Equals(selectable.ObjectId, selection.ObjectId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return IsTypeAndBoundsMatch(selectable, selection);
+    }
+
+    public static bool IsTypeAndBoundsMatch(IPanelSelectableObject selectable, PanelSelectionInfo selection)
+    {
+        return selectable.ElementKind == Panel2DDocumentStorage.ParseElementKind(selection.Kind)
+            && AreClose(selectable.X, selection.X)
+            && AreClose(selectable.Y, selection.Y)
+            && AreClose(selectable.Width, selection.Width)
+            && AreClose(selectable.Height, selection.Height);
+    }
+
+    public static bool IsSame(IPanelSelectableObject left, IPanelSelectableObject right)
+    {
+        if (!string.IsNullOrWhiteSpace(left.ObjectId)
+            && !string.IsNullOrWhiteSpace(right.ObjectId))
+        {
+            return string.Equals(left.ObjectId, right.ObjectId, StringComparison.Ordinal);
+        }
+
+        return left.ElementKind == right.ElementKind
+            && AreClose(left.X, right.X)
+            && AreClose(left.Y, right.Y)
+            && AreClose(left.Width, right.Width)
+            && AreClose(left.Height, right.Height);
+    }
+
+    public static bool TryCreateFromVisual(FrameworkElement element, out IPanelSelectableObject selectable)
+    {
+        var kind = element switch
+        {
+            Rectangle => PanelElementKind.Rectangle,
+            Image => PanelElementKind.Image,
+            _ => PanelElementKind.Unknown
+        };
+
+        if (kind == PanelElementKind.Unknown)
+        {
+            selectable = null!;
+            return false;
+        }
+
+        selectable = new VisualPanelSelectableObject(
+            element.Uid?.Trim() ?? string.Empty,
+            kind,
+            Canvas.GetLeft(element),
+            Canvas.GetTop(element),
+            element.Width,
+            element.Height);
+        return true;
+    }
+
+    private static bool AreClose(double left, double right)
+    {
+        return Math.Abs(left - right) < 0.01d;
+    }
+
+    private sealed record VisualPanelSelectableObject(
+        string ObjectId,
+        PanelElementKind ElementKind,
+        double X,
+        double Y,
+        double Width,
+        double Height) : IPanelSelectableObject;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelSelectionContracts.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelSelectionContracts.cs
@@ -50,6 +50,21 @@ internal static class PanelSelectionContract
             && AreClose(selectable.Height, selection.Height);
     }
 
+    public static bool IsSameSelection(PanelSelectionInfo left, PanelSelectionInfo right)
+    {
+        if (!string.IsNullOrWhiteSpace(left.ObjectId)
+            && !string.IsNullOrWhiteSpace(right.ObjectId))
+        {
+            return string.Equals(left.ObjectId, right.ObjectId, StringComparison.Ordinal);
+        }
+
+        return Panel2DDocumentStorage.ParseElementKind(left.Kind) == Panel2DDocumentStorage.ParseElementKind(right.Kind)
+            && AreClose(left.X, right.X)
+            && AreClose(left.Y, right.Y)
+            && AreClose(left.Width, right.Width)
+            && AreClose(left.Height, right.Height);
+    }
+
     public static bool IsSame(IPanelSelectableObject left, IPanelSelectableObject right)
     {
         if (!string.IsNullOrWhiteSpace(left.ObjectId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
@@ -142,16 +142,7 @@ public sealed class HierarchyViewModel : INotifyPropertyChanged
 
     private static bool IsSelectionMatch(PanelSelectionInfo left, PanelSelectionInfo right)
     {
-        return string.Equals(left.Kind, right.Kind, StringComparison.OrdinalIgnoreCase)
-            && AreClose(left.X, right.X)
-            && AreClose(left.Y, right.Y)
-            && AreClose(left.Width, right.Width)
-            && AreClose(left.Height, right.Height);
-    }
-
-    private static bool AreClose(double left, double right)
-    {
-        return Math.Abs(left - right) < 0.01d;
+        return PanelSelectionContract.IsSameSelection(left, right);
     }
 
     private static IEnumerable<HierarchyItemViewModel> Flatten(IEnumerable<HierarchyItemViewModel> items)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -17,10 +17,10 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
         var elements = Panel2DDocumentStorage.DeserializeLayout(document?.PanelLayoutJson);
         var groups = new List<HierarchyItemViewModel>
         {
-            BuildGroup("Images", elements, "image", "Image"),
-            BuildGroup("Rectangles", elements, "rectangle", "Rectangle"),
-            BuildGroup("Anchors", elements, "anchor", "Anchor"),
-            BuildGroup("Zones", elements, "zone", "Zone")
+            BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
+            BuildGroup("Rectangles", elements, PanelElementKind.Rectangle, "Rectangle"),
+            BuildGroup("Anchors", elements, PanelElementKind.Anchor, "Anchor"),
+            BuildGroup("Zones", elements, PanelElementKind.Zone, "Zone")
         };
 
         return groups;
@@ -29,11 +29,12 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
     private static HierarchyItemViewModel BuildGroup(
         string groupName,
         IReadOnlyList<PanelElementFile> elements,
-        string kind,
+        PanelElementKind kind,
         string itemPrefix)
     {
+        var kindToken = Panel2DDocumentStorage.SerializeElementKind(kind);
         var matches = elements
-            .Where(element => string.Equals(element.Kind, kind, StringComparison.OrdinalIgnoreCase))
+            .Where(element => element.ElementKind == kind)
             .Select((element, index) =>
             {
                 var x = Math.Round(element.X);
@@ -48,7 +49,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
                     $"{kind}:{element.ObjectId}",
                     panelSelection: new PanelSelectionInfo(
                         element.ObjectId,
-                        kind,
+                        kindToken,
                         element.X,
                         element.Y,
                         element.Width,
@@ -57,6 +58,6 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
             .ToArray();
 
         var label = matches.Length > 0 ? $"{groupName} ({matches.Length})" : $"{groupName} (0)";
-        return new HierarchyItemViewModel(label, $"group:{kind}", isGroup: true, children: matches);
+        return new HierarchyItemViewModel(label, $"group:{kindToken}", isGroup: true, children: matches);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -46,7 +46,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
                     : element.Name.Trim();
                 return new HierarchyItemViewModel(
                     displayName,
-                    $"{kind}:{element.ObjectId}",
+                    $"{kindToken}:{element.ObjectId}",
                     panelSelection: new PanelSelectionInfo(
                         element.ObjectId,
                         kindToken,

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -54,7 +54,7 @@
 - [x] Ensure every editable panel object has a display name
 - [x] Ensure object type is explicit and queryable
 - [x] Ensure image and rectangle objects share common selectable-object contract
-- [ ] Ensure hierarchy and inspector use the same selected object identity
+- [x] Ensure hierarchy and inspector use the same selected object identity
 - [ ] Ensure save/load preserves object IDs and names
 
 ## Next Up

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -55,7 +55,7 @@
 - [x] Ensure object type is explicit and queryable
 - [x] Ensure image and rectangle objects share common selectable-object contract
 - [x] Ensure hierarchy and inspector use the same selected object identity
-- [ ] Ensure save/load preserves object IDs and names
+- [x] Ensure save/load preserves object IDs and names
 
 ## Next Up
 - [ ] Improve panel editor usability:

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -52,7 +52,7 @@
 ### Panel Editor Object Model Cleanup
 - [x] Ensure every editable panel object has a stable object ID
 - [x] Ensure every editable panel object has a display name
-- [ ] Ensure object type is explicit and queryable
+- [x] Ensure object type is explicit and queryable
 - [ ] Ensure image and rectangle objects share common selectable-object contract
 - [ ] Ensure hierarchy and inspector use the same selected object identity
 - [ ] Ensure save/load preserves object IDs and names

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -53,7 +53,7 @@
 - [x] Ensure every editable panel object has a stable object ID
 - [x] Ensure every editable panel object has a display name
 - [x] Ensure object type is explicit and queryable
-- [ ] Ensure image and rectangle objects share common selectable-object contract
+- [x] Ensure image and rectangle objects share common selectable-object contract
 - [ ] Ensure hierarchy and inspector use the same selected object identity
 - [ ] Ensure save/load preserves object IDs and names
 

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -51,7 +51,7 @@
 
 ### Panel Editor Object Model Cleanup
 - [x] Ensure every editable panel object has a stable object ID
-- [ ] Ensure every editable panel object has a display name
+- [x] Ensure every editable panel object has a display name
 - [ ] Ensure object type is explicit and queryable
 - [ ] Ensure image and rectangle objects share common selectable-object contract
 - [ ] Ensure hierarchy and inspector use the same selected object identity


### PR DESCRIPTION
### Motivation
- Panel elements created or loaded from layout could be nameless, which prevents useful hierarchy labels and renaming workflows.
- Ensure the editor always exposes a readable display name for images and rectangles so hierarchy/inspector features work reliably.

### Description
- Normalize deserialized elements in `Panel2DDocumentStorage.NormalizeElement` to always set a trimmed `Kind`, a stable `ObjectId`, and a non-empty `Name` via a new naming helper.
- Add `CreateDefaultElementName` and `NormalizeElementName` helpers to `Panel2DDocumentStorage` to derive readable default names from element kind and object id.
- Assign default names when new elements are created in `PanelElementFactory.CreateRectangleElement` and `CreateImageElement` using the shared helper.
- Ensure visual-to-data mapping in `PanelElementFactory.CreateElementFromVisual` also supplies a default name for elements created from visuals. 
- Update `TASKS.md` to mark the display-name checklist item as completed.

### Testing
- Attempted to build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not run in this environment because the `dotnet` SDK is not available (`dotnet: command not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eca9dd87d08327b1d3a24226b62b8c)