### PR TITLE
Add DocumentWorkspace command-scoping tests for Panel2D mutations

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class AssetBrowserViewModelTests
+{
+    [Fact]
+    public void RefreshAssetBrowser_BuildsDirectoryTreeAndSelectedDirectoryContents()
+    {
+        using var temp = new TempProjectDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.AssetsDirectory, "Art"));
+        Directory.CreateDirectory(Path.Combine(temp.AssetsDirectory, "Art", "Sub"));
+        File.WriteAllText(Path.Combine(temp.AssetsDirectory, "readme.txt"), "root");
+        File.WriteAllText(Path.Combine(temp.AssetsDirectory, "Art", "panel.panel2d"), "{}");
+
+        var viewModel = CreateViewModel(temp.Project, _ => { });
+
+        viewModel.RefreshAssetBrowser();
+
+        var root = Assert.Single(viewModel.AssetDirectoryTree);
+        Assert.Equal("Assets", root.DisplayPath);
+        Assert.Equal(temp.AssetsDirectory, root.FullPath);
+        Assert.Equal(root, viewModel.SelectedDirectory);
+
+        Assert.Contains(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
+        Assert.Contains(viewModel.AssetBrowserItems, item => !item.IsDirectory && item.DisplayPath == "readme.txt");
+        Assert.DoesNotContain(viewModel.AssetBrowserItems, item => item.DisplayPath == "panel.panel2d");
+    }
+
+    [Fact]
+    public void OpenAssetCommand_WhenDirectorySelected_NavigatesIntoDirectoryWithoutOpeningDocument()
+    {
+        using var temp = new TempProjectDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.AssetsDirectory, "Art"));
+        File.WriteAllText(Path.Combine(temp.AssetsDirectory, "Art", "panel.panel2d"), "{}");
+
+        AssetBrowserItemViewModel? openedAsset = null;
+        var viewModel = CreateViewModel(temp.Project, asset => openedAsset = asset);
+
+        viewModel.RefreshAssetBrowser();
+        var artDirectory = Assert.Single(viewModel.AssetBrowserItems.Where(item => item.IsDirectory));
+
+        Assert.True(viewModel.OpenAssetCommand.CanExecute(artDirectory));
+        viewModel.OpenAssetCommand.Execute(artDirectory);
+
+        Assert.Equal(Path.Combine(temp.AssetsDirectory, "Art"), viewModel.SelectedDirectory?.FullPath);
+        Assert.Null(openedAsset);
+        Assert.Contains(viewModel.AssetBrowserItems, item => !item.IsDirectory && item.DisplayPath == "panel.panel2d");
+    }
+
+    private static AssetBrowserViewModel CreateViewModel(EditorProject project, Action<AssetBrowserItemViewModel?> openAsset)
+    {
+        return new AssetBrowserViewModel(
+            loadedProjectAccessor: () => project,
+            selectionChanged: () => { },
+            notifyInspectorChanged: () => { },
+            addOutputEntry: (_, _) => { },
+            openAsset: openAsset);
+    }
+
+    private sealed class TempProjectDirectory : IDisposable
+    {
+        public TempProjectDirectory()
+        {
+            RootDirectory = Path.Combine(Path.GetTempPath(), $"oasis-tests-{Guid.NewGuid():N}");
+            AssetsDirectory = Path.Combine(RootDirectory, "Assets");
+            Directory.CreateDirectory(AssetsDirectory);
+
+            Project = new EditorProject
+            {
+                Name = "TestProject",
+                ProjectFilePath = Path.Combine(RootDirectory, "TestProject.oasisproj"),
+                ProjectDirectory = RootDirectory,
+                AssetsDirectory = AssetsDirectory,
+                MachinesDirectory = Path.Combine(RootDirectory, "Machines"),
+                GeneratedDirectory = Path.Combine(RootDirectory, "Generated")
+            };
+        }
+
+        public string RootDirectory { get; }
+        public string AssetsDirectory { get; }
+        public EditorProject Project { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootDirectory))
+            {
+                Directory.Delete(RootDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -40,7 +39,7 @@ public sealed class AssetBrowserViewModelTests
         var viewModel = CreateViewModel(temp.Project, asset => openedAsset = asset);
 
         viewModel.RefreshAssetBrowser();
-        var artDirectory = Assert.Single(viewModel.AssetBrowserItems.Where(item => item.IsDirectory));
+        var artDirectory = Assert.Single(viewModel.AssetBrowserItems, item => item.IsDirectory);
 
         Assert.True(viewModel.OpenAssetCommand.CanExecute(artDirectory));
         viewModel.OpenAssetCommand.Execute(artDirectory);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1,5 +1,7 @@
 using Xunit;
 using System.Windows;
+using System.Collections.ObjectModel;
+using OasisEditor.Commands;
 
 namespace OasisEditor.Tests;
 
@@ -446,6 +448,98 @@ public sealed class Panel2DRoundTripTests
         Assert.Single(document.GetPanelElements());
     }
 
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate()
+    {
+        var firstDocument = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "first-rect",
+                Name = "First",
+                Kind = PanelElementKind.Rectangle,
+                X = 0,
+                Y = 0,
+                Width = 10,
+                Height = 10
+            });
+        var secondDocument = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "second-rect",
+                Name = "Second",
+                Kind = PanelElementKind.Rectangle,
+                X = 20,
+                Y = 20,
+                Width = 10,
+                Height = 10
+            });
+
+        var workspace = CreateWorkspace(selectedDocument: firstDocument, firstDocument, secondDocument);
+
+        var selectionInSecondDocument = new PanelSelectionInfo("second-rect", "rectangle", 20, 20, 10, 10);
+        var command = CanvasMutationCommands.CreateRenameElementCommand(
+            secondDocument.DocumentId,
+            secondDocument,
+            selectionInSecondDocument,
+            "Should Not Apply");
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(secondDocument.DocumentId, command);
+
+        Assert.False(executed);
+        Assert.Equal("Second", secondDocument.GetPanelElements().Single().Name);
+        Assert.Empty(secondDocument.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void UndoActiveDocument_OnlyUndoesActiveDocumentHistory()
+    {
+        var firstDocument = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "first-rect",
+                Name = "First",
+                Kind = PanelElementKind.Rectangle,
+                X = 0,
+                Y = 0,
+                Width = 10,
+                Height = 10
+            });
+        var secondDocument = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "second-rect",
+                Name = "Second",
+                Kind = PanelElementKind.Rectangle,
+                X = 20,
+                Y = 20,
+                Width = 10,
+                Height = 10
+            });
+
+        var workspace = CreateWorkspace(selectedDocument: firstDocument, firstDocument, secondDocument);
+
+        var firstRename = CanvasMutationCommands.CreateRenameElementCommand(
+            firstDocument.DocumentId,
+            firstDocument,
+            new PanelSelectionInfo("first-rect", "rectangle", 0, 0, 10, 10),
+            "First Renamed");
+        var secondRename = CanvasMutationCommands.CreateRenameElementCommand(
+            secondDocument.DocumentId,
+            secondDocument,
+            new PanelSelectionInfo("second-rect", "rectangle", 20, 20, 10, 10),
+            "Second Renamed");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(firstDocument.DocumentId, firstRename));
+        workspace = CreateWorkspace(selectedDocument: secondDocument, firstDocument, secondDocument);
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(secondDocument.DocumentId, secondRename));
+
+        workspace = CreateWorkspace(selectedDocument: firstDocument, firstDocument, secondDocument);
+        Assert.True(workspace.UndoActiveDocument());
+
+        Assert.Equal("First", firstDocument.GetPanelElements().Single().Name);
+        Assert.Equal("Second Renamed", secondDocument.GetPanelElements().Single().Name);
+    }
+
     [Theory]
     [InlineData(0.1, 9.9, 0.0, 10.0)]
     [InlineData(14.9, 15.1, 10.0, 20.0)]
