### PR TITLE
Add MFME component mapper and mapper unit tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeComponentMapperTests.cs
@@ -29,7 +29,7 @@ public sealed class MfmeComponentMapperTests
         Assert.Equal(0, mapped.Y);
         Assert.Equal(800, mapped.Width);
         Assert.Equal(600, mapped.Height);
-        Assert.Equal("Background/bg.png", mapped.AssetPath);
+        Assert.Equal("background/bg.png", mapped.AssetPath);
         Assert.Equal("#AABBCC", mapped.PrimaryColor);
     }
 
@@ -59,7 +59,7 @@ public sealed class MfmeComponentMapperTests
         Assert.Equal(PanelElementKind.Lamp, mapped.Kind);
         Assert.Equal("Lamp 4", mapped.Name);
         Assert.Equal(4, mapped.DisplayNumber);
-        Assert.Equal("Lamps/lamp4.png", mapped.AssetPath);
+        Assert.Equal("lamps/lamp4.png", mapped.AssetPath);
         Assert.Equal("#00FF00", mapped.PrimaryColor);
         Assert.Equal("#000011", mapped.SecondaryColor);
         Assert.Equal("#FFFFFF", mapped.TextColor);
@@ -80,6 +80,7 @@ public sealed class MfmeComponentMapperTests
             Height = 150,
             Number = 2,
             Stops = 24,
+            ReelHeight = 250,
             Reversed = true,
             BandImageFileName = "band.png"
         };
@@ -93,7 +94,8 @@ public sealed class MfmeComponentMapperTests
         Assert.Equal("2", mapped.MfmeSourceId);
         Assert.Equal(24, mapped.Stops);
         Assert.True(mapped.Reversed);
-        Assert.Equal("Reels/band.png", mapped.AssetPath);
+        Assert.Equal("reels/band.png", mapped.AssetPath);
+        Assert.Equal(5d / 24d, mapped.VisibleScale!.Value, 6);
     }
 
     [Fact]
@@ -139,6 +141,7 @@ public sealed class MfmeComponentMapperTests
         Assert.Equal(7, mapped.DisplayNumber);
         Assert.True(mapped.Reversed);
         Assert.Equal("#DD8800", mapped.PrimaryColor);
+        Assert.Null(mapped.AssetPath);
     }
 
     [Fact]
@@ -176,5 +179,22 @@ public sealed class MfmeComponentMapperTests
         var mapped = Assert.Single(result.Elements);
         Assert.Equal(100, mapped.Width);
         Assert.Equal(100, mapped.Height);
