### PR TITLE
Move Panel2D canvas mutations to operate on live model state

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -233,7 +233,7 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            if (!PanelSelectionContract.IsMatch(elements[index], _selection))
+            if (!PanelSelectionContract.IsMatch(Panel2DDocumentStorage.ToStorageElement(elements[index]), _selection))
             {
                 return;
             }
@@ -298,16 +298,6 @@ internal static class CanvasMutationCommands
 
     private static bool IsMatch(PanelElementModel element, PanelSelectionInfo selection)
     {
-        if (!string.IsNullOrWhiteSpace(selection.ObjectId))
-        {
-            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
-        }
-
-        return string.Equals(element.Name, selection.DisplayName, StringComparison.Ordinal)
-               && element.Kind == selection.Kind
-               && Math.Abs(element.X - selection.X) < 0.0001
-               && Math.Abs(element.Y - selection.Y) < 0.0001
-               && Math.Abs(element.Width - selection.Width) < 0.0001
-               && Math.Abs(element.Height - selection.Height) < 0.0001;
+        return PanelSelectionContract.IsMatch(Panel2DDocumentStorage.ToStorageElement(element), selection);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -55,18 +55,19 @@ internal static class CanvasMutationCommands
         public void Execute()
         {
             WasExecuted = false;
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
+            var elementModel = Panel2DDocumentStorage.ToModel(_element);
             var index = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
-            elements.Insert(index, _element);
+            elements.Insert(index, elementModel);
             _insertIndex = index;
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.SetPanelElements(elements);
             _document.MarkDirty();
             WasExecuted = true;
         }
 
         public void Undo()
         {
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
             if (elements.Count == 0)
             {
                 return;
@@ -76,7 +77,7 @@ internal static class CanvasMutationCommands
             if (_insertIndex is int index
                 && index >= 0
                 && index < elements.Count
-                && PanelSelectionContract.IsSame(elements[index], _element))
+                && IsSameElement(elements[index], _element))
             {
                 elements.RemoveAt(index);
                 removed = true;
@@ -86,7 +87,7 @@ internal static class CanvasMutationCommands
             {
                 for (var i = elements.Count - 1; i >= 0; i--)
                 {
-                    if (!PanelSelectionContract.IsSame(elements[i], _element))
+                    if (!IsSameElement(elements[i], _element))
                     {
                         continue;
                     }
@@ -99,7 +100,7 @@ internal static class CanvasMutationCommands
 
             if (removed)
             {
-                _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+                _document.SetPanelElements(elements);
                 _document.MarkDirty();
             }
         }
@@ -129,16 +130,16 @@ internal static class CanvasMutationCommands
         public void Execute()
         {
             WasExecuted = false;
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
             if (!TryFindMatchingElementIndex(elements, _selection, out var index))
             {
                 return;
             }
 
-            _deletedElement = elements[index];
+            _deletedElement = Panel2DDocumentStorage.ToStorageElement(elements[index]);
             _deletedIndex = index;
             elements.RemoveAt(index);
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.SetPanelElements(elements);
             _document.MarkDirty();
             WasExecuted = true;
         }
@@ -150,10 +151,10 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
             var insertIndex = Math.Clamp(index, 0, elements.Count);
-            elements.Insert(insertIndex, _deletedElement);
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            elements.Insert(insertIndex, Panel2DDocumentStorage.ToModel(_deletedElement));
+            _document.SetPanelElements(elements);
             _document.MarkDirty();
         }
     }
@@ -188,7 +189,7 @@ internal static class CanvasMutationCommands
         public void Execute()
         {
             WasExecuted = false;
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
             if (!TryFindMatchingElementIndex(elements, _selection, out var index))
             {
                 return;
@@ -196,14 +197,14 @@ internal static class CanvasMutationCommands
 
             var existing = elements[index];
             var normalizedNewName = _newName.Trim();
-            if (string.Equals(existing.Name?.Trim(), normalizedNewName, StringComparison.Ordinal))
+            if (string.Equals(existing.Name.Trim(), normalizedNewName, StringComparison.Ordinal))
             {
                 return;
             }
 
             _renamedIndex = index;
             _previousName = existing.Name;
-            elements[index] = new PanelElementFile
+            elements[index] = new PanelElementModel
             {
                 ObjectId = existing.ObjectId,
                 Name = normalizedNewName,
@@ -214,7 +215,7 @@ internal static class CanvasMutationCommands
                 Height = existing.Height
             };
 
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.SetPanelElements(elements);
             _document.MarkDirty();
             WasExecuted = true;
         }
@@ -226,7 +227,7 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            var elements = Panel2DDocumentStorage.DeserializeLayout(_document.PanelLayoutJson).ToList();
+            var elements = _document.GetPanelElements().ToList();
             if (index < 0 || index >= elements.Count)
             {
                 return;
@@ -238,7 +239,7 @@ internal static class CanvasMutationCommands
             }
 
             var existing = elements[index];
-            elements[index] = new PanelElementFile
+            elements[index] = new PanelElementModel
             {
                 ObjectId = existing.ObjectId,
                 Name = _previousName ?? string.Empty,
@@ -249,12 +250,12 @@ internal static class CanvasMutationCommands
                 Height = existing.Height
             };
 
-            _document.PanelLayoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+            _document.SetPanelElements(elements);
             _document.MarkDirty();
         }
     }
 
-    private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementFile> elements, PanelSelectionInfo selection, out int index)
+    private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementModel> elements, PanelSelectionInfo selection, out int index)
     {
         if (!string.IsNullOrWhiteSpace(selection.ObjectId))
         {
@@ -271,7 +272,7 @@ internal static class CanvasMutationCommands
         for (var i = 0; i < elements.Count; i++)
         {
             var element = elements[i];
-            if (!PanelSelectionContract.IsMatch(element, selection))
+            if (!IsMatch(element, selection))
             {
                 continue;
             }
@@ -282,5 +283,31 @@ internal static class CanvasMutationCommands
 
         index = -1;
         return false;
+    }
+
+    private static bool IsSameElement(PanelElementModel model, PanelElementFile storageElement)
+    {
+        return string.Equals(model.ObjectId, storageElement.ObjectId, StringComparison.Ordinal)
+               && string.Equals(model.Name, storageElement.Name, StringComparison.Ordinal)
+               && model.Kind == Panel2DDocumentStorage.ParseElementKind(storageElement.Kind)
+               && Math.Abs(model.X - storageElement.X) < 0.0001
+               && Math.Abs(model.Y - storageElement.Y) < 0.0001
+               && Math.Abs(model.Width - storageElement.Width) < 0.0001
+               && Math.Abs(model.Height - storageElement.Height) < 0.0001;
+    }
+
+    private static bool IsMatch(PanelElementModel element, PanelSelectionInfo selection)
+    {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId))
+        {
+            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
+        }
+
+        return string.Equals(element.Name, selection.DisplayName, StringComparison.Ordinal)
+               && element.Kind == selection.Kind
+               && Math.Abs(element.X - selection.X) < 0.0001
+               && Math.Abs(element.Y - selection.Y) < 0.0001
+               && Math.Abs(element.Width - selection.Width) < 0.0001
+               && Math.Abs(element.Height - selection.Height) < 0.0001;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -8,6 +8,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private readonly CommandService _commandService;
     private EditorDocument _document;
     private string? _panelLayoutJson;
+    private Panel2DDocumentModel _panelDocumentModel;
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
     private double _panelPanX;
@@ -25,6 +26,12 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         DocumentId = documentId ?? Guid.NewGuid();
         _commandService = commandService ?? new CommandService(new CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
+        _panelDocumentModel = new Panel2DDocumentModel
+        {
+            Elements = Panel2DDocumentStorage.DeserializeLayout(panelLayoutJson)
+                .Select(Panel2DDocumentStorage.ToModel)
+                .ToArray()
+        };
     }
 
     public EditorDocument Document => _document;
@@ -67,8 +74,33 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             }
 
             _panelLayoutJson = value;
