### PR TITLE
docs: Phase K MFME import reconnaissance and TASKS update

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md
+++ b/WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md
@@ -1,0 +1,205 @@
+# MFME Import Plan (Phase K Reconnaissance)
+
+Date: 2026-04-27
+
+This document captures reconnaissance for **Phase K** in `TASKS.md` and defines the first MFME extract import contract for the WPF Oasis editor.
+
+Legacy source references used for this plan:
+
+- Unity importer entry: `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
+- Unity extract loader: `UnityProjects/LayoutEditor/Assets/OasisPackages/MFMEExtract/Extractor/Extractor.cs`
+- MFME shared extract DTOs/helpers under: `WindowsNetProjects/MfmeTools/MfmeTools/Shared/**`
+
+> For this feature track, Unity/MfmeTools projects are **reference-only**. Do not modify them.
+
+---
+
+## 1) First-milestone source extract contract
+
+The WPF importer should initially target an **already-created extract folder** produced by legacy tooling.
+
+### Expected extract layout on disk
+
+- Extract root directory name: `.extract`
+- Component image subfolders used by milestone 1:
+  - `background/`
+  - `lamps/`
+  - `reels/`
+- Other known folders (deferred for milestone 1):
+  - `buttons/`, `bitmaps/`, `misc/`
+- Optional ROM ident file in `misc/romident.txt`
+
+### Expected manifest file format
+
+- Layout manifest filename pattern: `<ASName>.json` in the extract root.
+- JSON is written with `TypeNameHandling.Auto`, with component polymorphism represented by runtime type metadata.
+- Unity loader currently deserializes this JSON with `TypeNameHandling.Auto`.
+- Unity loader also performs assembly-name replacement (`"MfmeTools"` -> `"Assembly-CSharp"`) before deserialization; the WPF importer must not rely on this exact replacement, and should instead parse into WPF-owned DTOs.
+
+### Minimum root fields to read
+
+From `Shared/Extract/Layout.cs`:
+- `ASName`
+- `MameRomIdent` (optional for this milestone)
+- `Components[]` (polymorphic component list)
+
+---
+
+## 2) Minimum DTO fields needed for milestone-1 component support
+
+The following fields are sufficient for first-pass WPF import of:
+**Background, Lamp, Reel, SevenSegment, Alpha/AlphaNew/MatrixAlpha**.
+
+### Common base data (all supported components)
+From `ExtractComponentBase`:
+- `Position` (x, y)
+- `Size` (width, height)
+- `TextBoxText`
+- `TextBoxFontName`
+- `TextBoxFontStyle`
+- `TextBoxFontSize`
+- `ZOrder`
+
+### Background
+From `ExtractComponentBackground`:
+- `BmpImageFilename`
+- `Color`
+
+### Lamp
+From `ExtractComponentLamp`:
+- `LampElements[0]` first element only for milestone 1:
+  - `NumberAsText` / parsed `Number`
+  - `OnColor`
+  - `BmpImageFilename`
+- Component-level fields used by current Unity mapping:
+  - `OffImageColor`
+  - `TextColor`
+  - `NoOutline`
+  - `ButtonNumberAsString`, `CoinNote`, `Inverted`, `Shortcut1` (input metadata retained if simple)
+  - `TextBox*` font/text fields (from base)
+
+### Reel
+From `ExtractComponentReel`:
+- `Number` (with Unity quirk `+1` during mapping)
+- `Stops`
+- `Reversed`
+- `BandBmpImageFilename`
+- `HasOverlay` and `OverlayBmpImageFilename` (defer full visual compositing)
+
+### SevenSegment
+From `ExtractComponentSevenSegment`:
+- `Number`
+- `SegmentOnColor`
+- (optional metadata to retain later: `SegmentOffColor`, `SegmentBackgroundColor`)
+
+### Alpha / AlphaNew / MatrixAlpha
+From `ExtractComponentAlpha`:
+- `Number`
+- `Reversed`
+- `Color`
+- `BmpImageFilename` (if present)
+
+From `ExtractComponentAlphaNew`:
+- `Number`
+- `Reversed`
+- `OnColor`
+
+From `ExtractComponentMatrixAlpha`:
+- `Number`
+- `OnColor`, `OffColor`, `BackgroundColor`
+
+For milestone 1, normalize all three source types into one WPF Alpha import shape.
+
+---
+
+## 3) Unity importer mapping rules to preserve initially
+
+These behaviors in `ExtractImporter.cs` should be matched for parity in milestone 1 where practical:
+
+1. **Background**
+   - Name fixed to `Background`
+   - Position `(0,0)`
+   - Size from extract component size
+   - Color from extract background color
+   - Optional background image loaded from `background/<BmpImageFilename>`
+
+2. **Lamp**
+   - Uses component position/size directly
+   - Uses first lamp element (`LampElements[0]`) only
+   - Number set from first lamp element number
+   - Name currently fixed `Lamp`
+   - On/Off/Text colors imported
+   - Text/font fields imported from textbox fields
+   - Image path uses `lamps/<LampElements[0].BmpImageFilename>` when present
+
+3. **Reel**
+   - Uses component position/size directly
+   - **Number mapping quirk:** `componentReel.Number = extract.Number + 1`
+   - Name format: `Reel <number>`
+   - Band image from `reels/<BandBmpImageFilename>`
+   - Stops and reversed imported
+   - Visible symbol scale in Unity derived from:
+     - `symbolHeight = (bandHeight / Stops)`
+     - `visibleRows = reelHeight / symbolHeight`
+
+4. **SevenSegment**
+   - Position/size from extract
+   - Number copied directly
+   - Segment/on color imported
+   - Name format: `7 Segment <number>`
+
+5. **Alpha / AlphaNew / MatrixAlpha**
+   - All map to same runtime component (`ComponentAlpha`)
+   - Name fixed `Alpha`
+   - `Reversed` set where source provides it
+   - Color from source (`Color` or `OnColor`)
+   - **Unity quirk:** MatrixAlpha currently imported as Alpha
+
+---
+
+## 4) Known quirks to preserve for first pass
+
+- Reel number offset: **`MFME Reel Number + 1`**.
+- MatrixAlpha treated as Alpha.
+- Lamp import uses only lamp element index 0 (not all 12 elements).
+- Component-type dispatch in legacy importer is strict runtime-type matching and unsupported types are logged and skipped.
+
+---
+
+## 5) Deferred behavior (explicitly out of milestone scope)
+
+These behaviors exist in legacy code but should be deferred in WPF milestone 1:
+
+- Runtime/editor-only component types outside first supported set.
+- Complex lamp input mapping beyond straightforward metadata capture (coin/note, effect, platform-specific input port derivation).
+- Temporary reel overlay compositing into background imagery.
+- Final runtime-accurate lamp/reel/segment rendering fidelity.
+- Any dependency on launching/automating MFME executable.
+
+---
+
+## 6) Asset-copy conventions for WPF importer
+
+For WPF project safety and portability, imported images should be copied under the active Oasis project rather than referenced in-place.
+
+Proposed destination convention:
+
+- `Assets/MfmeImport/<layout-or-extract-name>/Background/`
+- `Assets/MfmeImport/<layout-or-extract-name>/Lamps/`
+- `Assets/MfmeImport/<layout-or-extract-name>/Reels/`
+
+Rules:
+- Store project-relative asset paths in imported Panel2D elements.
+- Sanitize folder and file names.
+- Prevent path traversal.
+- Handle collisions deterministically.
+- Missing source image should produce a warning but still import an editable placeholder element where possible.
+
+---
+
+## 7) Initial parser/importer boundary guidance
+
+- Keep extract parsing and normalization in UI-agnostic classes under a focused `Features/MfmeImport` area.
+- Parse legacy manifest into **WPF-owned minimal DTOs**, not Unity runtime components.
+- Unsupported component types should be skipped with structured warnings (not hard failure).
+- Any document mutation must occur via document-scoped undoable commands in later phases.

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -19,21 +19,21 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [ ] Add/update tests where practical under the existing OasisEditor test project
 
 ### Phase K — Legacy Import and Extract Format Reconnaissance
-- [ ] Inspect the Unity importer entry point at `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
-  - [ ] Document the exact field mappings currently used for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
-  - [ ] Note existing Unity importer quirks that should be preserved initially, such as Reel number `+ 1` and MatrixAlpha importing as Alpha
-  - [ ] Note behavior that should be deferred, such as runtime-only editor components, complex lamp inputs, and temporary reel overlay compositing
-- [ ] Inspect MFME extract DTOs/helpers under `WindowsNetProjects/MfmeTools/MfmeTools/Shared`
-  - [ ] Identify the minimum DTO fields needed for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
-  - [ ] Identify how extract image folders and filenames are represented
-  - [ ] Identify the extract manifest/layout file format that the WPF editor should read first
-- [ ] Add `Docs/MfmeImportPlan.md` under `WindowsNetProjects/OasisEditor`
-  - [ ] Summarise the source extract contract for the first milestone
-  - [ ] Summarise component mapping rules
-  - [ ] Summarise asset-copy conventions
-  - [ ] List deferred behavior explicitly
-  - [ ] Include a short note that legacy projects are reference-only for this track
-- [ ] Build the WPF solution after the reconnaissance/documentation-only changes if project files changed; otherwise no build is required
+- [x] Inspect the Unity importer entry point at `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
+  - [x] Document the exact field mappings currently used for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
+  - [x] Note existing Unity importer quirks that should be preserved initially, such as Reel number `+ 1` and MatrixAlpha importing as Alpha
+  - [x] Note behavior that should be deferred, such as runtime-only editor components, complex lamp inputs, and temporary reel overlay compositing
+- [x] Inspect MFME extract DTOs/helpers under `WindowsNetProjects/MfmeTools/MfmeTools/Shared`
+  - [x] Identify the minimum DTO fields needed for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
+  - [x] Identify how extract image folders and filenames are represented
+  - [x] Identify the extract manifest/layout file format that the WPF editor should read first
+- [x] Add `Docs/MfmeImportPlan.md` under `WindowsNetProjects/OasisEditor`
+  - [x] Summarise the source extract contract for the first milestone
+  - [x] Summarise component mapping rules
+  - [x] Summarise asset-copy conventions
+  - [x] List deferred behavior explicitly
+  - [x] Include a short note that legacy projects are reference-only for this track
+- [x] Build the WPF solution after the reconnaissance/documentation-only changes if project files changed; otherwise no build is required
 
 ### Phase L — MFME Import Domain Boundary
 - [ ] Add a focused MFME import feature folder under the WPF editor project


### PR DESCRIPTION
### Motivation
- Capture Phase K reconnaissance for MFME extract import and formalise the initial on-disk contract, mapping rules, and asset-copy conventions so subsequent implementation phases can follow a clear, UI-agnostic boundary.

### Description
- Add `WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md` documenting the `.extract` layout, `<ASName>.json` manifest expectations, minimum DTO fields for Background/Lamp/Reel/SevenSegment/Alpha variants, Unity-parity mapping rules and quirks (e.g., reel `+1`, MatrixAlpha→Alpha), deferred behaviors, and proposed `Assets/MfmeImport/...` copy conventions, and update `WindowsNetProjects/OasisEditor/TASKS.md` to mark the Phase K checklist items complete.

### Testing
- No automated tests were run because this change is documentation-only and does not modify source or project files; no build or test execution was required for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef205cb7848327adb973eae9e32e11)