+    }
+
+    [Fact]
+    public void Map_ReelWithoutHeight_DoesNotSetVisibleScale()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeReelComponentData
+        {
+            Kind = MfmeComponentKind.Reel,
+            SourceType = "ExtractComponentReel",
+            Stops = 20
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Null(mapped.VisibleScale);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeComponentMapperTests.cs
@@ -1,0 +1,180 @@
+using System;
+using OasisEditor.Features.MfmeImport;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeComponentMapperTests
+{
+    [Fact]
+    public void Map_Background_UsesOriginAndBackgroundName()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeBackgroundComponentData
+        {
+            Kind = MfmeComponentKind.Background,
+            SourceType = "ExtractComponentBackground",
+            Width = 800,
+            Height = 600,
+            ImageFileName = "bg.png",
+            Color = "#AABBCC"
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Background, mapped.Kind);
+        Assert.Equal("Background", mapped.Name);
+        Assert.Equal(0, mapped.X);
+        Assert.Equal(0, mapped.Y);
+        Assert.Equal(800, mapped.Width);
+        Assert.Equal(600, mapped.Height);
+        Assert.Equal("Background/bg.png", mapped.AssetPath);
+        Assert.Equal("#AABBCC", mapped.PrimaryColor);
+    }
+
+    [Fact]
+    public void Map_Lamp_MapsFirstPassLampFields()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeLampComponentData
+        {
+            Kind = MfmeComponentKind.Lamp,
+            SourceType = "ExtractComponentLamp",
+            X = 12,
+            Y = 34,
+            Width = 56,
+            Height = 78,
+            Number = 4,
+            ImageFileName = "lamp4.png",
+            OnColor = "#00FF00",
+            OffColor = "#000011",
+            TextColor = "#FFFFFF",
+            DisplayName = "HOLD"
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, mapped.Kind);
+        Assert.Equal("Lamp 4", mapped.Name);
+        Assert.Equal(4, mapped.DisplayNumber);
+        Assert.Equal("Lamps/lamp4.png", mapped.AssetPath);
+        Assert.Equal("#00FF00", mapped.PrimaryColor);
+        Assert.Equal("#000011", mapped.SecondaryColor);
+        Assert.Equal("#FFFFFF", mapped.TextColor);
+        Assert.Equal("HOLD", mapped.Text);
+    }
+
+    [Fact]
+    public void Map_Reel_AppliesUnityNumberOffsetAndMetadata()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeReelComponentData
+        {
+            Kind = MfmeComponentKind.Reel,
+            SourceType = "ExtractComponentReel",
+            X = 20,
+            Y = 30,
+            Width = 100,
+            Height = 150,
+            Number = 2,
+            Stops = 24,
+            Reversed = true,
+            BandImageFileName = "band.png"
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Reel, mapped.Kind);
+        Assert.Equal("Reel 3", mapped.Name);
+        Assert.Equal(3, mapped.DisplayNumber);
+        Assert.Equal("2", mapped.MfmeSourceId);
+        Assert.Equal(24, mapped.Stops);
+        Assert.True(mapped.Reversed);
+        Assert.Equal("Reels/band.png", mapped.AssetPath);
+    }
+
+    [Fact]
+    public void Map_SevenSegment_MapsNumberAndColor()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeSevenSegmentComponentData
+        {
+            Kind = MfmeComponentKind.SevenSegment,
+            SourceType = "ExtractComponentSevenSegment",
+            Number = 9,
+            SegmentOnColor = "#123456"
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.SevenSegment, mapped.Kind);
+        Assert.Equal("7 Segment 9", mapped.Name);
+        Assert.Equal(9, mapped.DisplayNumber);
+        Assert.Equal("#123456", mapped.PrimaryColor);
+    }
+
+    [Fact]
+    public void Map_AlphaVariants_MapToSingleAlphaKind()
+    {
+        var mapper = new MfmeComponentMapper();
+        var alpha = new MfmeAlphaComponentData
+        {
+            Kind = MfmeComponentKind.Alpha,
+            SourceType = "ExtractComponentMatrixAlpha",
+            Number = 7,
+            Reversed = true,
+            Color = "#DD8800",
+            AlphaVariant = "MatrixAlpha"
+        };
+
+        var result = mapper.Map([alpha]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Alpha, mapped.Kind);
+        Assert.Equal("Alpha", mapped.Name);
+        Assert.Equal(7, mapped.DisplayNumber);
+        Assert.True(mapped.Reversed);
+        Assert.Equal("#DD8800", mapped.PrimaryColor);
+    }
+
+    [Fact]
+    public void Map_UnsupportedComponent_SkipsWithWarning()
+    {
+        var mapper = new MfmeComponentMapper();
+        var unsupported = new MfmeUnknownComponentData
+        {
+            Kind = MfmeComponentKind.Unknown,
+            SourceType = "UnsupportedThing"
+        };
+
+        var result = mapper.Map([unsupported]);
+
+        Assert.Empty(result.Elements);
+        Assert.Single(result.SkippedComponents);
+        var warning = Assert.Single(result.Warnings);
+        Assert.Equal("unsupported-component", warning.Code);
+    }
+
+    [Fact]
+    public void Map_InvalidDimensions_FallsBackToDefaults()
+    {
+        var mapper = new MfmeComponentMapper();
+        var component = new MfmeLampComponentData
+        {
+            Kind = MfmeComponentKind.Lamp,
+            SourceType = "ExtractComponentLamp",
+            Width = 0,
+            Height = double.NaN
+        };
+
+        var result = mapper.Map([component]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(100, mapped.Width);
+        Assert.Equal(100, mapped.Height);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -94,6 +94,7 @@ public sealed class MfmeExtractReaderTests
                   "Size": { "X": 120, "Y": 130 },
                   "Number": 2,
                   "Stops": 20,
+                  "Height": 250,
                   "Reversed": true,
                   "BandBmpImageFilename": "reel.png"
                 },
@@ -126,6 +127,7 @@ public sealed class MfmeExtractReaderTests
         Assert.Equal(7, lamp.Number);
         var reel = Assert.IsType<MfmeReelComponentData>(result.ImportedElements[2]);
         Assert.Equal(20, reel.Stops);
+        Assert.Equal(250, reel.ReelHeight);
         Assert.True(reel.Reversed);
         Assert.IsType<MfmeSevenSegmentComponentData>(result.ImportedElements[3]);
         var alpha = Assert.IsType<MfmeAlphaComponentData>(result.ImportedElements[4]);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopyServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopyServiceTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using OasisEditor.Features.MfmeImport;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeImportAssetCopyServiceTests
+{
+    [Fact]
+    public void CopyAssets_CopiesToExpectedProjectRelativePaths()
+    {
+        using var temp = new TempPaths();
+        Directory.CreateDirectory(Path.Combine(temp.ExtractRoot, "background"));
+        File.WriteAllText(Path.Combine(temp.ExtractRoot, "background", "bg.png"), "bg");
+
+        var service = new MfmeImportAssetCopyService();
+        var result = service.CopyAssets(temp.CreateContext(), "Demo Layout", [
+            new PanelElementModel
+            {
+                ObjectId = "bg1",
+                Kind = PanelElementKind.Background,
+                Name = "Background",
+                Width = 10,
+                Height = 10,
+                AssetPath = "background/bg.png"
+            }
+        ]);
+
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal("Assets/MfmeImport/Demo Layout/Background/bg.png", mapped.AssetPath);
+        Assert.Single(result.CopiedAssets);
+        Assert.Empty(result.Warnings);
+        Assert.True(File.Exists(Path.Combine(temp.ProjectRoot, mapped.AssetPath!.Replace('/', Path.DirectorySeparatorChar))));
+    }
+
+    [Fact]
+    public void CopyAssets_MissingSourceImage_AddsWarningAndKeepsElement()
+    {
+        using var temp = new TempPaths();
+
+        var service = new MfmeImportAssetCopyService();
+        var result = service.CopyAssets(temp.CreateContext(), "Demo", [
+            new PanelElementModel
+            {
+                ObjectId = "lamp1",
+                Kind = PanelElementKind.Lamp,
+                Name = "Lamp",
+                Width = 10,
+                Height = 10,
+                AssetPath = "lamps/missing.png"
+            }
+        ]);
+
+        var element = Assert.Single(result.Elements);
+        Assert.Null(element.AssetPath);
+        Assert.Empty(result.CopiedAssets);
+        var warning = Assert.Single(result.Warnings);
+        Assert.Equal("missing-asset", warning.Code);
+    }
+
+    [Fact]
+    public void CopyAssets_PreventsPathTraversal()
+    {
+        using var temp = new TempPaths();
+
+        var service = new MfmeImportAssetCopyService();
+        var result = service.CopyAssets(temp.CreateContext(), "Demo", [
+            new PanelElementModel
+            {
+                ObjectId = "evil",
+                Kind = PanelElementKind.Image,
+                Name = "Evil",
+                Width = 10,
+                Height = 10,
+                AssetPath = "../../outside.png"
+            }
+        ]);
+
+        Assert.Empty(result.CopiedAssets);
+        var warning = Assert.Single(result.Warnings);
+        Assert.Equal("invalid-asset-path", warning.Code);
+    }
+
+    [Fact]
+    public void CopyAssets_DuplicateDestinationNames_UsesDeterministicSuffix()
+    {
+        using var temp = new TempPaths();
+        Directory.CreateDirectory(Path.Combine(temp.ExtractRoot, "lamps"));
+        Directory.CreateDirectory(Path.Combine(temp.ExtractRoot, "reels"));
+        File.WriteAllText(Path.Combine(temp.ExtractRoot, "lamps", "shared.png"), "lamp");
+        File.WriteAllText(Path.Combine(temp.ExtractRoot, "reels", "shared.png"), "reel");
+
+        var service = new MfmeImportAssetCopyService();
+        var result = service.CopyAssets(temp.CreateContext(), "Demo", [
+            new PanelElementModel
+            {
+                ObjectId = "one",
+                Kind = PanelElementKind.Lamp,
+                Name = "Lamp",
+                Width = 10,
+                Height = 10,
+                AssetPath = "lamps/shared.png"
+            },
+            new PanelElementModel
+            {
+                ObjectId = "two",
+                Kind = PanelElementKind.Lamp,
+                Name = "Reel",
+                Width = 10,
+                Height = 10,
+                AssetPath = "lamps/shared.png"
+            }
+        ]);
+
+        Assert.Equal(1, result.CopiedAssets.Count);
+        Assert.Equal(result.Elements[0].AssetPath, result.Elements[1].AssetPath);
+    }
+
+    private sealed class TempPaths : IDisposable
+    {
+        public TempPaths()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"oasis-mfme-copy-tests-{Guid.NewGuid():N}");
+            ProjectRoot = Path.Combine(Root, "Project");
+            AssetsRoot = Path.Combine(ProjectRoot, "Assets");
+            ExtractRoot = Path.Combine(Root, "sample.extract");
+
+            Directory.CreateDirectory(ProjectRoot);
+            Directory.CreateDirectory(AssetsRoot);
+            Directory.CreateDirectory(ExtractRoot);
+        }
+
+        public string Root { get; }
+        public string ProjectRoot { get; }
+        public string AssetsRoot { get; }
+        public string ExtractRoot { get; }
+
+        public MfmeImportContext CreateContext()
+        {
+            return new MfmeImportContext
+            {
+                SourceExtractPath = ExtractRoot,
+                ProjectRootPath = ProjectRoot,
+                AssetsRootPath = AssetsRoot,
+                CopyAssetsToProject = true
+            };
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopyServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopyServiceTests.cs
@@ -113,7 +113,7 @@ public sealed class MfmeImportAssetCopyServiceTests
             }
         ]);
 
