### PR TITLE
Add Window menu for reopening and focusing editor panes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -82,9 +82,20 @@
                 <MenuItem Header="_Project Settings"
                           Command="{Binding OpenProjectSettingsCommand}" />
             </MenuItem>
+            <MenuItem Header="_Window">
+                <MenuItem Header="_Assets"
+                          Click="OnAssetsWindowMenuItemClicked" />
+                <MenuItem Header="_Hierarchy"
+                          Click="OnHierarchyWindowMenuItemClicked" />
+                <MenuItem Header="_Inspector"
+                          Click="OnInspectorWindowMenuItemClicked" />
+                <MenuItem Header="_Output"
+                          Click="OnOutputWindowMenuItemClicked" />
+            </MenuItem>
         </Menu>
 
-        <views:EditorShellView Grid.Row="1"
+        <views:EditorShellView x:Name="EditorShell"
+                               Grid.Row="1"
                                Margin="0" />
 
         <StatusBar Grid.Row="2"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Input;
+using OasisEditor.Views;
 
 namespace OasisEditor;
 
@@ -58,6 +59,26 @@ public partial class MainWindow : Window
     private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         SaveWindowPlacement();
+    }
+
+    private void OnAssetsWindowMenuItemClicked(object sender, RoutedEventArgs e)
+    {
+        EditorShell.ShowOrFocusToolWindow(EditorToolWindowId.Assets);
+    }
+
+    private void OnHierarchyWindowMenuItemClicked(object sender, RoutedEventArgs e)
+    {
+        EditorShell.ShowOrFocusToolWindow(EditorToolWindowId.Hierarchy);
+    }
+
+    private void OnInspectorWindowMenuItemClicked(object sender, RoutedEventArgs e)
+    {
+        EditorShell.ShowOrFocusToolWindow(EditorToolWindowId.Inspector);
+    }
+
+    private void OnOutputWindowMenuItemClicked(object sender, RoutedEventArgs e)
+    {
+        EditorShell.ShowOrFocusToolWindow(EditorToolWindowId.Output);
     }
 
     private void ApplyWindowPlacement()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -11,7 +11,7 @@
              d:DesignHeight="450"
              d:DesignWidth="900">
     <Grid Background="{DynamicResource EditorBackgroundBrush}">
-        <avalonDock:DockingManager
+        <avalonDock:DockingManager x:Name="DockingManager"
                                    Background="{DynamicResource EditorBackgroundBrush}">
             <avalonDock:DockingManager.Resources>
                 <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,3 +1,4 @@
+using AvalonDock.Layout;
 using System.Windows.Controls;
 
 namespace OasisEditor.Views;
@@ -7,5 +8,32 @@ public partial class EditorShellView : UserControl
     public EditorShellView()
     {
         InitializeComponent();
+    }
+
+    public void ShowOrFocusToolWindow(EditorToolWindowId toolWindowId)
+    {
+        var target = FindToolWindow(toolWindowId);
+        if (target is null)
+        {
+            return;
+        }
+
+        if (target.IsHidden)
+        {
+            target.Show();
+            target.Float();
+        }
+
+        target.Show();
+        target.IsSelected = true;
+        target.IsActive = true;
+    }
+
+    private LayoutAnchorable? FindToolWindow(EditorToolWindowId toolWindowId)
+    {
+        var contentId = toolWindowId.ToString();
+        return DockingManager.Layout.Descendents()
+            .OfType<LayoutAnchorable>()
+            .FirstOrDefault(anchorable => string.Equals(anchorable.ContentId, contentId, StringComparison.Ordinal));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
@@ -1,0 +1,9 @@
+namespace OasisEditor.Views;
+
+public enum EditorToolWindowId
+{
+    Assets,
+    Hierarchy,
+    Inspector,
+    Output
+}


### PR DESCRIPTION
### Motivation
- Users could not restore panes (Assets, Hierarchy, Inspector, Output) after closing them from the main editor UI, so a Window menu is needed to reopen or focus these panes.
- The editor uses AvalonDock anchorables, so the fix should locate anchorables by `ContentId` and either show/float them when hidden or select/activate when already present.

### Description
- Added a top-level `Window` menu in `MainWindow.xaml` with menu items for `Assets`, `Hierarchy`, `Inspector`, and `Output` and bound them to click handlers. 
- Exposed the shell instance in XAML (`<views:EditorShellView x:Name="EditorShell" />`) and added click handlers in `MainWindow.xaml.cs` that call into the shell view. 
- Added `EditorToolWindowId` enum to represent pane identifiers (`Assets`, `Hierarchy`, `Inspector`, `Output`).
- Named the AvalonDock `DockingManager` in `EditorShellView.xaml` and implemented `ShowOrFocusToolWindow(EditorToolWindowId)` in `EditorShellView.xaml.cs` which finds the `LayoutAnchorable` by `ContentId`, reopens and floats hidden panes, and selects/activates open panes.

### Testing
- Attempted to build the solution with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not run in this environment because `dotnet` is not available (`dotnet: command not found`).
- No automated test suite was executed due to the missing `dotnet` tool in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecdabaffb48327b0e5029c331a2bd6)