### PR TITLE
docs: finalize Phase K MFME import reconnaissance

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md
+++ b/WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md
@@ -166,3 +166,62 @@ For this feature track:
 
 - `UnityProjects/LayoutEditor` and `WindowsNetProjects/MfmeTools` are **reference sources** for mapping/parsing behavior.
 - Do not modify those projects as part of OasisEditor MFME import milestones unless a future task explicitly requires it.
+
+
+## Phase K Reconnaissance Notes (2026-04-27)
+
+Reference-only sources inspected:
+
+- `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
+- `WindowsNetProjects/MfmeTools/MfmeTools/Shared/Extract/*`
+- `WindowsNetProjects/MfmeTools/MfmeTools/Shared/ExtractComponents/*`
+
+Confirmed Unity importer mapping behavior for currently targeted legacy components:
+
+- `ExtractComponentBackground` -> `ComponentBackground`
+  - Position forced to `(0, 0)`
+  - Size from extract component `Size`
+  - Color from extract component `Color`
+  - Optional image from `background/<BmpImageFilename>` when filename is non-empty
+  - Name set to `Background`
+- `ExtractComponentLamp` -> `ComponentLamp`
+  - Position/size from extract component `Position` + `Size`
+  - Uses only `LampElements[0]` for first-pass number/on-color/image mapping
+  - Lamp image read from `lamps/<LampElements[0].BmpImageFilename>` when present
+  - `OffImageColor`, `TextColor`, text/font fields, and `NoOutline` are mapped
+  - Name set to `Lamp`
+- `ExtractComponentReel` -> `ComponentReel`
+  - Position/size from extract component
+  - Reel number mapped as `Number + 1`
+  - Stops + reversed copied directly
+  - Band image from `reels/<BandBmpImageFilename>`
+  - Visible scale from Unity first-pass formula: `(Height / 50f) / Stops`
+  - Name set to `Reel <number>`
+- `ExtractComponentSevenSegment` -> `Component7Segment`
+  - Position/size from extract component
+  - Number from `Number`
+  - Color from `SegmentOnColor`
+  - Name set to `7 Segment <number>`
+- `ExtractComponentAlpha` and `ExtractComponentAlphaNew` -> `ComponentAlpha`
+  - Position/size from extract component
+  - Reversed from source component
+  - Name set to `Alpha`
+- `ExtractComponentMatrixAlpha` -> `ComponentAlpha` (temporary compatibility path)
+  - Position/size from extract component
+  - Reversed forced to `false`
+  - Name set to `Alpha`
+
+Confirmed extract storage contract details from `MfmeTools.Shared.Extract`:
+
+- Extract root folder name is `.extract`
+- Resource subfolders are `background`, `reels`, `lamps`, `buttons`, `bitmaps`, and `misc`
+- Rom ident filename is `misc/romident.txt`
+- Manifest JSON is written as `.extract/<ASName>.json`
+- JSON serialization uses `TypeNameHandling.Auto`
+
+Deferred/non-goal behaviors to keep out of the first WPF milestone:
+
+- Runtime-only importer behavior for non-target component types (checkbox/button/bandreel/etc.)
+- Temporary reel/bandreel overlay compositing into the imported background image
+- Detailed MFME input routing behavior (button/coin/effect port mapping)
+- MFME-perspective-accurate reel rendering beyond placeholder/native first-pass properties

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -29,23 +29,23 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [ ] Add/update tests where practical under the existing OasisEditor test project
 
 ### Phase K — Legacy Import and Extract Format Reconnaissance
-- [ ] Inspect the Unity importer entry point at `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
-  - [ ] Document how each supported MFME extract component is currently converted into the legacy Unity editor's internal component model
-  - [ ] Document the exact source-to-target mappings currently used for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
-  - [ ] Note Unity importer quirks that should inform the WPF converter initially, such as Reel number `+ 1` and MatrixAlpha importing as Alpha
-  - [ ] Note behavior that should be deferred, such as runtime-only editor components, complex lamp inputs, and temporary reel overlay compositing
-- [ ] Inspect MFME extract DTOs/helpers under `WindowsNetProjects/MfmeTools/MfmeTools/Shared`
-  - [ ] Identify the minimum legacy extract fields needed to build native Oasis Background, Lamp, Reel, SevenSegment, and Alpha components
-  - [ ] Identify how extract image folders and filenames are represented
-  - [ ] Identify the extract manifest/layout file format that the WPF editor should read first
-- [ ] Add `Docs/MfmeImportPlan.md` under `WindowsNetProjects/OasisEditor`
-  - [ ] State clearly that MFME is a legacy import format only
-  - [ ] Summarise the source extract contract for the first milestone
-  - [ ] Summarise conversion rules from legacy MFME extract components to native Oasis components
-  - [ ] Summarise asset-copy conventions
-  - [ ] List deferred behavior explicitly
-  - [ ] Include a short note that legacy projects are reference-only for this track
-- [ ] Build the WPF solution after the reconnaissance/documentation-only changes if project files changed; otherwise no build is required
+- [x] Inspect the Unity importer entry point at `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MFME/ExtractImporter.cs`
+  - [x] Document how each supported MFME extract component is currently converted into the legacy Unity editor's internal component model
+  - [x] Document the exact source-to-target mappings currently used for Background, Lamp, Reel, SevenSegment, Alpha, AlphaNew, and MatrixAlpha
+  - [x] Note Unity importer quirks that should inform the WPF converter initially, such as Reel number `+ 1` and MatrixAlpha importing as Alpha
+  - [x] Note behavior that should be deferred, such as runtime-only editor components, complex lamp inputs, and temporary reel overlay compositing
+- [x] Inspect MFME extract DTOs/helpers under `WindowsNetProjects/MfmeTools/MfmeTools/Shared`
+  - [x] Identify the minimum legacy extract fields needed to build native Oasis Background, Lamp, Reel, SevenSegment, and Alpha components
+  - [x] Identify how extract image folders and filenames are represented
+  - [x] Identify the extract manifest/layout file format that the WPF editor should read first
+- [x] Add `Docs/MfmeImportPlan.md` under `WindowsNetProjects/OasisEditor`
+  - [x] State clearly that MFME is a legacy import format only
+  - [x] Summarise the source extract contract for the first milestone
+  - [x] Summarise conversion rules from legacy MFME extract components to native Oasis components
+  - [x] Summarise asset-copy conventions
+  - [x] List deferred behavior explicitly
+  - [x] Include a short note that legacy projects are reference-only for this track
+- [x] Build the WPF solution after the reconnaissance/documentation-only changes if project files changed; otherwise no build is required *(no project file changes in this phase)*
 
 ### Phase L — Import Domain Boundary
 - [ ] Add a focused legacy import feature folder under the WPF editor project


### PR DESCRIPTION
### Motivation
- Capture findings from inspecting the legacy Unity MFME importer and shared MFME DTOs to drive the WPF OasisEditor MFME-import implementation and explicitly record which behaviors are deferred for the first milestone.

### Description
- Add a dated `Phase K Reconnaissance Notes (2026-04-27)` section to `WindowsNetProjects/OasisEditor/Docs/MfmeImportPlan.md` that documents confirmed component mappings, extract folder/manifest contract, and deferred/non-goal behaviors for the initial WPF importer pass, and mark the Phase K checklist items complete in `WindowsNetProjects/OasisEditor/TASKS.md`.

### Testing
- Documentation-only change; validated by inspecting diffs and the updated files (`Docs/MfmeImportPlan.md` and `TASKS.md`) and no build or runtime tests were required for this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef3240e2208327836984efe8bc9d86)