### PR TITLE
Add richer native Panel2D placeholder visuals in factory

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Media;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -37,6 +39,59 @@ public sealed class PanelElementFactoryTests
             var roundTrip = PanelElementFactory.CreateElementFromVisual(visual!);
             Assert.NotNull(roundTrip);
             Assert.Equal(kind, roundTrip!.ElementKind);
+        });
+    }
+
+    [Fact]
+    public void CreateVisualFromElement_LampWithoutImage_UsesLampNumberAndDisplayText()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "lamp-1",
+                Name = "Lamp 9",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Lamp),
+                Width = 90,
+                Height = 40,
+                DisplayNumber = 9,
+                DisplayText = "HOLD",
+                OnColorHex = "#FF00CC00"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            var detail = Assert.IsType<TextBlock>(stack.Children[1]);
+
+            Assert.Equal("Lamp 9", title.Text);
+            Assert.Equal("HOLD", detail.Text);
+            Assert.Equal(Visibility.Visible, detail.Visibility);
+        });
+    }
+
+    [Fact]
+    public void CreateVisualFromElement_BackgroundWithoutImage_UsesConfiguredColor()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "bg-1",
+                Name = "Background",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Background),
+                Width = 320,
+                Height = 180,
+                OffColorHex = "#FF112233"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var brush = Assert.IsType<SolidColorBrush>(border.Background);
+            Assert.Equal(Color.FromArgb(0xFF, 0x11, 0x22, 0x33), brush.Color);
         });
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Xunit;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -3,7 +3,6 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using System.IO;
 
 namespace OasisEditor;
 
@@ -296,7 +295,7 @@ internal static class PanelElementFactory
         }
 
         var candidate = assetPath.Trim();
-        if (!Path.IsPathRooted(candidate))
+        if (!System.IO.Path.IsPathRooted(candidate))
         {
             return false;
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using System.IO;
 
 namespace OasisEditor;
 
@@ -67,11 +68,11 @@ internal static class PanelElementFactory
         {
             PanelElementKind.Rectangle => CreateRectangleVisual(element),
             PanelElementKind.Image => CreateImageVisual(element),
-            PanelElementKind.Background => CreatePlaceholderComponentVisual(element, "Background"),
-            PanelElementKind.Lamp => CreatePlaceholderComponentVisual(element, "Lamp"),
-            PanelElementKind.Reel => CreatePlaceholderComponentVisual(element, "Reel"),
-            PanelElementKind.SevenSegment => CreatePlaceholderComponentVisual(element, "7 Segment"),
-            PanelElementKind.Alpha => CreatePlaceholderComponentVisual(element, "Alpha"),
+            PanelElementKind.Background => CreateBackgroundVisual(element),
+            PanelElementKind.Lamp => CreateLampVisual(element),
+            PanelElementKind.Reel => CreateReelVisual(element),
+            PanelElementKind.SevenSegment => CreateSevenSegmentVisual(element),
+            PanelElementKind.Alpha => CreateAlphaVisual(element),
             _ => null
         };
 
@@ -160,7 +161,73 @@ internal static class PanelElementFactory
         };
     }
 
+    private static FrameworkElement CreateBackgroundVisual(PanelElementFile element)
+    {
+        var surface = CreatePlaceholderComponentVisual(element, "Background", element.OffColorHex);
+        if (TryCreateImageSource(element.AssetPath, out var source))
+        {
+            surface.Child = new Image
+            {
+                Stretch = Stretch.Fill,
+                Source = source
+            };
+        }
+
+        return surface;
+    }
+
+    private static FrameworkElement CreateLampVisual(PanelElementFile element)
+    {
+        var label = element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp";
+        var surface = CreatePlaceholderComponentVisual(element, label, element.OnColorHex ?? element.OffColorHex, element.DisplayText);
+        if (TryCreateImageSource(element.AssetPath, out var source))
+        {
+            surface.Child = new Image
+            {
+                Stretch = Stretch.Fill,
+                Source = source
+            };
+        }
+
+        return surface;
+    }
+
+    private static FrameworkElement CreateReelVisual(PanelElementFile element)
+    {
+        var label = element.DisplayNumber.HasValue ? $"Reel {element.DisplayNumber.Value}" : "Reel";
+        var surface = CreatePlaceholderComponentVisual(element, label, "#1E293B");
+        if (TryCreateImageSource(element.AssetPath, out var source))
+        {
+            surface.Child = new Image
+            {
+                Stretch = Stretch.Fill,
+                Source = source
+            };
+        }
+
+        return surface;
+    }
+
+    private static FrameworkElement CreateSevenSegmentVisual(PanelElementFile element)
+    {
+        var label = element.DisplayNumber.HasValue
+            ? $"7 Segment {element.DisplayNumber.Value}"
+            : "7 Segment";
+        return CreatePlaceholderComponentVisual(element, label, element.OnColorHex, element.DisplayText);
+    }
+
+    private static FrameworkElement CreateAlphaVisual(PanelElementFile element)
+    {
+        var label = element.IsReversed == true ? "Alpha (Reversed)" : "Alpha";
+        return CreatePlaceholderComponentVisual(element, label, "#1F2937", element.DisplayText);
+    }
+
     private static FrameworkElement CreatePlaceholderComponentVisual(PanelElementFile element, string label)
