### PR TITLE
Phase F: Command surface review document and TASKS.md update

### DIFF
--- a/WindowsNetProjects/OasisEditor/PhaseF.CommandReview.md
+++ b/WindowsNetProjects/OasisEditor/PhaseF.CommandReview.md
@@ -1,0 +1,47 @@
+# Phase F Command Surface Review
+
+Review date: 2026-04-26
+
+This is a behavior-preserving review pass for Task **Phase F / Review current hierarchy keyboard handlers and asset double-click handlers**.
+
+## Hierarchy keyboard handlers (current state)
+
+### Existing command paths
+
+- **Delete** is wired in `HierarchyView.xaml.cs` `OnTreeViewPreviewKeyDown` and routes to `MainWindowViewModel.DeleteSelectedHierarchyItem()`.
+- **Rename (F2)** is wired in `HierarchyView.xaml.cs` `OnTreeViewPreviewKeyDown`, currently prompts via `Interaction.InputBox`, then routes to `MainWindowViewModel.RenameSelectedHierarchyItem(string)`.
+
+### What is already implemented
+
+- Rename command path exists for selected Panel2D hierarchy entity.
+- Delete command path exists for selected Panel2D hierarchy entity.
+- Both paths are routed through document canvas mutation commands (`CanvasMutationCommands`) via `MainWindowViewModel.ExecuteDocumentCanvasCommand(...)`.
+
+### Confirmed command gaps
+
+- **Cut**: not implemented in hierarchy keyboard handling.
+- **Copy**: not implemented in hierarchy keyboard handling.
+- **Paste**: not implemented in hierarchy keyboard handling.
+- **Duplicate**: not implemented in hierarchy keyboard handling.
+
+## Asset handlers (current state)
+
+### Existing command paths
+
+- **Open (double-click)** is wired in `AssetBrowserView.xaml.cs` `OnAssetListMouseDoubleClick`, which executes `MainWindowViewModel.OpenAssetCommand`.
+- `OpenAssetCommand` is provided by `AssetBrowserViewModel.OpenAssetCommand` and delegates to the existing app-level open flow via callback.
+
+### What is already implemented
+
+- Asset file open on double-click is implemented.
+
+### Confirmed command gaps
+
+- **Show in Explorer**: not implemented.
+- **Asset Rename**: not implemented.
+- **Asset Delete**: not implemented.
+
+## Notes for next implementation task
+
+- Keep keyboard/menu/context-menu entry points routed through the same ViewModel methods.
+- Keep view code-behind limited to right-click selection glue where required by WPF.

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -16,10 +16,10 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
 - [ ] Add tests where practical; keep tests under the Editor solution only
 
 ### Phase F — Shared Context Menu Command Foundation
-- [ ] Review current hierarchy keyboard handlers and asset double-click handlers
-  - [ ] Identify commands already implemented for rename/delete/open
-  - [ ] Identify command gaps for cut/copy/paste/duplicate/show-in-explorer/assets rename/assets delete
-  - [ ] Do not change behavior in this review step
+- [x] Review current hierarchy keyboard handlers and asset double-click handlers
+  - [x] Identify commands already implemented for rename/delete/open
+  - [x] Identify command gaps for cut/copy/paste/duplicate/show-in-explorer/assets rename/assets delete
+  - [x] Do not change behavior in this review step
 - [ ] Add a reusable command pattern for pane item context menus
   - [ ] Keep View code-behind limited to selecting the right-clicked item before opening the menu, if needed
   - [ ] Put command execution and CanExecute logic on the relevant ViewModel or focused service


### PR DESCRIPTION
### Motivation
- Capture the current state of hierarchy keyboard handlers and asset double-click behavior as a behavior-preserving review step and mark the Phase F checklist complete.

### Description
- Added `WindowsNetProjects/OasisEditor/PhaseF.CommandReview.md` summarizing implemented command paths (hierarchy Rename/Delete and asset Open) and identified gaps (Cut/Copy/Paste/Duplicate/Show In Explorer/asset Rename/asset Delete), and updated `WindowsNetProjects/OasisEditor/TASKS.md` to mark the Phase F review and its subitems complete.

### Testing
- Attempted to run `dotnet build OasisEditor.sln` to satisfy the per-task build check but the build could not be executed in this environment because `dotnet` is not installed, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee0e2b8e648327a68ddf1230cfb8ad)