-        Assert.Equal(1, result.CopiedAssets.Count);
+        Assert.Single(result.CopiedAssets);
         Assert.Equal(result.Elements[0].AssetPath, result.Elements[1].AssetPath);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -700,7 +700,7 @@ public sealed class Panel2DRoundTripTests
 
         Assert.True(duplicateExecuted);
         Assert.True(document.IsDirty);
-        Assert.Equal(1, document.CommandService.History.Entries.Count);
+        Assert.Single(document.CommandService.History.Entries);
     }
 
     [Fact]
@@ -727,7 +727,7 @@ public sealed class Panel2DRoundTripTests
         Assert.True(firstExecution);
         Assert.False(secondExecution);
         Assert.True(document.IsDirty);
-        Assert.Equal(1, document.CommandService.History.Entries.Count);
+        Assert.Single(document.CommandService.History.Entries);
         Assert.Equal(2, document.GetPanelElements().Count);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -116,7 +116,8 @@ public sealed class Panel2DRoundTripTests
                     TextColor = "#FF00FF",
                     Text = "HELLO",
                     Reversed = true,
-                    Stops = 20
+                    Stops = 20,
+                    VisibleScale = 0.25
                 }
             ]
         };
@@ -142,6 +143,7 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal("HELLO", element.Text);
         Assert.True(element.Reversed);
         Assert.Equal(20, element.Stops);
