### PR TITLE
Mark Panel2D canvas mutations dirty on real changes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -51,6 +51,7 @@ internal static class CanvasMutationCommands
             elements.Insert(index, _element);
             _insertIndex = index;
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
 
         public void Undo()
@@ -89,6 +90,7 @@ internal static class CanvasMutationCommands
             if (removed)
             {
                 _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+                _document.MarkDirty();
             }
         }
     }
@@ -118,6 +120,7 @@ internal static class CanvasMutationCommands
             elements.Insert(index, _element);
             _insertIndex = index;
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
 
         public void Undo()
@@ -156,6 +159,7 @@ internal static class CanvasMutationCommands
             if (removed)
             {
                 _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+                _document.MarkDirty();
             }
         }
     }
@@ -191,6 +195,7 @@ internal static class CanvasMutationCommands
             _deletedIndex = index;
             elements.RemoveAt(index);
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
 
         public void Undo()
@@ -204,6 +209,7 @@ internal static class CanvasMutationCommands
             var insertIndex = Math.Clamp(index, 0, elements.Count);
             elements.Insert(insertIndex, _deletedElement);
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
     }
 
@@ -241,12 +247,18 @@ internal static class CanvasMutationCommands
             }
 
             var existing = elements[index];
+            var normalizedNewName = _newName.Trim();
+            if (string.Equals(existing.Name?.Trim(), normalizedNewName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
             _renamedIndex = index;
             _previousName = existing.Name;
             elements[index] = new PanelElementFile
             {
                 ObjectId = existing.ObjectId,
-                Name = _newName,
+                Name = normalizedNewName,
                 Kind = existing.Kind,
                 X = existing.X,
                 Y = existing.Y,
@@ -255,6 +267,7 @@ internal static class CanvasMutationCommands
             };
 
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
 
         public void Undo()
@@ -288,6 +301,7 @@ internal static class CanvasMutationCommands
             };
 
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.MarkDirty();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -6,6 +6,7 @@ namespace OasisEditor;
 public sealed class DocumentTabViewModel : INotifyPropertyChanged
 {
     private readonly CommandService _commandService;
+    private EditorDocument _document;
     private string? _panelLayoutJson;
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
@@ -20,13 +21,13 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         Guid? documentId = null,
         CommandService? commandService = null)
     {
-        Document = document;
+        _document = document;
         DocumentId = documentId ?? Guid.NewGuid();
         _commandService = commandService ?? new CommandService(new CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
     }
 
-    public EditorDocument Document { get; }
+    public EditorDocument Document => _document;
     public Guid DocumentId { get; }
     public CommandService CommandService => _commandService;
     public string Title => Document.IsDirty ? $"{Document.Title}*" : Document.Title;
@@ -41,6 +42,19 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public string FilePath => Document.FilePath;
     public string ContentSummary => Document.ContentSummary;
     public bool IsDirty => Document.IsDirty;
+
+    public void MarkDirty()
+    {
+        if (_document.IsDirty)
+        {
+            return;
+        }
+
+        _document = _document.MarkDirty();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Document)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDirty)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
+    }
 
     public string? PanelLayoutJson
     {


### PR DESCRIPTION
### Motivation
- Ensure the editor tab dirty indicator updates only for real Panel2D layout mutations so the tab `*` reflects true unsaved changes.
- Provide a focused API to mark a document dirty without replacing unrelated tab state or losing runtime ViewModel identity.
- Prevent no-op rename/add/delete actions from incorrectly toggling dirty state or polluting undo/redo history.

### Description
- Added a mutable document backing and `MarkDirty()` API on `DocumentTabViewModel` to update document state and raise `PropertyChanged` for `Document`, `IsDirty`, and `Title` without replacing the whole tab object.
- Updated `CanvasMutationCommands` so rectangle/image add and delete operations call `DocumentTabViewModel.MarkDirty()` only when an actual insertion or removal occurs, and undo also marks the document dirty when it applies a real change.
- Tightened rename behavior in `RenameElementMutationCommand` to normalize the new name (`Trim()`) and skip the mutation (and dirty transition) when the normalized name equals the existing name.

### Testing
- Attempted to build the Editor project with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj`, but the build could not be run in this environment because `dotnet` is not available (`dotnet: command not found`).
- No other automated tests were executed in this environment; manual smoke tests should be performed locally (open/save, add/delete/rename Panel2D elements, verify tab `*` and undo/redo behavior) once a full build is possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecfa54c530832795706770f58db227)