### PR TITLE
Dock Preferences and Project Settings into AvalonDock tool windows

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -32,6 +32,8 @@ public partial class MainWindow : Window
         Closing += OnClosing;
         EditorKeyboardShortcuts.RegisterWindowBindings(this);
         _viewModel = new MainWindowViewModel(applicationThemeService, preferencesStore, this, startupProjectFilePath);
+        _viewModel.ToolWindowOpenRequested += OnToolWindowOpenRequested;
+        _viewModel.ToolWindowCloseRequested += OnToolWindowCloseRequested;
         DataContext = _viewModel;
 
         CommandBindings.Add(new CommandBinding(CanvasPanBehavior.UndoCommand, (_, args) =>
@@ -58,6 +60,16 @@ public partial class MainWindow : Window
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         ApplyWindowPlacement();
+    }
+
+    private void OnToolWindowOpenRequested(EditorToolWindowId toolWindowId)
+    {
+        _editorShell.ShowOrFocusToolWindow(toolWindowId);
+    }
+
+    private void OnToolWindowCloseRequested(EditorToolWindowId toolWindowId)
+    {
+        _editorShell.HideToolWindow(toolWindowId);
     }
 
     private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using System.Collections.Specialized;
 using Microsoft.Win32;
 using EditorCommands = OasisEditor.Commands;
+using OasisEditor.Views;
 
 namespace OasisEditor;
 
@@ -24,8 +25,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private EditorProject? _loadedProject;
     private DocumentTabViewModel? _selectedDocument;
     private ThemePreference _selectedThemePreference;
-    private PreferencesWindow? _preferencesWindow;
-    private ProjectSettingsWindow? _projectSettingsWindow;
     private readonly AssetBrowserViewModel _assetBrowser;
     private readonly OutputLogViewModel _outputLog;
     private readonly InspectorViewModel _inspector;
@@ -35,6 +34,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
 
     public event PropertyChangedEventHandler? PropertyChanged;
+    public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
+    public event Action<EditorToolWindowId>? ToolWindowCloseRequested;
 
     public MainWindowViewModel(
         IApplicationThemeService applicationThemeService,
@@ -629,50 +630,24 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OpenPreferences()
     {
-        if (_preferencesWindow is { IsLoaded: true })
-        {
-            _preferencesWindow.Activate();
-            return;
-        }
-
-        _preferencesWindow = new PreferencesWindow
-        {
-            Owner = _ownerWindow,
-            DataContext = this
-        };
-
-        _preferencesWindow.Closed += (_, _) => _preferencesWindow = null;
-        _preferencesWindow.Show();
-        AddOutputEntry("Opened Preferences window.", OutputLogStatus.Info);
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.Preferences);
+        AddOutputEntry("Opened Preferences pane.", OutputLogStatus.Info);
     }
 
     private void OpenProjectSettings()
     {
-        if (_projectSettingsWindow is { IsLoaded: true })
-        {
-            _projectSettingsWindow.Activate();
-            return;
-        }
-
-        _projectSettingsWindow = new ProjectSettingsWindow
-        {
-            Owner = _ownerWindow,
-            DataContext = this
-        };
-
-        _projectSettingsWindow.Closed += (_, _) => _projectSettingsWindow = null;
-        _projectSettingsWindow.Show();
-        AddOutputEntry("Opened Project Settings window.", OutputLogStatus.Info);
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.ProjectSettings);
+        AddOutputEntry("Opened Project Settings pane.", OutputLogStatus.Info);
     }
 
     private void ClosePreferences()
     {
-        _preferencesWindow?.Close();
+        ToolWindowCloseRequested?.Invoke(EditorToolWindowId.Preferences);
     }
 
     private void CloseProjectSettings()
     {
-        _projectSettingsWindow?.Close();
+        ToolWindowCloseRequested?.Invoke(EditorToolWindowId.ProjectSettings);
     }
 
     private bool CanCloseProject()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -55,6 +55,24 @@
                                 </Border>
                             </layout:LayoutAnchorable>
 
