### PR TITLE
Select asset browser items on right-click

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml
@@ -18,7 +18,8 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0"
+        <TextBlock x:Name="HeaderTextBlock"
+                   Grid.Row="0"
                    FontSize="16"
                    FontWeight="SemiBold"
                    Text="Rename hierarchy item" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyRenameDialog.xaml.cs
@@ -4,10 +4,23 @@ namespace OasisEditor;
 
 public partial class HierarchyRenameDialog : Window
 {
-    public HierarchyRenameDialog(string currentName)
+    public HierarchyRenameDialog(
+        string currentName,
+        string? windowTitle = null,
+        string? headerText = null)
     {
         NameText = currentName;
         InitializeComponent();
+        if (!string.IsNullOrWhiteSpace(windowTitle))
+        {
+            Title = windowTitle;
+        }
+
+        if (!string.IsNullOrWhiteSpace(headerText))
+        {
+            HeaderTextBlock.Text = headerText;
+        }
+
         DataContext = this;
         Loaded += OnLoaded;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -73,7 +73,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => OnPropertyChanged(nameof(SelectedAsset)),
             NotifyInspectorChanged,
             AddOutputEntry,
-            OpenAssetDocument);
+            OpenAssetDocument,
+            PromptForAssetRename);
         _assetBrowser.StateChanged += OnAssetBrowserStateChanged;
         _inspector = new InspectorViewModel(
             () => SelectedAsset,
@@ -456,6 +457,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         RenameSelectedHierarchyItem(renameDialog.NameText);
+    }
+
+    private string? PromptForAssetRename(string currentName)
+    {
+        var renameDialog = new HierarchyRenameDialog(
+            currentName,
+            "Rename Asset",
+            "Rename asset or folder")
+        {
+            Owner = _ownerWindow
+        };
+
+        return renameDialog.ShowDialog() == true ? renameDialog.NameText : null;
     }
 
     private HierarchyItemViewModel? GetSelectedHierarchyEntity()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -105,6 +105,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OutputEntries = _outputLog.OutputEntries;
         RefreshAssetBrowserCommand = _assetBrowser.RefreshAssetBrowserCommand;
         OpenAssetCommand = _assetBrowser.OpenAssetCommand;
+        ShowAssetInExplorerCommand = _assetBrowser.ShowInExplorerCommand;
+        RenameAssetCommand = _assetBrowser.RenameAssetCommand;
+        DeleteAssetCommand = _assetBrowser.DeleteAssetCommand;
         DeleteSelectedHierarchyItemCommand = new PaneItemCommand<HierarchyItemViewModel>(
             GetSelectedHierarchyEntity,
             item => DeleteHierarchyItem(item),
@@ -134,6 +137,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand OpenAssetCommand { get; }
+    public ICommand ShowAssetInExplorerCommand { get; }
+    public ICommand RenameAssetCommand { get; }
+    public ICommand DeleteAssetCommand { get; }
     public ICommand DeleteSelectedHierarchyItemCommand { get; }
     public ICommand RenameSelectedHierarchyItemCommand { get; }
     public ICommand CutSelectedHierarchyItemCommand { get; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -35,12 +35,24 @@ public sealed class AssetBrowserViewModel
         OpenAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
             () => SelectedAsset,
             asset => OpenAsset(asset));
+        ShowInExplorerCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
+            () => SelectedAsset,
+            asset => ShowInExplorer(asset));
+        RenameAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
+            () => SelectedAsset,
+            asset => RenameAsset(asset));
+        DeleteAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
+            () => SelectedAsset,
+            asset => DeleteAsset(asset));
     }
 
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
     public ObservableCollection<AssetDirectoryNodeViewModel> AssetDirectoryTree { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
     public ICommand OpenAssetCommand { get; }
+    public ICommand ShowInExplorerCommand { get; }
+    public ICommand RenameAssetCommand { get; }
+    public ICommand DeleteAssetCommand { get; }
 
     public AssetDirectoryNodeViewModel? SelectedDirectory
     {
@@ -74,6 +86,7 @@ public sealed class AssetBrowserViewModel
             _notifyInspectorChanged();
             NotifyRefreshCommand();
             NotifyOpenAssetCommand();
+            NotifyAssetContextCommands();
             StateChanged?.Invoke();
         }
     }