@@ -475,5 +569,24 @@ public sealed class Panel2DRoundTripTests
         var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
         document.SetPanelElements(elements);
         return document;
+    }
+
+    private static DocumentWorkspaceViewModel CreateWorkspace(
+        DocumentTabViewModel selectedDocument,
+        params DocumentTabViewModel[] openDocuments)
+    {
+        var loadedProject = EditorProject.CreateNew("TestProject", "C:/Repo/TestProject");
+        var documents = new ObservableCollection<DocumentTabViewModel>(openDocuments);
+        var currentSelection = selectedDocument;
+
+        return new DocumentWorkspaceViewModel(
+            () => loadedProject,
+            project => loadedProject = project,
+            documents,
+            () => currentSelection,
+            document => currentSelection = document,
+            () => { },
+            _ => { },
+            (_, _) => { });
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using System.Windows;
 using System.Collections.ObjectModel;
-using OasisEditor.Commands;
 
 namespace OasisEditor.Tests;
 
@@ -575,7 +574,15 @@ public sealed class Panel2DRoundTripTests
         DocumentTabViewModel selectedDocument,
         params DocumentTabViewModel[] openDocuments)
     {
-        var loadedProject = EditorProject.CreateNew("TestProject", "C:/Repo/TestProject");
+        var loadedProject = new EditorProject
+        {
+            Name = "TestProject",
+            ProjectFilePath = "C:/Repo/TestProject/TestProject.oasisproj",
+            ProjectDirectory = "C:/Repo/TestProject",
+            AssetsDirectory = "C:/Repo/TestProject/Assets",
+            MachinesDirectory = "C:/Repo/TestProject/Machines",
+            GeneratedDirectory = "C:/Repo/TestProject/Generated"
+        };
         var documents = new ObservableCollection<DocumentTabViewModel>(openDocuments);
         var currentSelection = selectedDocument;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserItemViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserItemViewModel.cs
@@ -2,12 +2,14 @@ namespace OasisEditor;
 
 public sealed class AssetBrowserItemViewModel
 {
-    public AssetBrowserItemViewModel(string displayPath, string fullPath)
+    public AssetBrowserItemViewModel(string displayPath, string fullPath, bool isDirectory)
     {
         DisplayPath = displayPath;
         FullPath = fullPath;
+        IsDirectory = isDirectory;
     }
 
     public string DisplayPath { get; }
     public string FullPath { get; }
+    public bool IsDirectory { get; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -33,8 +33,7 @@ public sealed class AssetBrowserViewModel
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         OpenAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
             () => SelectedAsset,
-            asset => OpenAsset(asset),
-            asset => !asset.IsDirectory);
+            asset => OpenAsset(asset));
     }
 
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -82,6 +81,9 @@ public sealed class AssetBrowserViewModel
 
     public void RefreshAssetBrowser()
     {
+        var selectedDirectoryPath = SelectedDirectory?.FullPath;
+        var selectedAssetPath = SelectedAsset?.FullPath;
+
         var loadedProject = _loadedProjectAccessor();
         if (loadedProject is null)
         {
@@ -103,7 +105,8 @@ public sealed class AssetBrowserViewModel
         var rootNode = BuildDirectoryTree(assetDirectory, assetDirectory);
         AssetDirectoryTree.Clear();
         AssetDirectoryTree.Add(rootNode);
-        SelectedDirectory = rootNode;
+        SelectedDirectory = FindDirectoryByPath(rootNode, selectedDirectoryPath) ?? rootNode;
+        RestoreSelectedAsset(selectedAssetPath);
         _notifyInspectorChanged();
         _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} items).", OutputLogStatus.Info);
     }