+        Assert.Equal(0.25, element.VisibleScale);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeComponentMapper.cs
@@ -16,6 +16,7 @@ internal sealed class MfmeComponentMapper
 {
     private const double DefaultWidth = 100d;
     private const double DefaultHeight = 100d;
+    private const int MfmeHeightPerVisibleSymbol = 50;
 
     public MfmeComponentMappingResult Map(IReadOnlyList<MfmeExtractComponentData> components)
     {
@@ -71,7 +72,7 @@ internal sealed class MfmeComponentMapper
             y: 0,
             width: component.Width,
             height: component.Height,
-            assetPath: BuildAssetPath("Background", component.ImageFileName),
+            assetPath: BuildAssetPath("background", component.ImageFileName),
             sourceType: component.SourceType,
             sourceId: null,
             displayNumber: null,
@@ -80,7 +81,8 @@ internal sealed class MfmeComponentMapper
             textColor: null,
             text: null,
             reversed: false,
-            stops: null);
+            stops: null,
+            visibleScale: null);
     }
 
     private static PanelElementModel MapLamp(MfmeLampComponentData component)
@@ -93,7 +95,7 @@ internal sealed class MfmeComponentMapper
             y: component.Y,
             width: component.Width,
             height: component.Height,
-            assetPath: BuildAssetPath("Lamps", component.ImageFileName),
+            assetPath: BuildAssetPath("lamps", component.ImageFileName),
             sourceType: component.SourceType,
             sourceId: component.Number?.ToString(),
             displayNumber: component.Number,
@@ -102,13 +104,15 @@ internal sealed class MfmeComponentMapper
             textColor: component.TextColor,
             text: component.DisplayName,
             reversed: false,
-            stops: null);
+            stops: null,
+            visibleScale: null);
     }
 
     private static PanelElementModel MapReel(MfmeReelComponentData component)
     {
         var reelNumber = component.Number.HasValue ? component.Number.Value + 1 : (int?)null;
         var name = reelNumber.HasValue ? $"Reel {reelNumber.Value}" : "Reel";
+        var visibleScale = TryCalculateVisibleScale(component.Stops, component.ReelHeight);
 
         return CreateElement(
             kind: PanelElementKind.Reel,
@@ -117,7 +121,7 @@ internal sealed class MfmeComponentMapper
             y: component.Y,
             width: component.Width,
             height: component.Height,
-            assetPath: BuildAssetPath("Reels", component.BandImageFileName),
+            assetPath: BuildAssetPath("reels", component.BandImageFileName),
             sourceType: component.SourceType,
             sourceId: component.Number?.ToString(),
             displayNumber: reelNumber,
@@ -126,7 +130,8 @@ internal sealed class MfmeComponentMapper
             textColor: null,
             text: null,
             reversed: component.Reversed,
-            stops: component.Stops is > 0 ? component.Stops : null);
+            stops: component.Stops is > 0 ? component.Stops : null,
+            visibleScale: visibleScale);
     }
 
     private static PanelElementModel MapSevenSegment(MfmeSevenSegmentComponentData component)
@@ -148,7 +153,8 @@ internal sealed class MfmeComponentMapper
             textColor: null,
             text: null,
             reversed: false,
-            stops: null);
+            stops: null,
+            visibleScale: null);
     }
 
     private static PanelElementModel MapAlpha(MfmeAlphaComponentData component)
@@ -160,7 +166,7 @@ internal sealed class MfmeComponentMapper
             y: component.Y,
             width: component.Width,
             height: component.Height,
-            assetPath: BuildAssetPath("Lamps", component.ImageFileName),
+            assetPath: null,
             sourceType: component.SourceType,
             sourceId: component.Number?.ToString(),
             displayNumber: component.Number,
@@ -169,7 +175,8 @@ internal sealed class MfmeComponentMapper
             textColor: null,
             text: null,
             reversed: component.Reversed,
-            stops: null);
+            stops: null,
+            visibleScale: null);
     }
 
     private static PanelElementModel CreateElement(
@@ -188,7 +195,8 @@ internal sealed class MfmeComponentMapper
         string? textColor,
         string? text,
         bool reversed,
-        int? stops)
+        int? stops,
+        double? visibleScale)
     {
         return new PanelElementModel
         {
@@ -208,7 +216,8 @@ internal sealed class MfmeComponentMapper
             TextColor = textColor,
             Text = text,
             Reversed = reversed,
-            Stops = stops
+            Stops = stops,
+            VisibleScale = visibleScale
         };
     }
 
@@ -230,5 +239,17 @@ internal sealed class MfmeComponentMapper
         }
 
         return value;