+            _panelDocumentModel = new Panel2DDocumentModel
+            {
+                Elements = Panel2DDocumentStorage.DeserializeLayout(value)
+                    .Select(Panel2DDocumentStorage.ToModel)
+                    .ToArray()
+            };
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
         }
+    }
+
+    public IReadOnlyList<PanelElementModel> GetPanelElements()
+    {
+        return _panelDocumentModel.Elements;
+    }
+
+    public void SetPanelElements(IReadOnlyList<PanelElementModel> elements)
+    {
+        _panelDocumentModel = new Panel2DDocumentModel
+        {
+            Title = _panelDocumentModel.Title,
+            Summary = _panelDocumentModel.Summary,
+            Elements = elements.ToArray()
+        };
+
+        _panelLayoutJson = Panel2DDocumentStorage.SerializeLayout(
+            Panel2DDocumentStorage.ToStorageElements(_panelDocumentModel));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
     }
 
     public PanelSelectionInfo? HierarchySelectedPanelSelection

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -84,12 +84,12 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
     }
 
-    public IReadOnlyList<PanelElementModel> GetPanelElements()
+    internal IReadOnlyList<PanelElementModel> GetPanelElements()
     {
         return _panelDocumentModel.Elements;
     }
 
-    public void SetPanelElements(IReadOnlyList<PanelElementModel> elements)
+    internal void SetPanelElements(IReadOnlyList<PanelElementModel> elements)
     {
         _panelDocumentModel = new Panel2DDocumentModel
         {

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -60,7 +60,7 @@ These tasks come from the Editor code review. Complete them in order. Build and 
   - [x] Add conversion between the new model and existing `PanelElementFile` storage DTOs
   - [x] Keep existing `.panel2d` file format working
 - [ ] Move Panel2D mutation commands to operate on the live model first
-  - [ ] Add element, delete element, and rename element should mutate the model
+  - [x] Add element, delete element, and rename element should mutate the model
   - [ ] Update JSON/layout sync as a projection of the model, not as the canonical state
   - [ ] Preserve undo/redo behaviour
   - [ ] Verify save/open round-trips existing panel files


### PR DESCRIPTION
### Motivation
- Prepare the editor to use a live, UI-agnostic Panel2D model so mutation commands operate on in-memory state rather than raw JSON.
- Continue Phase C of the refactor plan so hierarchy/inspector and later sync steps can read from a stable model projection.

### Description
- Added a `Panel2DDocumentModel` instance to `DocumentTabViewModel` and initialize it from `PanelLayoutJson` when the tab is created or when `PanelLayoutJson` is set. 
- Exposed `GetPanelElements()` and `SetPanelElements(...)` on `DocumentTabViewModel` and made `SetPanelElements` project the model back to JSON via `Panel2DDocumentStorage.ToStorageElements`/`SerializeLayout`.
- Updated add/delete/rename canvas mutation commands in `CanvasMutationCommands.cs` to mutate `PanelElementModel` collections returned by `GetPanelElements()` first and then call `SetPanelElements(...)` to update `PanelLayoutJson`, preserving undo/redo semantics and the existing factory entrypoints for rectangle/image commands.
- Added matching helpers (`IsSameElement` and `IsMatch`) and used `Panel2DDocumentStorage.ToModel` / `ToStorageElement` conversions where needed, and updated `TASKS.md` to mark the model-first add/delete/rename subtask complete.

### Testing
- Attempted to build the solution with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not run in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`).
- No automated unit tests were present or executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed7f1c8bcc8327a55b43a384cc0a41)