### PR TITLE
Add native Panel2D placeholder visual support in PanelElementFactory

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PanelElementFactoryTests
+{
+    [Theory]
+    [InlineData(PanelElementKind.Background)]
+    [InlineData(PanelElementKind.Lamp)]
+    [InlineData(PanelElementKind.Reel)]
+    [InlineData(PanelElementKind.SevenSegment)]
+    [InlineData(PanelElementKind.Alpha)]
+    public void CreateVisualFromElement_ForNativeKinds_PreservesElementKindForRoundTrip(PanelElementKind kind)
+    {
+        var source = new PanelElementFile
+        {
+            ObjectId = "obj-1",
+            Name = "Element",
+            Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
+            X = 10,
+            Y = 20,
+            Width = 100,
+            Height = 40
+        };
+
+        var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+        Assert.NotNull(visual);
+        Assert.Equal(kind, PanelElementFactory.GetElementKind(visual!));
+
+        var roundTrip = PanelElementFactory.CreateElementFromVisual(visual!);
+        Assert.NotNull(roundTrip);
+        Assert.Equal(kind, roundTrip!.ElementKind);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -12,25 +15,53 @@ public sealed class PanelElementFactoryTests
     [InlineData((int)PanelElementKind.Alpha)]
     public void CreateVisualFromElement_ForNativeKinds_PreservesElementKindForRoundTrip(int kindValue)
     {
-        var kind = (PanelElementKind)kindValue;
-        var source = new PanelElementFile
+        RunInSta(() =>
         {
-            ObjectId = "obj-1",
-            Name = "Element",
-            Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
-            X = 10,
-            Y = 20,
-            Width = 100,
-            Height = 40
-        };
+            var kind = (PanelElementKind)kindValue;
+            var source = new PanelElementFile
+            {
+                ObjectId = "obj-1",
+                Name = "Element",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
+                X = 10,
+                Y = 20,
+                Width = 100,
+                Height = 40
+            };
 
-        var visual = PanelElementFactory.CreateVisualFromElement(source);
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
 
-        Assert.NotNull(visual);
-        Assert.Equal(kind, PanelElementFactory.GetElementKind(visual!));
+            Assert.NotNull(visual);
+            Assert.Equal(kind, PanelElementFactory.GetElementKind(visual!));
 
-        var roundTrip = PanelElementFactory.CreateElementFromVisual(visual!);
-        Assert.NotNull(roundTrip);
-        Assert.Equal(kind, roundTrip!.ElementKind);
+            var roundTrip = PanelElementFactory.CreateElementFromVisual(visual!);
+            Assert.NotNull(roundTrip);
+            Assert.Equal(kind, roundTrip!.ElementKind);
+        });
+    }
+
+    private static void RunInSta(Action action)
+    {
+        Exception? captured = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                captured = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (captured is not null)
+        {
+            ExceptionDispatchInfo.Capture(captured).Throw();
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -5,13 +5,14 @@ namespace OasisEditor.Tests;
 public sealed class PanelElementFactoryTests
 {
     [Theory]
-    [InlineData(PanelElementKind.Background)]
-    [InlineData(PanelElementKind.Lamp)]
-    [InlineData(PanelElementKind.Reel)]
-    [InlineData(PanelElementKind.SevenSegment)]
-    [InlineData(PanelElementKind.Alpha)]
-    public void CreateVisualFromElement_ForNativeKinds_PreservesElementKindForRoundTrip(PanelElementKind kind)
+    [InlineData((int)PanelElementKind.Background)]
+    [InlineData((int)PanelElementKind.Lamp)]
+    [InlineData((int)PanelElementKind.Reel)]
+    [InlineData((int)PanelElementKind.SevenSegment)]
+    [InlineData((int)PanelElementKind.Alpha)]
+    public void CreateVisualFromElement_ForNativeKinds_PreservesElementKindForRoundTrip(int kindValue)
     {
+        var kind = (PanelElementKind)kindValue;
         var source = new PanelElementFile
         {
             ObjectId = "obj-1",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -15,6 +15,13 @@ internal static class PanelElementFactory
             typeof(PanelElementFactory),
             new PropertyMetadata(string.Empty));
 
+    public static readonly DependencyProperty ElementKindProperty =
+        DependencyProperty.RegisterAttached(
+            "ElementKind",
+            typeof(PanelElementKind),
+            typeof(PanelElementFactory),
+            new PropertyMetadata(PanelElementKind.Unknown));
+
     public const double NewRectangleWidth = 180;
     public const double NewRectangleHeight = 120;
     public const double NewImageWidth = 220;
@@ -56,40 +63,34 @@ internal static class PanelElementFactory
 
     public static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
     {
-        if (element.ElementKind == PanelElementKind.Rectangle)
+        FrameworkElement? visual = element.ElementKind switch
         {
-            var rectangle = new Rectangle
-            {
-                Uid = element.ObjectId,
-                Width = element.Width <= 0 ? NewRectangleWidth : element.Width,
-                Height = element.Height <= 0 ? NewRectangleHeight : element.Height
-            };
+            PanelElementKind.Rectangle => CreateRectangleVisual(element),
+            PanelElementKind.Image => CreateImageVisual(element),
+            PanelElementKind.Background => CreatePlaceholderComponentVisual(element, "Background"),
+            PanelElementKind.Lamp => CreatePlaceholderComponentVisual(element, "Lamp"),
+            PanelElementKind.Reel => CreatePlaceholderComponentVisual(element, "Reel"),
+            PanelElementKind.SevenSegment => CreatePlaceholderComponentVisual(element, "7 Segment"),
+            PanelElementKind.Alpha => CreatePlaceholderComponentVisual(element, "Alpha"),
+            _ => null
+        };
 
-            SetElementName(rectangle, element.Name);
-            return rectangle;
+        if (visual is null)
+        {
+            return null;
         }
 
-        if (element.ElementKind == PanelElementKind.Image)
-        {
-            var image = new Image
-            {
-                Uid = element.ObjectId,
-                Width = element.Width <= 0 ? NewImageWidth : element.Width,
-                Height = element.Height <= 0 ? NewImageHeight : element.Height,
-                Stretch = Stretch.Fill,
-                Source = CreatePlaceholderImageSource()
-            };
-
-            SetElementName(image, element.Name);
-            return image;
-        }
-
-        return null;
+        SetElementName(visual, element.Name);
+        SetElementKind(visual, element.ElementKind);
+        return visual;
     }
 
     public static PanelElementFile? CreateElementFromVisual(FrameworkElement child)
     {
-        var kind = child switch
+        var attachedKind = GetElementKind(child);
+        var kind = attachedKind != PanelElementKind.Unknown
+            ? attachedKind
+            : child switch
         {
             Rectangle => PanelElementKind.Rectangle,
             Image => PanelElementKind.Image,
@@ -125,6 +126,62 @@ internal static class PanelElementFactory
     public static void SetElementName(DependencyObject dependencyObject, string value)
     {
         dependencyObject.SetValue(ElementNameProperty, value);
+    }
+
+    public static PanelElementKind GetElementKind(DependencyObject dependencyObject)
+    {
+        return (PanelElementKind)dependencyObject.GetValue(ElementKindProperty);
+    }
+
+    public static void SetElementKind(DependencyObject dependencyObject, PanelElementKind value)
+    {
+        dependencyObject.SetValue(ElementKindProperty, value);
+    }
+
+    private static FrameworkElement CreateRectangleVisual(PanelElementFile element)
+    {
+        return new Rectangle
+        {
+            Uid = element.ObjectId,
+            Width = element.Width <= 0 ? NewRectangleWidth : element.Width,
+            Height = element.Height <= 0 ? NewRectangleHeight : element.Height
+        };
+    }
+
+    private static FrameworkElement CreateImageVisual(PanelElementFile element)
+    {
+        return new Image
+        {
+            Uid = element.ObjectId,
+            Width = element.Width <= 0 ? NewImageWidth : element.Width,
+            Height = element.Height <= 0 ? NewImageHeight : element.Height,
+            Stretch = Stretch.Fill,
+            Source = CreatePlaceholderImageSource()
+        };
+    }
+
+    private static FrameworkElement CreatePlaceholderComponentVisual(PanelElementFile element, string label)
+    {
+        var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
+        var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
+        var border = new Border
+        {
+            Uid = element.ObjectId,
+            Width = width,
+            Height = height,
+            BorderThickness = new Thickness(1),
+            BorderBrush = Brushes.SlateGray,
+            Background = Brushes.Transparent,
+            Child = new TextBlock
+            {
+                Text = label,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Foreground = Brushes.LightSteelBlue
+            }
+        };
+
+        return border;
     }
 
     private static ImageSource CreatePlaceholderImageSource()

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -177,9 +177,9 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [ ] Build and run tests
 
 ### Phase Q — Panel2D Visual Projection for Native Imported Components
-- [ ] Update `PanelElementFactory` or introduce focused visual factories for new native Panel2D kinds
-  - [ ] Keep WPF-specific visual creation separate from import/domain conversion
-  - [ ] Preserve existing Rectangle/Image behavior
+- [x] Update `PanelElementFactory` or introduce focused visual factories for new native Panel2D kinds
+  - [x] Keep WPF-specific visual creation separate from import/domain conversion
+  - [x] Preserve existing Rectangle/Image behavior
 - [ ] Add placeholder visual projection for native Background
   - [ ] Use imported image when available
   - [ ] Fall back to a filled rectangle using imported/native color when no image is available


### PR DESCRIPTION
### Motivation
- Provide WPF visual projection for native Panel2D kinds introduced for MFME import (Background, Lamp, Reel, SevenSegment, Alpha) so imported components can be shown in the editor UI as placeholders.
- Preserve element-kind identity across visual projection so native kinds do not collapse into rectangle/image inference when the layout is round-tripped.
- Progress Phase Q work by centralizing WPF-specific visual creation while keeping domain/import logic UI-agnostic.

### Description
- Added an attached `ElementKind` dependency property and `GetElementKind`/`SetElementKind` helpers to `PanelElementFactory` so visuals can carry their `PanelElementKind` metadata.
- Reworked `CreateVisualFromElement` to switch on `element.ElementKind` and produce appropriate visuals, adding `CreateRectangleVisual`, `CreateImageVisual`, and `CreatePlaceholderComponentVisual` helpers for native kinds (placeholder `Border` + `TextBlock`).
- Updated `CreateElementFromVisual` to prefer the attached `ElementKind` when present so the element kind round-trips correctly from visual back to `PanelElementFile`.
- Added `PanelElementFactoryTests` to verify that visuals for native kinds are created and that kind-preserving round-trip (`CreateVisualFromElement` -> `CreateElementFromVisual`) returns the original `PanelElementKind`.
- Checked the corresponding Phase Q checklist item in `TASKS.md` as completed for the factory update.

### Testing
- Added unit tests in `OasisEditor.Tests/PanelElementFactoryTests.cs` to assert visual creation and kind-preserving round-trip for native kinds but did not execute them in this environment.
- Attempted to run tooling but `dotnet` is not available in the execution environment (`dotnet: command not found`), so no automated builds or test runs were performed here.
- Manual code inspection and local repository search were used to verify related changes and test presence; CI or a developer machine should run `dotnet build` and `dotnet test` to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef60fa17b883279cfcdd1d5bbe5df4)