### PR TITLE
Extract HierarchyPanelCommandService and delegate hierarchy commands from MainWindowViewModel

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -120,6 +121,59 @@ public sealed class AssetBrowserViewModelTests
 
         Assert.True(Directory.Exists(folderPath));
         Assert.Contains(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
+    }
+
+    [Fact]
+    public void RenameAssetCommand_WhenFileSelected_RenamesAndRefreshesSelection()
+    {
+        using var temp = new TempProjectDirectory();
+        var filePath = Path.Combine(temp.AssetsDirectory, "old-name.panel2d");
+        File.WriteAllText(filePath, "{}");
+        var expectedPath = Path.Combine(temp.AssetsDirectory, "new-name.panel2d");
+
+        var viewModel = new AssetBrowserViewModel(
+            loadedProjectAccessor: () => temp.Project,
+            selectionChanged: () => { },
+            notifyInspectorChanged: () => { },
+            addOutputEntry: (_, _) => { },
+            openAsset: _ => { },
+            requestAssetRename: _ => "new-name.panel2d");
+
+        viewModel.RefreshAssetBrowser();
+        var fileItem = Assert.Single(viewModel.AssetBrowserItems, item => !item.IsDirectory && item.DisplayPath == "old-name.panel2d");
+
+        Assert.True(viewModel.RenameAssetCommand.CanExecute(fileItem));
+        viewModel.RenameAssetCommand.Execute(fileItem);
+
+        Assert.False(File.Exists(filePath));
+        Assert.True(File.Exists(expectedPath));
+        Assert.Equal("new-name.panel2d", viewModel.SelectedAsset?.DisplayPath);
+        Assert.Contains(viewModel.AssetBrowserItems, item => !item.IsDirectory && item.DisplayPath == "new-name.panel2d");
+    }
+
+    [Fact]
+    public void SelectedDirectory_OutsideAssetsRoot_IsIgnoredForContents()
+    {
+        using var temp = new TempProjectDirectory();
+        File.WriteAllText(Path.Combine(temp.AssetsDirectory, "inside.txt"), "ok");
+        var outsideDirectory = Path.Combine(temp.RootDirectory, "Outside");
+        Directory.CreateDirectory(outsideDirectory);
+        File.WriteAllText(Path.Combine(outsideDirectory, "outside.txt"), "nope");
+
+        var outputEntries = new List<string>();
+        var viewModel = new AssetBrowserViewModel(
+            loadedProjectAccessor: () => temp.Project,
+            selectionChanged: () => { },
+            notifyInspectorChanged: () => { },
+            addOutputEntry: (message, _) => outputEntries.Add(message),
+            openAsset: _ => { },
+            requestAssetRename: _ => null);
+
+        viewModel.RefreshAssetBrowser();
+        viewModel.SelectedDirectory = new AssetDirectoryNodeViewModel("Outside", outsideDirectory);
+
+        Assert.Empty(viewModel.AssetBrowserItems);
+        Assert.Contains(outputEntries, message => message.Contains("outside the Assets root", StringComparison.OrdinalIgnoreCase));
     }
 
     private static AssetBrowserViewModel CreateViewModel(EditorProject project, Action<AssetBrowserItemViewModel?> openAsset)

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -344,6 +344,63 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void ExecuteDocumentCanvasCommand_RenameNoOp_DoesNotRecordHistory()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+
+        var noOpRename = CanvasMutationCommands.CreateRenameElementCommand(
+            document.DocumentId,
+            document,
+            new PanelSelectionInfo("rect-1", "rectangle", 10, 10, 20, 20),
+            "  Rect 1  ");
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, noOpRename);
+
+        Assert.False(executed);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Equal("Rect 1", document.GetPanelElements().Single().Name);
+    }
+
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_DeleteMissingSelection_DoesNotRecordHistory()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+
+        var deleteMissing = CanvasMutationCommands.CreateDeleteElementCommand(
+            document.DocumentId,
+            document,
+            new PanelSelectionInfo("missing-id", "rectangle", 10, 10, 20, 20));
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, deleteMissing);
+
+        Assert.False(executed);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Single(document.GetPanelElements());
+    }
+
+    [Fact]
     public void DuplicateElementCommand_CreatesOffsetElementWithNewObjectIdAndCopyName()
     {
         var document = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
@@ -1,0 +1,212 @@
+namespace OasisEditor;
+
+internal sealed class HierarchyPanelCommandService
+{
+    private readonly Func<DocumentTabViewModel?> _selectedDocumentAccessor;
+    private readonly Func<Guid, Commands.ICommand, bool> _executeCanvasCommand;
+    private readonly Action<Guid, PanelSelectionInfo?> _updateDocumentSelection;
+    private readonly Action _notifyCanExecuteChanged;
+    private PanelElementClipboardPayload? _clipboardPayload;
+
+    public HierarchyPanelCommandService(
+        Func<DocumentTabViewModel?> selectedDocumentAccessor,
+        Func<Guid, Commands.ICommand, bool> executeCanvasCommand,
+        Action<Guid, PanelSelectionInfo?> updateDocumentSelection,
+        Action notifyCanExecuteChanged)
+    {
+        _selectedDocumentAccessor = selectedDocumentAccessor;
+        _executeCanvasCommand = executeCanvasCommand;
+        _updateDocumentSelection = updateDocumentSelection;
+        _notifyCanExecuteChanged = notifyCanExecuteChanged;
+    }
+
+    public bool CanDeleteSelected()
+    {
+        return TryGetSelectionDocument(out var document, out var selection) && document.HasPanelElement(selection);
+    }
+
+    public bool DeleteSelected()
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        {
+            return false;
+        }
+
+        var command = CanvasMutationCommands.CreateDeleteElementCommand(document.DocumentId, document, selection);
+        var wasDeleted = _executeCanvasCommand(document.DocumentId, command);
+        if (wasDeleted)
+        {
+            _updateDocumentSelection(document.DocumentId, null);
+        }
+
+        return wasDeleted;
+    }
+
+    public bool TryGetSelectedName(out string currentName)
+    {
+        currentName = string.Empty;
+        if (!TryGetSelectionDocument(out var document, out var selection))
+        {
+            return false;
+        }
+
+        if (!document.TryGetPanelElement(selection, out var matchingElement))
+        {
+            return false;
+        }
+
+        currentName = matchingElement.Name ?? string.Empty;
+        return true;
+    }
+
+    public bool RenameSelected(string newName)
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection))
+        {
+            return false;
+        }
+
+        var normalizedName = newName?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName) || !document.HasPanelElement(selection))
+        {
+            return false;
+        }
+
+        var command = CanvasMutationCommands.CreateRenameElementCommand(
+            document.DocumentId,
+            document,
+            selection,
+            normalizedName);
+        return _executeCanvasCommand(document.DocumentId, command);
+    }
+
+    public bool CanCopySelected()
+    {
+        return TryGetSelectionDocument(out var document, out var selection) && document.HasPanelElement(selection);
+    }
+
+    public bool CanCutSelected()
+    {
+        return CanCopySelected();
+    }
+
+    public bool CanPasteSelected()
+    {
+        var selectedDocument = _selectedDocumentAccessor();
+        return selectedDocument is not null
+               && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
+               && _clipboardPayload is not null;
+    }
+
+    public bool CanDuplicateSelected()
+    {
+        return TryGetSelectionDocument(out var document, out var selection) && document.HasPanelElement(selection);
+    }
+
+    public void ExecuteCutSelected()
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        {
+            return;
+        }
+
+        if (!TryCopySelectedToClipboard())
+        {
+            return;
+        }
+
+        DeleteSelected();
+    }
+
+    public void ExecuteCopySelected()
+    {
+        TryCopySelectedToClipboard();
+    }
+
+    public void ExecutePasteSelected()
+    {
+        var selectedDocument = _selectedDocumentAccessor();
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        var clipboardPayload = _clipboardPayload;
+        if (clipboardPayload is null)
+        {
+            return;
+        }
+
+        var command = CanvasMutationCommands.CreatePasteElementCommand(
+            selectedDocument.DocumentId,
+            selectedDocument,
+            clipboardPayload.Element);
+        _executeCanvasCommand(selectedDocument.DocumentId, command);
+    }
+
+    public void ExecuteDuplicateSelected()
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        {
+            return;
+        }
+
+        var command = CanvasMutationCommands.CreateDuplicateElementCommand(
+            document.DocumentId,
+            document,
+            selection);
+
+        _executeCanvasCommand(document.DocumentId, command);
+    }
+
+    private bool TryCopySelectedToClipboard()
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection))
+        {
+            return false;
+        }
+
+        if (!document.TryGetPanelElement(selection, out var element))
+        {
+            return false;
+        }
+
+        _clipboardPayload = new PanelElementClipboardPayload
+        {
+            Element = new PanelElementModel
+            {
+                ObjectId = element.ObjectId,
+                Name = element.Name,
+                Kind = element.Kind,
+                X = element.X,
+                Y = element.Y,
+                Width = element.Width,
+                Height = element.Height
+            }
+        };
+
+        _notifyCanExecuteChanged();
+        return true;
+    }
+
+    private bool TryGetSelectionDocument(out DocumentTabViewModel document, out PanelSelectionInfo selection)
+    {
+        document = null!;
+        selection = default;
+
+        var selectedDocument = _selectedDocumentAccessor();
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return false;
+        }
+
+        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selected)
+        {
+            return false;
+        }
+
+        document = selectedDocument;
+        selection = selected;
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -32,7 +32,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly HierarchyViewModel _hierarchy;
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
-    private PanelElementClipboardPayload? _panelClipboardPayload;
+    private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -85,6 +85,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _hierarchy = new HierarchyViewModel(
             () => SelectedDocument,
             [new Panel2DHierarchyProvider()]);
