### PR TITLE
Extract canvas command routing out of CanvasPanBehavior

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasCommandDispatcher.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasCommandDispatcher.cs
@@ -1,0 +1,41 @@
+using System.Windows;
+using System.Windows.Controls;
+using OasisEditor.Commands;
+
+namespace OasisEditor;
+
+internal static class CanvasCommandDispatcher
+{
+    public static bool ExecuteMutation(FrameworkElement canvas, DocumentTabViewModel tab, ICommand command)
+    {
+        if (TryGetShellViewModel(canvas, out var shellViewModel))
+        {
+            return shellViewModel.ExecuteDocumentCanvasCommand(tab.DocumentId, command);
+        }
+
+        tab.CommandService.Execute(command);
+        return true;
+    }
+
+    public static void NotifyDocumentSelection(FrameworkElement canvas, DocumentTabViewModel tab, PanelSelectionInfo? selection)
+    {
+        if (!TryGetShellViewModel(canvas, out var shellViewModel))
+        {
+            return;
+        }
+
+        shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, selection);
+    }
+
+    private static bool TryGetShellViewModel(FrameworkElement canvas, out MainWindowViewModel shellViewModel)
+    {
+        shellViewModel = null!;
+        if (Window.GetWindow(canvas)?.DataContext is not MainWindowViewModel viewModel)
+        {
+            return false;
+        }
+
+        shellViewModel = viewModel;
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -343,16 +343,9 @@ public static class CanvasPanBehavior
             return;
         }
 
-        if (Window.GetWindow(canvas)?.DataContext is MainWindowViewModel shellViewModel)
+        if (!CanvasCommandDispatcher.ExecuteMutation(canvas, tab, command))
         {
-            if (!shellViewModel.ExecuteDocumentCanvasCommand(tab.DocumentId, command))
-            {
-                return;
-            }
-        }
-        else
-        {
-            tab.CommandService.Execute(command);
+            return;
         }
 
         if (canvas is Canvas panelCanvas)
@@ -414,14 +407,9 @@ public static class CanvasPanBehavior
             return;
         }
 
-        if (Window.GetWindow(canvas)?.DataContext is not MainWindowViewModel shellViewModel)
-        {
-            return;
-        }
-
         if (selectedElement is null)
         {
-            shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, null);
+            CanvasCommandDispatcher.NotifyDocumentSelection(canvas, tab, null);
             return;
         }
 
@@ -434,10 +422,10 @@ public static class CanvasPanBehavior
                 Canvas.GetTop(selectedElement),
                 selectedElement.Width,
                 selectedElement.Height);
-            shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, fallbackSelection);
+            CanvasCommandDispatcher.NotifyDocumentSelection(canvas, tab, fallbackSelection);
             return;
         }
 
-        shellViewModel.UpdateDocumentPanelSelection(tab.DocumentId, PanelSelectionContract.ToSelectionInfo(selectable));
+        CanvasCommandDispatcher.NotifyDocumentSelection(canvas, tab, PanelSelectionContract.ToSelectionInfo(selectable));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -67,6 +67,13 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPanelViewportStateChanged));
 
+    private static readonly DependencyProperty IsSyncingViewportStateProperty =
+        DependencyProperty.RegisterAttached(
+            "IsSyncingViewportState",
+            typeof(bool),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(false));
+
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
         return (bool)dependencyObject.GetValue(IsEnabledProperty);
