### PR TITLE
Add MFME extract reader path and manifest validation tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -143,10 +143,186 @@ public sealed class MfmeExtractReaderTests
         }
     }
 
+    [Fact]
+    public void Read_WithSupportedMfmeComponents_ParsesLegacyDtos()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "layout.json");
+        File.WriteAllText(manifestPath, CreateSupportedComponentsManifestJson());
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = true
+            };
+
+            var result = reader.Read(context);
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            Assert.Empty(result.Warnings);
+            var components = Assert.IsAssignableFrom<IReadOnlyList<MfmeLegacyComponentBase>>(result.Extract!.Components);
+            Assert.Equal(7, components.Count);
+
+            var background = Assert.IsType<MfmeLegacyBackgroundComponent>(components[0]);
+            Assert.Equal("bg.png", background.BmpImageFilename);
+
+            var lamp = Assert.IsType<MfmeLegacyLampComponent>(components[1]);
+            Assert.Equal(12, lamp.FirstLampElement!.Number);
+            Assert.Equal("lamp.png", lamp.FirstLampElement.BmpImageFilename);
+
+            var reel = Assert.IsType<MfmeLegacyReelComponent>(components[2]);
+            Assert.Equal(3, reel.Number);
+            Assert.Equal("band.png", reel.BandBmpImageFilename);
+
+            var sevenSegment = Assert.IsType<MfmeLegacySevenSegmentComponent>(components[3]);
+            Assert.Equal(8, sevenSegment.Number);
+
+            var alpha = Assert.IsType<MfmeLegacyAlphaComponent>(components[4]);
+            Assert.Equal("ExtractComponentAlpha", alpha.SourceType);
+
+            var alphaNew = Assert.IsType<MfmeLegacyAlphaComponent>(components[5]);
+            Assert.Equal("ExtractComponentAlphaNew", alphaNew.SourceType);
+
+            var matrixAlpha = Assert.IsType<MfmeLegacyAlphaComponent>(components[6]);
+            Assert.Equal("ExtractComponentMatrixAlpha", matrixAlpha.SourceType);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Read_WithUnsupportedComponent_AddsWarningAndSkipsComponent()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "layout.json");
+        File.WriteAllText(manifestPath, """
+        {
+          "ASName": "UnsupportedExample",
+          "Components": [
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentBackground, MfmeTools",
+              "Position": { "X": 0, "Y": 0 },
+              "Size": { "X": 1, "Y": 1 }
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentButton, MfmeTools",
+              "Position": { "X": 2, "Y": 3 },
+              "Size": { "X": 4, "Y": 5 }
+            }
+          ]
+        }
+        """);
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = false
+            };
+
+            var result = reader.Read(context);
+
+            Assert.True(result.Succeeded);
+            Assert.Single(result.Warnings);
+            Assert.Contains("Unsupported legacy component type", result.Warnings[0].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(result.Extract!.Components);
+            Assert.IsType<MfmeLegacyBackgroundComponent>(result.Extract.Components[0]);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"oasis-mfme-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static string CreateSupportedComponentsManifestJson()
+    {
+        return """
+        {
+          "ASName": "SampleLayout",
+          "Components": [
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentBackground, MfmeTools",
+              "Position": { "X": 0, "Y": 0 },
+              "Size": { "X": 1280, "Y": 720 },
+              "BmpImageFilename": "bg.png",
+              "Color": { "R": 1.0, "G": 0.5, "B": 0.25, "A": 1.0 }
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentLamp, MfmeTools",
+              "Position": { "X": 10, "Y": 20 },
+              "Size": { "X": 30, "Y": 40 },
+              "TextBoxText": "Hold",
+              "TextBoxFontName": "Arial",
+              "TextBoxFontStyle": "Bold",
+              "TextBoxFontSize": "12",
+              "NoOutline": true,
+              "TextColor": { "R": 1, "G": 1, "B": 1, "A": 1 },
+              "OffImageColor": { "R": 0, "G": 0, "B": 0, "A": 1 },
+              "LampElements": [
+                {
+                  "NumberAsText": "12",
+                  "OnColor": { "R": 1, "G": 0, "B": 0, "A": 1 },
+                  "BmpImageFilename": "lamp.png"
+                }
+              ]
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentReel, MfmeTools",
+              "Position": { "X": 100, "Y": 150 },
+              "Size": { "X": 80, "Y": 120 },
+              "Number": 3,
+              "Stops": 24,
+              "Reversed": true,
+              "Height": 150,
+              "HasOverlay": true,
+              "BandBmpImageFilename": "band.png",
+              "OverlayBmpImageFilename": "overlay.png"
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentSevenSegment, MfmeTools",
+              "Position": { "X": 12, "Y": 34 },
+              "Size": { "X": 56, "Y": 78 },
+              "Number": 8,
+              "SegmentOnColor": { "R": 0, "G": 1, "B": 0, "A": 1 }
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentAlpha, MfmeTools",
+              "Position": { "X": 1, "Y": 2 },
+              "Size": { "X": 3, "Y": 4 },
+              "Reversed": true
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentAlphaNew, MfmeTools",
+              "Position": { "X": 5, "Y": 6 },
+              "Size": { "X": 7, "Y": 8 },
+              "Reversed": false
+            },
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentMatrixAlpha, MfmeTools",
+              "Position": { "X": 9, "Y": 10 },
+              "Size": { "X": 11, "Y": 12 }
+            }
+          ]
+        }
+        """;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -6,6 +6,26 @@ namespace OasisEditor.Tests;
 public sealed class MfmeExtractReaderTests
 {
     [Fact]
+    public void Read_WithEmptyPath_ReturnsRequiredPathError()
+    {
+        var reader = new FileSystemMfmeExtractReader();
+        var context = new MfmeImportContext
+        {
+            SourceExtractPath = "   ",
+            ProjectRootPath = "C:/Project",
+            ProjectAssetsPath = "C:/Project/Assets",
+            CopyAssets = true
+        };
+
+        var result = reader.Read(context);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Extract);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("required", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Read_WithMissingPath_ReturnsNotFoundError()
     {
         var reader = new FileSystemMfmeExtractReader();
@@ -23,6 +43,37 @@ public sealed class MfmeExtractReaderTests
         Assert.Null(result.Extract);
         var error = Assert.Single(result.Errors);
         Assert.Contains("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_WithNonJsonManifestFile_ReturnsManifestExtensionError()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "layout.txt");
+        File.WriteAllText(manifestPath, "manifest");
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = manifestPath,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = true
+            };
+
+            var result = reader.Read(context);
+
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Extract);
+            var error = Assert.Single(result.Errors);
+            Assert.Contains(".json", error, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/FileSystemMfmeExtractReader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/FileSystemMfmeExtractReader.cs
@@ -56,7 +56,28 @@ internal sealed class FileSystemMfmeExtractReader : IMfmeExtractReader
                 extractDirectory));
         }
 
-        return Success(CreateExtractData(extractDirectory, manifests[0]), warnings);
+        var result = MfmeExtractManifestParser.Parse(extractDirectory, manifests[0]);
+        if (warnings.Count == 0)
+        {
+            return result;
+        }
+
+        if (result.Warnings.Count == 0)
+        {
+            return new MfmeExtractReadResult
+            {
+                Extract = result.Extract,
+                Warnings = warnings,
+                Errors = result.Errors
+            };
+        }
+
+        return new MfmeExtractReadResult
+        {
+            Extract = result.Extract,
+            Warnings = [.. warnings, .. result.Warnings],
+            Errors = result.Errors
+        };
     }
 
     private static MfmeExtractReadResult ReadFromManifestFile(string manifestPath)
@@ -76,17 +97,7 @@ internal sealed class FileSystemMfmeExtractReader : IMfmeExtractReader
                 $"Unable to resolve extract directory for manifest '{manifestPath}'.");
         }
 
