### PR TITLE
Style AvalonDock context menus to match editor menus

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -14,7 +14,15 @@
         <avalonDock:DockingManager x:Name="DockingManager"
                                    Background="{DynamicResource EditorBackgroundBrush}">
             <avalonDock:DockingManager.Resources>
-                <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />
+                <ResourceDictionary>
+                    <ResourceDictionary.MergedDictionaries>
+                        <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />
+                    </ResourceDictionary.MergedDictionaries>
+                    <Style TargetType="{x:Type ContextMenu}"
+                           BasedOn="{StaticResource EditorContextMenuStyle}" />
+                    <Style TargetType="{x:Type MenuItem}"
+                           BasedOn="{StaticResource EditorContextMenuItemStyle}" />
+                </ResourceDictionary>
             </avalonDock:DockingManager.Resources>
             <avalonDock:DockingManager.Theme>
                 <themes:Vs2013DarkTheme />


### PR DESCRIPTION
### Motivation
- AvalonDock-generated context menus used the default AvalonDock styles and did not match the editor's existing context menus and top menu visuals, so scope styles to the DockingManager so its menus inherit the editor look.

### Description
- Replace the single `ResourceDictionary` reference in `Views/EditorShellView.xaml` with a merged `ResourceDictionary` and add implicit `ContextMenu` and `MenuItem` styles that are `BasedOn` the existing `EditorContextMenuStyle` and `EditorContextMenuItemStyle`, scoped to the `DockingManager` resources so AvalonDock menus render consistently with the editor.

### Testing
- Attempted `dotnet build OasisEditor.sln`, which could not run in this environment because `dotnet` is not installed (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee71ac9210832792ddb1147667e376)