### PR TITLE
Fix disabled Delete action in hierarchy context menu

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -431,10 +431,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private HierarchyItemViewModel? GetSelectedHierarchyEntity()
     {
-        return HierarchyItems.FirstOrDefault(item =>
+        return EnumerateHierarchyItems(HierarchyItems).FirstOrDefault(item =>
             item.IsSelected &&
             !item.IsGroup &&
             item.PanelSelection is PanelSelectionInfo);
+    }
+
+    private static IEnumerable<HierarchyItemViewModel> EnumerateHierarchyItems(IEnumerable<HierarchyItemViewModel> roots)
+    {
+        foreach (var item in roots)
+        {
+            yield return item;
+
+            foreach (var child in EnumerateHierarchyItems(item.Children))
+            {
+                yield return child;
+            }
+        }
     }
 
     private bool CanDeleteHierarchyItem(HierarchyItemViewModel hierarchyItem)


### PR DESCRIPTION
### Motivation
- The hierarchy’s root nodes are category/group rows so the previous selected-entity lookup only searched top-level items and could not find a selected nested entity, leaving the `Delete` context-menu item permanently disabled.

### Description
- Add a recursive enumerator `EnumerateHierarchyItems` and update `GetSelectedHierarchyEntity` to use `EnumerateHierarchyItems(HierarchyItems).FirstOrDefault(...)` so the selected leaf node is discovered across the full tree (file: `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` but the build could not be executed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`), so no automated tests were run; a code review and logic verification confirm the selection lookup now traverses nested hierarchy nodes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee1b8a9d348327aeacb2645a14700c)