### PR TITLE
Add reusable pane item command foundation

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -6,6 +6,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
                 <ResourceDictionary Source="Styles/OasisPalette.xaml" />
+                <ResourceDictionary Source="Styles/Menu.xaml" />
                 <ResourceDictionary Source="Styles/AvalonDockVs2013Palette.xaml" />
             </ResourceDictionary.MergedDictionaries>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -25,7 +25,7 @@
               Style="{DynamicResource EditorMenuStyle}">
             <Menu.Resources>
                 <Style TargetType="{x:Type MenuItem}"
-                       BasedOn="{DynamicResource EditorMenuItemStyle}">
+                       BasedOn="{StaticResource EditorMenuItemStyle}">
                     <Style.Triggers>
                         <Trigger Property="Role"
                                  Value="TopLevelHeader">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -20,13 +20,12 @@
 
         <Menu Grid.Row="0"
               MinHeight="24"
-              Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-              Foreground="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}"
-              BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
               BorderThickness="0,0,0,1"
-              Padding="0">
+              Padding="0"
+              Style="{DynamicResource EditorMenuStyle}">
             <Menu.Resources>
-                <Style TargetType="{x:Type MenuItem}">
+                <Style TargetType="{x:Type MenuItem}"
+                       BasedOn="{DynamicResource EditorMenuItemStyle}">
                     <Style.Triggers>
                         <Trigger Property="Role"
                                  Value="TopLevelHeader">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -101,6 +101,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OutputEntries = _outputLog.OutputEntries;
         RefreshAssetBrowserCommand = _assetBrowser.RefreshAssetBrowserCommand;
         OpenAssetCommand = _assetBrowser.OpenAssetCommand;
+        DeleteSelectedHierarchyItemCommand = new PaneItemCommand<HierarchyItemViewModel>(
+            GetSelectedHierarchyEntity,
+            item => DeleteHierarchyItem(item),
+            CanDeleteHierarchyItem);
         ClearOutputCommand = _outputLog.ClearOutputCommand;
         ApplyInspectorSummaryCommand = _inspector.ApplyInspectorSummaryCommand;
         AddOutputEntry("Editor shell initialized.", OutputLogStatus.Info);
@@ -119,6 +123,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand OpenAssetCommand { get; }
+    public ICommand DeleteSelectedHierarchyItemCommand { get; }
     public ICommand ClearOutputCommand { get; }
     public ICommand OpenPreferencesCommand { get; }
     public ICommand OpenProjectSettingsCommand { get; }
@@ -214,6 +219,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 NotifyInspectorChanged();
                 NotifyDocumentCommands();
                 RefreshHierarchy();
+                NotifyHierarchyCommands();
             }
         }
     }
@@ -281,6 +287,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         SelectedDocument.HierarchySelectedPanelSelection = selection;
+        NotifyHierarchyCommands();
     }
 
     public bool DeleteSelectedHierarchyItem()
@@ -364,6 +371,38 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             selection,
             normalizedName);
         return ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
+    }
+
+    private HierarchyItemViewModel? GetSelectedHierarchyEntity()
+    {
+        return HierarchyItems.FirstOrDefault(item =>
+            item.IsSelected &&
+            !item.IsGroup &&
+            item.PanelSelection is PanelSelectionInfo);
+    }
+
+    private bool CanDeleteHierarchyItem(HierarchyItemViewModel hierarchyItem)
+    {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        return !hierarchyItem.IsGroup &&
+               hierarchyItem.PanelSelection is PanelSelectionInfo selection &&
+               selectedDocument.HasPanelElement(selection);
+    }
+
+    private void DeleteHierarchyItem(HierarchyItemViewModel hierarchyItem)
+    {
+        if (!CanDeleteHierarchyItem(hierarchyItem))
+        {
+            return;
+        }
+
+        SelectHierarchyItem(hierarchyItem);
+        DeleteSelectedHierarchyItem();
     }
 
     private bool CanOpenUntitledDocument()
@@ -743,6 +782,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RefreshHierarchy();
     }
 
+
+    private void NotifyHierarchyCommands()
+    {
+        if (DeleteSelectedHierarchyItemCommand is PaneItemCommand<HierarchyItemViewModel> deleteHierarchyCommand)
+        {
+            deleteHierarchyCommand.RaiseCanExecuteChanged();
+        }
+    }
+
     private static string ResolveProjectDirectory(string projectDirectory, JsonElement layoutElement, string propertyName)
     {
         if (!layoutElement.TryGetProperty(propertyName, out var directoryElement))
@@ -866,6 +914,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(HierarchyItems));
         OnPropertyChanged(nameof(HasHierarchyItems));
         OnPropertyChanged(nameof(HierarchyEmptyStateMessage));
+        NotifyHierarchyCommands();
     }
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -879,6 +928,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
             NotifyInspectorChanged();
