### PR TITLE
Add hierarchy copy/paste support for Panel2D elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -412,6 +412,40 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal("Rect Original Copy 2", duplicate.Name);
     }
 
+    [Fact]
+    public void PasteElementCommand_CreatesOffsetElementWithNewObjectIdAndSupportsUndo()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "source-id",
+                Name = "Rect Original",
+                Kind = PanelElementKind.Rectangle,
+                X = 30,
+                Y = 40,
+                Width = 50,
+                Height = 60
+            });
+
+        var source = document.GetPanelElements().Single();
+        var command = CanvasMutationCommands.CreatePasteElementCommand(document.DocumentId, document, source);
+        var tracked = Assert.IsAssignableFrom<Commands.IExecutionTrackedCommand>(command);
+
+        command.Execute();
+
+        Assert.True(tracked.WasExecuted);
+        Assert.Equal(2, document.GetPanelElements().Count);
+        var pasted = document.GetPanelElements().Single(element => element.ObjectId != "source-id");
+        Assert.Equal("Rect Original (2)", pasted.Name);
+        Assert.Equal(40, pasted.X);
+        Assert.Equal(50, pasted.Y);
+        Assert.Equal(50, pasted.Width);
+        Assert.Equal(60, pasted.Height);
+
+        command.Undo();
+        Assert.Single(document.GetPanelElements());
+    }
+
     [Theory]
     [InlineData(0.1, 9.9, 0.0, 10.0)]
     [InlineData(14.9, 15.1, 10.0, 20.0)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -34,6 +34,14 @@ internal static class CanvasMutationCommands
         return new DuplicateElementMutationCommand(documentId, document, selection);
     }
 
+    public static Commands.ICommand CreatePasteElementCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelElementModel sourceElement)
+    {
+        return new PasteElementMutationCommand(documentId, document, sourceElement);
+    }
+
     private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
@@ -344,6 +352,81 @@ internal static class CanvasMutationCommands
         }
     }
 
