### PR TITLE
Consolidate Add Rectangle/Image commands into shared AddPanelElementMutationCommand

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -4,12 +4,12 @@ internal static class CanvasMutationCommands
 {
     public static Commands.ICommand CreateAddRectangleCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
     {
-        return new AddRectangleMutationCommand(documentId, document, element);
+        return new AddPanelElementMutationCommand(documentId, document, element, "Add rectangle");
     }
 
     public static Commands.ICommand CreateAddImageCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
     {
-        return new AddImageMutationCommand(documentId, document, element);
+        return new AddPanelElementMutationCommand(documentId, document, element, "Add image");
     }
 
     public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
@@ -26,96 +26,29 @@ internal static class CanvasMutationCommands
         return new RenameElementMutationCommand(documentId, document, selection, newName);
     }
 
-    private sealed class AddRectangleMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
         private readonly DocumentTabViewModel _document;
         private readonly PanelElementFile _element;
+        private readonly string _description;
         private int? _insertIndex;
 
-        public AddRectangleMutationCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
+        public AddPanelElementMutationCommand(
+            Guid documentId,
+            DocumentTabViewModel document,
+            PanelElementFile element,
+            string description)
         {
             _documentId = documentId;
             _document = document;
             _element = element;
+            _description = description;
         }
 
         public Guid DocumentId => _documentId;
 
-        public string Description => "Add rectangle";
-
-        public bool WasExecuted { get; private set; }
-
-        public void Execute()
-        {
-            WasExecuted = false;
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
-            var index = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
-            elements.Insert(index, _element);
-            _insertIndex = index;
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
-            _document.MarkDirty();
-            WasExecuted = true;
-        }
-
-        public void Undo()
-        {
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
-            if (elements.Count == 0)
-            {
-                return;
-            }
-
-            var removed = false;
-            if (_insertIndex is int index
-                && index >= 0
-                && index < elements.Count
-                && PanelSelectionContract.IsSame(elements[index], _element))
-            {
-                elements.RemoveAt(index);
-                removed = true;
-            }
-
-            if (!removed)
-            {
-                for (var i = elements.Count - 1; i >= 0; i--)
-                {
-                    if (!PanelSelectionContract.IsSame(elements[i], _element))
-                    {
-                        continue;
-                    }
-
-                    elements.RemoveAt(i);
-                    removed = true;
-                    break;
-                }
-            }
-
-            if (removed)
-            {
-                _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
-                _document.MarkDirty();
-            }
-        }
-    }
-
-    private sealed class AddImageMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
-    {
-        private readonly Guid _documentId;
-        private readonly DocumentTabViewModel _document;
-        private readonly PanelElementFile _element;
-        private int? _insertIndex;
-
-        public AddImageMutationCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
-        {
-            _documentId = documentId;
-            _document = document;
-            _element = element;
-        }
-
-        public Guid DocumentId => _documentId;
-
-        public string Description => "Add image";
+        public string Description => _description;
 
         public bool WasExecuted { get; private set; }
 


### PR DESCRIPTION
### Motivation
- Remove duplicated add-element mutation implementations to simplify maintenance and ensure consistent behavior for adding panel elements.
- Preserve existing public factory APIs and user-facing undo/redo descriptions while centralizing insertion logic.

### Description
- Replaced the two separate `AddRectangleMutationCommand` and `AddImageMutationCommand` implementations with a single `AddPanelElementMutationCommand` inside `CanvasMutationCommands.cs`.
- Updated `CreateAddRectangleCommand` and `CreateAddImageCommand` to return the shared command and pass the appropriate description (`"Add rectangle"` / `"Add image"`).
- Kept the existing insert/undo logic and `IExecutionTrackedCommand` semantics so undo/redo behavior and command descriptions remain unchanged.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment lacks the `dotnet` CLI (`dotnet: command not found`), so no build or automated tests were executed.
- No additional automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecfca8d3f483279c96df9c8edfc547)