### PR TITLE
Persist OasisEditor main window state per project

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -3,4 +3,15 @@ namespace OasisEditor;
 public sealed class EditorPreferences
 {
     public ThemePreference ThemePreference { get; init; } = ThemePreference.Dark;
+
+    public Dictionary<string, ProjectWindowState> ProjectWindowStates { get; init; } = new();
+}
+
+public sealed class ProjectWindowState
+{
+    public double Left { get; init; }
+    public double Top { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public bool IsMaximized { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -5,6 +5,9 @@ namespace OasisEditor;
 
 public partial class MainWindow : Window
 {
+    private readonly EditorPreferencesStore _preferencesStore;
+    private readonly string _startupProjectFilePath;
+
     public MainWindow(
         IApplicationThemeService applicationThemeService,
         EditorPreferencesStore preferencesStore,
@@ -15,7 +18,12 @@ public partial class MainWindow : Window
             throw new InvalidOperationException("Editor shell requires an active loaded project.");
         }
 
+        _preferencesStore = preferencesStore;
+        _startupProjectFilePath = NormalizeProjectPath(startupProjectFilePath);
+
         InitializeComponent();
+        Loaded += OnLoaded;
+        Closing += OnClosing;
         EditorKeyboardShortcuts.RegisterWindowBindings(this);
         var viewModel = new MainWindowViewModel(applicationThemeService, preferencesStore, this, startupProjectFilePath);
         DataContext = viewModel;
@@ -39,5 +47,70 @@ public partial class MainWindow : Window
             args.CanExecute = viewModel.CanRedoActiveDocument();
             args.Handled = true;
         }));
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        ApplyWindowPlacement();
+    }
+
+    private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        SaveWindowPlacement();
+    }
+
+    private void ApplyWindowPlacement()
+    {
+        var preferences = _preferencesStore.Load();
+        if (!preferences.ProjectWindowStates.TryGetValue(_startupProjectFilePath, out var persistedState))
+        {
+            WindowState = WindowState.Maximized;
+            return;
+        }
+
+        var width = ClampToMinimum(persistedState.Width, MinWidth);
+        var height = ClampToMinimum(persistedState.Height, MinHeight);
+        Width = width;
+        Height = height;
+        Left = persistedState.Left;
+        Top = persistedState.Top;
+        WindowState = persistedState.IsMaximized ? WindowState.Maximized : WindowState.Normal;
+    }
+
+    private void SaveWindowPlacement()
+    {
+        var preferences = _preferencesStore.Load();
+        var states = new Dictionary<string, ProjectWindowState>(preferences.ProjectWindowStates, StringComparer.OrdinalIgnoreCase);
+        var bounds = WindowState == WindowState.Normal ? new Rect(Left, Top, Width, Height) : RestoreBounds;
+
+        states[_startupProjectFilePath] = new ProjectWindowState
+        {
+            Left = bounds.Left,
+            Top = bounds.Top,
+            Width = bounds.Width,
+            Height = bounds.Height,
+            IsMaximized = WindowState == WindowState.Maximized
+        };
+
+        _preferencesStore.Save(new EditorPreferences
+        {
+            ThemePreference = preferences.ThemePreference,
+            ProjectWindowStates = states
+        });
+    }
+
+    private static double ClampToMinimum(double value, double minimum)
+    {
+        if (double.IsNaN(value) || value <= 0)
+        {
+            return minimum;
+        }
+
+        return value < minimum ? minimum : value;
+    }
+
+    private static string NormalizeProjectPath(string projectFilePath)
+    {
+        return Path.GetFullPath(projectFilePath.Trim());
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Windows;
 using System.Windows.Input;
 


### PR DESCRIPTION
### Motivation
- Ensure the Editor window opens maximized the first time a project is opened and restores the exact previous window state when reopening the same project.

### Description
- Add `ProjectWindowStates` to `EditorPreferences` and introduce the `ProjectWindowState` model to persist per-project position, size and maximized flag (`WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs`).
- Wire `MainWindow` to load and save per-project placement by storing a normalized project file path, subscribing to `Loaded` and `Closing` events, and applying saved bounds or defaulting to maximized on first open (`WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs`).
- Persisted state uses `RestoreBounds` when the window is maximized, enforces minimum dimensions via `ClampToMinimum`, and saves the updated `EditorPreferences` with the `ProjectWindowStates` map.

### Testing
- Attempted automated build: `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj` which could not run in this environment because `dotnet` is not installed and therefore the build was not executed.
- Changes were compiled into the repository and committed locally (no runtime verification possible here due to missing .NET runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecd2917c2083278093481d657e94d0)