+            NotifyHierarchyCommands();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PaneItemCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PaneItemCommand.cs
@@ -1,0 +1,50 @@
+using System.Windows.Input;
+
+namespace OasisEditor;
+
+public sealed class PaneItemCommand<TItem> : ICommand
+    where TItem : class
+{
+    private readonly Func<TItem?> _selectedItemAccessor;
+    private readonly Action<TItem> _execute;
+    private readonly Predicate<TItem>? _canExecuteItem;
+
+    public PaneItemCommand(
+        Func<TItem?> selectedItemAccessor,
+        Action<TItem> execute,
+        Predicate<TItem>? canExecuteItem = null)
+    {
+        _selectedItemAccessor = selectedItemAccessor;
+        _execute = execute;
+        _canExecuteItem = canExecuteItem;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        var item = parameter as TItem ?? _selectedItemAccessor();
+        return item is not null && (_canExecuteItem?.Invoke(item) ?? true);
+    }
+
+    public void Execute(object? parameter)
+    {
+        var item = parameter as TItem ?? _selectedItemAccessor();
+        if (item is null)
+        {
+            return;
+        }
+
+        if (_canExecuteItem is not null && !_canExecuteItem(item))
+        {
+            return;
+        }
+
+        _execute(item);
+    }
+
+    public void RaiseCanExecuteChanged()
+    {
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
@@ -131,4 +131,20 @@
             </Trigger>
         </Style.Triggers>
     </Style>
+
+    <Style x:Key="EditorContextMenuStyle"
+           TargetType="{x:Type ContextMenu}">
+        <Setter Property="Background"
+                Value="{DynamicResource ToolBarBackgroundBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource BorderSubtleBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
+        <Setter Property="Padding"
+                Value="4" />
+    </Style>
+
+    <Style x:Key="EditorContextMenuItemStyle"
+           TargetType="{x:Type MenuItem}"
+           BasedOn="{StaticResource EditorMenuItemStyle}" />
 </ResourceDictionary>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -29,7 +29,9 @@ public sealed class AssetBrowserViewModel
 
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
-        OpenAssetCommand = new RelayCommand(OpenAsset);
+        OpenAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
+            () => SelectedAsset,
+            asset => OpenAsset(asset));
     }
 
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -50,6 +52,7 @@ public sealed class AssetBrowserViewModel
             _selectionChanged();
             _notifyInspectorChanged();
             NotifyRefreshCommand();
+            NotifyOpenAssetCommand();
         }
     }
 
@@ -101,15 +104,17 @@ public sealed class AssetBrowserViewModel
         }
     }
 
-    private void OpenAsset()
+    private void OpenAsset(AssetBrowserItemViewModel asset)
     {
-        var asset = SelectedAsset;
-        if (asset is null)
-        {
-            return;
-        }
-
         SelectedAsset = asset;
         _openAsset(asset);
+    }
+
+    private void NotifyOpenAssetCommand()
+    {
+        if (OpenAssetCommand is PaneItemCommand<AssetBrowserItemViewModel> openAssetCommand)
+        {
+            openAssetCommand.RaiseCanExecuteChanged();
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -31,8 +31,10 @@ public partial class HierarchyView : UserControl
 
         if (eventArgs.Key == Key.Delete)
         {
-            if (viewModel.DeleteSelectedHierarchyItem())
+            var command = viewModel.DeleteSelectedHierarchyItemCommand;
+            if (command.CanExecute(null))
             {
+                command.Execute(null);
                 eventArgs.Handled = true;
             }
 


### PR DESCRIPTION
### Motivation

- Introduce a small reusable command abstraction to centralize pane-item command `CanExecute`/`Execute` semantics and enable shared keyboard/context-menu entry points. 
- Prepare the codebase for Phase F/G work (hierarchy and asset context menus) by making selection-aware commands easy to add and requery. 

### Description

- Added a generic `PaneItemCommand<TItem>` that evaluates `CanExecute` against either the passed parameter or a selected-item accessor and exposes `RaiseCanExecuteChanged()` for requerying. 
- Replaced the `OpenAssetCommand` implementation in `AssetBrowserViewModel` to use `PaneItemCommand<AssetBrowserItemViewModel>` and added selection-change notification to requery the command via `NotifyOpenAssetCommand`. 
- Added a document-scoped `DeleteSelectedHierarchyItemCommand` to `MainWindowViewModel` implemented with `PaneItemCommand<HierarchyItemViewModel>` and added helper methods `GetSelectedHierarchyEntity`, `CanDeleteHierarchyItem`, and `DeleteHierarchyItem`. 
- Routed existing Hierarchy `Delete` key handling through the new command surface and added calls to `NotifyHierarchyCommands()` from hierarchy/selection refresh points so command state stays in sync.

### Testing

- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not available (build failed with `/bin/bash: dotnet: command not found`).
- No additional automated unit tests were executed in this environment; no new tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee0ec7ad0c8327b6a118c1a9db2ea7)