### PR TITLE
Add MFME import preparation service to combine read/map/copy flow

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportPreparationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportPreparationServiceTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using OasisEditor.Features.MfmeImport;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeImportPreparationServiceTests
+{
+    [Fact]
+    public void Prepare_MapsAndCopiesAssets_WhenCopyEnabled()
+    {
+        using var temp = new TempPaths();
+        WriteManifest(temp.ExtractRoot, "DemoLayout");
+
+        Directory.CreateDirectory(Path.Combine(temp.ExtractRoot, "background"));
+        File.WriteAllText(Path.Combine(temp.ExtractRoot, "background", "bg.png"), "background-bytes");
+
+        var service = CreateService();
+        var result = service.Prepare(temp.CreateContext(copyAssets: true));
+
+        Assert.False(result.HasErrors);
+        Assert.Equal("DemoLayout", result.LayoutName);
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Background, mapped.Kind);
+        Assert.Equal("Assets/MfmeImport/DemoLayout/Background/bg.png", mapped.AssetPath);
+        Assert.Single(result.CopiedAssets);
+        Assert.Empty(result.SkippedComponents);
+    }
+
+    [Fact]
+    public void Prepare_KeepsExtractRelativeAssetPath_WhenCopyDisabled()
+    {
+        using var temp = new TempPaths();
+        WriteManifest(temp.ExtractRoot, "DemoLayout");
+
+        var service = CreateService();
+        var result = service.Prepare(temp.CreateContext(copyAssets: false));
+
+        Assert.False(result.HasErrors);
+        var mapped = Assert.Single(result.Elements);
+        Assert.Equal("background/bg.png", mapped.AssetPath);
+        Assert.Empty(result.CopiedAssets);
+    }
+
+    [Fact]
+    public void Prepare_ReturnsReaderErrors_ForMissingExtractPath()
+    {
+        using var temp = new TempPaths();
+        Directory.Delete(temp.ExtractRoot, recursive: true);
+
+        var service = CreateService();
+        var result = service.Prepare(temp.CreateContext(copyAssets: true));
+
+        Assert.True(result.HasErrors);
+        Assert.Empty(result.Elements);
+        Assert.Contains(result.Errors, message => message.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static MfmeImportPreparationService CreateService()
+    {
+        return new MfmeImportPreparationService(
+            new MfmeExtractReader(),
+            new MfmeComponentMapper(),
+            new MfmeImportAssetCopyService());
+    }
+
+    private static void WriteManifest(string extractRoot, string layoutName)
+    {
+        var manifestPath = Path.Combine(extractRoot, layoutName + ".json");
+        var manifest =
+            """
+            {
+              "ASName": "DemoLayout",
+              "Components": [
+                {
+                  "$type": "MfmeTools.Shared.Extract.ExtractComponentBackground, MfmeTools",
+                  "Position": { "X": 0, "Y": 0 },
+                  "Size": { "Width": 640, "Height": 360 },
+                  "BmpImageFilename": "bg.png",
+                  "Color": "#112233"
+                }
+              ]
+            }
+            """;
+
+        File.WriteAllText(manifestPath, manifest.Replace("DemoLayout", layoutName, StringComparison.Ordinal));
+    }
+
+    private sealed class TempPaths : IDisposable
+    {
+        public TempPaths()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"oasis-mfme-prepare-tests-{Guid.NewGuid():N}");
+            ProjectRoot = Path.Combine(Root, "Project");
+            AssetsRoot = Path.Combine(ProjectRoot, "Assets");
+            ExtractRoot = Path.Combine(Root, "DemoLayout");
+
+            Directory.CreateDirectory(ProjectRoot);
+            Directory.CreateDirectory(AssetsRoot);
+            Directory.CreateDirectory(ExtractRoot);
+        }
+
+        public string Root { get; }
+        public string ProjectRoot { get; }
+        public string AssetsRoot { get; }
+        public string ExtractRoot { get; }
+
+        public MfmeImportContext CreateContext(bool copyAssets)
+        {
+            return new MfmeImportContext
+            {
+                SourceExtractPath = ExtractRoot,
+                ProjectRootPath = ProjectRoot,
+                AssetsRootPath = AssetsRoot,
+                CopyAssetsToProject = copyAssets
+            };
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -545,7 +545,18 @@ public sealed class Panel2DRoundTripTests
                 X = 30,
                 Y = 40,
                 Width = 50,
-                Height = 60
+                Height = 60,
+                AssetPath = "Assets/MfmeImport/sample.png",
+                MfmeSourceType = "ExtractComponentLamp",
+                MfmeSourceId = "4",
+                DisplayNumber = 4,
+                PrimaryColor = "#00FF00",
+                SecondaryColor = "#001100",
+                TextColor = "#FFFFFF",
+                Text = "HOLD",
+                Reversed = true,
+                Stops = 24,
+                VisibleScale = 0.25
             });
 
         var selection = new PanelSelectionInfo("source-id", "rectangle", 30, 40, 50, 60);