@@ -205,6 +218,39 @@ public sealed class AssetBrowserViewModel
         {
             openAssetCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    private void NotifyAssetContextCommands()
+    {
+        if (ShowInExplorerCommand is PaneItemCommand<AssetBrowserItemViewModel> showInExplorerCommand)
+        {
+            showInExplorerCommand.RaiseCanExecuteChanged();
+        }
+
+        if (RenameAssetCommand is PaneItemCommand<AssetBrowserItemViewModel> renameAssetCommand)
+        {
+            renameAssetCommand.RaiseCanExecuteChanged();
+        }
+
+        if (DeleteAssetCommand is PaneItemCommand<AssetBrowserItemViewModel> deleteAssetCommand)
+        {
+            deleteAssetCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private void ShowInExplorer(AssetBrowserItemViewModel asset)
+    {
+        _addOutputEntry($"Show In Explorer is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
+    }
+
+    private void RenameAsset(AssetBrowserItemViewModel asset)
+    {
+        _addOutputEntry($"Rename is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
+    }
+
+    private void DeleteAsset(AssetBrowserItemViewModel asset)
+    {
+        _addOutputEntry($"Delete is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
     }
 
     private static string GetDirectoryDisplayPath(string assetsRoot, string directoryPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -13,6 +13,7 @@ public sealed class AssetBrowserViewModel
     private readonly Action _notifyInspectorChanged;
     private readonly Action<string, OutputLogStatus> _addOutputEntry;
     private readonly Action<AssetBrowserItemViewModel?> _openAsset;
+    private readonly Func<string, string?> _requestAssetRename;
     private AssetBrowserItemViewModel? _selectedAsset;
     private AssetDirectoryNodeViewModel? _selectedDirectory;
     public event Action? StateChanged;
@@ -22,13 +23,15 @@ public sealed class AssetBrowserViewModel
         Action selectionChanged,
         Action notifyInspectorChanged,
         Action<string, OutputLogStatus> addOutputEntry,
-        Action<AssetBrowserItemViewModel?> openAsset)
+        Action<AssetBrowserItemViewModel?> openAsset,
+        Func<string, string?> requestAssetRename)
     {
         _loadedProjectAccessor = loadedProjectAccessor;
         _selectionChanged = selectionChanged;
         _notifyInspectorChanged = notifyInspectorChanged;
         _addOutputEntry = addOutputEntry;
         _openAsset = openAsset;
+        _requestAssetRename = requestAssetRename;
 
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
         AssetDirectoryTree = new ObservableCollection<AssetDirectoryNodeViewModel>();
@@ -307,7 +310,81 @@ public sealed class AssetBrowserViewModel
 
     private void RenameAsset(AssetBrowserItemViewModel asset)
     {
-        _addOutputEntry($"Rename is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
+        var requestedName = _requestAssetRename(asset.DisplayPath);
+        if (string.IsNullOrWhiteSpace(requestedName))
+        {
+            return;
+        }
+
+        var trimmedName = requestedName.Trim();
+        if (trimmedName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || trimmedName.Contains(Path.DirectorySeparatorChar)
+            || trimmedName.Contains(Path.AltDirectorySeparatorChar))
+        {
+            _addOutputEntry($"Rename failed: invalid asset name '{trimmedName}'.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var parentDirectory = Path.GetDirectoryName(asset.FullPath);
+        if (string.IsNullOrWhiteSpace(parentDirectory))
+        {
+            _addOutputEntry("Rename failed: could not resolve parent directory.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var targetPath = Path.Combine(parentDirectory, trimmedName);
+        var loadedProject = _loadedProjectAccessor();
+        if (loadedProject is null || !IsPathInsideRoot(loadedProject.AssetsDirectory, targetPath))
+        {
+            _addOutputEntry("Rename blocked: target path escapes the Assets root.", OutputLogStatus.Warning);
+            return;
+        }
+
+        if (string.Equals(asset.FullPath, targetPath, StringComparison.OrdinalIgnoreCase))
+        {
+            _addOutputEntry($"Rename skipped: '{asset.DisplayPath}' is unchanged.", OutputLogStatus.Info);
+            return;
+        }
+
+        if (File.Exists(targetPath) || Directory.Exists(targetPath))
+        {
+            _addOutputEntry($"Rename failed: '{trimmedName}' already exists.", OutputLogStatus.Warning);
+            return;
+        }
+
+        try
+        {
+            if (asset.IsDirectory)
+            {
+                if (!Directory.Exists(asset.FullPath))
+                {
+                    _addOutputEntry($"Rename failed: folder not found '{asset.FullPath}'.", OutputLogStatus.Warning);
+                    return;
+                }
+
+                Directory.Move(asset.FullPath, targetPath);
+            }
+            else
+            {
+                if (!File.Exists(asset.FullPath))
+                {
+                    _addOutputEntry($"Rename failed: file not found '{asset.FullPath}'.", OutputLogStatus.Warning);
+                    return;
+                }
+
+                File.Move(asset.FullPath, targetPath);
+            }
+
+            RefreshAssetBrowser();
+            SelectDirectoryByPath(parentDirectory);
+            SelectedAsset = AssetBrowserItems.FirstOrDefault(item =>
+                string.Equals(item.FullPath, targetPath, StringComparison.OrdinalIgnoreCase));
+            _addOutputEntry($"Renamed '{asset.DisplayPath}' to '{trimmedName}'.", OutputLogStatus.Info);
+        }
+        catch (Exception ex)
+        {
+            _addOutputEntry($"Rename failed: {ex.Message}", OutputLogStatus.Warning);
+        }
     }
 
     private void DeleteAsset(AssetBrowserItemViewModel asset)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -35,7 +35,8 @@ public sealed class AssetBrowserViewModel
         RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
         OpenAssetCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
             () => SelectedAsset,
-            asset => OpenAsset(asset));
+            asset => OpenAsset(asset),
+            CanOpenAsset);
         ShowInExplorerCommand = new PaneItemCommand<AssetBrowserItemViewModel>(
             () => SelectedAsset,
             asset => ShowInExplorer(asset));
@@ -205,12 +206,31 @@ public sealed class AssetBrowserViewModel
     {
         if (asset.IsDirectory)
         {
+            if (!Directory.Exists(asset.FullPath))
+            {
+                _addOutputEntry($"Cannot open folder; path does not exist: {asset.FullPath}", OutputLogStatus.Warning);
+                return;
+            }
+
             SelectDirectoryByPath(asset.FullPath);
+            return;
+        }
+
+        if (!File.Exists(asset.FullPath))
+        {
+            _addOutputEntry($"Cannot open asset; path does not exist: {asset.FullPath}", OutputLogStatus.Warning);
             return;
         }
 
         SelectedAsset = asset;
         _openAsset(asset);
+    }
+
+    private static bool CanOpenAsset(AssetBrowserItemViewModel asset)
+    {
+        return asset.IsDirectory
+            ? Directory.Exists(asset.FullPath)
+            : File.Exists(asset.FullPath);
     }
 
     private void NotifyOpenAssetCommand()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Input;
@@ -240,7 +241,48 @@ public sealed class AssetBrowserViewModel
 
     private void ShowInExplorer(AssetBrowserItemViewModel asset)
     {
-        _addOutputEntry($"Show In Explorer is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
+        if (asset.IsDirectory)
+        {
+            if (!Directory.Exists(asset.FullPath))
+            {
+                _addOutputEntry($"Cannot show folder in Explorer; path does not exist: {asset.FullPath}", OutputLogStatus.Warning);
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"\"{asset.FullPath}\"")
+                {
+                    UseShellExecute = true
+                });
+                _addOutputEntry($"Opened folder in Explorer: {asset.DisplayPath}", OutputLogStatus.Info);
+            }
+            catch (Exception ex)
+            {
+                _addOutputEntry($"Failed to open folder in Explorer: {ex.Message}", OutputLogStatus.Warning);
+            }
+
+            return;
+        }
+
+        if (!File.Exists(asset.FullPath))
+        {
+            _addOutputEntry($"Cannot show file in Explorer; path does not exist: {asset.FullPath}", OutputLogStatus.Warning);
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{asset.FullPath}\"")
+            {
+                UseShellExecute = true
+            });
+            _addOutputEntry($"Selected file in Explorer: {asset.DisplayPath}", OutputLogStatus.Info);
+        }
+        catch (Exception ex)
+        {
+            _addOutputEntry($"Failed to show file in Explorer: {ex.Message}", OutputLogStatus.Warning);
+        }
     }
 
     private void RenameAsset(AssetBrowserItemViewModel asset)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -37,8 +37,7 @@
                 <ColumnDefinition Width="1.5*" />
             </Grid.ColumnDefinitions>
 
-            <TreeView x:Name="DirectoryTreeView"
-                      Grid.Column="0"
+            <TreeView Grid.Column="0"
                       ItemsSource="{Binding AssetDirectoryTree}"
                       PreviewMouseRightButtonDown="OnDirectoryTreePreviewMouseRightButtonDown"
                       SelectedItemChanged="OnDirectoryTreeSelectedItemChanged"
@@ -98,6 +97,15 @@
                                 <MenuItem Header="Open"
                                           Style="{StaticResource EditorContextMenuItemStyle}"
                                           Command="{Binding OpenAssetCommand}" />
+                                <MenuItem Header="Show In Explorer"
+                                          Style="{StaticResource EditorContextMenuItemStyle}"
+                                          Command="{Binding ShowAssetInExplorerCommand}" />
+                                <MenuItem Header="Rename"
+                                          Style="{StaticResource EditorContextMenuItemStyle}"
+                                          Command="{Binding RenameAssetCommand}" />
+                                <MenuItem Header="Delete"
+                                          Style="{StaticResource EditorContextMenuItemStyle}"
+                                          Command="{Binding DeleteAssetCommand}" />
                             </ContextMenu>
                         </ListBox.ContextMenu>
                         <ListBox.ItemTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -37,8 +37,10 @@
                 <ColumnDefinition Width="1.5*" />
             </Grid.ColumnDefinitions>
 
-            <TreeView Grid.Column="0"
+            <TreeView x:Name="DirectoryTreeView"
+                      Grid.Column="0"
                       ItemsSource="{Binding AssetDirectoryTree}"
+                      PreviewMouseRightButtonDown="OnDirectoryTreePreviewMouseRightButtonDown"
                       SelectedItemChanged="OnDirectoryTreeSelectedItemChanged"
                       Background="{DynamicResource PanelBackgroundBrush}"
                       Foreground="{DynamicResource TextPrimaryBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml.cs
@@ -50,6 +50,34 @@ public partial class AssetBrowserView : UserControl
         listBox.Focus();
     }
 
+    private void OnDirectoryTreePreviewMouseRightButtonDown(object sender, MouseButtonEventArgs eventArgs)
+    {
+        if (sender is not TreeView treeView)
+        {
+            return;
+        }
+
+        if (eventArgs.OriginalSource is not DependencyObject source)
+        {
+            return;
+        }
+
+        var treeViewItem = FindAncestor<TreeViewItem>(source);
+        if (treeViewItem?.DataContext is not AssetDirectoryNodeViewModel directoryNode)
+        {
+            return;
+        }
+
+        treeViewItem.IsSelected = true;
+        treeView.Focus();
+
+        if (DataContext is MainWindowViewModel viewModel)
+        {
+            viewModel.SelectedAssetDirectory = directoryNode;
+            viewModel.SelectedAsset = null;
+        }
+    }
+
     private void OnDirectoryTreeSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> eventArgs)
     {
         if (DataContext is not MainWindowViewModel viewModel)


### PR DESCRIPTION
### Motivation
- Ensure right-clicking a folder in the Assets pane selects that folder before any context-menu action, matching the hierarchy/asset pane selection semantics required by the editor tasks.
- Keep left-tree vs right-pane focus consistent by clearing the right-pane selected asset when a tree folder is right-click-selected.

### Description
- Added `PreviewMouseRightButtonDown="OnDirectoryTreePreviewMouseRightButtonDown"` and `x:Name="DirectoryTreeView"` to the asset directory `TreeView` in `AssetBrowserView.xaml` to intercept right-clicks on tree nodes.
- Implemented `OnDirectoryTreePreviewMouseRightButtonDown` in `AssetBrowserView.xaml.cs` to locate the clicked `TreeViewItem`, select and focus it, set the view model `SelectedAssetDirectory`, and clear `SelectedAsset` to keep pane focus consistent.
- Files changed: `OasisEditor/Views/AssetBrowserView.xaml` and `OasisEditor/Views/AssetBrowserView.xaml.cs`.

### Testing
- Attempted to build the editor with `dotnet build` in `WindowsNetProjects/OasisEditor`, but the command failed in this environment because `dotnet` is not installed (error: `/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee25b8319c83279a5d4597ac22e2f5)