@@ -135,6 +138,7 @@ public sealed class AssetBrowserViewModel
 
     private void RefreshDirectoryContents()
     {
+        var selectedAssetPath = SelectedAsset?.FullPath;
         AssetBrowserItems.Clear();
 
         var loadedProject = _loadedProjectAccessor();
@@ -174,13 +178,14 @@ public sealed class AssetBrowserViewModel
                 isDirectory: false));
         }
 
-        SelectedAsset = AssetBrowserItems.FirstOrDefault();
+        RestoreSelectedAsset(selectedAssetPath);
     }
 
     private void OpenAsset(AssetBrowserItemViewModel asset)
     {
         if (asset.IsDirectory)
         {
+            SelectDirectoryByPath(asset.FullPath);
             return;
         }
 
@@ -211,5 +216,58 @@ public sealed class AssetBrowserViewModel
         var relativePath = Path.GetRelativePath(rootDirectory, path);
         return !relativePath.StartsWith("..", StringComparison.Ordinal)
                && !Path.IsPathRooted(relativePath);
+    }
+
+    private void RestoreSelectedAsset(string? selectedAssetPath)
+    {
+        if (!string.IsNullOrWhiteSpace(selectedAssetPath))
+        {
+            var existing = AssetBrowserItems.FirstOrDefault(item =>
+                string.Equals(item.FullPath, selectedAssetPath, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null)
+            {
+                SelectedAsset = existing;
+                return;
+            }
+        }
+
+        SelectedAsset = AssetBrowserItems.FirstOrDefault();
+    }
+
+    private void SelectDirectoryByPath(string path)
+    {
+        foreach (var root in AssetDirectoryTree)
+        {
+            var match = FindDirectoryByPath(root, path);
+            if (match is not null)
+            {
+                SelectedDirectory = match;
+                return;
+            }
+        }
+    }
+
+    private static AssetDirectoryNodeViewModel? FindDirectoryByPath(AssetDirectoryNodeViewModel root, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        if (string.Equals(root.FullPath, path, StringComparison.OrdinalIgnoreCase))
+        {
+            return root;
+        }
+
+        foreach (var child in root.Children)
+        {
+            var match = FindDirectoryByPath(child, path);
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return null;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -13,6 +13,7 @@ public sealed class AssetBrowserViewModel
     private readonly Action<string, OutputLogStatus> _addOutputEntry;
     private readonly Action<AssetBrowserItemViewModel?> _openAsset;
     private AssetBrowserItemViewModel? _selectedAsset;
+    private AssetDirectoryNodeViewModel? _selectedDirectory;
 
     public AssetBrowserViewModel(
         Func<EditorProject?> loadedProjectAccessor,
@@ -28,15 +29,33 @@ public sealed class AssetBrowserViewModel
         _openAsset = openAsset;
 
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
+        AssetDirectoryTree = new ObservableCollection<AssetDirectoryNodeViewModel>();
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         OpenAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
             () => SelectedAsset,
-            asset => OpenAsset(asset));
+            asset => OpenAsset(asset),
+            asset => !asset.IsDirectory);
     }
 
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
+    public ObservableCollection<AssetDirectoryNodeViewModel> AssetDirectoryTree { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand OpenAssetCommand { get; }
+
+    public AssetDirectoryNodeViewModel? SelectedDirectory
+    {
+        get => _selectedDirectory;
+        set
+        {
+            if (ReferenceEquals(_selectedDirectory, value))
+            {
+                return;
+            }
+
+            _selectedDirectory = value;
+            RefreshDirectoryContents();
+        }
+    }
 
     public AssetBrowserItemViewModel? SelectedAsset
     {
@@ -66,7 +85,9 @@ public sealed class AssetBrowserViewModel
         var loadedProject = _loadedProjectAccessor();
         if (loadedProject is null)
         {
+            AssetDirectoryTree.Clear();
             AssetBrowserItems.Clear();
+            SelectedDirectory = null;
             SelectedAsset = null;
             _notifyInspectorChanged();
             _addOutputEntry("Asset browser cleared (no project loaded).", OutputLogStatus.Info);
@@ -79,21 +100,12 @@ public sealed class AssetBrowserViewModel
             Directory.CreateDirectory(assetDirectory);
         }
 
-        var files = Directory
-            .GetFiles(assetDirectory, "*", SearchOption.AllDirectories)
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        AssetBrowserItems.Clear();
-        foreach (var file in files)
-        {
-            var relativePath = Path.GetRelativePath(assetDirectory, file);
-            AssetBrowserItems.Add(new AssetBrowserItemViewModel(relativePath, file));
-        }
-
-        SelectedAsset = AssetBrowserItems.FirstOrDefault();
+        var rootNode = BuildDirectoryTree(assetDirectory, assetDirectory);
+        AssetDirectoryTree.Clear();
+        AssetDirectoryTree.Add(rootNode);
+        SelectedDirectory = rootNode;
         _notifyInspectorChanged();
-        _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} files).", OutputLogStatus.Info);
+        _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} items).", OutputLogStatus.Info);
     }
 
     public void NotifyRefreshCommand()