@@ -565,6 +576,17 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal(source.Y + 10, duplicate.Y);
         Assert.Equal(source.Width, duplicate.Width);
         Assert.Equal(source.Height, duplicate.Height);
+        Assert.Equal(source.AssetPath, duplicate.AssetPath);
+        Assert.Equal(source.MfmeSourceType, duplicate.MfmeSourceType);
+        Assert.Equal(source.MfmeSourceId, duplicate.MfmeSourceId);
+        Assert.Equal(source.DisplayNumber, duplicate.DisplayNumber);
+        Assert.Equal(source.PrimaryColor, duplicate.PrimaryColor);
+        Assert.Equal(source.SecondaryColor, duplicate.SecondaryColor);
+        Assert.Equal(source.TextColor, duplicate.TextColor);
+        Assert.Equal(source.Text, duplicate.Text);
+        Assert.Equal(source.Reversed, duplicate.Reversed);
+        Assert.Equal(source.Stops, duplicate.Stops);
+        Assert.Equal(source.VisibleScale, duplicate.VisibleScale);
     }
 
     [Fact]
@@ -615,7 +637,18 @@ public sealed class Panel2DRoundTripTests
                 X = 30,
                 Y = 40,
                 Width = 50,
-                Height = 60
+                Height = 60,
+                AssetPath = "Assets/MfmeImport/source.png",
+                MfmeSourceType = "ExtractComponentReel",
+                MfmeSourceId = "2",
+                DisplayNumber = 3,
+                PrimaryColor = "#111111",
+                SecondaryColor = "#222222",
+                TextColor = "#333333",
+                Text = "Sample",
+                Reversed = true,
+                Stops = 12,
+                VisibleScale = 0.5
             });
 
         var source = document.GetPanelElements().Single();
@@ -632,9 +665,65 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal(50, pasted.Y);
         Assert.Equal(50, pasted.Width);
         Assert.Equal(60, pasted.Height);
+        Assert.Equal(source.AssetPath, pasted.AssetPath);
+        Assert.Equal(source.MfmeSourceType, pasted.MfmeSourceType);
+        Assert.Equal(source.MfmeSourceId, pasted.MfmeSourceId);
+        Assert.Equal(source.DisplayNumber, pasted.DisplayNumber);
+        Assert.Equal(source.PrimaryColor, pasted.PrimaryColor);
+        Assert.Equal(source.SecondaryColor, pasted.SecondaryColor);
+        Assert.Equal(source.TextColor, pasted.TextColor);
+        Assert.Equal(source.Text, pasted.Text);
+        Assert.Equal(source.Reversed, pasted.Reversed);
+        Assert.Equal(source.Stops, pasted.Stops);
+        Assert.Equal(source.VisibleScale, pasted.VisibleScale);
 
         command.Undo();
         Assert.Single(document.GetPanelElements());
+    }
+
+    [Fact]
+    public void RenameElementCommand_PreservesMfmeMetadata()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rename-id",
+                Name = "Original",
+                Kind = PanelElementKind.Alpha,
+                X = 5,
+                Y = 6,
+                Width = 7,
+                Height = 8,
+                AssetPath = "Assets/MfmeImport/alpha.png",
+                MfmeSourceType = "ExtractComponentAlpha",
+                MfmeSourceId = "7",
+                DisplayNumber = 7,
+                PrimaryColor = "#AAAAAA",
+                SecondaryColor = "#BBBBBB",
+                TextColor = "#CCCCCC",
+                Text = "ALPHA",
+                Reversed = true,
+                Stops = 30,
+                VisibleScale = 0.2
+            });
+
+        var selection = new PanelSelectionInfo("rename-id", "alpha", 5, 6, 7, 8);
+        var command = CanvasMutationCommands.CreateRenameElementCommand(document.DocumentId, document, selection, "Renamed");
+
+        command.Execute();
+        var renamed = document.GetPanelElements().Single();
+        Assert.Equal("Renamed", renamed.Name);
+        Assert.Equal("Assets/MfmeImport/alpha.png", renamed.AssetPath);
+        Assert.Equal("ExtractComponentAlpha", renamed.MfmeSourceType);
+        Assert.Equal("7", renamed.MfmeSourceId);
+        Assert.Equal(7, renamed.DisplayNumber);
+        Assert.Equal("#AAAAAA", renamed.PrimaryColor);
+        Assert.Equal("#BBBBBB", renamed.SecondaryColor);
+        Assert.Equal("#CCCCCC", renamed.TextColor);
+        Assert.Equal("ALPHA", renamed.Text);
+        Assert.True(renamed.Reversed);
+        Assert.Equal(30, renamed.Stops);
+        Assert.Equal(0.2, renamed.VisibleScale);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -220,16 +220,7 @@ internal static class CanvasMutationCommands
 
             _renamedIndex = index;
             _previousName = existing.Name;