+    }
+
+    private static double? TryCalculateVisibleScale(int? stops, int? reelHeight)
+    {
+        if (!stops.HasValue || !reelHeight.HasValue || stops.Value <= 0 || reelHeight.Value <= 0)
+        {
+            return null;
+        }
+
+        var visibleSymbols = (double)reelHeight.Value / MfmeHeightPerVisibleSymbol;
+        var scale = visibleSymbols / stops.Value;
+        return scale > 0 ? scale : null;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeComponentMapper.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed record MfmeComponentMappingResult
+{
+    public IReadOnlyList<PanelElementModel> Elements { get; init; } = [];
+
+    public IReadOnlyList<MfmeExtractComponentData> SkippedComponents { get; init; } = [];
+
+    public IReadOnlyList<MfmeImportWarning> Warnings { get; init; } = [];
+}
+
+internal sealed class MfmeComponentMapper
+{
+    private const double DefaultWidth = 100d;
+    private const double DefaultHeight = 100d;
+
+    public MfmeComponentMappingResult Map(IReadOnlyList<MfmeExtractComponentData> components)
+    {
+        ArgumentNullException.ThrowIfNull(components);
+
+        var mappedElements = new List<PanelElementModel>(components.Count);
+        var skipped = new List<MfmeExtractComponentData>();
+        var warnings = new List<MfmeImportWarning>();
+
+        foreach (var component in components)
+        {
+            switch (component)
+            {
+                case MfmeBackgroundComponentData background:
+                    mappedElements.Add(MapBackground(background));
+                    break;
+                case MfmeLampComponentData lamp:
+                    mappedElements.Add(MapLamp(lamp));
+                    break;
+                case MfmeReelComponentData reel:
+                    mappedElements.Add(MapReel(reel));
+                    break;
+                case MfmeSevenSegmentComponentData sevenSegment:
+                    mappedElements.Add(MapSevenSegment(sevenSegment));
+                    break;
+                case MfmeAlphaComponentData alpha:
+                    mappedElements.Add(MapAlpha(alpha));
+                    break;
+                default:
+                    skipped.Add(component);
+                    warnings.Add(new MfmeImportWarning(
+                        Code: "unsupported-component",
+                        Message: $"Skipped unsupported MFME component '{component.SourceType}'.",
+                        ContextPath: component.SourceType));
+                    break;
+            }
+        }
+
+        return new MfmeComponentMappingResult
+        {
+            Elements = mappedElements,
+            SkippedComponents = skipped,
+            Warnings = warnings
+        };
+    }
+
+    private static PanelElementModel MapBackground(MfmeBackgroundComponentData component)
+    {
+        return CreateElement(
+            kind: PanelElementKind.Background,
+            name: "Background",
+            x: 0,
+            y: 0,
+            width: component.Width,
+            height: component.Height,
+            assetPath: BuildAssetPath("Background", component.ImageFileName),
+            sourceType: component.SourceType,
+            sourceId: null,
+            displayNumber: null,
+            primaryColor: component.Color,
+            secondaryColor: null,
+            textColor: null,
+            text: null,
+            reversed: false,
+            stops: null);
+    }
+
+    private static PanelElementModel MapLamp(MfmeLampComponentData component)
+    {
+        var name = component.Number.HasValue ? $"Lamp {component.Number.Value}" : "Lamp";
+        return CreateElement(
+            kind: PanelElementKind.Lamp,
+            name: name,
+            x: component.X,
+            y: component.Y,
+            width: component.Width,
+            height: component.Height,
+            assetPath: BuildAssetPath("Lamps", component.ImageFileName),
+            sourceType: component.SourceType,
+            sourceId: component.Number?.ToString(),
+            displayNumber: component.Number,
+            primaryColor: component.OnColor,
+            secondaryColor: component.OffColor,
+            textColor: component.TextColor,
+            text: component.DisplayName,
+            reversed: false,
+            stops: null);
+    }
+
+    private static PanelElementModel MapReel(MfmeReelComponentData component)
+    {
+        var reelNumber = component.Number.HasValue ? component.Number.Value + 1 : (int?)null;
+        var name = reelNumber.HasValue ? $"Reel {reelNumber.Value}" : "Reel";
+
+        return CreateElement(
+            kind: PanelElementKind.Reel,
+            name: name,
+            x: component.X,
+            y: component.Y,
+            width: component.Width,
+            height: component.Height,
+            assetPath: BuildAssetPath("Reels", component.BandImageFileName),
+            sourceType: component.SourceType,
+            sourceId: component.Number?.ToString(),
+            displayNumber: reelNumber,
+            primaryColor: null,
+            secondaryColor: null,
+            textColor: null,
+            text: null,
+            reversed: component.Reversed,
+            stops: component.Stops is > 0 ? component.Stops : null);
+    }
+
+    private static PanelElementModel MapSevenSegment(MfmeSevenSegmentComponentData component)
+    {
+        var name = component.Number.HasValue ? $"7 Segment {component.Number.Value}" : "7 Segment";
+        return CreateElement(
+            kind: PanelElementKind.SevenSegment,
+            name: name,
+            x: component.X,
+            y: component.Y,
+            width: component.Width,
+            height: component.Height,
+            assetPath: null,
+            sourceType: component.SourceType,
+            sourceId: component.Number?.ToString(),
+            displayNumber: component.Number,
+            primaryColor: component.SegmentOnColor,
+            secondaryColor: null,
+            textColor: null,
+            text: null,
+            reversed: false,
+            stops: null);
+    }
+
+    private static PanelElementModel MapAlpha(MfmeAlphaComponentData component)
+    {
+        return CreateElement(
+            kind: PanelElementKind.Alpha,
+            name: "Alpha",
+            x: component.X,
+            y: component.Y,
+            width: component.Width,
+            height: component.Height,
+            assetPath: BuildAssetPath("Lamps", component.ImageFileName),
+            sourceType: component.SourceType,
+            sourceId: component.Number?.ToString(),
+            displayNumber: component.Number,
+            primaryColor: component.Color,
+            secondaryColor: null,
+            textColor: null,
+            text: null,
+            reversed: component.Reversed,
+            stops: null);
+    }
+
+    private static PanelElementModel CreateElement(
+        PanelElementKind kind,
+        string name,
+        double x,
+        double y,
+        double width,
+        double height,
+        string? assetPath,
+        string sourceType,
+        string? sourceId,
+        int? displayNumber,
+        string? primaryColor,
+        string? secondaryColor,
+        string? textColor,
+        string? text,
+        bool reversed,
+        int? stops)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = Guid.NewGuid().ToString("N"),
+            Name = name,
+            Kind = kind,
+            X = x,
+            Y = y,
+            Width = NormalizeDimension(width, DefaultWidth),
+            Height = NormalizeDimension(height, DefaultHeight),
+            AssetPath = assetPath,
+            MfmeSourceType = sourceType,
+            MfmeSourceId = sourceId,
+            DisplayNumber = displayNumber,
+            PrimaryColor = primaryColor,
+            SecondaryColor = secondaryColor,
+            TextColor = textColor,
+            Text = text,
+            Reversed = reversed,
+            Stops = stops
+        };
+    }
+
+    private static string? BuildAssetPath(string categoryFolder, string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return null;
+        }
+
+        return $"{categoryFolder}/{fileName.Trim()}";
+    }
+
+    private static double NormalizeDimension(double value, double fallback)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+        {
+            return fallback;
+        }
+
+        return value;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractComponentData.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractComponentData.cs
@@ -55,6 +55,8 @@ internal sealed record MfmeReelComponentData : MfmeExtractComponentData
 
     public int? Stops { get; init; }
 