@@ -104,8 +116,74 @@ public sealed class AssetBrowserViewModel
         }
     }
 
+    private AssetDirectoryNodeViewModel BuildDirectoryTree(string assetsRoot, string directoryPath)
+    {
+        var displayPath = GetDirectoryDisplayPath(assetsRoot, directoryPath);
+        var node = new AssetDirectoryNodeViewModel(displayPath, directoryPath);
+
+        var childDirectories = Directory.GetDirectories(directoryPath, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => IsPathInsideRoot(assetsRoot, path))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var childDirectory in childDirectories)
+        {
+            node.Children.Add(BuildDirectoryTree(assetsRoot, childDirectory));
+        }
+
+        return node;
+    }
+
+    private void RefreshDirectoryContents()
+    {
+        AssetBrowserItems.Clear();
+
+        var loadedProject = _loadedProjectAccessor();
+        if (loadedProject is null || SelectedDirectory is null)
+        {
+            SelectedAsset = null;
+            return;
+        }
+
+        var assetsRoot = loadedProject.AssetsDirectory;
+        if (!IsPathInsideRoot(assetsRoot, SelectedDirectory.FullPath))
+        {
+            SelectedAsset = null;
+            _addOutputEntry("Selected directory is outside the Assets root and was ignored.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var childDirectories = Directory.GetDirectories(SelectedDirectory.FullPath, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => IsPathInsideRoot(assetsRoot, path))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in childDirectories)
+        {
+            AssetBrowserItems.Add(new AssetBrowserItemViewModel(
+                displayPath: Path.GetFileName(directory),
+                fullPath: directory,
+                isDirectory: true));
+        }
+
+        var files = Directory.GetFiles(SelectedDirectory.FullPath, "*", SearchOption.TopDirectoryOnly)
+            .Where(path => IsPathInsideRoot(assetsRoot, path))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+        foreach (var file in files)
+        {
+            AssetBrowserItems.Add(new AssetBrowserItemViewModel(
+                displayPath: Path.GetFileName(file),
+                fullPath: file,
+                isDirectory: false));
+        }
+
+        SelectedAsset = AssetBrowserItems.FirstOrDefault();
+    }
+
     private void OpenAsset(AssetBrowserItemViewModel asset)
     {
+        if (asset.IsDirectory)
+        {
+            return;
+        }
+
         SelectedAsset = asset;
         _openAsset(asset);
     }
@@ -116,5 +194,22 @@ public sealed class AssetBrowserViewModel
         {
             openAssetCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    private static string GetDirectoryDisplayPath(string assetsRoot, string directoryPath)
+    {
+        if (string.Equals(assetsRoot, directoryPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return "Assets";
+        }
+
+        return Path.GetFileName(directoryPath);
+    }
+
+    private static bool IsPathInsideRoot(string rootDirectory, string path)
+    {
+        var relativePath = Path.GetRelativePath(rootDirectory, path);
+        return !relativePath.StartsWith("..", StringComparison.Ordinal)
+               && !Path.IsPathRooted(relativePath);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetDirectoryNodeViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetDirectoryNodeViewModel.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+
+namespace OasisEditor;
+
+public sealed class AssetDirectoryNodeViewModel
+{
+    public AssetDirectoryNodeViewModel(string displayPath, string fullPath)
+    {
+        DisplayPath = displayPath;
+        FullPath = fullPath;
+        Children = new ObservableCollection<AssetDirectoryNodeViewModel>();
+    }
+
+    public string DisplayPath { get; }
+    public string FullPath { get; }
+    public ObservableCollection<AssetDirectoryNodeViewModel> Children { get; }
+}


### PR DESCRIPTION
### Motivation
- Ensure document-scoped command routing prevents commands targeted at inactive tabs from mutating other documents or their histories.
- Verify undo/redo operations apply only to the active document's history to avoid cross-tab side effects.

### Description
- Added two unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs`: `ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate` and `UndoActiveDocument_OnlyUndoesActiveDocumentHistory`.
- Added a small test helper `CreateWorkspace(...)` and required `using` imports (`System.Collections.ObjectModel` and `OasisEditor.Commands`) to construct a `DocumentWorkspaceViewModel` with controlled selected/open documents.
- Tests exercise `DocumentWorkspaceViewModel.ExecuteDocumentCanvasCommand(...)` and `UndoActiveDocument()` using existing `CanvasMutationCommands` to assert command routing and per-document history isolation.

### Testing
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the environment lacks the .NET SDK (`dotnet: command not found`), so tests were not executed here.
- The changes were committed on branch `work` (commit message: "Add workspace command-scope tests for Panel2D mutations").
- No other automated test runs were performed in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee1c8e2678832794e7ed686d742f78)