+    private sealed class PasteElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private const double PasteOffset = 10.0;
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly PanelElementModel _sourceElement;
+        private PanelElementModel? _pastedElement;
+        private int? _insertIndex;
+
+        public PasteElementMutationCommand(Guid documentId, DocumentTabViewModel document, PanelElementModel sourceElement)
+        {
+            _documentId = documentId;
+            _document = document;
+            _sourceElement = sourceElement;
+        }
+
+        public Guid DocumentId => _documentId;
+
+        public string Description => "Paste element";
+
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetPanelElements().ToList();
+
+            if (_pastedElement is null)
+            {
+                _pastedElement = new PanelElementModel
+                {
+                    ObjectId = BuildUniqueObjectId(elements),
+                    Name = BuildUniqueName(_sourceElement.Name, elements),
+                    Kind = _sourceElement.Kind,
+                    X = _sourceElement.X + PasteOffset,
+                    Y = _sourceElement.Y + PasteOffset,
+                    Width = _sourceElement.Width,
+                    Height = _sourceElement.Height
+                };
+                _insertIndex = elements.Count;
+            }
+
+            var pastedElement = _pastedElement;
+            if (pastedElement is null || elements.Any(element => string.Equals(element.ObjectId, pastedElement.ObjectId, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            var insertIndex = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
+            elements.Insert(insertIndex, pastedElement);
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            var pastedElement = _pastedElement;
+            if (pastedElement is null)
+            {
+                return;
+            }
+
+            var elements = _document.GetPanelElements().ToList();
+            var removed = elements.RemoveAll(element => string.Equals(element.ObjectId, pastedElement.ObjectId, StringComparison.Ordinal)) > 0;
+            if (!removed)
+            {
+                return;
+            }
+
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+        }
+    }
+
     private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementModel> elements, PanelSelectionInfo selection, out int index)
     {
         if (!string.IsNullOrWhiteSpace(selection.ObjectId))
@@ -421,6 +504,32 @@ internal static class CanvasMutationCommands
         while (true)
         {
             var candidate = $"{copyBase} {suffix}";
+            if (!existingNames.Contains(candidate))
+            {
+                return candidate;
+            }
+
+            suffix++;
+        }
+    }
+
+    private static string BuildUniqueName(string sourceName, IReadOnlyList<PanelElementModel> elements)
+    {
+        var baseName = string.IsNullOrWhiteSpace(sourceName)
+            ? "Element"
+            : sourceName.Trim();
+        var existingNames = new HashSet<string>(
+            elements.Select(element => element.Name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        if (!existingNames.Contains(baseName))
+        {
+            return baseName;
+        }
+
+        var suffix = 2;
+        while (true)
+        {
+            var candidate = $"{baseName} ({suffix})";
             if (!existingNames.Contains(candidate))
             {
                 return candidate;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -31,6 +31,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly HierarchyViewModel _hierarchy;
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
+    private PanelElementClipboardPayload? _panelClipboardPayload;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -462,9 +463,29 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private static bool CanCutSelectedHierarchyItem() => false;
 
-    private static bool CanCopySelectedHierarchyItem() => false;
+    private bool CanCopySelectedHierarchyItem()
+    {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
 
-    private static bool CanPasteHierarchyItem() => false;
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
+        {
+            return false;
+        }
+
+        return selectedDocument.HasPanelElement(selection);
+    }
+
+    private bool CanPasteHierarchyItem()
+    {
+        var selectedDocument = SelectedDocument;
+        return selectedDocument is not null
+               && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
+               && _panelClipboardPayload is not null;
+    }
 
     private bool CanDuplicateSelectedHierarchyItem()
     {
@@ -486,12 +507,59 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
     }
 
-    private static void ExecuteCopySelectedHierarchyItem()
+    private void ExecuteCopySelectedHierarchyItem()
     {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
+        {
+            return;
+        }
+
+        if (!selectedDocument.TryGetPanelElement(selection, out var element))
+        {
+            return;
+        }
+
+        _panelClipboardPayload = new PanelElementClipboardPayload
+        {
+            Element = new PanelElementModel
+            {
+                ObjectId = element.ObjectId,
+                Name = element.Name,
+                Kind = element.Kind,
+                X = element.X,
+                Y = element.Y,
+                Width = element.Width,
+                Height = element.Height
+            }
+        };
+        NotifyHierarchyCommands();
     }
 
-    private static void ExecutePasteHierarchyItem()
+    private void ExecutePasteHierarchyItem()
     {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        var clipboardPayload = _panelClipboardPayload;
+        if (clipboardPayload is null)
+        {
+            return;
+        }
+
+        var command = CanvasMutationCommands.CreatePasteElementCommand(
+            selectedDocument.DocumentId,
+            selectedDocument,
+            clipboardPayload.Element);
+        ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
     }
 
     private void ExecuteDuplicateSelectedHierarchyItem()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -461,7 +461,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         DeleteSelectedHierarchyItem();
     }
 
-    private static bool CanCutSelectedHierarchyItem() => false;
+    private bool CanCutSelectedHierarchyItem()
+    {
+        return CanCopySelectedHierarchyItem();
+    }
 
     private bool CanCopySelectedHierarchyItem()
     {
@@ -503,11 +506,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return selectedDocument.HasPanelElement(selection);
     }
 
-    private static void ExecuteCutSelectedHierarchyItem()
-    {
-    }
-
-    private void ExecuteCopySelectedHierarchyItem()
+    private void ExecuteCutSelectedHierarchyItem()
     {
         var selectedDocument = SelectedDocument;
         if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
@@ -520,25 +519,25 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        if (!selectedDocument.TryGetPanelElement(selection, out var element))
+        if (!selectedDocument.HasPanelElement(selection))
         {
             return;
         }
 
-        _panelClipboardPayload = new PanelElementClipboardPayload
+        if (!TryCopySelectedHierarchyItemToClipboard())
         {
-            Element = new PanelElementModel
-            {
-                ObjectId = element.ObjectId,
-                Name = element.Name,
-                Kind = element.Kind,
-                X = element.X,
-                Y = element.Y,
-                Width = element.Width,
-                Height = element.Height
-            }
-        };
-        NotifyHierarchyCommands();
+            return;
+        }
+
+        DeleteSelectedHierarchyItem();
+    }
+
+    private void ExecuteCopySelectedHierarchyItem()
+    {
+        if (!TryCopySelectedHierarchyItemToClipboard())
+        {
+            return;
+        }
     }
 
     private void ExecutePasteHierarchyItem()
@@ -560,6 +559,41 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             selectedDocument,
             clipboardPayload.Element);
         ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
+    }
+
+    private bool TryCopySelectedHierarchyItemToClipboard()
+    {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
+        {
+            return false;
+        }
+
+        if (!selectedDocument.TryGetPanelElement(selection, out var element))
+        {
+            return false;
+        }
+
+        _panelClipboardPayload = new PanelElementClipboardPayload
+        {
+            Element = new PanelElementModel
+            {
+                ObjectId = element.ObjectId,
+                Name = element.Name,
+                Kind = element.Kind,
+                X = element.X,
+                Y = element.Y,
+                Width = element.Width,
+                Height = element.Height
+            }
+        };
+        NotifyHierarchyCommands();
+        return true;
     }
 
     private void ExecuteDuplicateSelectedHierarchyItem()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementClipboardPayload.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementClipboardPayload.cs
@@ -1,0 +1,6 @@
+namespace OasisEditor;
+
+internal sealed class PanelElementClipboardPayload
+{
+    public required PanelElementModel Element { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -57,13 +57,13 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
   - [x] Offset the duplicate slightly on the canvas if practical
   - [x] Execute through the document command system
   - [x] Preserve undo/redo behavior
-- [ ] Implement Copy/Paste for Panel2D hierarchy entities
-  - [ ] Use an editor-owned clipboard format for Panel2D element data
-  - [ ] Paste must create new stable object IDs
-  - [ ] Paste must target the active document only
-  - [ ] Disable Paste when clipboard data is missing or incompatible
-  - [ ] Execute Paste through the document command system
-  - [ ] Preserve undo/redo behavior
+- [x] Implement Copy/Paste for Panel2D hierarchy entities
+  - [x] Use an editor-owned clipboard format for Panel2D element data
+  - [x] Paste must create new stable object IDs
+  - [x] Paste must target the active document only
+  - [x] Disable Paste when clipboard data is missing or incompatible
+  - [x] Execute Paste through the document command system
+  - [x] Preserve undo/redo behavior
 - [ ] Implement Cut for Panel2D hierarchy entities
   - [ ] Copy selected entity to the editor clipboard first
   - [ ] Delete through the document command system only after copy succeeds

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -64,10 +64,10 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
   - [x] Disable Paste when clipboard data is missing or incompatible
   - [x] Execute Paste through the document command system
   - [x] Preserve undo/redo behavior
-- [ ] Implement Cut for Panel2D hierarchy entities
-  - [ ] Copy selected entity to the editor clipboard first
-  - [ ] Delete through the document command system only after copy succeeds
-  - [ ] Preserve undo/redo behavior for the delete portion
+- [x] Implement Cut for Panel2D hierarchy entities
+  - [x] Copy selected entity to the editor clipboard first
+  - [x] Delete through the document command system only after copy succeeds
+  - [x] Preserve undo/redo behavior for the delete portion
 - [ ] Verify hierarchy context menu behavior
   - [ ] Right-click selects the intended entity
   - [ ] Group rows do not expose invalid entity actions


### PR DESCRIPTION
### Motivation
- Complete Phase G work by adding copy/paste support for Panel2D hierarchy entities so users can copy an element in the hierarchy and paste it into the active document with undo/redo semantics.
- Keep behavior document-scoped, undoable, and consistent with the existing duplicate/command infrastructure and preserve name/ID uniqueness rules.

### Description
- Add an in-memory editor clipboard payload type `PanelElementClipboardPayload` to hold copied `PanelElementModel` data. (`OasisEditor/PanelElementClipboardPayload.cs`)
- Implement hierarchy copy/paste enablement and execution in `MainWindowViewModel` including `CanExecute` checks and routing paste through the document command path. (`MainWindowViewModel.cs`)
- Add `CanvasMutationCommands.CreatePasteElementCommand` and `PasteElementMutationCommand` which generate a new stable `ObjectId`, apply a small offset, produce a unique name when conflicts occur, mark the document dirty, and support undo/redo and execution tracking. (`CanvasMutationCommands.cs`)
- Add a unit test covering paste behavior (new object creation, name conflict handling, offset placement, and undo). (`OasisEditor.Tests/Panel2DRoundTripTests.cs`) and mark the Phase G Copy/Paste checklist as completed in `TASKS.md`.

### Testing
- Added unit test `PasteElementCommand_CreatesOffsetElementWithNewObjectIdAndSupportsUndo` to `OasisEditor.Tests/Panel2DRoundTripTests.cs` but no test run completed in this environment.
- Attempted to run `dotnet test OasisEditor.sln` but the command could not be executed because `dotnet` is not available in the container, so automated tests were not run here.
- Committed the changes and updated `TASKS.md` to reflect the implemented Copy/Paste items.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee18dbf88c8327993a1a804dae8dba)