### PR TITLE
Add initial MFME import boundary and file-system extract reader

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using OasisEditor.Features.MfmeImport;
 
 namespace OasisEditor.Tests;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -1,0 +1,100 @@
+using OasisEditor.Features.MfmeImport;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeExtractReaderTests
+{
+    [Fact]
+    public void Read_WithMissingPath_ReturnsNotFoundError()
+    {
+        var reader = new FileSystemMfmeExtractReader();
+        var context = new MfmeImportContext
+        {
+            SourceExtractPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}"),
+            ProjectRootPath = "C:/Project",
+            ProjectAssetsPath = "C:/Project/Assets",
+            CopyAssets = true
+        };
+
+        var result = reader.Read(context);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Extract);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_WithExtractDirectoryAndSingleManifest_ReturnsExtractData()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "sample-layout.json");
+        File.WriteAllText(manifestPath, "{}");
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = true
+            };
+
+            var result = reader.Read(context);
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            Assert.Empty(result.Warnings);
+            Assert.NotNull(result.Extract);
+            Assert.Equal(extractDirectory, result.Extract.ExtractRootPath);
+            Assert.Equal(manifestPath, result.Extract.ManifestPath);
+            Assert.Equal("sample-layout", result.Extract.LayoutName);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Read_WithExtractDirectoryAndMultipleManifests_AddsWarning()
+    {
+        var extractDirectory = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(extractDirectory, "b-layout.json"), "{}");
+        var firstManifest = Path.Combine(extractDirectory, "a-layout.json");
+        File.WriteAllText(firstManifest, "{}");
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = false
+            };
+
+            var result = reader.Read(context);
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            var warning = Assert.Single(result.Warnings);
+            Assert.Equal("mfme.extract.manifest.multiple", warning.Code);
+            Assert.Equal(firstManifest, result.Extract!.ManifestPath);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"oasis-mfme-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -595,7 +595,7 @@ public sealed class Panel2DRoundTripTests
 
         Assert.True(duplicateExecuted);
         Assert.True(document.IsDirty);
-        Assert.Equal(1, document.CommandService.History.Entries.Count);
+        Assert.Single(document.CommandService.History.Entries);
     }
 
     [Fact]
@@ -622,7 +622,7 @@ public sealed class Panel2DRoundTripTests
         Assert.True(firstExecution);
         Assert.False(secondExecution);
         Assert.True(document.IsDirty);
-        Assert.Equal(1, document.CommandService.History.Entries.Count);
+        Assert.Single(document.CommandService.History.Entries);
         Assert.Equal(2, document.GetPanelElements().Count);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/FileSystemMfmeExtractReader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/FileSystemMfmeExtractReader.cs