-            elements[index] = new PanelElementModel
-            {
-                ObjectId = existing.ObjectId,
-                Name = normalizedNewName,
-                Kind = existing.Kind,
-                X = existing.X,
-                Y = existing.Y,
-                Width = existing.Width,
-                Height = existing.Height
-            };
+            elements[index] = CloneElement(existing, name: normalizedNewName);
 
             _document.SetPanelElements(elements);
             _document.MarkDirty();
@@ -255,16 +246,7 @@ internal static class CanvasMutationCommands
             }
 
             var existing = elements[index];
-            elements[index] = new PanelElementModel
-            {
-                ObjectId = existing.ObjectId,
-                Name = _previousName ?? string.Empty,
-                Kind = existing.Kind,
-                X = existing.X,
-                Y = existing.Y,
-                Width = existing.Width,
-                Height = existing.Height
-            };
+            elements[index] = CloneElement(existing, name: _previousName ?? string.Empty);
 
             _document.SetPanelElements(elements);
             _document.MarkDirty();
@@ -306,16 +288,12 @@ internal static class CanvasMutationCommands
                 }
 
                 var sourceElement = elements[sourceIndex];
-                _duplicatedElement = new PanelElementModel
-                {
-                    ObjectId = BuildUniqueObjectId(elements),
-                    Name = BuildDuplicateName(sourceElement, elements),
-                    Kind = sourceElement.Kind,
-                    X = sourceElement.X + DuplicateOffset,
-                    Y = sourceElement.Y + DuplicateOffset,
-                    Width = sourceElement.Width,
-                    Height = sourceElement.Height
-                };
+                _duplicatedElement = CloneElement(
+                    sourceElement,
+                    objectId: BuildUniqueObjectId(elements),
+                    name: BuildDuplicateName(sourceElement, elements),
+                    x: sourceElement.X + DuplicateOffset,
+                    y: sourceElement.Y + DuplicateOffset);
                 _insertIndex = Math.Clamp(sourceIndex + 1, 0, elements.Count);
             }
 
@@ -381,16 +359,12 @@ internal static class CanvasMutationCommands
 
             if (_pastedElement is null)
             {
-                _pastedElement = new PanelElementModel
-                {
-                    ObjectId = BuildUniqueObjectId(elements),
-                    Name = BuildUniqueName(_sourceElement.Name, elements),
-                    Kind = _sourceElement.Kind,
-                    X = _sourceElement.X + PasteOffset,
-                    Y = _sourceElement.Y + PasteOffset,
-                    Width = _sourceElement.Width,
-                    Height = _sourceElement.Height
-                };
+                _pastedElement = CloneElement(
+                    _sourceElement,
+                    objectId: BuildUniqueObjectId(elements),
+                    name: BuildUniqueName(_sourceElement.Name, elements),
+                    x: _sourceElement.X + PasteOffset,
+                    y: _sourceElement.Y + PasteOffset);
                 _insertIndex = elements.Count;
             }
 
@@ -537,5 +511,35 @@ internal static class CanvasMutationCommands
 
             suffix++;
         }
