### PR TITLE
Add tests for duplicate/paste no-op behavior, document review notes, and task updates

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -7,6 +7,48 @@ namespace OasisEditor.Tests;
 public sealed class HierarchyPanelCommandServiceTests
 {
     [Fact]
+    public void SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "source-id",
+                Name = "Rect One",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 20,
+                Width = 30,
+                Height = 40
+            });
+        var workspace = CreateWorkspace(document, document);
+        var service = CreateService(document, workspace);
+
+        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("source-id", "rectangle", 10, 20, 30, 40);
+        service.ExecuteCopySelected();
+        service.ExecutePasteSelected();
+        service.ExecuteDuplicateSelected();
+        service.ExecuteCutSelected();
+
+        Assert.Equal(2, document.GetPanelElements().Count);
+        Assert.Equal(2, document.GetPanelElements().Select(element => element.ObjectId).Distinct(StringComparer.Ordinal).Count());
+
+        Assert.True(workspace.UndoActiveDocument());
+        Assert.Equal(3, document.GetPanelElements().Count);
+
+        Assert.True(workspace.RedoActiveDocument());
+        Assert.Equal(2, document.GetPanelElements().Count);
+
+        var savedContent = DocumentWorkspaceViewModel.BuildDocumentContent(document);
+        var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData("C:/Repo/TestProject/Assets/panel.panel2d", savedContent);
+        var reopened = new DocumentTabViewModel(
+            EditorDocument.CreateFromFile("C:/Repo/TestProject/Assets/panel.panel2d", openData.Summary, openData.PanelTitle),
+            openData.PanelLayoutJson);
+
+        Assert.Equal(2, reopened.GetPanelElements().Count);
+        Assert.Equal(2, reopened.GetPanelElements().Select(element => element.ObjectId).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
     public void ExecutePasteSelected_AfterCopy_CreatesNewObjectIdAndRecordsCommand()
     {
         var document = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -562,6 +562,71 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void ExecuteDocumentCanvasCommand_DuplicateCommand_MarksDirtyOnlyForRealMutation()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+
+        var missingSelectionDuplicate = CanvasMutationCommands.CreateDuplicateElementCommand(
+            document.DocumentId,
+            document,
+            new PanelSelectionInfo("missing-id", "rectangle", 10, 10, 20, 20));
+        var noOpExecuted = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, missingSelectionDuplicate);
+
+        Assert.False(noOpExecuted);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+
+        var validDuplicate = CanvasMutationCommands.CreateDuplicateElementCommand(
+            document.DocumentId,
+            document,
+            new PanelSelectionInfo("rect-1", "rectangle", 10, 10, 20, 20));
+        var duplicateExecuted = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, validDuplicate);
+
+        Assert.True(duplicateExecuted);
+        Assert.True(document.IsDirty);
+        Assert.Equal(1, document.CommandService.History.Entries.Count);
+    }
+
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_PasteCommand_ReExecutingSameCommandDoesNotRecordNoOp()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "source-id",
+                Name = "Rect Original",
+                Kind = PanelElementKind.Rectangle,
+                X = 30,
+                Y = 40,
+                Width = 50,
+                Height = 60
+            });
+        var workspace = CreateWorkspace(document, document);
+        var source = document.GetPanelElements().Single();
+        var pasteCommand = CanvasMutationCommands.CreatePasteElementCommand(document.DocumentId, document, source);
+
+        var firstExecution = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, pasteCommand);
+        var secondExecution = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, pasteCommand);
+
+        Assert.True(firstExecution);
+        Assert.False(secondExecution);
+        Assert.True(document.IsDirty);
+        Assert.Equal(1, document.CommandService.History.Entries.Count);
+        Assert.Equal(2, document.GetPanelElements().Count);
+    }
+
+    [Fact]
     public void ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate()
     {
         var firstDocument = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/PhaseJ.DocumentMutationReview.md
+++ b/WindowsNetProjects/OasisEditor/PhaseJ.DocumentMutationReview.md
@@ -1,0 +1,41 @@
+# Phase J Document Mutation Command Coverage Review
+
+Review date: 2026-04-26
+
+This is a behavior-preserving review pass for Task **Phase J / Review document mutation command coverage**.
+
+## Scope reviewed
+
+- `CanvasMutationCommands` duplicate and paste command implementations.
+- Command-history recording guards in `Commands.CommandService`.
+- Dirty-state mutation behavior through `DocumentTabViewModel.MarkDirty()`.
+
+## Findings
+
+### Duplicate and paste are execution-tracked commands
+
+- `DuplicateElementMutationCommand` and `PasteElementMutationCommand` both implement `IExecutionTrackedCommand` and initialize `WasExecuted = false` at the start of each `Execute()` call.
+- `WasExecuted` is set to `true` only after a real list mutation (`SetPanelElements`) and dirty mark (`MarkDirty`).
+- If the selected source is missing (duplicate) or insertion cannot proceed (duplicate/paste object-ID collision guard), `Execute()` returns without mutating the model and leaves `WasExecuted = false`.
+
+### No-op commands are not recorded
+
+- `CommandService.Execute()` records command history only when either:
+  - the command is not execution-tracked, or
+  - `IExecutionTrackedCommand.WasExecuted == true` after execution.
+- This provides the same no-op history safety contract used by add/delete/rename mutations.
+
+### Dirty state changes only on real mutations
+
+- Duplicate and paste mark dirty only after successful insertion.
+- Duplicate and paste undo paths mark dirty only when a matching inserted element is actually removed.
+- Failed/no-op execute and undo paths do not call `MarkDirty()`.
+
+## Conclusion
+
+Duplicate and paste already conform to the same mutation safety contracts as add/delete/rename:
+
+- document-scoped command execution,
+- no-op protection through execution tracking,
+- history entries only for real mutations,
+- dirty state updates only for real mutations.

--- a/WindowsNetProjects/OasisEditor/PhaseJ.SmokeTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseJ.SmokeTestAttempt.md
@@ -1,0 +1,31 @@
+# Phase J Smoke Test Attempt
+
+Date: 2026-04-26
+
+## Goal
+
+Attempt the **Phase J — Smoke test full editor flow** checklist from `TASKS.md`.
+
+## Environment constraints encountered
+
+1. The container does not provide the .NET SDK/CLI (`dotnet` is unavailable).
+2. The Oasis editor is a WPF desktop application and cannot be launched in this headless Linux container.
+
+Because of those constraints, the requested UI smoke steps (project creation/opening, asset navigation, `.panel2d` open, hierarchy context-menu commands, undo/redo, and save/reopen verification) could not be executed here.
+
+## Verification attempted
+
+- `dotnet --info` (fails: command not found)
+- `dotnet test` (fails: command not found)
+
+## Next action when run on a Windows dev machine
+
+Execute the manual Phase J smoke checklist in `TASKS.md` section:
+
+- Create/open project
+- Refresh assets
+- Navigate folders in Assets pane
+- Open a `.panel2d` asset
+- Use hierarchy context menu rename/delete/duplicate/copy/paste/cut
+- Use undo/redo after hierarchy mutations
+- Save/reopen and verify panel contents

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -152,17 +152,18 @@ These tasks come from the latest Editor code review. Complete them in order. Bui
   - [x] Move any new cohesive asset-browser logic back into `AssetBrowserViewModel` or focused services
   - [x] Move any new hierarchy command logic into hierarchy/document command helpers where practical
   - [x] Keep MainWindowViewModel as orchestration, not a dumping ground
-- [ ] Review document mutation command coverage
-  - [ ] Ensure Duplicate/Paste use the same command safety contracts as add/delete/rename
-  - [ ] Ensure no-op commands are not recorded
-  - [ ] Ensure dirty state changes only for real mutations
-- [ ] Add or update tests for new behavior where practical
-  - [ ] Duplicate creates a new object ID
-  - [ ] Paste creates new object IDs
-  - [ ] Rename/delete no-op cases are not recorded
-  - [ ] Asset browser tree excludes paths outside Assets root
-  - [ ] Asset rename/delete refreshes expected collections
+- [x] Review document mutation command coverage
+  - [x] Ensure Duplicate/Paste use the same command safety contracts as add/delete/rename
+  - [x] Ensure no-op commands are not recorded
+  - [x] Ensure dirty state changes only for real mutations
+- [x] Add or update tests for new behavior where practical
+  - [x] Duplicate creates a new object ID
+  - [x] Paste creates new object IDs
+  - [x] Rename/delete no-op cases are not recorded
+  - [x] Asset browser tree excludes paths outside Assets root
+  - [x] Asset rename/delete refreshes expected collections
 - [ ] Smoke test full editor flow
+  - [ ] Blocked in current container; see `PhaseJ.SmokeTestAttempt.md`
   - [ ] Create/open project
   - [ ] Refresh assets
   - [ ] Navigate folders in Assets pane


### PR DESCRIPTION
### Motivation

- Ensure duplicate and paste canvas commands conform to existing mutation safety contracts so that no-op executions are not recorded and the document dirty state only changes on real mutations.
- Add higher-level coverage for a typical hierarchy command flow including undo/redo and save/reopen to guard regression risk.
- Capture findings and the smoke-test attempt in documentation and update the task checklist to reflect reviewed items.

### Description

- Add `SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements` to `HierarchyPanelCommandServiceTests` to exercise copy/paste/duplicate/cut plus undo/redo and save/reopen verification.
- Add `ExecuteDocumentCanvasCommand_DuplicateCommand_MarksDirtyOnlyForRealMutation` and `ExecuteDocumentCanvasCommand_PasteCommand_ReExecutingSameCommandDoesNotRecordNoOp` to `Panel2DRoundTripTests` to validate no-op protection, history recording, and dirty-state behavior for duplicate and paste commands.
- Add `PhaseJ.DocumentMutationReview.md` documenting the review findings about `IExecutionTrackedCommand`, `CommandService` history guards, and dirty-state behavior for duplicate/paste commands.
- Add `PhaseJ.SmokeTestAttempt.md` documenting environment constraints that prevented running the interactive smoke test here and update `TASKS.md` to mark the reviewed items as completed.

### Testing

- No automated tests could be executed in this environment because `dotnet` is unavailable (attempted `dotnet --info` and `dotnet test` failed).
- The PR adds unit tests (`HierarchyPanelCommandServiceTests.SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements`, `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_DuplicateCommand_MarksDirtyOnlyForRealMutation`, and `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_PasteCommand_ReExecutingSameCommandDoesNotRecordNoOp`) which are intended to be run on a Windows development machine where `dotnet test` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee5a6f6378832782e73c7a833b6925)