+    {
+        return CreatePlaceholderComponentVisual(element, label, null, null);
+    }
+
+    private static Border CreatePlaceholderComponentVisual(PanelElementFile element, string label, string? backgroundColorHex, string? detailText = null)
     {
         var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
         var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
@@ -171,17 +238,82 @@ internal static class PanelElementFactory
             Height = height,
             BorderThickness = new Thickness(1),
             BorderBrush = Brushes.SlateGray,
-            Background = Brushes.Transparent,
-            Child = new TextBlock
+            Background = TryCreateBrush(backgroundColorHex, Brushes.Transparent),
+            Child = new StackPanel
             {
-                Text = label,
-                HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                Foreground = Brushes.LightSteelBlue
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = label,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        TextAlignment = TextAlignment.Center,
+                        Foreground = Brushes.LightSteelBlue
+                    },
+                    new TextBlock
+                    {
+                        Text = detailText ?? string.Empty,
+                        Margin = new Thickness(0, 4, 0, 0),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        TextAlignment = TextAlignment.Center,
+                        Foreground = Brushes.Gainsboro,
+                        FontSize = 10,
+                        Visibility = string.IsNullOrWhiteSpace(detailText) ? Visibility.Collapsed : Visibility.Visible
+                    }
+                }
             }
         };
 
         return border;
+    }
+
+    private static Brush TryCreateBrush(string? colorHex, Brush fallback)
+    {
+        if (string.IsNullOrWhiteSpace(colorHex))
+        {
+            return fallback;
+        }
+
+        try
+        {
+            var color = (Color)ColorConverter.ConvertFromString(colorHex);
+            return new SolidColorBrush(color);
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+
+    private static bool TryCreateImageSource(string? assetPath, out ImageSource? source)
+    {
+        source = null;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (!Path.IsPathRooted(candidate))
+        {
+            return false;
+        }
+
+        if (!File.Exists(candidate))
+        {
+            return false;
+        }
+
+        var bitmap = new BitmapImage();
+        bitmap.BeginInit();
+        bitmap.UriSource = new Uri(candidate, UriKind.Absolute);
+        bitmap.CacheOption = BitmapCacheOption.OnLoad;
+        bitmap.EndInit();
+        bitmap.Freeze();
+        source = bitmap;
+        return true;
     }
 
     private static ImageSource CreatePlaceholderImageSource()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -300,7 +300,7 @@ internal static class PanelElementFactory
             return false;
         }
 
-        if (!File.Exists(candidate))
+        if (!System.IO.File.Exists(candidate))
         {
             return false;
         }


### PR DESCRIPTION
### Motivation
- Provide clearer, kind-specific placeholder visuals for native Panel2D elements imported from legacy MFME extracts so the editor canvas reflects imported metadata. 
- Surface display metadata (display number, display text, reversed state, and configured colors) in the visual projection to improve import debugging and UX. 
- Allow optional use of image assets when an absolute file path is available while keeping visuals safe and WPF-only (no domain/schema changes). 

### Description
- Replaced generic native-kind placeholders with dedicated builders `CreateBackgroundVisual`, `CreateLampVisual`, `CreateReelVisual`, `CreateSevenSegmentVisual`, and `CreateAlphaVisual` in `OasisEditor/PanelElementFactory.cs`. 
- Expanded placeholder composition to use a `StackPanel` with label and optional detail text, and added `TryCreateBrush` to parse hex colors with a safe fallback. 
- Added `TryCreateImageSource` to attempt loading an absolute-path image file into a `BitmapImage` (only when the path is rooted and the file exists), and wired image use into the new kind-specific visuals. 
- Kept element-kind attached properties and the round-trip conversion path intact and added two unit tests in `OasisEditor.Tests/PanelElementFactoryTests.cs` to assert lamp label/detail rendering and background color application while preserving existing round-trip assertions. 

### Testing
- Added unit tests `PanelElementFactoryTests` (existing round-trip theory plus new `CreateVisualFromElement_LampWithoutImage_UsesLampNumberAndDisplayText` and `CreateVisualFromElement_BackgroundWithoutImage_UsesConfiguredColor`) under `WindowsNetProjects/OasisEditor/OasisEditor.Tests`. 
- Attempted to run `dotnet test` in this environment, but the CLI is unavailable and the run failed with `dotnet: command not found`, so tests were not executed here. 
- Static inspection and local execution in an appropriate Windows/.NET environment are recommended to run the new STA WPF tests (they require an STA thread).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef6336bdac8327aafb1ea7ec6809be)