### PR TITLE
Add Panel2D schema validation, migration hooks, and tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -73,7 +73,7 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
-    public void BuildOpenDocumentData_WithInvalidPanelJson_FallsBackToPreview()
+    public void BuildOpenDocumentData_WithInvalidPanelJson_ReturnsClearErrorSummary()
     {
         const string path = "C:/Repo/Assets/bad.panel2d";
         const string invalidJson = "{ not valid json";
@@ -81,8 +81,8 @@ public sealed class Panel2DRoundTripTests
         var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData(path, invalidJson);
 
         Assert.Null(openData.PanelLayoutJson);
-        Assert.Null(openData.PanelTitle);
-        Assert.Contains("{ not valid json", openData.Summary);
+        Assert.Equal("bad.panel2d", openData.PanelTitle);
+        Assert.Contains("Malformed JSON", openData.Summary);
     }
 
     [Fact]
@@ -120,6 +120,83 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal(2, element.Y);
         Assert.Equal(3, element.Width);
         Assert.Equal(4, element.Height);
+    }
+
+    [Fact]
+    public void TryReadValidated_WithFutureSchemaVersion_ReturnsUnsupportedVersionError()
+    {
+        const string sourceJson = """
+        {
+          "SchemaVersion": 2,
+          "Title": "Future Panel",
+          "Summary": "Future",
+          "Elements": []
+        }
+        """;
+
+        var success = Panel2DDocumentStorage.TryReadValidated(sourceJson, out _, out var errorMessage);
+
+        Assert.False(success);
+        Assert.Contains("Unsupported schema version '2'", errorMessage);
+    }
+
+    [Fact]
+    public void TryReadValidated_WithInvalidElementKind_ReturnsValidationError()
+    {
+        const string sourceJson = """
+        {
+          "SchemaVersion": 1,
+          "Title": "Invalid Kind Panel",
+          "Summary": "Invalid",
+          "Elements": [
+            {
+              "ObjectId": "obj-1",
+              "Name": "Bad Kind",
+              "Kind": "triangle",
+              "X": 1,
+              "Y": 2,
+              "Width": 3,
+              "Height": 4
+            }
+          ]
+        }
+        """;
+
+        var success = Panel2DDocumentStorage.TryReadValidated(sourceJson, out _, out var errorMessage);
+
+        Assert.False(success);
+        Assert.Contains("unsupported kind", errorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryReadValidated_WithMissingNameAndObjectId_NormalizesValues()
+    {
+        const string sourceJson = """
+        {
+          "SchemaVersion": 1,
+          "Title": "Normalizable Panel",
+          "Summary": "Normalizable",
+          "Elements": [
+            {
+              "ObjectId": "",
+              "Name": "",
+              "Kind": "rectangle",
+              "X": 1,
+              "Y": 2,
+              "Width": 30,
+              "Height": 40
+            }
+          ]
+        }
+        """;
+
+        var success = Panel2DDocumentStorage.TryReadValidated(sourceJson, out var parsed, out var errorMessage);
+
+        Assert.True(success);
+        Assert.Equal(string.Empty, errorMessage);
+        var element = Assert.Single(parsed.Elements);
+        Assert.False(string.IsNullOrWhiteSpace(element.ObjectId));
+        Assert.StartsWith("Rectangle ", element.Name);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -5,6 +5,8 @@ namespace OasisEditor;
 
 internal static class Panel2DDocumentStorage
 {
+    public const int CurrentSchemaVersion = 1;
+
     internal static PanelElementKind ParseElementKind(string? kind)
     {
         if (string.Equals(kind, "rectangle", StringComparison.OrdinalIgnoreCase))
@@ -46,7 +48,7 @@ internal static class Panel2DDocumentStorage
     {
         var payload = new Panel2DDocumentFile
         {
-            SchemaVersion = 1,
+            SchemaVersion = CurrentSchemaVersion,
             Title = title,
             Summary = summary,
             SavedAtUtc = DateTime.UtcNow,
@@ -58,7 +60,7 @@ internal static class Panel2DDocumentStorage
 
     public static bool TryCreateSummary(string content, out string summary)
     {
-        if (!TryRead(content, out var document))
+        if (!TryReadValidated(content, out var document, out _))
         {
             summary = string.Empty;
             return false;
@@ -82,6 +84,83 @@ internal static class Panel2DDocumentStorage
             document = new Panel2DDocumentFile();
             return false;
         }
+    }
+
+    public static bool TryReadValidated(string content, out Panel2DDocumentFile document, out string errorMessage)
+    {
+        if (!TryRead(content, out var parsed))
+        {
+            document = new Panel2DDocumentFile();
+            errorMessage = "Malformed JSON.";
+            return false;
+        }
+
+        if (!TryMigrateToCurrentSchema(parsed, out var migrated, out errorMessage))
+        {
+            document = new Panel2DDocumentFile();
+            return false;
+        }
+
+        if (!TryValidateAndNormalize(migrated, out var normalized, out errorMessage))
+        {
+            document = new Panel2DDocumentFile();
+            return false;
+        }
+
+        document = normalized;
+        return true;
+    }
+
+    public static bool TryMigrateToCurrentSchema(Panel2DDocumentFile source, out Panel2DDocumentFile migrated, out string errorMessage)
+    {
+        if (source.SchemaVersion == CurrentSchemaVersion)
+        {
+            migrated = source;
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        migrated = new Panel2DDocumentFile();
+        errorMessage = source.SchemaVersion > CurrentSchemaVersion
+            ? $"Unsupported schema version '{source.SchemaVersion}'. Current supported version is {CurrentSchemaVersion}."
+            : $"Unsupported schema version '{source.SchemaVersion}'.";
+        return false;
+    }
+
+    public static bool TryValidateAndNormalize(Panel2DDocumentFile source, out Panel2DDocumentFile normalized, out string errorMessage)
+    {
+        if (source.SchemaVersion != CurrentSchemaVersion)
+        {
+            normalized = new Panel2DDocumentFile();
+            errorMessage = $"Unsupported schema version '{source.SchemaVersion}'.";
+            return false;
+        }
+
+        var elements = source.Elements ?? [];
+        foreach (var element in elements)
+        {
+            var normalizedKind = ParseElementKind(element.Kind);
+            if (normalizedKind == PanelElementKind.Unknown)
+            {
+                normalized = new Panel2DDocumentFile();
+                errorMessage = $"Element '{element.ObjectId}' has unsupported kind '{element.Kind}'.";
+                return false;
+            }
+
+            if (!IsValidDimension(element.Width) || !IsValidDimension(element.Height))
+            {
+                normalized = new Panel2DDocumentFile();
+                errorMessage = $"Element '{element.ObjectId}' has invalid dimensions.";
+                return false;
+            }
+        }
+
+        normalized = source with
+        {
+            Elements = elements.Select(NormalizeElement).ToArray()
+        };
+        errorMessage = string.Empty;
+        return true;
     }
 
 
@@ -199,6 +278,13 @@ internal static class Panel2DDocumentStorage
             ? CreateDefaultElementName(kind, objectId)
             : name.Trim();
     }
+
+    private static bool IsValidDimension(double value)
+    {
+        return !double.IsNaN(value)
+            && !double.IsInfinity(value)
+            && value > 0;
+    }
 }
 
 internal enum PanelElementKind
@@ -210,7 +296,7 @@ internal enum PanelElementKind
     Zone
 }
 
-internal sealed class Panel2DDocumentFile
+internal sealed record Panel2DDocumentFile
 {
     public int SchemaVersion { get; init; }
     public string Title { get; init; } = string.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -243,16 +243,23 @@ public sealed class DocumentWorkspaceViewModel
 
     internal static OpenDocumentData BuildOpenDocumentData(string path, string content)
     {
-        if (string.Equals(Path.GetExtension(path), ".panel2d", StringComparison.OrdinalIgnoreCase)
-            && Panel2DDocumentStorage.TryRead(content, out var panelDocument))
+        if (string.Equals(Path.GetExtension(path), ".panel2d", StringComparison.OrdinalIgnoreCase))
         {
-            var summary = string.IsNullOrWhiteSpace(panelDocument.Summary)
-                ? "Panel document opened."
-                : panelDocument.Summary.Trim();
-            var title = string.IsNullOrWhiteSpace(panelDocument.Title)
-                ? Path.GetFileName(path)
-                : panelDocument.Title.Trim();
-            return new OpenDocumentData(summary, Panel2DDocumentStorage.SerializeLayout(panelDocument.Elements), title);
+            if (Panel2DDocumentStorage.TryReadValidated(content, out var panelDocument, out var errorMessage))
+            {
+                var summary = string.IsNullOrWhiteSpace(panelDocument.Summary)
+                    ? "Panel document opened."
+                    : panelDocument.Summary.Trim();
+                var title = string.IsNullOrWhiteSpace(panelDocument.Title)
+                    ? Path.GetFileName(path)
+                    : panelDocument.Title.Trim();
+                return new OpenDocumentData(summary, Panel2DDocumentStorage.SerializeLayout(panelDocument.Elements), title);
+            }
+
+            return new OpenDocumentData(
+                $"Failed to open panel document: {errorMessage}",
+                null,
+                Path.GetFileName(path));
         }
 
         var preview = content.Length > 300 ? $"{content[..300]}..." : content;

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -70,20 +70,20 @@ These tasks come from the Editor code review. Complete them in order. Build and 
   - [x] Verify hierarchy refreshes after add/delete/rename
 
 ### Phase D — Storage, Validation, and Migration
-- [ ] Add explicit Panel2D schema validation
-  - [ ] Validate `SchemaVersion`
-  - [ ] Validate required element IDs, names, kinds, and dimensions
-  - [ ] Normalise recoverable issues and report unrecoverable ones cleanly
-  - [ ] Ensure malformed JSON fails gracefully with a clear output-log/error message
-- [ ] Add Panel2D schema migration hooks
-  - [ ] Keep schema version 1 as the current format
-  - [ ] Add a small migration entry point even if there are no migrations yet
-  - [ ] Ensure future schema versions fail with an explicit unsupported-version message
-- [ ] Add tests for Panel2D storage/model behaviour
-  - [ ] Round-trip rectangle and image elements
-  - [ ] Preserve object IDs and names
-  - [ ] Normalise missing IDs/names only when intended
-  - [ ] Reject or report unsupported schema versions
+- [x] Add explicit Panel2D schema validation
+  - [x] Validate `SchemaVersion`
+  - [x] Validate required element IDs, names, kinds, and dimensions
+  - [x] Normalise recoverable issues and report unrecoverable ones cleanly
+  - [x] Ensure malformed JSON fails gracefully with a clear output-log/error message
+- [x] Add Panel2D schema migration hooks
+  - [x] Keep schema version 1 as the current format
+  - [x] Add a small migration entry point even if there are no migrations yet
+  - [x] Ensure future schema versions fail with an explicit unsupported-version message
+- [x] Add tests for Panel2D storage/model behaviour
+  - [x] Round-trip rectangle and image elements
+  - [x] Preserve object IDs and names
+  - [x] Normalise missing IDs/names only when intended
+  - [x] Reject or report unsupported schema versions
 
 ### Phase E — Deferred Planning Only
 - [ ] Plan layer ordering support only


### PR DESCRIPTION
### Motivation
- Provide explicit schema validation and a migration entry point for `.panel2d` storage so malformed or unsupported files fail clearly instead of silently becoming previews.
- Normalize recoverable issues (missing IDs/names) and reject unrecoverable issues (unsupported schema versions or invalid element kinds/dimensions) to protect user data and prepare for future schema migrations.
- Surface clear error summaries to the editor UI when a panel file cannot be opened as a valid Panel2D document.

### Description
- Introduced `CurrentSchemaVersion` and a validated read pipeline: `TryReadValidated`, `TryMigrateToCurrentSchema`, and `TryValidateAndNormalize` in `Panel2DDocumentStorage` to centralize schema/version checks, migration entry point, element-kind validation, dimension checks, and normalization of recoverable fields.
- Switched serialization to use `CurrentSchemaVersion` and added `IsValidDimension` utility to guard width/height values.
- Converted `Panel2DDocumentFile` to a `record` and kept `PanelElementFile` as a record to simplify normalization/with-expression usage.
- Updated `DocumentWorkspaceViewModel.BuildOpenDocumentData` to use the validated read and to return a clear failure summary and no layout when the `.panel2d` content is malformed or unsupported (sets `PanelLayoutJson` to `null` and `PanelTitle` to the file name when failing).
- Added unit tests to `OasisEditor.Tests/Panel2DRoundTripTests.cs` covering malformed JSON handling, unsupported/future schema version rejection, invalid element-kind validation, and normalization of missing name/objectId, and renamed an existing test to reflect the new behavior.
- Updated `TASKS.md` to mark Phase D items (validation/migration/testing) as completed.

### Testing
- Added automated unit tests: `BuildOpenDocumentData_WithInvalidPanelJson_ReturnsClearErrorSummary`, `TryReadValidated_WithFutureSchemaVersion_ReturnsUnsupportedVersionError`, `TryReadValidated_WithInvalidElementKind_ReturnsValidationError`, and `TryReadValidated_WithMissingNameAndObjectId_NormalizesValues` in `Panel2DRoundTripTests` and preserved existing round-trip tests.
- Attempted to run `dotnet test OasisEditor.sln` in this environment, but the command failed because the runtime (`dotnet`) is not available here; tests were not executed in this container.
- The new tests are committed and should be executed by CI or locally with `dotnet test` to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee04416fdc8327a40afe377da0af23)