@@ -1,0 +1,116 @@
+using System.IO;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class FileSystemMfmeExtractReader : IMfmeExtractReader
+{
+    public MfmeExtractReadResult Read(MfmeImportContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.IsNullOrWhiteSpace(context.SourceExtractPath))
+        {
+            return Error("mfme.extract.path.empty", "Source extract path is required.");
+        }
+
+        var sourcePath = context.SourceExtractPath.Trim();
+
+        if (ContainsInvalidPathChars(sourcePath))
+        {
+            return Error("mfme.extract.path.invalid", $"Source extract path is invalid: '{sourcePath}'.");
+        }
+
+        if (Directory.Exists(sourcePath))
+        {
+            return ReadFromExtractDirectory(sourcePath);
+        }
+
+        if (File.Exists(sourcePath))
+        {
+            return ReadFromManifestFile(sourcePath);
+        }
+
+        return Error("mfme.extract.path.notFound", $"Source extract path was not found: '{sourcePath}'.");
+    }
+
+    private static MfmeExtractReadResult ReadFromExtractDirectory(string extractDirectory)
+    {
+        var manifests = Directory
+            .EnumerateFiles(extractDirectory, "*.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (manifests.Length == 0)
+        {
+            return Error(
+                "mfme.extract.manifest.missing",
+                $"No manifest JSON file was found in extract directory '{extractDirectory}'.");
+        }
+
+        var warnings = new List<MfmeImportWarning>();
+        if (manifests.Length > 1)
+        {
+            warnings.Add(new MfmeImportWarning(
+                "mfme.extract.manifest.multiple",
+                $"Multiple manifest JSON files were found in '{extractDirectory}'. The first file in sorted order will be used.",
+                extractDirectory));
+        }
+
+        return Success(CreateExtractData(extractDirectory, manifests[0]), warnings);
+    }
+
+    private static MfmeExtractReadResult ReadFromManifestFile(string manifestPath)
+    {
+        if (!string.Equals(Path.GetExtension(manifestPath), ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return Error(
+                "mfme.extract.manifest.extension",
+                $"Expected a .json manifest file but got '{manifestPath}'.");
+        }
+
+        var extractDirectory = Path.GetDirectoryName(manifestPath);
+        if (string.IsNullOrWhiteSpace(extractDirectory))
+        {
+            return Error(
+                "mfme.extract.manifest.directory",
+                $"Unable to resolve extract directory for manifest '{manifestPath}'.");
+        }
+
+        return Success(CreateExtractData(extractDirectory, manifestPath), []);
+    }
+
+    private static MfmeLegacyExtractData CreateExtractData(string extractDirectory, string manifestPath)
+    {
+        return new MfmeLegacyExtractData
+        {
+            ExtractRootPath = extractDirectory,
+            ManifestPath = manifestPath,
+            LayoutName = Path.GetFileNameWithoutExtension(manifestPath)
+        };
+    }
+
+    private static bool ContainsInvalidPathChars(string path)
+    {
+        return path.IndexOfAny(Path.GetInvalidPathChars()) >= 0;
+    }
+
+    private static MfmeExtractReadResult Error(string code, string error)
+    {
+        return new MfmeExtractReadResult
+        {
+            Extract = null,
+            Warnings = [],
+            Errors = [new MfmeImportWarning(code, error).Message]
+        };
+    }
+
+    private static MfmeExtractReadResult Success(MfmeLegacyExtractData extract, IReadOnlyList<MfmeImportWarning> warnings)
+    {
+        return new MfmeExtractReadResult
+        {
+            Extract = extract,
+            Warnings = warnings,
+            Errors = []
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/IMfmeExtractReader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/IMfmeExtractReader.cs
@@ -1,0 +1,6 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal interface IMfmeExtractReader
+{
+    MfmeExtractReadResult Read(MfmeImportContext context);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractReadResult.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractReadResult.cs
@@ -1,0 +1,12 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class MfmeExtractReadResult
+{
+    public MfmeLegacyExtractData? Extract { get; init; }
+
+    public required IReadOnlyList<MfmeImportWarning> Warnings { get; init; }
+
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    public bool Succeeded => Errors.Count == 0;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportContext.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportContext.cs
@@ -1,0 +1,14 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class MfmeImportContext
+{
+    public required string SourceExtractPath { get; init; }
+
+    public required string ProjectRootPath { get; init; }
+
+    public required string ProjectAssetsPath { get; init; }
+
+    public bool CopyAssets { get; init; } = true;
+
+    public string? LayoutDisplayName { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportResult.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportResult.cs
@@ -1,0 +1,16 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class MfmeImportResult
+{
+    public required IReadOnlyList<PanelElementModel> ImportedElements { get; init; }
+
+    public required IReadOnlyList<string> CopiedAssetRelativePaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedLegacyComponentTypes { get; init; }
+
+    public required IReadOnlyList<MfmeImportWarning> Warnings { get; init; }
+
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    public bool Succeeded => Errors.Count == 0;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportWarning.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportWarning.cs
@@ -1,0 +1,3 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed record MfmeImportWarning(string Code, string Message, string? Context = null);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractData.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractData.cs
@@ -1,0 +1,10 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class MfmeLegacyExtractData
+{
+    public required string ExtractRootPath { get; init; }
+
+    public required string ManifestPath { get; init; }
+
+    public required string LayoutName { get; init; }
+}


### PR DESCRIPTION
### Motivation
- Establish a clean, UI-agnostic import boundary for legacy MFME extracts as Phase L groundwork so MFME remains an import-only source format.
- Provide a simple, deterministic extract-reader implementation to validate/resolve extract paths and choose a manifest file before adding conversion logic.

### Description
- Added a new feature folder `OasisEditor/Features/MfmeImport` with lightweight import contracts: `MfmeImportContext`, `MfmeImportResult`, `MfmeImportWarning`, `MfmeLegacyExtractData`, `MfmeExtractReadResult`, and `IMfmeExtractReader`.
- Implemented `FileSystemMfmeExtractReader` which validates `SourceExtractPath`, accepts either an extract directory or a direct manifest `.json` file, emits explicit errors for missing/invalid paths, and emits a deterministic warning when multiple manifests are present (picks the first sorted file).
- Added unit tests in `OasisEditor.Tests/MfmeExtractReaderTests.cs` that cover missing path error, single-manifest directory success, and multi-manifest deterministic selection with a warning.
- Kept implementation UI-free and internal to the editor project so later conversion/mapping logic can consume the reader result.

### Testing
- Added automated tests: `MfmeExtractReaderTests` with three cases: missing path returns error, directory with single manifest returns extract data, and directory with multiple manifests yields a warning and deterministic manifest selection.
- Attempted to run `dotnet test` in the environment, but execution failed because `dotnet` was not available (`/bin/bash: dotnet: command not found`), so tests were not executed here.
- Tests are present and should pass when run in a development environment with the .NET SDK; no compile/run-time verification was performed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef332b2f9883278a30bf3b1df907f2)