### PR TITLE
Replace hierarchy rename InputBox with editor-owned dialog

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
@@ -3,9 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Rename Hierarchy Item"
         Width="420"
-        Height="180"
+        Height="200"
         MinWidth="360"
-        MinHeight="170"
+        MinHeight="200"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Background="{DynamicResource PanelBackgroundBrush}"
@@ -14,7 +14,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
@@ -30,6 +30,9 @@
 
         <TextBox x:Name="NameTextBox"
                  Grid.Row="2"
+                 MinHeight="30"
+                 Padding="8,4"
+                 VerticalContentAlignment="Center"
                  Text="{Binding NameText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel Grid.Row="3"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
@@ -1,0 +1,51 @@
+<Window x:Class="OasisEditor.HierarchyRenameDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Rename Hierarchy Item"
+        Width="420"
+        Height="180"
+        MinWidth="360"
+        MinHeight="170"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="{DynamicResource PanelBackgroundBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontSize="16"
+                   FontWeight="SemiBold"
+                   Text="Rename hierarchy item" />
+
+        <TextBlock Grid.Row="1"
+                   Margin="0,12,0,6"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="Name" />
+
+        <TextBox x:Name="NameTextBox"
+                 Grid.Row="2"
+                 Text="{Binding NameText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,14,0,0">
+            <Button MinWidth="90"
+                    Padding="12,6"
+                    Margin="0,0,8,0"
+                    IsCancel="True"
+                    Content="Cancel" />
+            <Button MinWidth="90"
+                    Padding="12,6"
+                    IsDefault="True"
+                    Click="OnRenameClicked"
+                    Content="Rename" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+public partial class HierarchyRenameDialog : Window
+{
+    public HierarchyRenameDialog(string currentName)
+    {
+        NameText = currentName;
+        InitializeComponent();
+        DataContext = this;
+        Loaded += OnLoaded;
+    }
+
+    public string NameText { get; set; }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        NameTextBox.Focus();
+        NameTextBox.SelectAll();
+    }
+
+    private void OnRenameClicked(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(NameText))
+        {
+            return;
+        }
+
+        DialogResult = true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -8,7 +8,6 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.Win32;
-using Microsoft.VisualBasic;
 using EditorCommands = OasisEditor.Commands;
 
 namespace OasisEditor;
@@ -416,16 +415,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        var renamed = Interaction.InputBox(
-            "Enter a new name for the selected hierarchy object:",
-            "Rename Hierarchy Item",
-            currentName);
-        if (string.IsNullOrWhiteSpace(renamed))
+        var renameDialog = new HierarchyRenameDialog(currentName)
+        {
+            Owner = _ownerWindow
+        };
+
+        if (renameDialog.ShowDialog() != true)
         {
             return;
         }
 
-        RenameSelectedHierarchyItem(renamed);
+        RenameSelectedHierarchyItem(renameDialog.NameText);
     }
 
     private HierarchyItemViewModel? GetSelectedHierarchyEntity()

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -40,11 +40,11 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
   - [x] Rename
   - [x] Duplicate
   - [x] Delete
-- [ ] Route Rename through the existing rename behavior
-  - [ ] Preserve F2 rename behavior
-  - [ ] Avoid `Microsoft.VisualBasic.Interaction.InputBox` long-term if a simple editor-owned dialog can be added without scope creep
-  - [ ] Mark the document dirty only when the name actually changes
-  - [ ] Preserve undo/redo behavior
+- [x] Route Rename through the existing rename behavior
+  - [x] Preserve F2 rename behavior
+  - [x] Avoid `Microsoft.VisualBasic.Interaction.InputBox` long-term if a simple editor-owned dialog can be added without scope creep
+  - [x] Mark the document dirty only when the name actually changes
+  - [x] Preserve undo/redo behavior
 - [ ] Route Delete through the existing delete behavior
   - [ ] Preserve Delete key behavior
   - [ ] Do not record no-op delete commands


### PR DESCRIPTION
### Motivation
- Remove the dependency on `Microsoft.VisualBasic.Interaction.InputBox` and provide a small, themed editor-owned dialog for hierarchy rename that fits the app's WPF style and theme rules.
- Preserve the existing rename command path and UX (F2 and context-menu rename) while avoiding the legacy InputBox API.

### Description
- Added a new WPF dialog `HierarchyRenameDialog` implemented in `OasisEditor/HierarchyRenameDialog.xaml` and `OasisEditor/HierarchyRenameDialog.xaml.cs` which focuses/selects the current name and validates non-empty input before confirming.
- Replaced the old `Interaction.InputBox` usage in `MainWindowViewModel` with the new dialog and removed the `using Microsoft.VisualBasic;` import; the code still calls `RenameSelectedHierarchyItem(...)` so existing command routing and undo/dirty behavior are preserved.
- Updated `TASKS.md` to mark the Phase G rename-routing checklist items as completed.

### Testing
- Attempted an automated build with `dotnet build OasisEditor.sln`, but the environment does not have the `dotnet` SDK installed so the build could not be executed.
- No automated unit tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee14e09354832786eff97a37d95562)