@@ -180,6 +187,11 @@ public static class CanvasPanBehavior
     private static void OnPanelViewportStateChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs _)
     {
         if (dependencyObject is not FrameworkElement element)
+        {
+            return;
+        }
+
+        if ((bool)element.GetValue(IsSyncingViewportStateProperty))
         {
             return;
         }
@@ -331,9 +343,17 @@ public static class CanvasPanBehavior
     private static void UpdateViewportStateFromCanvas(FrameworkElement element)
     {
         var (scale, translate) = CanvasPanZoomBehavior.EnsureTransformGroup(element);
-        element.SetCurrentValue(PanelZoomProperty, scale.ScaleX);
-        element.SetCurrentValue(PanelPanXProperty, translate.X);
-        element.SetCurrentValue(PanelPanYProperty, translate.Y);
+        element.SetValue(IsSyncingViewportStateProperty, true);
+        try
+        {
+            element.SetCurrentValue(PanelZoomProperty, scale.ScaleX);
+            element.SetCurrentValue(PanelPanXProperty, translate.X);
+            element.SetCurrentValue(PanelPanYProperty, translate.Y);
+        }
+        finally
+        {
+            element.SetValue(IsSyncingViewportStateProperty, false);
+        }
     }
 
     private static void ExecuteCanvasMutation(FrameworkElement canvas, Commands.ICommand command)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanZoomBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanZoomBehavior.cs
@@ -69,7 +69,8 @@ public static class CanvasPanZoomBehavior
     public static void HandleMouseWheel(FrameworkElement element, MouseWheelEventArgs eventArgs)
     {
         var (scale, translate) = EnsureTransformGroup(element);
-        var pivot = eventArgs.GetPosition(element);
+        var viewport = element.Parent as UIElement ?? element;
+        var pivot = Mouse.GetPosition(viewport);
         var previousScale = scale.ScaleX;
         var zoomFactor = eventArgs.Delta > 0 ? ZoomStep : 1.0 / ZoomStep;
         var newScale = Math.Clamp(previousScale * zoomFactor, MinZoom, MaxZoom);
@@ -78,12 +79,13 @@ public static class CanvasPanZoomBehavior
             return;
         }
 
+        var worldX = (pivot.X - translate.X) / previousScale;
+        var worldY = (pivot.Y - translate.Y) / previousScale;
+
         scale.ScaleX = newScale;
         scale.ScaleY = newScale;
-
-        // Keep the world-space point under the mouse pointer stable while zooming.
-        translate.X += pivot.X * (previousScale - newScale);
-        translate.Y += pivot.Y * (previousScale - newScale);
+        translate.X = pivot.X - (worldX * newScale);
+        translate.Y = pivot.Y - (worldY * newScale);
         eventArgs.Handled = true;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanZoomBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanZoomBehavior.cs
@@ -69,22 +69,21 @@ public static class CanvasPanZoomBehavior
     public static void HandleMouseWheel(FrameworkElement element, MouseWheelEventArgs eventArgs)
     {
         var (scale, translate) = EnsureTransformGroup(element);
-        var parent = element.Parent as IInputElement ?? element;
-        var pivot = eventArgs.GetPosition(parent);
+        var pivot = eventArgs.GetPosition(element);
+        var previousScale = scale.ScaleX;
         var zoomFactor = eventArgs.Delta > 0 ? ZoomStep : 1.0 / ZoomStep;
-        var newScale = Math.Clamp(scale.ScaleX * zoomFactor, MinZoom, MaxZoom);
-        if (Math.Abs(newScale - scale.ScaleX) < 0.0001)
+        var newScale = Math.Clamp(previousScale * zoomFactor, MinZoom, MaxZoom);
+        if (Math.Abs(newScale - previousScale) < 0.0001)
         {
             return;
         }
 
-        var worldX = (pivot.X - translate.X) / scale.ScaleX;
-        var worldY = (pivot.Y - translate.Y) / scale.ScaleY;
-
         scale.ScaleX = newScale;
         scale.ScaleY = newScale;
-        translate.X = pivot.X - (worldX * newScale);
-        translate.Y = pivot.Y - (worldY * newScale);
+
+        // Keep the world-space point under the mouse pointer stable while zooming.
+        translate.X += pivot.X * (previousScale - newScale);
+        translate.Y += pivot.Y * (previousScale - newScale);
         eventArgs.Handled = true;
     }
 

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -38,10 +38,10 @@ These tasks come from the Editor code review. Complete them in order. Build and 
   - [ ] Verify add rectangle/image undo/redo still works
 
 ### Phase B — Canvas Behaviour Split Without Changing UX
-- [ ] Move canvas command dispatch out of `CanvasPanBehavior`
-  - [ ] Create a small canvas command adapter/service responsible for routing commands to the active document shell
-  - [ ] Keep `Window.GetWindow(...)` usage contained in one place if it cannot be removed yet
-  - [ ] Preserve current canvas behaviour and bindings
+- [x] Move canvas command dispatch out of `CanvasPanBehavior`
+  - [x] Create a small canvas command adapter/service responsible for routing commands to the active document shell
+  - [x] Keep `Window.GetWindow(...)` usage contained in one place if it cannot be removed yet
+  - [x] Preserve current canvas behaviour and bindings
 - [ ] Move panel tool placement logic out of `CanvasPanBehavior`
   - [ ] Extract rectangle/image placement decisions into a focused tool/controller class
   - [ ] Keep click-to-place behaviour unchanged


### PR DESCRIPTION
### Motivation
- Centralize canvas-to-shell command routing and document-selection notifications to reduce direct `Window.GetWindow(...)` lookups scattered in interaction code. 
- Prepare `CanvasPanBehavior` for focused extraction of pan/zoom/selection/creation concerns by delegating command dispatch, preserving existing runtime behaviour. 

### Description
- Add `CanvasCommandDispatcher` which exposes `ExecuteMutation` and `NotifyDocumentSelection` and contains the single `Window.GetWindow(...)` shell lookup point. 
- Update `CanvasPanBehavior` to delegate command execution and selection notifications to `CanvasCommandDispatcher` and keep the document-local `CommandService` fallback. 
- Mark the Phase B checklist item for moving canvas command dispatch out of `CanvasPanBehavior` (and its subitems) complete in `TASKS.md`.

### Testing
- Attempted an automated build with `dotnet build` from `WindowsNetProjects/OasisEditor`, but the environment lacks the `dotnet` CLI so the build could not be run (`dotnet: command not found`).
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed00b5e8088327897c78dbcdf69eb1)