+        _hierarchyPanelCommands = new HierarchyPanelCommandService(
+            () => SelectedDocument,
+            ExecuteDocumentCanvasCommand,
+            UpdateDocumentPanelSelection,
+            NotifyHierarchyCommands);
 
         var preferences = _preferencesStore.Load();
         _selectedThemePreference = preferences.ThemePreference;
@@ -353,85 +358,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public bool DeleteSelectedHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        if (!selectedDocument.HasPanelElement(selection))
-        {
-            return false;
-        }
-
-        var command = CanvasMutationCommands.CreateDeleteElementCommand(selectedDocument.DocumentId, selectedDocument, selection);
-        var wasDeleted = ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
-        if (wasDeleted)
-        {
-            UpdateDocumentPanelSelection(selectedDocument.DocumentId, null);
-        }
-
-        return wasDeleted;
+        return _hierarchyPanelCommands.DeleteSelected();
     }
 
     public bool TryGetSelectedHierarchyItemName(out string currentName)
     {
-        currentName = string.Empty;
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        if (!selectedDocument.TryGetPanelElement(selection, out var matchingElement))
-        {
-            return false;
-        }
-
-        currentName = matchingElement.Name ?? string.Empty;
-        return true;
+        return _hierarchyPanelCommands.TryGetSelectedName(out currentName);
     }
 
     public bool RenameSelectedHierarchyItem(string newName)
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        var normalizedName = newName?.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedName))
-        {
-            return false;
-        }
-
-        if (!selectedDocument.HasPanelElement(selection))
-        {
-            return false;
-        }
-
-        var command = CanvasMutationCommands.CreateRenameElementCommand(
-            selectedDocument.DocumentId,
-            selectedDocument,
-            selection,
-            normalizedName);
-        return ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
+        return _hierarchyPanelCommands.RenameSelected(newName);
     }
 
     private bool CanRenameSelectedHierarchyItem()
