### PR TITLE
Add Panel2D live model types and storage converters

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -1,0 +1,19 @@
+namespace OasisEditor;
+
+internal sealed class Panel2DDocumentModel
+{
+    public string Title { get; init; } = string.Empty;
+    public string Summary { get; init; } = string.Empty;
+    public IReadOnlyList<PanelElementModel> Elements { get; init; } = [];
+}
+
+internal sealed class PanelElementModel
+{
+    public string ObjectId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public PanelElementKind Kind { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -84,6 +84,55 @@ internal static class Panel2DDocumentStorage
         }
     }
 
+
+    public static Panel2DDocumentModel ToModel(Panel2DDocumentFile document)
+    {
+        return new Panel2DDocumentModel
+        {
+            Title = document.Title,
+            Summary = document.Summary,
+            Elements = document.Elements
+                .Select(NormalizeElement)
+                .Select(ToModel)
+                .ToArray()
+        };
+    }
+
+    public static IReadOnlyList<PanelElementFile> ToStorageElements(Panel2DDocumentModel model)
+    {
+        return model.Elements
+            .Select(ToStorageElement)
+            .ToArray();
+    }
+
+    public static PanelElementModel ToModel(PanelElementFile element)
+    {
+        var normalized = NormalizeElement(element);
+        return new PanelElementModel
+        {
+            ObjectId = normalized.ObjectId,
+            Name = normalized.Name,
+            Kind = ParseElementKind(normalized.Kind),
+            X = normalized.X,
+            Y = normalized.Y,
+            Width = normalized.Width,
+            Height = normalized.Height
+        };
+    }
+
+    public static PanelElementFile ToStorageElement(PanelElementModel element)
+    {
+        return NormalizeElement(new PanelElementFile
+        {
+            ObjectId = element.ObjectId,
+            Name = element.Name,
+            Kind = SerializeElementKind(element.Kind),
+            X = element.X,
+            Y = element.Y,
+            Width = element.Width,
+            Height = element.Height
+        });
+    }
     public static string SerializeLayout(IReadOnlyList<PanelElementFile> elements)
     {
         return JsonSerializer.Serialize(elements);

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -54,11 +54,11 @@ These tasks come from the Editor code review. Complete them in order. Build and 
 
 ### Phase C — Panel2D Live Model Preparation
 - [ ] Create a domain-facing Panel2D model separate from JSON storage
-  - [ ] Add `Panel2DDocumentModel` with panel title/summary and a collection/list of `PanelElementModel`
-  - [ ] Add `PanelElementModel` fields for object ID, name, kind, X, Y, width, and height
-  - [ ] Keep the model UI-agnostic: no WPF types, controls, brushes, or dependency properties
-  - [ ] Add conversion between the new model and existing `PanelElementFile` storage DTOs
-  - [ ] Keep existing `.panel2d` file format working
+  - [x] Add `Panel2DDocumentModel` with panel title/summary and a collection/list of `PanelElementModel`
+  - [x] Add `PanelElementModel` fields for object ID, name, kind, X, Y, width, and height
+  - [x] Keep the model UI-agnostic: no WPF types, controls, brushes, or dependency properties
+  - [x] Add conversion between the new model and existing `PanelElementFile` storage DTOs
+  - [x] Keep existing `.panel2d` file format working
 - [ ] Move Panel2D mutation commands to operate on the live model first
   - [ ] Add element, delete element, and rename element should mutate the model
   - [ ] Update JSON/layout sync as a projection of the model, not as the canonical state


### PR DESCRIPTION
### Motivation
- Prepare a UI-agnostic in-memory model for Panel2D to decouple runtime/editor state from JSON storage and enable subsequent migration of mutation commands to operate on a live model.
- Provide stable conversion helpers so existing `.panel2d` files remain compatible while normalising IDs/names/kinds via existing storage rules.

### Description
- Add `Panel2DDocumentModel` and `PanelElementModel` (UI-agnostic types containing title, summary, and element ID/name/kind/geometry fields) in `OasisEditor/Panel2DDocumentModel.cs`.
- Add storage↔model conversion helpers (`ToModel`, `ToStorageElements`, `ToModel(PanelElementFile)`, `ToStorageElement(PanelElementModel)`) into `Panel2DDocumentStorage.cs` and reuse existing `NormalizeElement`/kind serialization to preserve file-format compatibility.
- Update `TASKS.md` Phase C checklist to mark the model and DTO-conversion subtasks as completed.
- Keep the new model free of WPF types and preserve existing `.panel2d` layout serialization behavior.

### Testing
- Attempted to run a build with `cd WindowsNetProjects/OasisEditor && dotnet build`, but `dotnet` is not available in the current environment so no automated build/tests could be executed (error: `/bin/bash: dotnet: command not found`).
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed7dbf2f0883279aa2bcb0b802d860)