+    }
+
+    private static PanelElementModel CloneElement(
+        PanelElementModel source,
+        string? objectId = null,
+        string? name = null,
+        double? x = null,
+        double? y = null)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = objectId ?? source.ObjectId,
+            Name = name ?? source.Name,
+            Kind = source.Kind,
+            X = x ?? source.X,
+            Y = y ?? source.Y,
+            Width = source.Width,
+            Height = source.Height,
+            AssetPath = source.AssetPath,
+            MfmeSourceType = source.MfmeSourceType,
+            MfmeSourceId = source.MfmeSourceId,
+            DisplayNumber = source.DisplayNumber,
+            PrimaryColor = source.PrimaryColor,
+            SecondaryColor = source.SecondaryColor,
+            TextColor = source.TextColor,
+            Text = source.Text,
+            Reversed = source.Reversed,
+            Stops = source.Stops,
+            VisibleScale = source.VisibleScale
+        };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportPreparationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportPreparationService.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed record MfmePreparedImportResult
+{
+    public string? LayoutName { get; init; }
+
+    public IReadOnlyList<PanelElementModel> Elements { get; init; } = [];
+
+    public IReadOnlyList<string> CopiedAssets { get; init; } = [];
+
+    public IReadOnlyList<MfmeExtractComponentData> SkippedComponents { get; init; } = [];
+
+    public IReadOnlyList<MfmeImportWarning> Warnings { get; init; } = [];
+
+    public IReadOnlyList<string> Errors { get; init; } = [];
+
+    public bool HasErrors => Errors.Count > 0;
+}
+
+internal sealed class MfmeImportPreparationService
+{
+    private readonly IMfmeExtractReader _extractReader;
+    private readonly MfmeComponentMapper _componentMapper;
+    private readonly MfmeImportAssetCopyService _assetCopyService;
+
+    public MfmeImportPreparationService(
+        IMfmeExtractReader extractReader,
+        MfmeComponentMapper componentMapper,
+        MfmeImportAssetCopyService assetCopyService)
+    {
+        _extractReader = extractReader ?? throw new ArgumentNullException(nameof(extractReader));
+        _componentMapper = componentMapper ?? throw new ArgumentNullException(nameof(componentMapper));
+        _assetCopyService = assetCopyService ?? throw new ArgumentNullException(nameof(assetCopyService));
+    }
+
+    public MfmePreparedImportResult Prepare(MfmeImportContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var readResult = _extractReader.Read(context);
+        var warnings = new List<MfmeImportWarning>(readResult.Warnings);
+        var errors = new List<string>(readResult.Errors);
+        var skipped = new List<MfmeExtractComponentData>(readResult.SkippedComponents);
+        var copiedAssets = new List<string>();
+
+        if (errors.Count > 0 || readResult.ExtractDocument is null)
+        {
+            if (errors.Count == 0)
+            {
+                errors.Add("MFME extract reader did not return a parsed extract document.");
+            }
+
+            return new MfmePreparedImportResult
+            {
+                LayoutName = readResult.ExtractDocument?.LayoutName,
+                Elements = [],
+                CopiedAssets = copiedAssets,
+                SkippedComponents = skipped,
+                Warnings = warnings,
+                Errors = errors
+            };
+        }
+
+        var mapping = _componentMapper.Map(readResult.ImportedElements);
+        warnings.AddRange(mapping.Warnings);
+        skipped.AddRange(mapping.SkippedComponents);
+
+        var elements = mapping.Elements;
+
+        if (context.CopyAssetsToProject && elements.Count > 0)
+        {
+            var copyResult = _assetCopyService.CopyAssets(context, readResult.ExtractDocument.LayoutName, elements);
+            elements = copyResult.Elements;
+            copiedAssets.AddRange(copyResult.CopiedAssets);
+            warnings.AddRange(copyResult.Warnings);
+        }
+
+        return new MfmePreparedImportResult
+        {
+            LayoutName = readResult.ExtractDocument.LayoutName,
+            Elements = elements,
+            CopiedAssets = copiedAssets,
+            SkippedComponents = skipped,
+            Warnings = warnings,
+            Errors = errors
+        };
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a single preparation step that orchestrates MFME extract reading, mapping to `PanelElementModel`, and optional project asset copying for downstream import commands and UI integration. 
- Reduce duplication by reusing the existing `IMfmeExtractReader`, `MfmeComponentMapper`, and `MfmeImportAssetCopyService` and return a consolidated result shape usable by import commands and the output log.

### Description

- Add `MfmeImportPreparationService` that calls `IMfmeExtractReader.Read()`, maps components with `MfmeComponentMapper.Map()`, and optionally copies assets via `MfmeImportAssetCopyService.CopyAssets()` returning a `MfmePreparedImportResult`.
- Add the `MfmePreparedImportResult` record to carry `LayoutName`, prepared `PanelElementModel` instances, copied asset paths, skipped components, warnings, and errors.
- Create integration-style tests in `OasisEditor.Tests/MfmeImportPreparationServiceTests.cs` that cover copy-enabled path rewriting/copy behavior, copy-disabled behavior preserving extract-relative paths, and error propagation for a missing extract path.
- Reuse existing MFME import classes under `OasisEditor/Features/MfmeImport/` without changing reader/mapper/copy implementations.

### Testing

- Added unit/integration tests in `OasisEditor.Tests/MfmeImportPreparationServiceTests.cs` that exercise prepare-with-copy, prepare-without-copy, and missing-extract scenarios; these tests are included in the change. 
- Could not run `dotnet test` in this environment because the .NET SDK is not available (`dotnet: command not found`), so tests were not executed here. 
- No build or runtime verification was performed in-container for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef2b19edd88327870dc0060208492a)