+    public int? ReelHeight { get; init; }
+
     public bool Reversed { get; init; }
 
     public string? BandImageFileName { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractComponentParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractComponentParser.cs
@@ -103,6 +103,7 @@ internal static class MfmeExtractComponentParser
                 RawJson = common.RawJson,
                 Number = TryReadInt(component, "Number"),
                 Stops = TryReadInt(component, "Stops"),
+                ReelHeight = TryReadInt(component, "Height"),
                 Reversed = TryReadBool(component, "Reversed"),
                 BandImageFileName = bandImage
             };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopyService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopyService.cs
@@ -52,7 +52,7 @@ internal sealed class MfmeImportAssetCopyService
                     Code: "invalid-asset-path",
                     Message: $"Skipped invalid asset path '{element.AssetPath}'.",
                     ContextPath: element.ObjectId));
-                updated.Add(element with { AssetPath = null });
+                updated.Add(CloneWithAssetPath(element, null));
                 continue;
             }
 
@@ -62,13 +62,13 @@ internal sealed class MfmeImportAssetCopyService
                     Code: "missing-asset",
                     Message: $"Missing MFME source image '{sourceAssetPath}'.",
                     ContextPath: element.ObjectId));
-                updated.Add(element with { AssetPath = null });
+                updated.Add(CloneWithAssetPath(element, null));
                 continue;
             }
 
             if (copiedDestinationBySource.TryGetValue(sourceAssetPath, out var existingDestination))
             {
-                updated.Add(element with { AssetPath = ToProjectRelativePath(projectRootFullPath, existingDestination) });
+                updated.Add(CloneWithAssetPath(element, ToProjectRelativePath(projectRootFullPath, existingDestination)));
                 continue;
             }
 
@@ -82,7 +82,7 @@ internal sealed class MfmeImportAssetCopyService
             copied.Add(destinationPath);
             copiedDestinationBySource[sourceAssetPath] = destinationPath;
 
-            updated.Add(element with { AssetPath = ToProjectRelativePath(projectRootFullPath, destinationPath) });
+            updated.Add(CloneWithAssetPath(element, ToProjectRelativePath(projectRootFullPath, destinationPath)));
         }
 
         return new MfmeImportAssetCopyResult
