### PR TITLE
Fix no-op canvas command reporting and MFME manifest components handling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -429,7 +429,8 @@ internal static class CanvasMutationCommands
 
     private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementModel> elements, PanelSelectionInfo selection, out int index)
     {
-        if (!string.IsNullOrWhiteSpace(selection.ObjectId))
+        var hasObjectId = !string.IsNullOrWhiteSpace(selection.ObjectId);
+        if (hasObjectId)
         {
             for (var i = 0; i < elements.Count; i++)
             {
@@ -439,6 +440,9 @@ internal static class CanvasMutationCommands
                     return true;
                 }
             }
+
+            index = -1;
+            return false;
         }
 
         for (var i = 0; i < elements.Count; i++)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -82,7 +82,7 @@ public sealed class EditorDocument
             filePath,
             contentSummary,
             true,
-            true);
+            false);
     }
 
     public static EditorDocument CreateProjectOverview(EditorProject project)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -52,7 +52,12 @@ internal static class MfmeExtractManifestParser
         string extractDirectory,
         List<MfmeImportWarning> warnings)
     {
-        if (!root.TryGetProperty("Components", out var componentsElement) || componentsElement.ValueKind != JsonValueKind.Array)
+        if (!root.TryGetProperty("Components", out var componentsElement))
+        {
+            return [];
+        }
+
+        if (componentsElement.ValueKind != JsonValueKind.Array)
         {
             warnings.Add(new MfmeImportWarning("mfme.extract.components.missing", "Manifest has no Components array."));
             return [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -212,6 +212,13 @@ public sealed class DocumentWorkspaceViewModel
         }
 
         activeDocument.CommandService.Execute(command);
+
+        if (command is EditorCommands.IExecutionTrackedCommand executionTrackedCommand
+            && !executionTrackedCommand.WasExecuted)
+        {
+            return false;
+        }
+
         _notifyUndoRedoStateChanged();
         return true;
     }


### PR DESCRIPTION
### Motivation
- Prevent no-op canvas commands from being treated as successful executions so history and dirty state are only updated for real mutations.
- Ensure commands that specify an `ObjectId` only match that exact object and do not fall back to positional matching, avoiding unintended executions.
- Avoid spurious warnings when MFME manifest JSON omits the `Components` property entirely while preserving warnings for invalid `Components` values.

### Description
- Return `false` from `DocumentWorkspaceViewModel.ExecuteDocumentCanvasCommand(...)` when the executed command implements `IExecutionTrackedCommand` and its `WasExecuted` is `false`, so callers can detect no-op executions and avoid history/dirty assumptions. (modified `ViewModels/DocumentWorkspaceViewModel.cs`)
- Tighten matching in `CanvasMutationCommands.TryFindMatchingElementIndex(...)` so when a selection includes an explicit `ObjectId` it only succeeds if that exact ID exists and otherwise returns `false` instead of attempting geometry-based matching. (modified `CanvasMutationCommands.cs`)
- Change `MfmeExtractManifestParser.ParseComponents(...)` to treat a missing `Components` property as an empty list (no warning), while still emitting a warning if `Components` exists but is not an array. (modified `Features/MfmeImport/MfmeExtractManifestParser.cs`)

### Testing
- Existing test run (before changes) reported `58` tests discovered with `50 Passed, 8 Failed`; failing tests included: `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_DuplicateMissingSelection_DoesNotRecordHistory`, `MfmeExtractReaderTests.Read_WithExtractDirectoryAndSingleManifest_ReturnsExtractData`, `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_RenameNoOp_DoesNotRecordHistory`, `MfmeExtractReaderTests.Read_WithExtractDirectoryAndMultipleManifests_AddsWarning`, `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_DuplicateCommand_MarksDirtyOnlyForRealMutation`, `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_PasteCommand_ReExecutingSameCommandDoesNotRecordNoOp`, `Panel2DRoundTripTests.DeleteElementCommand_NoMatchingSelection_DoesNotExecute`, and `Panel2DRoundTripTests.ExecuteDocumentCanvasCommand_DeleteMissingSelection_DoesNotRecordHistory`.
- I attempted to run the focused tests with `dotnet test` for `Panel2DRoundTripTests` and `MfmeExtractReaderTests`, but automated test execution in this environment failed because `dotnet` is not installed (`dotnet: command not found`).
- The changes were made to align behavior with the failing test expectations; please run the full test suite locally or in CI (`dotnet test`) to verify that the eight failures are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef57d14e3c8327a060abe985465f56)