@@ -519,163 +456,42 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanCutSelectedHierarchyItem()
     {
-        return CanCopySelectedHierarchyItem();
+        return _hierarchyPanelCommands.CanCutSelected();
     }
 
     private bool CanCopySelectedHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        return selectedDocument.HasPanelElement(selection);
+        return _hierarchyPanelCommands.CanCopySelected();
     }
 
     private bool CanPasteHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        return selectedDocument is not null
-               && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
-               && _panelClipboardPayload is not null;
+        return _hierarchyPanelCommands.CanPasteSelected();
     }
 
     private bool CanDuplicateSelectedHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        return selectedDocument.HasPanelElement(selection);
+        return _hierarchyPanelCommands.CanDuplicateSelected();
     }
 
     private void ExecuteCutSelectedHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return;
-        }
-
-        if (!selectedDocument.HasPanelElement(selection))
-        {
-            return;
-        }
-
-        if (!TryCopySelectedHierarchyItemToClipboard())
-        {
-            return;
-        }
-
-        DeleteSelectedHierarchyItem();
+        _hierarchyPanelCommands.ExecuteCutSelected();
     }
 
     private void ExecuteCopySelectedHierarchyItem()
     {
-        if (!TryCopySelectedHierarchyItemToClipboard())
-        {
-            return;
-        }
+        _hierarchyPanelCommands.ExecuteCopySelected();
     }
 
     private void ExecutePasteHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return;
