### PR TITLE
Open assets in document pane via double-click

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -100,6 +100,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AssetBrowserItems = _assetBrowser.AssetBrowserItems;
         OutputEntries = _outputLog.OutputEntries;
         RefreshAssetBrowserCommand = _assetBrowser.RefreshAssetBrowserCommand;
+        OpenAssetCommand = _assetBrowser.OpenAssetCommand;
         ClearOutputCommand = _outputLog.ClearOutputCommand;
         ApplyInspectorSummaryCommand = _inspector.ApplyInspectorSummaryCommand;
         AddOutputEntry("Editor shell initialized.", OutputLogStatus.Info);
@@ -117,6 +118,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
+    public ICommand OpenAssetCommand { get; }
     public ICommand ClearOutputCommand { get; }
     public ICommand OpenPreferencesCommand { get; }
     public ICommand OpenProjectSettingsCommand { get; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -70,7 +70,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => LoadedProject,
             () => OnPropertyChanged(nameof(SelectedAsset)),
             NotifyInspectorChanged,
-            AddOutputEntry);
+            AddOutputEntry,
+            OpenAssetDocument);
         _inspector = new InspectorViewModel(
             () => SelectedAsset,
             () => SelectedDocument,
@@ -411,24 +412,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         try
         {
-            var path = dialog.FileName;
-            var content = File.ReadAllText(path);
-            var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData(path, content);
-
-            var openedNewTab = _documentWorkspace.OpenOrSelectDocument(path, openData.Summary, openData.PanelLayoutJson);
-            if (!openedNewTab)
-            {
-                AddOutputEntry($"Switched to already open document tab for {path}", OutputLogStatus.Info);
-            }
-
-            var selectedTitle = SelectedDocument?.Title ?? Path.GetFileName(path);
-            StatusMessage = openedNewTab
-                ? $"Opened document: {selectedTitle}"
-                : $"Activated open document tab: {selectedTitle}";
-            AddOutputEntry(openedNewTab
-                ? $"Opened document file {path}"
-                : $"Activated existing document tab for {path}",
-                OutputLogStatus.Info);
+            OpenDocumentFromPath(dialog.FileName);
         }
         catch (Exception ex)
         {
@@ -436,6 +420,46 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Open document failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Open Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private void OpenAssetDocument(AssetBrowserItemViewModel? asset)
+    {
+        if (asset is null)
+        {
+            return;
+        }
+
+        try
+        {
+            OpenDocumentFromPath(asset.FullPath);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            AddOutputEntry($"Open asset failed: {ex.Message}", OutputLogStatus.Error);
+            MessageBox.Show(ex.Message, "Open Asset Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private void OpenDocumentFromPath(string path)
+    {
+        var content = File.ReadAllText(path);
+        var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData(path, content);
+
+        var openedNewTab = _documentWorkspace.OpenOrSelectDocument(path, openData.Summary, openData.PanelLayoutJson);
+        if (!openedNewTab)
+        {
+            AddOutputEntry($"Switched to already open document tab for {path}", OutputLogStatus.Info);
+        }
+
+        var selectedTitle = SelectedDocument?.Title ?? Path.GetFileName(path);
+        StatusMessage = openedNewTab
+            ? $"Opened document: {selectedTitle}"
+            : $"Activated open document tab: {selectedTitle}";
+        AddOutputEntry(openedNewTab
+            ? $"Opened document file {path}"
+            : $"Activated existing document tab for {path}",
+            OutputLogStatus.Info);
     }
 
     private bool CanSaveSelectedDocument()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -11,25 +11,30 @@ public sealed class AssetBrowserViewModel
     private readonly Action _selectionChanged;
     private readonly Action _notifyInspectorChanged;
     private readonly Action<string, OutputLogStatus> _addOutputEntry;
+    private readonly Action<AssetBrowserItemViewModel?> _openAsset;
     private AssetBrowserItemViewModel? _selectedAsset;
 
     public AssetBrowserViewModel(
         Func<EditorProject?> loadedProjectAccessor,
         Action selectionChanged,
         Action notifyInspectorChanged,
-        Action<string, OutputLogStatus> addOutputEntry)
+        Action<string, OutputLogStatus> addOutputEntry,
+        Action<AssetBrowserItemViewModel?> openAsset)
     {
         _loadedProjectAccessor = loadedProjectAccessor;
         _selectionChanged = selectionChanged;
         _notifyInspectorChanged = notifyInspectorChanged;
         _addOutputEntry = addOutputEntry;
+        _openAsset = openAsset;
 
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
+        OpenAssetCommand = new RelayCommand(OpenAsset);
     }
 
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
+    public ICommand OpenAssetCommand { get; }
 
     public AssetBrowserItemViewModel? SelectedAsset
     {
@@ -94,5 +99,17 @@ public sealed class AssetBrowserViewModel
         {
             refreshRelayCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    private void OpenAsset(object? commandParameter)
+    {
+        var asset = commandParameter as AssetBrowserItemViewModel ?? SelectedAsset;
+        if (asset is null)
+        {
+            return;
+        }
+
+        SelectedAsset = asset;
+        _openAsset(asset);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -101,9 +101,9 @@ public sealed class AssetBrowserViewModel
         }
     }
 
-    private void OpenAsset(object? commandParameter)
+    private void OpenAsset()
     {
-        var asset = commandParameter as AssetBrowserItemViewModel ?? SelectedAsset;
+        var asset = SelectedAsset;
         if (asset is null)
         {
             return;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -23,20 +23,8 @@
 
         <ListBox Grid.Row="1"
                  ItemsSource="{Binding AssetBrowserItems}"
-                 SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
-            <ListBox.ItemContainerStyle>
-                <Style TargetType="{x:Type ListBoxItem}">
-                    <Setter Property="InputBindings">
-                        <Setter.Value>
-                            <InputBindingCollection>
-                                <MouseBinding Gesture="LeftDoubleClick"
-                                              Command="{Binding DataContext.OpenAssetCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                              CommandParameter="{Binding}" />
-                            </InputBindingCollection>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </ListBox.ItemContainerStyle>
+                 SelectedItem="{Binding SelectedAsset, Mode=TwoWay}"
+                 MouseDoubleClick="OnAssetListMouseDoubleClick">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding DisplayPath}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -24,6 +24,19 @@
         <ListBox Grid.Row="1"
                  ItemsSource="{Binding AssetBrowserItems}"
                  SelectedItem="{Binding SelectedAsset, Mode=TwoWay}">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="{x:Type ListBoxItem}">
+                    <Setter Property="InputBindings">
+                        <Setter.Value>
+                            <InputBindingCollection>
+                                <MouseBinding Gesture="LeftDoubleClick"
+                                              Command="{Binding DataContext.OpenAssetCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              CommandParameter="{Binding}" />
+                            </InputBindingCollection>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.ItemContainerStyle>
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <TextBlock Text="{Binding DisplayPath}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
@@ -13,15 +13,16 @@ public partial class AssetBrowserView : UserControl
 
     private void OnAssetListMouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        if (DataContext is not AssetBrowserViewModel viewModel)
+        if (DataContext is not MainWindowViewModel viewModel)
         {
             return;
         }
 
         var command = viewModel.OpenAssetCommand;
-        if (command.CanExecute(null))
+        var selectedAsset = viewModel.SelectedAsset;
+        if (command.CanExecute(selectedAsset))
         {
-            command.Execute(null);
+            command.Execute(selectedAsset);
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows.Controls;
+using System.Windows.Input;
+using OasisEditor;
 
 namespace OasisEditor.Views;
 
@@ -7,5 +9,20 @@ public partial class AssetBrowserView : UserControl
     public AssetBrowserView()
     {
         InitializeComponent();
+    }
+
+    private void OnAssetListMouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is not AssetBrowserViewModel viewModel)
+        {
+            return;
+        }
+
+        var command = viewModel.OpenAssetCommand;
+        var commandParameter = viewModel.SelectedAsset;
+        if (command.CanExecute(commandParameter))
+        {
+            command.Execute(commandParameter);
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
@@ -19,10 +19,9 @@ public partial class AssetBrowserView : UserControl
         }
 
         var command = viewModel.OpenAssetCommand;
-        var commandParameter = viewModel.SelectedAsset;
-        if (command.CanExecute(commandParameter))
+        if (command.CanExecute(null))
         {
-            command.Execute(commandParameter);
+            command.Execute(null);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Asset Browser behave like a typical editor by opening the asset file in the document workspace when the user double-clicks an asset. 
- Reuse centralized open/select tab logic so double-clicking an already-open asset activates its existing tab instead of opening duplicates.

### Description
- Added `OpenAssetCommand` to `AssetBrowserViewModel` and a private `OpenAsset` handler that selects the asset and invokes a provided open callback. (modified `ViewModels/AssetBrowserViewModel.cs`)
- Wired `MainWindowViewModel` to provide an `OpenAssetDocument` callback and refactored the menu-based open flow into `OpenDocumentFromPath` so both menu and double-click paths share the same open/select behavior. (modified `MainWindowViewModel.cs`)
- Updated `AssetBrowserView.xaml` to bind a `MouseBinding` for `LeftDoubleClick` on `ListBoxItem` to `OpenAssetCommand`, passing the clicked item as the command parameter. (modified `Views/AssetBrowserView.xaml`)

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` in this environment and it failed because `dotnet` is not installed, so no build was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecc4da9dec8327949bf9372dbf3ba0)