### PR TITLE
Implement asset browser delete command handling and add tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
@@ -85,6 +85,43 @@ public sealed class AssetBrowserViewModelTests
         Assert.Empty(viewModel.AssetBrowserItems);
     }
 
+    [Fact]
+    public void DeleteAssetCommand_WhenFileSelected_DeletesFileAndRefreshes()
+    {
+        using var temp = new TempProjectDirectory();
+        var filePath = Path.Combine(temp.AssetsDirectory, "delete-me.txt");
+        File.WriteAllText(filePath, "test");
+
+        var viewModel = CreateViewModel(temp.Project, _ => { });
+        viewModel.RefreshAssetBrowser();
+        var fileItem = Assert.Single(viewModel.AssetBrowserItems, item => !item.IsDirectory && item.DisplayPath == "delete-me.txt");
+
+        Assert.True(viewModel.DeleteAssetCommand.CanExecute(fileItem));
+        viewModel.DeleteAssetCommand.Execute(fileItem);
+
+        Assert.False(File.Exists(filePath));
+        Assert.DoesNotContain(viewModel.AssetBrowserItems, item => item.DisplayPath == "delete-me.txt");
+    }
+
+    [Fact]
+    public void DeleteAssetCommand_WhenFolderNotEmpty_BlocksDeletion()
+    {
+        using var temp = new TempProjectDirectory();
+        var folderPath = Path.Combine(temp.AssetsDirectory, "Art");
+        Directory.CreateDirectory(folderPath);
+        File.WriteAllText(Path.Combine(folderPath, "panel.panel2d"), "{}");
+
+        var viewModel = CreateViewModel(temp.Project, _ => { });
+        viewModel.RefreshAssetBrowser();
+        var folderItem = Assert.Single(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
+
+        Assert.True(viewModel.DeleteAssetCommand.CanExecute(folderItem));
+        viewModel.DeleteAssetCommand.Execute(folderItem);
+
+        Assert.True(Directory.Exists(folderPath));
+        Assert.Contains(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
+    }
+
     private static AssetBrowserViewModel CreateViewModel(EditorProject project, Action<AssetBrowserItemViewModel?> openAsset)
     {
         return new AssetBrowserViewModel(
@@ -92,7 +129,8 @@ public sealed class AssetBrowserViewModelTests
             selectionChanged: () => { },
             notifyInspectorChanged: () => { },
             addOutputEntry: (_, _) => { },
-            openAsset: openAsset);
+            openAsset: openAsset,
+            requestAssetRename: _ => null);
     }
 
     private sealed class TempProjectDirectory : IDisposable

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -442,7 +442,55 @@ public sealed class AssetBrowserViewModel
             return;
         }
 
-        _addOutputEntry($"Delete is not implemented yet ({asset.DisplayPath}).", OutputLogStatus.Info);
+        var loadedProject = _loadedProjectAccessor();
+        if (loadedProject is null || !IsPathInsideRoot(loadedProject.AssetsDirectory, asset.FullPath))
+        {
+            _addOutputEntry("Delete blocked: target path is outside the Assets root.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var parentDirectory = Path.GetDirectoryName(asset.FullPath) ?? SelectedDirectory?.FullPath ?? loadedProject.AssetsDirectory;
+        var selectedDirectoryPath = SelectedDirectory?.FullPath;
+
+        try
+        {
+            if (asset.IsDirectory)
+            {
+                if (!Directory.Exists(asset.FullPath))
+                {
+                    _addOutputEntry($"Delete skipped: folder not found '{asset.FullPath}'.", OutputLogStatus.Warning);
+                    return;
+                }
+
+                var hasChildren = Directory.EnumerateFileSystemEntries(asset.FullPath).Any();
+                if (hasChildren)
+                {
+                    _addOutputEntry($"Delete blocked: folder '{asset.DisplayPath}' is not empty.", OutputLogStatus.Warning);
+                    return;
+                }
+
+                Directory.Delete(asset.FullPath, recursive: false);
+                _addOutputEntry($"Deleted folder: {asset.DisplayPath}", OutputLogStatus.Info);
+            }
+            else
+            {
+                if (!File.Exists(asset.FullPath))
+                {
+                    _addOutputEntry($"Delete skipped: file not found '{asset.FullPath}'.", OutputLogStatus.Warning);
+                    return;
+                }
+
+                File.Delete(asset.FullPath);
+                _addOutputEntry($"Deleted file: {asset.DisplayPath}", OutputLogStatus.Info);
+            }
+
+            RefreshAssetBrowser();
+            SelectDirectoryByPath(selectedDirectoryPath ?? parentDirectory);
+        }
+        catch (Exception ex)
+        {
+            _addOutputEntry($"Delete failed: {ex.Message}", OutputLogStatus.Warning);
+        }
     }
 
     private static string GetDirectoryDisplayPath(string assetsRoot, string directoryPath)


### PR DESCRIPTION
### Motivation
- Add safe, project-root-aware deletion to the Asset Browser so users can remove files and empty folders from the project while preventing accidental removals outside the Assets root.  
- Align asset deletion with the Phase I task guidance to block non-empty folder deletion and provide clear output/logging for blocked/skipped/failure/success cases.

### Description
- Implemented `DeleteAsset` in `AssetBrowserViewModel` to validate the path is inside the project `Assets` root and to handle both file and directory deletion scenarios.  
- Block non-empty directory deletion and emit informative output messages for blocked, skipped, failed, and successful cases.  
- Refresh asset browser state after a successful delete and restore the directory selection safely using `RefreshAssetBrowser()` and `SelectDirectoryByPath(...)`.  
- Updated tests and test helper usage in `OasisEditor.Tests/AssetBrowserViewModelTests.cs` and added two unit tests: `DeleteAssetCommand_WhenFileSelected_DeletesFileAndRefreshes` and `DeleteAssetCommand_WhenFolderNotEmpty_BlocksDeletion`.

### Testing
- Added unit tests covering successful file deletion and blocked deletion of a non-empty folder in `OasisEditor.Tests/AssetBrowserViewModelTests.cs`.  
- Attempted to run the test suite with `dotnet test`, but the execution environment does not have the .NET SDK installed (`dotnet: command not found`), so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee4f79c690832781108d69c186ddd8)