-        }
-
-        var clipboardPayload = _panelClipboardPayload;
-        if (clipboardPayload is null)
-        {
-            return;
-        }
-
-        var command = CanvasMutationCommands.CreatePasteElementCommand(
-            selectedDocument.DocumentId,
-            selectedDocument,
-            clipboardPayload.Element);
-        ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
-    }
-
-    private bool TryCopySelectedHierarchyItemToClipboard()
-    {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return false;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return false;
-        }
-
-        if (!selectedDocument.TryGetPanelElement(selection, out var element))
-        {
-            return false;
-        }
-
-        _panelClipboardPayload = new PanelElementClipboardPayload
-        {
-            Element = new PanelElementModel
-            {
-                ObjectId = element.ObjectId,
-                Name = element.Name,
-                Kind = element.Kind,
-                X = element.X,
-                Y = element.Y,
-                Width = element.Width,
-                Height = element.Height
-            }
-        };
-        NotifyHierarchyCommands();
-        return true;
+        _hierarchyPanelCommands.ExecutePasteSelected();
     }
 
     private void ExecuteDuplicateSelectedHierarchyItem()
     {
-        var selectedDocument = SelectedDocument;
-        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
-        {
-            return;
-        }
-
-        if (selectedDocument.HierarchySelectedPanelSelection is not PanelSelectionInfo selection)
-        {
-            return;
-        }
-
-        if (!selectedDocument.HasPanelElement(selection))
-        {
-            return;
-        }
-
-        var command = CanvasMutationCommands.CreateDuplicateElementCommand(
-            selectedDocument.DocumentId,
-            selectedDocument,
-            selection);
-
-        ExecuteDocumentCanvasCommand(selectedDocument.DocumentId, command);
+        _hierarchyPanelCommands.ExecuteDuplicateSelected();
     }
 
     private bool CanOpenUntitledDocument()


### PR DESCRIPTION
### Motivation
- Reduce command logic surface in the shell `MainWindowViewModel` by moving Panel2D hierarchy command behavior into a focused service for better separation and testability.
- Preserve existing undo/redo and document-scoped execution semantics by keeping command dispatch through the existing canvas mutation commands.

### Description
- Add `HierarchyPanelCommandService` to encapsulate selection validation, clipboard payload state, and the operations `Delete`, `Rename`, `Cut`, `Copy`, `Paste`, and `Duplicate` for Panel2D hierarchy items, and to invoke canvas mutation commands via a supplied executor callback.
- Wire `MainWindowViewModel` to compose a `HierarchyPanelCommandService` instance and remove the local clipboard field, delegating methods such as `DeleteSelectedHierarchyItem`, `TryGetSelectedHierarchyItemName`, `RenameSelectedHierarchyItem`, `CanCut/Copy/Paste/Duplicate`, and the corresponding `Execute*` methods to the new service.
- Keep existing command routing and descriptions by continuing to create and execute `CanvasMutationCommands` inside the new service, and preserve `UpdateDocumentPanelSelection` / `NotifyHierarchyCommands` callbacks for UI state updates.

### Testing
- Attempted to run an automated build with `dotnet build OasisEditor.sln`, but the environment lacks the `dotnet` CLI so the build could not be executed (`dotnet: command not found`).
- No automated tests were run in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee5334c9108327a531861e6603c2e2)