### PR TITLE
Refactor hierarchy command wiring in MainWindowViewModel

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -121,10 +121,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RenameSelectedHierarchyItemCommand = new RelayCommand(
             RenameSelectedHierarchyItemWithPrompt,
             CanRenameSelectedHierarchyItem);
-        CutSelectedHierarchyItemCommand = new RelayCommand(ExecuteCutSelectedHierarchyItem, CanCutSelectedHierarchyItem);
-        CopySelectedHierarchyItemCommand = new RelayCommand(ExecuteCopySelectedHierarchyItem, CanCopySelectedHierarchyItem);
-        PasteHierarchyItemCommand = new RelayCommand(ExecutePasteHierarchyItem, CanPasteHierarchyItem);
-        DuplicateSelectedHierarchyItemCommand = new RelayCommand(ExecuteDuplicateSelectedHierarchyItem, CanDuplicateSelectedHierarchyItem);
+        CutSelectedHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteCutSelected(),
+            () => _hierarchyPanelCommands.CanCutSelected());
+        CopySelectedHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteCopySelected(),
+            () => _hierarchyPanelCommands.CanCopySelected());
+        PasteHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecutePasteSelected(),
+            () => _hierarchyPanelCommands.CanPasteSelected());
+        DuplicateSelectedHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteDuplicateSelected(),
+            () => _hierarchyPanelCommands.CanDuplicateSelected());
         ClearOutputCommand = _outputLog.ClearOutputCommand;
         ApplyInspectorSummaryCommand = _inspector.ApplyInspectorSummaryCommand;
         AddOutputEntry("Editor shell initialized.", OutputLogStatus.Info);
@@ -414,46 +422,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool CanDeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.CanDeleteItem(hierarchyItem);
 
     private void DeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.DeleteItem(hierarchyItem);
-
-    private bool CanCutSelectedHierarchyItem()
-    {
-        return _hierarchyPanelCommands.CanCutSelected();
-    }
-
-    private bool CanCopySelectedHierarchyItem()
-    {
-        return _hierarchyPanelCommands.CanCopySelected();
-    }
-
-    private bool CanPasteHierarchyItem()
-    {
-        return _hierarchyPanelCommands.CanPasteSelected();
-    }
-
-    private bool CanDuplicateSelectedHierarchyItem()
-    {
-        return _hierarchyPanelCommands.CanDuplicateSelected();
-    }
-
-    private void ExecuteCutSelectedHierarchyItem()
-    {
-        _hierarchyPanelCommands.ExecuteCutSelected();
-    }
-
-    private void ExecuteCopySelectedHierarchyItem()
-    {
-        _hierarchyPanelCommands.ExecuteCopySelected();
-    }
-
-    private void ExecutePasteHierarchyItem()
-    {
-        _hierarchyPanelCommands.ExecutePasteSelected();
-    }
-
-    private void ExecuteDuplicateSelectedHierarchyItem()
-    {
-        _hierarchyPanelCommands.ExecuteDuplicateSelected();
-    }
 
     private bool CanOpenUntitledDocument()
     {

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -148,10 +148,10 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
   - [x] Delete handles files, empty folders, missing paths, and non-empty folders safely
 
 ### Phase J — Follow-up Refactor Checks
-- [ ] Review `MainWindowViewModel` after context menu and asset browser changes
-  - [ ] Move any new cohesive asset-browser logic back into `AssetBrowserViewModel` or focused services
-  - [ ] Move any new hierarchy command logic into hierarchy/document command helpers where practical
-  - [ ] Keep MainWindowViewModel as orchestration, not a dumping ground
+- [x] Review `MainWindowViewModel` after context menu and asset browser changes
+  - [x] Move any new cohesive asset-browser logic back into `AssetBrowserViewModel` or focused services
+  - [x] Move any new hierarchy command logic into hierarchy/document command helpers where practical
+  - [x] Keep MainWindowViewModel as orchestration, not a dumping ground
 - [ ] Review document mutation command coverage
   - [ ] Ensure Duplicate/Paste use the same command safety contracts as add/delete/rename
   - [ ] Ensure no-op commands are not recorded


### PR DESCRIPTION
### Motivation
- Reduce `MainWindowViewModel` surface area by removing trivial command proxy methods and delegate hierarchy command execution/CanExecute directly to the focused service to keep orchestration minimal.
- Finish a follow-up refactor checklist item in `TASKS.md` verifying that `MainWindowViewModel` was reviewed after context-menu and asset browser changes.

### Description
- Bind `Cut/Copy/Paste/Duplicate` hierarchy commands in `MainWindowViewModel` directly to `HierarchyPanelCommandService` execute and `CanExecute` methods using `RelayCommand` rather than forwarding through private wrapper methods (changes in `MainWindowViewModel.cs`).
- Remove redundant private wrapper methods that only forwarded calls to `_hierarchyPanelCommands` to reduce indirection and class size.
- Mark the `Phase J` follow-up review for `MainWindowViewModel` as completed in `TASKS.md`.
- All changes are behavior-preserving and keep existing command paths and `HierarchyPanelCommandService` semantics intact.

### Testing
- Attempted to build the solution with `dotnet build /workspace/Oasis/WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be performed because `dotnet` is not available in the execution environment (error: `dotnet: command not found`).
- No automated test run was possible in this environment; functional behavior remains unchanged and callers still route through `HierarchyPanelCommandService`, so runtime behavior should be identical when built in a full .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee5946a2348327875de65c6933495a)