@@ -187,5 +187,30 @@ internal sealed class MfmeImportAssetCopyService
     {
         var relative = Path.GetRelativePath(projectRootPath, absolutePath);
         return relative.Replace('\\', '/');
+    }
+
+    private static PanelElementModel CloneWithAssetPath(PanelElementModel source, string? assetPath)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = source.ObjectId,
+            Name = source.Name,
+            Kind = source.Kind,
+            X = source.X,
+            Y = source.Y,
+            Width = source.Width,
+            Height = source.Height,
+            AssetPath = assetPath,
+            MfmeSourceType = source.MfmeSourceType,
+            MfmeSourceId = source.MfmeSourceId,
+            DisplayNumber = source.DisplayNumber,
+            PrimaryColor = source.PrimaryColor,
+            SecondaryColor = source.SecondaryColor,
+            TextColor = source.TextColor,
+            Text = source.Text,
+            Reversed = source.Reversed,
+            Stops = source.Stops,
+            VisibleScale = source.VisibleScale
+        };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopyService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopyService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed record MfmeImportAssetCopyResult
+{
+    public IReadOnlyList<PanelElementModel> Elements { get; init; } = [];
+
+    public IReadOnlyList<string> CopiedAssets { get; init; } = [];
+
+    public IReadOnlyList<MfmeImportWarning> Warnings { get; init; } = [];
+}
+
+internal sealed class MfmeImportAssetCopyService
+{
+    private const string ImportRootFolder = "MfmeImport";
+
+    public MfmeImportAssetCopyResult CopyAssets(
+        MfmeImportContext context,
+        string layoutName,
+        IReadOnlyList<PanelElementModel> elements)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(layoutName);
+        ArgumentNullException.ThrowIfNull(elements);
+
+        var copied = new List<string>();
+        var warnings = new List<MfmeImportWarning>();
+        var updated = new List<PanelElementModel>(elements.Count);
+
+        var safeLayoutName = SanitizeSegment(layoutName);
+        var assetsRootFullPath = Path.GetFullPath(context.AssetsRootPath);
+        var projectRootFullPath = Path.GetFullPath(context.ProjectRootPath);
+        var sourceExtractFullPath = Path.GetFullPath(context.SourceExtractPath);
+
+        var copiedDestinationBySource = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var element in elements)
+        {
+            if (string.IsNullOrWhiteSpace(element.AssetPath))
+            {
+                updated.Add(element);
+                continue;
+            }
+
+            if (!TryResolveSourceAsset(sourceExtractFullPath, element.AssetPath, out var sourceAssetPath, out var categoryFolder, out var fileName))
+            {
+                warnings.Add(new MfmeImportWarning(
+                    Code: "invalid-asset-path",
+                    Message: $"Skipped invalid asset path '{element.AssetPath}'.",
+                    ContextPath: element.ObjectId));
+                updated.Add(element with { AssetPath = null });
+                continue;
+            }
+
+            if (!File.Exists(sourceAssetPath))
+            {
+                warnings.Add(new MfmeImportWarning(
+                    Code: "missing-asset",
+                    Message: $"Missing MFME source image '{sourceAssetPath}'.",
+                    ContextPath: element.ObjectId));
+                updated.Add(element with { AssetPath = null });
+                continue;
+            }
+
+            if (copiedDestinationBySource.TryGetValue(sourceAssetPath, out var existingDestination))
+            {
+                updated.Add(element with { AssetPath = ToProjectRelativePath(projectRootFullPath, existingDestination) });
+                continue;
+            }
+
+            var destinationDirectory = Path.Combine(assetsRootFullPath, ImportRootFolder, safeLayoutName, categoryFolder);
+            Directory.CreateDirectory(destinationDirectory);
+
+            var safeFileName = SanitizeFileName(fileName);
+            var destinationPath = BuildUniqueDestinationPath(destinationDirectory, safeFileName);
+
+            File.Copy(sourceAssetPath, destinationPath, overwrite: false);
+            copied.Add(destinationPath);
+            copiedDestinationBySource[sourceAssetPath] = destinationPath;
+
+            updated.Add(element with { AssetPath = ToProjectRelativePath(projectRootFullPath, destinationPath) });
+        }
+
+        return new MfmeImportAssetCopyResult
+        {
+            Elements = updated,
+            CopiedAssets = copied,
+            Warnings = warnings
+        };
+    }
+
+    private static bool TryResolveSourceAsset(
+        string sourceExtractRoot,
+        string assetPath,
+        out string sourceAssetPath,
+        out string categoryFolder,
+        out string fileName)
+    {
+        sourceAssetPath = string.Empty;
+        categoryFolder = string.Empty;
+        fileName = string.Empty;
+
+        var normalized = assetPath.Replace('\\', '/').Trim();
+        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return false;
+        }
+
+        categoryFolder = NormalizeCategory(parts[0]);
+        fileName = parts[^1];
+
+        var candidate = Path.GetFullPath(Path.Combine(sourceExtractRoot, parts[0], fileName));
+        if (!candidate.StartsWith(sourceExtractRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        sourceAssetPath = candidate;
+        return true;
+    }
+
+    private static string BuildUniqueDestinationPath(string directory, string fileName)
+    {
+        var name = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        var candidate = Path.Combine(directory, fileName);
+
+        if (!File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var suffix = 2;
+        while (true)
+        {
+            candidate = Path.Combine(directory, $"{name}-{suffix}{extension}");
+            if (!File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            suffix++;
+        }
+    }
+
+    private static string NormalizeCategory(string sourceCategory)
+    {
+        return sourceCategory.ToLowerInvariant() switch
+        {
+            "background" => "Background",
+            "lamps" => "Lamps",
+            "reels" => "Reels",
+            _ => SanitizeSegment(sourceCategory)
+        };
+    }
+
+    private static string SanitizeSegment(string value)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var chars = value
+            .Trim()
+            .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
+            .ToArray();
+
+        var sanitized = new string(chars);
+        return string.IsNullOrWhiteSpace(sanitized) ? "Unnamed" : sanitized;
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var chars = value
+            .Trim()
+            .Select(ch => invalidChars.Contains(ch) ? '_' : ch)
+            .ToArray();
+
+        var sanitized = new string(chars);
+        return string.IsNullOrWhiteSpace(sanitized) ? "asset.bin" : sanitized;
+    }
+
+    private static string ToProjectRelativePath(string projectRootPath, string absolutePath)
+    {
+        var relative = Path.GetRelativePath(projectRootPath, absolutePath);
+        return relative.Replace('\\', '/');
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -26,4 +26,5 @@ internal sealed class PanelElementModel
     public string? Text { get; init; }
     public bool Reversed { get; init; }
     public int? Stops { get; init; }
+    public double? VisibleScale { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -236,7 +236,8 @@ internal static class Panel2DDocumentStorage
             TextColor = normalized.TextColor,
             Text = normalized.Text,
             Reversed = normalized.Reversed,
-            Stops = normalized.Stops
+            Stops = normalized.Stops,
+            VisibleScale = normalized.VisibleScale
         };
     }
 
@@ -260,7 +261,8 @@ internal static class Panel2DDocumentStorage
             TextColor = element.TextColor,
             Text = element.Text,
             Reversed = element.Reversed,
-            Stops = element.Stops
+            Stops = element.Stops,
+            VisibleScale = element.VisibleScale
         });
     }
 
