### PR TITLE
Project panel layout JSON from live model during sync

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -89,9 +89,9 @@ public static class PanelLayoutMapper
         try
         {
             canvas.SetCurrentValue(panelLayoutJsonProperty, layoutJson);
-            if (canvas.DataContext is DocumentTabViewModel tab)
+            if (canvas.DataContext is DocumentTabViewModel tabViewModel)
             {
-                tab.PanelLayoutJson = layoutJson;
+                tabViewModel.PanelLayoutJson = layoutJson;
             }
         }
         finally

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -75,15 +75,16 @@ public static class PanelLayoutMapper
             return;
         }
 
-        var elements = canvas.Children
-            .OfType<FrameworkElement>()
-            .Where(GetIsPersistedElement)
-            .Select(PanelElementFactory.CreateElementFromVisual)
-            .Where(element => element is not null)
-            .Cast<PanelElementFile>()
-            .ToArray();
-
-        var layoutJson = Panel2DDocumentStorage.SerializeLayout(elements);
+        var layoutJson = canvas.DataContext is DocumentTabViewModel tab
+            ? tab.GetPanelLayoutProjectionJson()
+            : Panel2DDocumentStorage.SerializeLayout(
+                canvas.Children
+                    .OfType<FrameworkElement>()
+                    .Where(GetIsPersistedElement)
+                    .Select(PanelElementFactory.CreateElementFromVisual)
+                    .Where(element => element is not null)
+                    .Cast<PanelElementFile>()
+                    .ToArray());
         canvas.SetValue(IsApplyingLayoutProperty, true);
         try
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -117,9 +117,14 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             Elements = elements.ToArray()
         };
 
-        _panelLayoutJson = Panel2DDocumentStorage.SerializeLayout(
-            Panel2DDocumentStorage.ToStorageElements(_panelDocumentModel));
+        _panelLayoutJson = GetPanelLayoutProjectionJson();
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
+    }
+
+    internal string GetPanelLayoutProjectionJson()
+    {
+        return Panel2DDocumentStorage.SerializeLayout(
+            Panel2DDocumentStorage.ToStorageElements(_panelDocumentModel));
     }
 
     public PanelSelectionInfo? HierarchySelectedPanelSelection

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -61,7 +61,7 @@ These tasks come from the Editor code review. Complete them in order. Build and 
   - [x] Keep existing `.panel2d` file format working
 - [ ] Move Panel2D mutation commands to operate on the live model first
   - [x] Add element, delete element, and rename element should mutate the model
-  - [ ] Update JSON/layout sync as a projection of the model, not as the canonical state
+  - [x] Update JSON/layout sync as a projection of the model, not as the canonical state
   - [ ] Preserve undo/redo behaviour
   - [ ] Verify save/open round-trips existing panel files
 - [ ] Make hierarchy and inspector read from the live Panel2D model where practical


### PR DESCRIPTION
### Motivation
- Continue Phase C work to make the in-memory Panel2D model the source of truth by ensuring JSON layout is generated as a projection of the live model instead of relying on the visual tree as canonical state.

### Description
- Prefer the `DocumentTabViewModel` live model when producing layout JSON by having `PanelLayoutMapper.SyncPanelLayout` call `tab.GetPanelLayoutProjectionJson()` when a `DocumentTabViewModel` is present and keep the visual-tree serialization as a fallback.
- Add `DocumentTabViewModel.GetPanelLayoutProjectionJson()` and reuse it from `SetPanelElements` so layout serialization is an explicit projection of the `Panel2DDocumentModel`.
- Mark the corresponding checklist item in `TASKS.md` as completed to reflect this Phase C progress.

### Testing
- Attempted to run `dotnet build OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not installed (no automated build result available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed841d93e08327a3373d665886c04e)