### PR TITLE
Make panel2D pan/zoom state document-specific

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -46,6 +46,27 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedPanelSelectionChanged));
 
+    public static readonly DependencyProperty PanelZoomProperty =
+        DependencyProperty.RegisterAttached(
+            "PanelZoom",
+            typeof(double),
+            typeof(CanvasPanBehavior),
+            new FrameworkPropertyMetadata(1.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelViewportStateChanged));
+
+    public static readonly DependencyProperty PanelPanXProperty =
+        DependencyProperty.RegisterAttached(
+            "PanelPanX",
+            typeof(double),
+            typeof(CanvasPanBehavior),
+            new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelViewportStateChanged));
+
+    public static readonly DependencyProperty PanelPanYProperty =
+        DependencyProperty.RegisterAttached(
+            "PanelPanY",
+            typeof(double),
+            typeof(CanvasPanBehavior),
+            new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelViewportStateChanged));
+
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
         return (bool)dependencyObject.GetValue(IsEnabledProperty);
@@ -96,6 +117,36 @@ public static class CanvasPanBehavior
         dependencyObject.SetValue(SelectedPanelSelectionProperty, value);
     }
 
+    public static double GetPanelZoom(DependencyObject dependencyObject)
+    {
+        return (double)dependencyObject.GetValue(PanelZoomProperty);
+    }
+
+    public static void SetPanelZoom(DependencyObject dependencyObject, double value)
+    {
+        dependencyObject.SetValue(PanelZoomProperty, value);
+    }
+
+    public static double GetPanelPanX(DependencyObject dependencyObject)
+    {
+        return (double)dependencyObject.GetValue(PanelPanXProperty);
+    }
+
+    public static void SetPanelPanX(DependencyObject dependencyObject, double value)
+    {
+        dependencyObject.SetValue(PanelPanXProperty, value);
+    }
+
+    public static double GetPanelPanY(DependencyObject dependencyObject)
+    {
+        return (double)dependencyObject.GetValue(PanelPanYProperty);
+    }
+
+    public static void SetPanelPanY(DependencyObject dependencyObject, double value)
+    {
+        dependencyObject.SetValue(PanelPanYProperty, value);
+    }
+
     private static void OnIsEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
     {
         if (dependencyObject is not FrameworkElement element)
@@ -107,6 +158,7 @@ public static class CanvasPanBehavior
         if (isEnabled)
         {
             CanvasPanZoomBehavior.EnsureTransformGroup(element);
+            ApplyViewportStateToCanvas(element);
             element.MouseDown += OnMouseDown;
             element.MouseLeftButtonDown += OnMouseLeftButtonDown;
             element.MouseMove += OnMouseMove;
@@ -125,6 +177,16 @@ public static class CanvasPanBehavior
         }
     }
 
+    private static void OnPanelViewportStateChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs _)
+    {
+        if (dependencyObject is not FrameworkElement element)
+        {
+            return;
+        }
+
+        ApplyViewportStateToCanvas(element);
+    }
+
     private static void OnMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
         if (sender is not FrameworkElement element)
@@ -133,6 +195,7 @@ public static class CanvasPanBehavior
         }
 
         CanvasPanZoomBehavior.HandleMouseDown(element, eventArgs);
+        UpdateViewportStateFromCanvas(element);
     }
 
     private static void OnMouseMove(object sender, MouseEventArgs eventArgs)
@@ -143,6 +206,7 @@ public static class CanvasPanBehavior
         }
 
         CanvasPanZoomBehavior.HandleMouseMove(element, eventArgs);
+        UpdateViewportStateFromCanvas(element);
     }
 
     private static void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs eventArgs)
@@ -232,6 +296,7 @@ public static class CanvasPanBehavior
         }
 
         CanvasPanZoomBehavior.HandleMouseWheel(element, eventArgs);
+        UpdateViewportStateFromCanvas(element);
     }
 
     private static void OnMouseUp(object sender, MouseButtonEventArgs eventArgs)
@@ -252,6 +317,23 @@ public static class CanvasPanBehavior
         }
 
         CanvasPanZoomBehavior.HandleLostMouseCapture(element);