@@ -306,7 +308,8 @@ internal static class Panel2DDocumentStorage
             SecondaryColor = NormalizeOptionalToken(element.SecondaryColor),
             TextColor = NormalizeOptionalToken(element.TextColor),
             Text = NormalizeOptionalToken(element.Text),
-            Stops = element.Stops is > 0 ? element.Stops : null
+            Stops = element.Stops is > 0 ? element.Stops : null,
+            VisibleScale = NormalizeOptionalScale(element.VisibleScale)
         };
     }
 
@@ -357,6 +360,22 @@ internal static class Panel2DDocumentStorage
             && !double.IsInfinity(value)
             && value > 0;
     }
+
+    private static double? NormalizeOptionalScale(double? value)
+    {
+        if (!value.HasValue)
+        {
+            return null;
+        }
+
+        var numeric = value.Value;
+        if (double.IsNaN(numeric) || double.IsInfinity(numeric) || numeric <= 0d)
+        {
+            return null;
+        }
+
+        return numeric;
+    }
 }
 
 internal enum PanelElementKind
@@ -401,6 +420,7 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public string? Text { get; init; }
     public bool Reversed { get; init; }
     public int? Stops { get; init; }
+    public double? VisibleScale { get; init; }
 
     [JsonIgnore]
     public PanelElementKind ElementKind => Panel2DDocumentStorage.ParseElementKind(Kind);


### PR DESCRIPTION
### Motivation
- Provide a UI-agnostic mapping layer to convert normalized MFME extract DTOs into the editor's `PanelElementModel` instances as the next step in Phase O of the MFME import work. 
- Preserve legacy importer parity (naming/numbering quirks) and emit structured warnings for unsupported components so downstream import/asset-copy steps can act deterministically.

### Description
- Added `MfmeComponentMapper` (`OasisEditor/Features/MfmeImport/MfmeComponentMapper.cs`) that maps supported `MfmeExtractComponentData` types (Background, Lamp, Reel, SevenSegment, Alpha) to `PanelElementModel` without any WPF dependencies. 
- Implemented mapping behaviors including background origin and fixed `Background` name, lamp first-element mapping, reel display-number parity (`Number + 1`), seven-segment and alpha normalization (MatrixAlpha -> Alpha), and per-kind asset-path hints (`Background/...`, `Lamps/...`, `Reels/...`).
- Added dimension normalization fallback to defaults when source sizes are invalid to ensure generated elements are well-formed for later insertion.
- Emit skipped-component collection and structured `MfmeImportWarning` entries for unsupported component kinds via `MfmeComponentMappingResult`.
- Added comprehensive unit tests (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeComponentMapperTests.cs`) that cover per-kind mapping, unsupported-component skip/warning, and invalid-dimension fallback scenarios.

### Testing
- Added automated unit tests in `MfmeComponentMapperTests` that exercise all mapped component kinds and edge cases; tests were added to the test project but were not executed in this environment. 
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj`, which failed in the container because `dotnet` is not installed (`dotnet: command not found`). 
- No test failures were observed at commit time in this environment since the test runner could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef26eb9c1883278f36dfcfc7fd1af4)