### PR TITLE
Prevent no-op Panel2D mutations from polluting undo/redo history

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -26,7 +26,7 @@ internal static class CanvasMutationCommands
         return new RenameElementMutationCommand(documentId, document, selection, newName);
     }
 
-    private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand
+    private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
         private readonly DocumentTabViewModel _document;
@@ -44,14 +44,18 @@ internal static class CanvasMutationCommands
 
         public string Description => "Add rectangle";
 
+        public bool WasExecuted { get; private set; }
+
         public void Execute()
         {
+            WasExecuted = false;
             var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
             var index = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
             elements.Insert(index, _element);
             _insertIndex = index;
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
             _document.MarkDirty();
+            WasExecuted = true;
         }
 
         public void Undo()
@@ -95,7 +99,7 @@ internal static class CanvasMutationCommands
         }
     }
 
-    private sealed class AddImageMutationCommand : Commands.IDocumentCommand
+    private sealed class AddImageMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
         private readonly DocumentTabViewModel _document;
@@ -113,14 +117,18 @@ internal static class CanvasMutationCommands
 
         public string Description => "Add image";
 
+        public bool WasExecuted { get; private set; }
+
         public void Execute()
         {
+            WasExecuted = false;
             var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
             var index = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
             elements.Insert(index, _element);
             _insertIndex = index;
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
             _document.MarkDirty();
+            WasExecuted = true;
         }
 
         public void Undo()
@@ -164,7 +172,7 @@ internal static class CanvasMutationCommands
         }
     }
 
-    private sealed class DeleteElementMutationCommand : Commands.IDocumentCommand
+    private sealed class DeleteElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
         private readonly DocumentTabViewModel _document;
@@ -183,8 +191,11 @@ internal static class CanvasMutationCommands
 
         public string Description => "Delete element";
 
+        public bool WasExecuted { get; private set; }
+
         public void Execute()
         {
+            WasExecuted = false;
             var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
             if (!TryFindMatchingElementIndex(elements, _selection, out var index))
             {
@@ -196,6 +207,7 @@ internal static class CanvasMutationCommands
             elements.RemoveAt(index);
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
             _document.MarkDirty();
+            WasExecuted = true;
         }
 
         public void Undo()
@@ -213,7 +225,7 @@ internal static class CanvasMutationCommands
         }
     }
 
-    private sealed class RenameElementMutationCommand : Commands.IDocumentCommand
+    private sealed class RenameElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
         private readonly DocumentTabViewModel _document;
@@ -238,8 +250,11 @@ internal static class CanvasMutationCommands
 
         public string Description => "Rename element";
 
+        public bool WasExecuted { get; private set; }
+
         public void Execute()
         {
+            WasExecuted = false;
             var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
             if (!TryFindMatchingElementIndex(elements, _selection, out var index))
             {
@@ -268,6 +283,7 @@ internal static class CanvasMutationCommands
 
             _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
             _document.MarkDirty();
+            WasExecuted = true;
         }
 
         public void Undo()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Commands/CommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Commands/CommandService.cs
@@ -38,6 +38,12 @@ public sealed class CommandService
         ValidateDocumentOwnership(command);
 
         command.Execute();
+        if (command is IExecutionTrackedCommand executionTrackedCommand
+            && !executionTrackedCommand.WasExecuted)
+        {
+            return;
+        }
+
         _history.RecordExecuted(command);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Commands/ICommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Commands/ICommand.cs
@@ -28,3 +28,12 @@ public interface IDocumentCommand : ICommand
 {
     Guid DocumentId { get; }
 }
+
+/// <summary>
+/// Optional command contract indicating whether the last execution produced a real mutation.
+/// Command services may use this to skip recording no-op executions in history.
+/// </summary>
+public interface IExecutionTrackedCommand : ICommand
+{
+    bool WasExecuted { get; }
+}


### PR DESCRIPTION
### Motivation
- Prevent no-op canvas/document mutation commands from being recorded in per-document undo/redo history to keep command stacks meaningful and protect undo/redo integrity as required by the Phase A correctness tasks.

### Description
- Added an optional command contract `IExecutionTrackedCommand` exposing `WasExecuted` so commands can report whether their last `Execute()` produced a real mutation.
- Updated `CommandService.Execute` to skip recording a command into `CommandHistory` when it implements `IExecutionTrackedCommand` and `WasExecuted` is `false`.
- Implemented execution tracking in Panel2D mutation commands in `CanvasMutationCommands.cs` (add-rectangle, add-image, delete-element, rename-element) and set `WasExecuted` only when a real mutation occurred (delete/rename now report no-op when target is missing or name unchanged, add commands report success).
- Preserved existing command descriptions, document ownership checks, and undo/redo semantics for commands that do execute.

### Testing
- Attempted to build the solution with `dotnet build OasisEditor.sln`, but the environment lacks the .NET SDK and the build could not be run (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecfba2e3d88327b48bd99880e3036c)