+    }
+
+    private static void ApplyViewportStateToCanvas(FrameworkElement element)
+    {
+        var (scale, translate) = CanvasPanZoomBehavior.EnsureTransformGroup(element);
+        scale.ScaleX = GetPanelZoom(element);
+        scale.ScaleY = GetPanelZoom(element);
+        translate.X = GetPanelPanX(element);
+        translate.Y = GetPanelPanY(element);
+    }
+
+    private static void UpdateViewportStateFromCanvas(FrameworkElement element)
+    {
+        var (scale, translate) = CanvasPanZoomBehavior.EnsureTransformGroup(element);
+        element.SetCurrentValue(PanelZoomProperty, scale.ScaleX);
+        element.SetCurrentValue(PanelPanXProperty, translate.X);
+        element.SetCurrentValue(PanelPanYProperty, translate.Y);
     }
 
     private static void ExecuteCanvasMutation(FrameworkElement canvas, Commands.ICommand command)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -492,7 +492,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 current.Document.SaveAs(savePath, current.ContentSummary).MarkClean(),
                 current.PanelLayoutJson,
                 current.DocumentId,
-                current.CommandService);
+                current.CommandService)
+            {
+                PanelZoom = current.PanelZoom,
+                PanelPanX = current.PanelPanX,
+                PanelPanY = current.PanelPanY
+            };
             _documentWorkspace.ReplaceDocument(current, updatedDocument);
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}", OutputLogStatus.Info);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -8,6 +8,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private readonly CommandService _commandService;
     private string? _panelLayoutJson;
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
+    private double _panelZoom = 1.0;
+    private double _panelPanX;
+    private double _panelPanY;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -66,6 +69,51 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
             _hierarchySelectedPanelSelection = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HierarchySelectedPanelSelection)));
+        }
+    }
+
+    public double PanelZoom
+    {
+        get => _panelZoom;
+        set
+        {
+            if (Math.Abs(_panelZoom - value) < 0.0001)
+            {
+                return;
+            }
+
+            _panelZoom = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelZoom)));
+        }
+    }
+
+    public double PanelPanX
+    {
+        get => _panelPanX;
+        set
+        {
+            if (Math.Abs(_panelPanX - value) < 0.0001)
+            {
+                return;
+            }
+
+            _panelPanX = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelPanX)));
+        }
+    }
+
+    public double PanelPanY
+    {
+        get => _panelPanY;
+        set
+        {
+            if (Math.Abs(_panelPanY - value) < 0.0001)
+            {
+                return;
+            }
+
+            _panelPanY = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelPanY)));
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -228,7 +228,12 @@ public sealed class DocumentWorkspaceViewModel
             selectedDocument.Document.WithContentSummary(summary).MarkDirty(),
             selectedDocument.PanelLayoutJson,
             selectedDocument.DocumentId,
-            selectedDocument.CommandService);
+            selectedDocument.CommandService)
+        {
+            PanelZoom = selectedDocument.PanelZoom,
+            PanelPanX = selectedDocument.PanelPanX,
+            PanelPanY = selectedDocument.PanelPanY
+        };
 
         ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, selectedDocument, updated));
         _setStatusMessage($"Updated inspector summary for {updated.Title}");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
@@ -109,6 +109,9 @@
                                             local:CanvasPanBehavior.IsImageToolActive="{Binding IsChecked, ElementName=ImageToolToggle}"
                                             local:CanvasPanBehavior.PanelLayoutJson="{Binding PanelLayoutJson, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             local:CanvasPanBehavior.SelectedPanelSelection="{Binding HierarchySelectedPanelSelection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            local:CanvasPanBehavior.PanelZoom="{Binding PanelZoom, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            local:CanvasPanBehavior.PanelPanX="{Binding PanelPanX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            local:CanvasPanBehavior.PanelPanY="{Binding PanelPanY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             Background="{DynamicResource PanelBackgroundBrush}">
                                         <Canvas.Resources>
                                             <Style TargetType="Rectangle">


### PR DESCRIPTION
### Motivation
- Multiple open Panel2D documents shared a single canvas transform, causing pan/zoom to follow the last-interacted tab instead of staying per-document.

### Description
- Add per-document viewport properties `PanelZoom`, `PanelPanX`, and `PanelPanY` to `DocumentTabViewModel` so each tab can own its pan/zoom state (`ViewModels/DocumentTabViewModel.cs`).
- Add attached properties `PanelZoom`, `PanelPanX`, and `PanelPanY` to `CanvasPanBehavior` and wire `OnPanelViewportStateChanged`, `ApplyViewportStateToCanvas`, and `UpdateViewportStateFromCanvas` to apply and sync the transform (`CanvasPanBehavior.cs`).
- Update `CanvasPanBehavior` to apply the bound viewport state when a canvas is enabled and to push updated values back during pan/zoom interactions (`OnMouseDown`, `OnMouseMove`, `OnMouseWheel`).
- Bind the new attached properties in the panel canvas view so each tab’s canvas is connected to its `DocumentTabViewModel` viewport state (`Views/PanelCanvasView.xaml`).

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but `dotnet` is not available in this environment so a build could not be performed.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eccd34224483278dd68b5b2ed9e901)