### PR TITLE
Use Panel2D live model for hierarchy and selection lookups

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -281,9 +281,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .Any(element => IsSelectionMatch(element, selection));
-        if (!hasMatchingElement)
+        if (!selectedDocument.HasPanelElement(selection))
         {
             return false;
         }
@@ -312,9 +310,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var matchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .FirstOrDefault(element => IsSelectionMatch(element, selection));
-        if (matchingElement is null)
+        if (!selectedDocument.TryGetPanelElement(selection, out var matchingElement))
         {
             return false;
         }
@@ -342,9 +338,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var hasMatchingElement = Panel2DDocumentStorage.DeserializeLayout(selectedDocument.PanelLayoutJson)
-            .Any(element => IsSelectionMatch(element, selection));
-        if (!hasMatchingElement)
+        if (!selectedDocument.HasPanelElement(selection))
         {
             return false;
         }
@@ -877,10 +871,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
-    private static bool IsSelectionMatch(PanelElementFile element, PanelSelectionInfo selection)
-    {
-        return PanelSelectionContract.IsMatch(element, selection);
-    }
 }
 
 internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Linq;
 using OasisEditor.Commands;
 
 namespace OasisEditor;
@@ -89,6 +90,24 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         return _panelDocumentModel.Elements;
     }
 
+    internal bool TryGetPanelElement(PanelSelectionInfo selection, out PanelElementModel element)
+    {
+        var match = _panelDocumentModel.Elements.FirstOrDefault(candidate => IsSelectionMatch(candidate, selection));
+        if (match is null)
+        {
+            element = new PanelElementModel();
+            return false;
+        }
+
+        element = match;
+        return true;
+    }
+
+    internal bool HasPanelElement(PanelSelectionInfo selection)
+    {
+        return _panelDocumentModel.Elements.Any(element => IsSelectionMatch(element, selection));
+    }
+
     internal void SetPanelElements(IReadOnlyList<PanelElementModel> elements)
     {
         _panelDocumentModel = new Panel2DDocumentModel
@@ -161,5 +180,17 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             _panelPanY = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelPanY)));
         }
+    }
+
+    private static bool IsSelectionMatch(PanelElementModel element, PanelSelectionInfo selection)
+    {
+        if (!string.IsNullOrWhiteSpace(selection.ObjectId)
+            && string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var storageElement = Panel2DDocumentStorage.ToStorageElement(element);
+        return PanelSelectionContract.IsMatch(storageElement, selection);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -265,7 +265,7 @@ public sealed class DocumentWorkspaceViewModel
     {
         if (document.Document.DocumentType == EditorDocumentType.Panel2D)
         {
-            var elements = Panel2DDocumentStorage.DeserializeLayout(document.PanelLayoutJson);
+            var elements = Panel2DDocumentStorage.ToStorageElements(document.GetPanelElements());
             return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -265,7 +265,9 @@ public sealed class DocumentWorkspaceViewModel
     {
         if (document.Document.DocumentType == EditorDocumentType.Panel2D)
         {
-            var elements = Panel2DDocumentStorage.ToStorageElements(document.GetPanelElements());
+            var elements = document.GetPanelElements()
+                .Select(Panel2DDocumentStorage.ToStorageElement)
+                .ToArray();
             return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -14,7 +14,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
             return [];
         }
 
-        var elements = Panel2DDocumentStorage.DeserializeLayout(document?.PanelLayoutJson);
+        var elements = document.GetPanelElements();
         var groups = new List<HierarchyItemViewModel>
         {
             BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
@@ -28,13 +28,13 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
 
     private static HierarchyItemViewModel BuildGroup(
         string groupName,
-        IReadOnlyList<PanelElementFile> elements,
+        IReadOnlyList<PanelElementModel> elements,
         PanelElementKind kind,
         string itemPrefix)
     {
         var kindToken = Panel2DDocumentStorage.SerializeElementKind(kind);
         var matches = elements
-            .Where(element => element.ElementKind == kind)
+            .Where(element => element.Kind == kind)
             .Select((element, index) =>
             {
                 var x = Math.Round(element.X);


### PR DESCRIPTION
### Motivation
- Move callers away from reparsing `PanelLayoutJson` and make the in-memory `Panel2DDocumentModel` the canonical source for hierarchy and selection checks.
- Reduce duplicate selection-matching logic and improve correctness when checking/renaming/deleting panel elements.

### Description
- Added live-model query helpers to `DocumentTabViewModel`: `TryGetPanelElement(PanelSelectionInfo)`, `HasPanelElement(PanelSelectionInfo)`, and an internal `IsSelectionMatch` matcher to centralize selection logic (`ViewModels/DocumentTabViewModel.cs`).
- Updated hierarchy rename/delete and selected-item name lookup flows in `MainWindowViewModel` to use the new live-model helpers instead of `Panel2DDocumentStorage.DeserializeLayout(...)` checks (`MainWindowViewModel.cs`).
- Changed `Panel2DHierarchyProvider` to build groups from the live `PanelElementModel` collection returned by `document.GetPanelElements()` and adjusted the `BuildGroup` signature to accept `PanelElementModel` (`ViewModels/Panel2DHierarchyProvider.cs`).
- Updated document save content generation to serialize from the live model projection via `Panel2DDocumentStorage.ToStorageElements(document.GetPanelElements())` (`ViewModels/DocumentWorkspaceViewModel.cs`).

### Testing
- Attempted a build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj` but it could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No automated unit tests were added or executed as part of this change due to the environment limitation stated above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed821d3834832794b6720d016730c1)