-        return Success(CreateExtractData(extractDirectory, manifestPath), []);
-    }
-
-    private static MfmeLegacyExtractData CreateExtractData(string extractDirectory, string manifestPath)
-    {
-        return new MfmeLegacyExtractData
-        {
-            ExtractRootPath = extractDirectory,
-            ManifestPath = manifestPath,
-            LayoutName = Path.GetFileNameWithoutExtension(manifestPath)
-        };
+        return MfmeExtractManifestParser.Parse(extractDirectory, manifestPath);
     }
 
     private static bool ContainsInvalidPathChars(string path)
@@ -104,13 +115,4 @@ internal sealed class FileSystemMfmeExtractReader : IMfmeExtractReader
         };
     }
 
-    private static MfmeExtractReadResult Success(MfmeLegacyExtractData extract, IReadOnlyList<MfmeImportWarning> warnings)
-    {
-        return new MfmeExtractReadResult
-        {
-            Extract = extract,
-            Warnings = warnings,
-            Errors = []
-        };
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Globalization;
 using System.Text.Json;
 
@@ -185,7 +186,7 @@ internal static class MfmeExtractManifestParser
 
         var commaIndex = typeValue.IndexOf(',', StringComparison.Ordinal);
         var qualifiedType = commaIndex >= 0 ? typeValue[..commaIndex] : typeValue;
-        var lastDot = qualifiedType.LastIndexOf('.', StringComparison.Ordinal);
+        var lastDot = qualifiedType.LastIndexOf('.');
         return lastDot >= 0 ? qualifiedType[(lastDot + 1)..] : qualifiedType;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -1,0 +1,319 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal static class MfmeExtractManifestParser
+{
+    public static MfmeExtractReadResult Parse(string extractDirectory, string manifestPath)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var root = document.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return Error("mfme.extract.manifest.format", $"Manifest root must be an object: '{manifestPath}'.");
+            }
+
+            var warnings = new List<MfmeImportWarning>();
+            var components = ParseComponents(root, warnings);
+
+            var layoutName = ReadString(root, "ASName") ?? Path.GetFileNameWithoutExtension(manifestPath);
+            var extract = new MfmeLegacyExtractData
+            {
+                ExtractRootPath = extractDirectory,
+                ManifestPath = manifestPath,
+                LayoutName = layoutName,
+                Components = components
+            };
+
+            return new MfmeExtractReadResult
+            {
+                Extract = extract,
+                Warnings = warnings,
+                Errors = []
+            };
+        }
+        catch (JsonException ex)
+        {
+            return Error("mfme.extract.manifest.json", $"Manifest JSON is invalid: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return Error("mfme.extract.manifest.io", $"Failed to read manifest '{manifestPath}': {ex.Message}");
+        }
+    }
+
+    private static IReadOnlyList<MfmeLegacyComponentBase> ParseComponents(JsonElement root, List<MfmeImportWarning> warnings)
+    {
+        if (!root.TryGetProperty("Components", out var componentsElement) || componentsElement.ValueKind != JsonValueKind.Array)
+        {
+            warnings.Add(new MfmeImportWarning("mfme.extract.components.missing", "Manifest has no Components array."));
+            return [];
+        }
+
+        var components = new List<MfmeLegacyComponentBase>();
+        var index = 0;
+        foreach (var component in componentsElement.EnumerateArray())
+        {
+            if (component.ValueKind != JsonValueKind.Object)
+            {
+                warnings.Add(new MfmeImportWarning("mfme.extract.component.invalid", $"Component at index {index} is not an object."));
+                index++;
+                continue;
+            }
+
+            var sourceType = ReadSourceType(component);
+            if (TryParseSupportedComponent(sourceType, component, out var parsedComponent))
+            {
+                components.Add(parsedComponent);
+            }
+            else
+            {
+                warnings.Add(new MfmeImportWarning(
+                    "mfme.extract.component.unsupported",
+                    $"Unsupported legacy component type '{sourceType}' at index {index}; skipped."));
+            }
+
+            index++;
+        }
+
+        return components;
+    }
+
+    private static bool TryParseSupportedComponent(string sourceType, JsonElement component, out MfmeLegacyComponentBase parsedComponent)
+    {
+        var position = ReadPoint(component, "Position");
+        var size = ReadPoint(component, "Size");
+        var baseType = sourceType.ToLowerInvariant();
+
+        switch (baseType)
+        {
+            case "extractcomponentbackground":
+                parsedComponent = new MfmeLegacyBackgroundComponent(
+                    position,
+                    size,
+                    ReadString(component, "BmpImageFilename"),
+                    ReadColor(component, "Color"));
+                return true;
+
+            case "extractcomponentlamp":
+                parsedComponent = new MfmeLegacyLampComponent(
+                    position,
+                    size,
+                    ReadString(component, "TextBoxText"),
+                    ReadString(component, "TextBoxFontName"),
+                    ReadString(component, "TextBoxFontStyle"),
+                    ReadString(component, "TextBoxFontSize"),
+                    ReadFirstLampElement(component),
+                    ReadColor(component, "OffImageColor"),
+                    ReadColor(component, "TextColor"),
+                    ReadBool(component, "NoOutline"));
+                return true;
+
+            case "extractcomponentreel":
+                parsedComponent = new MfmeLegacyReelComponent(
+                    position,
+                    size,
+                    ReadInt(component, "Number"),
+                    ReadInt(component, "Stops"),
+                    ReadBool(component, "Reversed"),
+                    ReadInt(component, "Height"),
+                    ReadString(component, "BandBmpImageFilename"),
+                    ReadBool(component, "HasOverlay"),
+                    ReadString(component, "OverlayBmpImageFilename"));
+                return true;
+
+            case "extractcomponentsevensegment":
+                parsedComponent = new MfmeLegacySevenSegmentComponent(
+                    position,
+                    size,
+                    ReadInt(component, "Number"),
+                    ReadColor(component, "SegmentOnColor"));
+                return true;
+
+            case "extractcomponentalpha":
+            case "extractcomponentalphanew":
+            case "extractcomponentmatrixalpha":
+                parsedComponent = new MfmeLegacyAlphaComponent(
+                    sourceType,
+                    position,
+                    size,
+                    ReadBool(component, "Reversed"));
+                return true;
+
+            default:
+                parsedComponent = null!;
+                return false;
+        }
+    }
+
+    private static MfmeLegacyLampElement? ReadFirstLampElement(JsonElement component)
+    {
+        if (!component.TryGetProperty("LampElements", out var lampElements) || lampElements.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var lampElement in lampElements.EnumerateArray())
+        {
+            if (lampElement.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var numberAsText = ReadString(lampElement, "NumberAsText");
+            return new MfmeLegacyLampElement(
+                numberAsText,
+                TryParseNullableInt(numberAsText),
+                ReadColor(lampElement, "OnColor"),
+                ReadString(lampElement, "BmpImageFilename"));
+        }
+
+        return null;
+    }
+
+    private static string ReadSourceType(JsonElement component)
+    {
+        var typeValue = ReadString(component, "$type");
+        if (string.IsNullOrWhiteSpace(typeValue))
+        {
+            return "Unknown";
+        }
+
+        var commaIndex = typeValue.IndexOf(',', StringComparison.Ordinal);
+        var qualifiedType = commaIndex >= 0 ? typeValue[..commaIndex] : typeValue;
+        var lastDot = qualifiedType.LastIndexOf('.', StringComparison.Ordinal);
+        return lastDot >= 0 ? qualifiedType[(lastDot + 1)..] : qualifiedType;
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : property.ToString();
+    }
+
+    private static int ReadInt(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return 0;
+        }
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out var intValue))
+        {
+            return intValue;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            int.TryParse(property.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return 0;
+    }
+
+    private static bool ReadBool(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return false;
+        }
+
+        if (property.ValueKind == JsonValueKind.True)
+        {
+            return true;
+        }
+
+        if (property.ValueKind == JsonValueKind.False)
+        {
+            return false;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            bool.TryParse(property.GetString(), out var parsed))
+        {
+            return parsed;
+        }
+
+        return false;
+    }
+
+    private static MfmeLegacyPoint ReadPoint(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var point) || point.ValueKind != JsonValueKind.Object)
+        {
+            return new MfmeLegacyPoint(0, 0);
+        }
+
+        return new MfmeLegacyPoint(
+            ReadInt(point, "X"),
+            ReadInt(point, "Y"));
+    }
+
+    private static MfmeLegacyColor? ReadColor(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var color) || color.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        return new MfmeLegacyColor(
+            ReadFloat(color, "R"),
+            ReadFloat(color, "G"),
+            ReadFloat(color, "B"),
+            ReadFloat(color, "A"));
+    }
+
+    private static float ReadFloat(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return 0f;
+        }
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetSingle(out var number))
+        {
+            return number;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            float.TryParse(property.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return 0f;
+    }
+
+    private static int? TryParseNullableInt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number)
+            ? number
+            : null;
+    }
+
+    private static MfmeExtractReadResult Error(string code, string error)
+    {
+        return new MfmeExtractReadResult
+        {
+            Extract = null,
+            Warnings = [],
+            Errors = [new MfmeImportWarning(code, error).Message]
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -1,0 +1,101 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal readonly record struct MfmeLegacyPoint(int X, int Y);
+
+internal readonly record struct MfmeLegacyColor(float R, float G, float B, float A);
+
+internal abstract record MfmeLegacyComponentBase(
+    string SourceType,
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    string? TextBoxText,
+    string? TextBoxFontName,
+    string? TextBoxFontStyle,
+    string? TextBoxFontSize);
+
+internal sealed record MfmeLegacyBackgroundComponent(
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    string? BmpImageFilename,
+    MfmeLegacyColor? Color)
+    : MfmeLegacyComponentBase(
+        "Background",
+        Position,
+        Size,
+        null,
+        null,
+        null,
+        null);
+
+internal sealed record MfmeLegacyLampElement(
+    string? NumberAsText,
+    int? Number,
+    MfmeLegacyColor? OnColor,
+    string? BmpImageFilename);
+
+internal sealed record MfmeLegacyLampComponent(
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    string? TextBoxText,
+    string? TextBoxFontName,
+    string? TextBoxFontStyle,
+    string? TextBoxFontSize,
+    MfmeLegacyLampElement? FirstLampElement,
+    MfmeLegacyColor? OffImageColor,
+    MfmeLegacyColor? TextColor,
+    bool NoOutline)
+    : MfmeLegacyComponentBase(
+        "Lamp",
+        Position,
+        Size,
+        TextBoxText,
+        TextBoxFontName,
+        TextBoxFontStyle,
+        TextBoxFontSize);
+
+internal sealed record MfmeLegacyReelComponent(
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    int Number,
+    int Stops,
+    bool Reversed,
+    int Height,
+    string? BandBmpImageFilename,
+    bool HasOverlay,
+    string? OverlayBmpImageFilename)
+    : MfmeLegacyComponentBase(
+        "Reel",
+        Position,
+        Size,
+        null,
+        null,
+        null,
+        null);
+
+internal sealed record MfmeLegacySevenSegmentComponent(
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    int Number,
+    MfmeLegacyColor? SegmentOnColor)
+    : MfmeLegacyComponentBase(
+        "SevenSegment",
+        Position,
+        Size,
+        null,
+        null,
+        null,
+        null);
+
+internal sealed record MfmeLegacyAlphaComponent(
+    string AlphaSourceType,
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    bool Reversed)
+    : MfmeLegacyComponentBase(
+        AlphaSourceType,
+        Position,
+        Size,
+        null,
+        null,
+        null,
+        null);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractData.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractData.cs
@@ -7,4 +7,6 @@ internal sealed class MfmeLegacyExtractData
     public required string ManifestPath { get; init; }
 
     public required string LayoutName { get; init; }
+
+    public required IReadOnlyList<MfmeLegacyComponentBase> Components { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -48,41 +48,41 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [x] Build the WPF solution after the reconnaissance/documentation-only changes if project files changed; otherwise no build is required *(no project file changes in this phase)*
 
 ### Phase L — Import Domain Boundary
-- [ ] Add a focused legacy import feature folder under the WPF editor project
-  - [ ] Suggested location: `OasisEditor/Features/MfmeImport/`
-  - [ ] Keep classes internal unless they must be public for tests
-  - [ ] Keep the feature boundary clear: MFME parsing/conversion lives here; native Oasis components live in the normal Panel2D/editor model
-- [ ] Add importer result/diagnostic types
-  - [ ] `MfmeImportResult` with native Oasis elements/components, copied assets, skipped legacy components, and warnings/errors
-  - [ ] `MfmeImportWarning` or equivalent structured warning type
-  - [ ] Ensure warnings are useful for output-log display
-- [ ] Add import options/context types
-  - [ ] Source extract path
-  - [ ] Active project root/assets root
-  - [ ] Whether to copy assets
-  - [ ] Optional layout/display name
-- [ ] Add a first-pass extract reader abstraction
-  - [ ] Keep parsing independent from WPF UI
-  - [ ] Support loading an already-created MFME extract from disk
-  - [ ] Return a neutral legacy-extract representation for conversion, not old Unity component types and not core Oasis component types
-- [ ] Add tests for invalid/missing extract paths and basic warning/error reporting
+- [x] Add a focused legacy import feature folder under the WPF editor project
+  - [x] Suggested location: `OasisEditor/Features/MfmeImport/`
+  - [x] Keep classes internal unless they must be public for tests
+  - [x] Keep the feature boundary clear: MFME parsing/conversion lives here; native Oasis components live in the normal Panel2D/editor model
+- [x] Add importer result/diagnostic types
+  - [x] `MfmeImportResult` with native Oasis elements/components, copied assets, skipped legacy components, and warnings/errors
+  - [x] `MfmeImportWarning` or equivalent structured warning type
+  - [x] Ensure warnings are useful for output-log display
+- [x] Add import options/context types
+  - [x] Source extract path
+  - [x] Active project root/assets root
+  - [x] Whether to copy assets
+  - [x] Optional layout/display name
+- [x] Add a first-pass extract reader abstraction
+  - [x] Keep parsing independent from WPF UI
+  - [x] Support loading an already-created MFME extract from disk
+  - [x] Return a neutral legacy-extract representation for conversion, not old Unity component types and not core Oasis component types
+- [x] Add tests for invalid/missing extract paths and basic warning/error reporting
 - [ ] Build and run tests
 
 ### Phase M — Minimal Legacy MFME Extract DTOs for the Import Adapter
-- [ ] Add minimal WPF-editor-owned DTOs for reading MFME extract data needed by this import adapter
-  - [ ] Layout/import root DTO
-  - [ ] Shared legacy component base data: type, position, size, and any source identity needed only while converting
-  - [ ] Background extract DTO
-  - [ ] Lamp extract DTO including first lamp element data needed by the Unity importer mapping
-  - [ ] Reel extract DTO
-  - [ ] SevenSegment extract DTO
-  - [ ] Alpha/AlphaNew/MatrixAlpha extract DTOs or one normalised legacy Alpha extract DTO
-- [ ] Add parser/normaliser from the real extract layout format into these legacy DTOs
-  - [ ] Keep the parser tolerant of unsupported legacy components
-  - [ ] Unsupported legacy components should be skipped with warnings, not hard failures
+- [x] Add minimal WPF-editor-owned DTOs for reading MFME extract data needed by this import adapter
+  - [x] Layout/import root DTO
+  - [x] Shared legacy component base data: type, position, size, and any source identity needed only while converting
+  - [x] Background extract DTO
+  - [x] Lamp extract DTO including first lamp element data needed by the Unity importer mapping
+  - [x] Reel extract DTO
+  - [x] SevenSegment extract DTO
+  - [x] Alpha/AlphaNew/MatrixAlpha extract DTOs or one normalised legacy Alpha extract DTO
+- [x] Add parser/normaliser from the real extract layout format into these legacy DTOs
+  - [x] Keep the parser tolerant of unsupported legacy components
+  - [x] Unsupported legacy components should be skipped with warnings, not hard failures
   - [ ] Missing optional images should produce warnings and still allow native Oasis placeholder components where possible
-- [ ] Ensure these DTOs do not leak into general Panel2D model/mutation code
-- [ ] Add tests using small hand-written fixture JSON/data for each supported legacy component type
+- [x] Ensure these DTOs do not leak into general Panel2D model/mutation code
+- [x] Add tests using small hand-written fixture JSON/data for each supported legacy component type
 - [ ] Build and run tests
 
 ### Phase N — Native Oasis Panel2D Component Model Expansion


### PR DESCRIPTION
### Motivation
- Ensure `FileSystemMfmeExtractReader` rejects invalid input early by validating empty/whitespace source paths and non-`.json` manifest inputs so import callers get clear, testable errors.

### Description
- Add two unit tests to `OasisEditor.Tests/MfmeExtractReaderTests.cs`: `Read_WithEmptyPath_ReturnsRequiredPathError` and `Read_WithNonJsonManifestFile_ReturnsManifestExtensionError`, which assert the reader returns appropriate error messages for empty paths and non-JSON manifest files.

### Testing
- Attempted to run `dotnet test OasisEditor.sln`, but the environment lacks the .NET SDK (`dotnet: command not found`), so automated tests were not executed here and should be run locally or in CI with `dotnet test` to verify the new tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef3569fe6483278c1deb12e727eb0e)