+                        <layout:LayoutAnchorable Title="Preferences"
+                                                 ContentId="Preferences"
+                                                 CanClose="True">
+                            <Border Padding="10"
+                                    Background="{DynamicResource InspectorBackgroundBrush}">
+                                <views:PreferencesView />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
+                        <layout:LayoutAnchorable Title="Project Settings"
+                                                 ContentId="ProjectSettings"
+                                                 CanClose="True">
+                            <Border Padding="10"
+                                    Background="{DynamicResource InspectorBackgroundBrush}">
+                                <views:ProjectSettingsView />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -8,6 +8,8 @@ public partial class EditorShellView : UserControl
     public EditorShellView()
     {
         InitializeComponent();
+        HideToolWindow(EditorToolWindowId.Preferences);
+        HideToolWindow(EditorToolWindowId.ProjectSettings);
     }
 
     public void ShowOrFocusToolWindow(EditorToolWindowId toolWindowId)
@@ -27,6 +29,12 @@ public partial class EditorShellView : UserControl
         target.Show();
         target.IsSelected = true;
         target.IsActive = true;
+    }
+
+    public void HideToolWindow(EditorToolWindowId toolWindowId)
+    {
+        var target = FindToolWindow(toolWindowId);
+        target?.Hide();
     }
 
     private LayoutAnchorable? FindToolWindow(EditorToolWindowId toolWindowId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
@@ -5,5 +5,7 @@ public enum EditorToolWindowId
     Assets,
     Hierarchy,
     Inspector,
-    Output
+    Output,
+    Preferences,
+    ProjectSettings
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -1,0 +1,34 @@
+<UserControl x:Class="OasisEditor.Views.PreferencesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="220"
+             d:DesignWidth="420">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Foreground="{DynamicResource TextPrimaryBrush}"
+                   Text="Editor Preferences" />
+
+        <TextBlock Grid.Row="1"
+                   Margin="0,16,0,6"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="Theme" />
+
+        <ComboBox Grid.Row="2"
+                  Width="180"
+                  VerticalAlignment="Top"
+                  HorizontalAlignment="Left"
+                  ItemsSource="{Binding ThemePreferences}"
+                  SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class PreferencesView : UserControl
+{
+    public PreferencesView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -1,0 +1,35 @@
+<UserControl x:Class="OasisEditor.Views.ProjectSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="340"
+             d:DesignWidth="560">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Foreground="{DynamicResource TextPrimaryBrush}"
+                   Text="Project Settings" />
+
+        <TextBlock Grid.Row="1" Margin="0,14,0,4" Text="Project" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="2" Text="{Binding LoadedProject.Name, TargetNullValue=No project loaded}" />
+
+        <TextBlock Grid.Row="3" Margin="0,12,0,4" Text="Project file" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="4" TextWrapping="Wrap" Text="{Binding LoadedProject.ProjectFilePath, TargetNullValue=Open or create a project first.}" />
+
+        <TextBlock Grid.Row="5" Margin="0,12,0,4" Text="Assets folder" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="6" TextWrapping="Wrap" Text="{Binding LoadedProject.AssetsDirectory, TargetNullValue=Open or create a project first.}" />
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class ProjectSettingsView : UserControl
+{
+    public ProjectSettingsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Convert the Preferences and Project Settings surfaces from standalone OS windows into dockable AvalonDock panes so they behave consistently with other tool windows (Hierarchy/Assets/Inspector) and can be docked, floated, or closed by the user.

### Description
- Added `Preferences` and `ProjectSettings` entries to the `EditorToolWindowId` enum so the settings surfaces are addressable as normal tool windows via `EditorToolWindowId`.
- Introduced `PreferencesView` and `ProjectSettingsView` user controls containing the existing settings UI so the content can be hosted inside AvalonDock panes via `UserControl` views.
- Added dockable `LayoutAnchorable` panes for `ContentId="Preferences"` and `ContentId="ProjectSettings"` to `EditorShellView.xaml` and hid them on startup using `HideToolWindow` in `EditorShellView` so they start closed but can be shown, floated, docked, or closed like other panes.
- Reworked `MainWindowViewModel` to raise `ToolWindowOpenRequested`/`ToolWindowCloseRequested` instead of instantiating `Window` objects, and wired `MainWindow` to call `EditorShellView.ShowOrFocusToolWindow`/`HideToolWindow` to display or hide the new panes.

### Testing
- Attempted to run `dotnet build OasisEditor.sln`, but the build could not be executed in this environment because the `dotnet` CLI is not installed (`/bin/bash: dotnet: command not found`).
- No automated unit tests were run due to the build environment limitation preventing a full build/test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee5fa399ec8327abff72e9e39bb74e)