### PR TITLE
Add native component groups to Panel2D hierarchy

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -6,15 +6,25 @@ namespace OasisEditor.Tests;
 
 public sealed class HierarchyPanelCommandServiceTests
 {
-    [Fact]
-    public void SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements()
+    [Theory]
+    [InlineData((int)PanelElementKind.Rectangle, "rectangle", "Rect One")]
+    [InlineData((int)PanelElementKind.Background, "background", "Background")]
+    [InlineData((int)PanelElementKind.Lamp, "lamp", "Lamp 7")]
+    [InlineData((int)PanelElementKind.Reel, "reel", "Reel 3")]
+    [InlineData((int)PanelElementKind.SevenSegment, "sevenSegment", "7 Segment 4")]
+    [InlineData((int)PanelElementKind.Alpha, "alpha", "Alpha")]
+    public void SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements(
+        int kindValue,
+        string kindToken,
+        string name)
     {
+        var kind = (PanelElementKind)kindValue;
         var document = CreatePanelDocument(
             new PanelElementModel
             {
                 ObjectId = "source-id",
-                Name = "Rect One",
-                Kind = PanelElementKind.Rectangle,
+                Name = name,
+                Kind = kind,
                 X = 10,
                 Y = 20,
                 Width = 30,
@@ -23,7 +33,7 @@ public sealed class HierarchyPanelCommandServiceTests
         var workspace = CreateWorkspace(document, document);
         var service = CreateService(document, workspace);
 
-        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("source-id", "rectangle", 10, 20, 30, 40);
+        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("source-id", kindToken, 10, 20, 30, 40);
         service.ExecuteCopySelected();
         service.ExecutePasteSelected();
         service.ExecuteDuplicateSelected();
@@ -46,6 +56,43 @@ public sealed class HierarchyPanelCommandServiceTests
 
         Assert.Equal(2, reopened.GetPanelElements().Count);
         Assert.Equal(2, reopened.GetPanelElements().Select(element => element.ObjectId).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Theory]
+    [InlineData((int)PanelElementKind.Background, "group:background", "background")]
+    [InlineData((int)PanelElementKind.Lamp, "group:lamp", "lamp")]
+    [InlineData((int)PanelElementKind.Reel, "group:reel", "reel")]
+    [InlineData((int)PanelElementKind.SevenSegment, "group:sevenSegment", "sevenSegment")]
+    [InlineData((int)PanelElementKind.Alpha, "group:alpha", "alpha")]
+    public void HierarchyProvider_NativeGroups_ExposeNativeSelectionTokens(
+        int kindValue,
+        string expectedGroupKey,
+        string expectedKindToken)
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "source-id",
+                Name = "Native",
+                Kind = (PanelElementKind)kindValue,
+                X = 10,
+                Y = 20,
+                Width = 30,
+                Height = 40
+            });
+
+        var provider = new Panel2DHierarchyProvider();
+        var groups = provider.Build(document);
+        var group = groups.Single(item => item.NodeKey == expectedGroupKey);
+        var child = Assert.Single(group.Children);
+
+        var selection = Assert.IsType<PanelSelectionInfo>(child.PanelSelection);
+        Assert.Equal("source-id", selection.ObjectId);
+        Assert.Equal(expectedKindToken, selection.KindToken);
+        Assert.Equal(10, selection.X);
+        Assert.Equal(20, selection.Y);
+        Assert.Equal(30, selection.Width);
+        Assert.Equal(40, selection.Height);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -88,7 +88,7 @@ public sealed class HierarchyPanelCommandServiceTests
 
         var selection = Assert.IsType<PanelSelectionInfo>(child.PanelSelection);
         Assert.Equal("source-id", selection.ObjectId);
-        Assert.Equal(expectedKindToken, selection.KindToken);
+        Assert.Equal(expectedKindToken, selection.Kind);
         Assert.Equal(10, selection.X);
         Assert.Equal(20, selection.Y);
         Assert.Equal(30, selection.Width);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -533,6 +533,71 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void HierarchyProvider_IncludesNativeComponentGroups()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "background-1",
+                Name = "Background",
+                Kind = PanelElementKind.Background,
+                X = 0,
+                Y = 0,
+                Width = 100,
+                Height = 100
+            },
+            new PanelElementModel
+            {
+                ObjectId = "lamp-1",
+                Name = "Lamp 1",
+                Kind = PanelElementKind.Lamp,
+                X = 10,
+                Y = 12,
+                Width = 20,
+                Height = 24
+            },
+            new PanelElementModel
+            {
+                ObjectId = "reel-1",
+                Name = "Reel 1",
+                Kind = PanelElementKind.Reel,
+                X = 32,
+                Y = 16,
+                Width = 26,
+                Height = 60
+            },
+            new PanelElementModel
+            {
+                ObjectId = "seven-1",
+                Name = "7 Segment 2",
+                Kind = PanelElementKind.SevenSegment,
+                X = 64,
+                Y = 20,
+                Width = 30,
+                Height = 16
+            },
+            new PanelElementModel
+            {
+                ObjectId = "alpha-1",
+                Name = "Alpha",
+                Kind = PanelElementKind.Alpha,
+                X = 96,
+                Y = 24,
+                Width = 34,
+                Height = 18
+            });
+
+        var provider = new Panel2DHierarchyProvider();
+        var groups = provider.Build(document);
+
+        Assert.Equal("Backgrounds (1)", groups.Single(g => g.NodeKey == "group:background").DisplayName);
+        Assert.Equal("Lamps (1)", groups.Single(g => g.NodeKey == "group:lamp").DisplayName);
+        Assert.Equal("Reels (1)", groups.Single(g => g.NodeKey == "group:reel").DisplayName);
+        Assert.Equal("Seven Segments (1)", groups.Single(g => g.NodeKey == "group:sevenSegment").DisplayName);
+        Assert.Equal("Alphas (1)", groups.Single(g => g.NodeKey == "group:alpha").DisplayName);
+    }
+
+    [Fact]
     public void DeleteElementCommand_TracksExecutionAndSupportsUndoRedo()
     {
         var document = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -139,6 +139,82 @@ public sealed class PanelElementFactoryTests
         });
     }
 
+    [Fact]
+    public void CreateVisualFromElement_ReelWithoutImage_UsesFallbackLabel()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "reel-1",
+                Name = "Reel 3",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Reel),
+                Width = 80,
+                Height = 120,
+                DisplayNumber = 3
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            Assert.Equal("Reel 3", title.Text);
+        });
+    }
+
+    [Fact]
+    public void CreateVisualFromElement_SevenSegment_UsesDisplayColorAndLabel()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "seven-1",
+                Name = "7 Segment 4",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.SevenSegment),
+                Width = 90,
+                Height = 40,
+                DisplayNumber = 4,
+                OnColorHex = "#FFCC2200"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            var background = Assert.IsType<SolidColorBrush>(border.Background);
+
+            Assert.Equal("7 Segment 4", title.Text);
+            Assert.Equal(Color.FromArgb(0xFF, 0xCC, 0x22, 0x00), background.Color);
+        });
+    }
+
+    [Fact]
+    public void CreateVisualFromElement_AlphaReversed_UsesReversedLabel()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "alpha-1",
+                Name = "Alpha",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Alpha),
+                Width = 120,
+                Height = 36,
+                IsReversed = true
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            Assert.Equal("Alpha (Reversed)", title.Text);
+        });
+    }
+
     private static void RunInSta(Action action)
     {
         Exception? captured = null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -18,6 +18,11 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
         var elements = panelDocument.GetPanelElements();
         var groups = new List<HierarchyItemViewModel>
         {
+            BuildGroup("Backgrounds", elements, PanelElementKind.Background, "Background"),
+            BuildGroup("Lamps", elements, PanelElementKind.Lamp, "Lamp"),
+            BuildGroup("Reels", elements, PanelElementKind.Reel, "Reel"),
+            BuildGroup("Seven Segments", elements, PanelElementKind.SevenSegment, "7 Segment"),
+            BuildGroup("Alphas", elements, PanelElementKind.Alpha, "Alpha"),
             BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
             BuildGroup("Rectangles", elements, PanelElementKind.Rectangle, "Rectangle"),
             BuildGroup("Anchors", elements, PanelElementKind.Anchor, "Anchor"),

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -180,22 +180,22 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [x] Update `PanelElementFactory` or introduce focused visual factories for new native Panel2D kinds
   - [x] Keep WPF-specific visual creation separate from import/domain conversion
   - [x] Preserve existing Rectangle/Image behavior
-- [ ] Add placeholder visual projection for native Background
-  - [ ] Use imported image when available
-  - [ ] Fall back to a filled rectangle using imported/native color when no image is available
-- [ ] Add placeholder visual projection for native Lamp
-  - [ ] Use imported lamp image when available
-  - [ ] Fall back to a colored rectangle with optional text
-  - [ ] Keep it selectable/model-backed like existing elements
-- [ ] Add placeholder visual projection for native Reel
-  - [ ] Use imported band image when available, clipped/scaled into the element bounds
-  - [ ] Fall back to a labeled placeholder rectangle
-- [ ] Add placeholder visual projection for native SevenSegment display
-  - [ ] Use a labeled/tinted placeholder visual for now
-  - [ ] Preserve number/color metadata in the native model
-- [ ] Add placeholder visual projection for native Alpha display
-  - [ ] Use a labeled placeholder visual for now
-  - [ ] Preserve reversed metadata in the native model
+- [x] Add placeholder visual projection for native Background
+  - [x] Use imported image when available
+  - [x] Fall back to a filled rectangle using imported/native color when no image is available
+- [x] Add placeholder visual projection for native Lamp
+  - [x] Use imported lamp image when available
+  - [x] Fall back to a colored rectangle with optional text
+  - [x] Keep it selectable/model-backed like existing elements
+- [x] Add placeholder visual projection for native Reel
+  - [x] Use imported band image when available, clipped/scaled into the element bounds
+  - [x] Fall back to a labeled placeholder rectangle
+- [x] Add placeholder visual projection for native SevenSegment display
+  - [x] Use a labeled/tinted placeholder visual for now
+  - [x] Preserve number/color metadata in the native model
+- [x] Add placeholder visual projection for native Alpha display
+  - [x] Use a labeled placeholder visual for now
+  - [x] Preserve reversed metadata in the native model
 - [x] Update hierarchy grouping/display for the new native element kinds
   - [x] Backgrounds
   - [x] Lamps

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -196,12 +196,12 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [ ] Add placeholder visual projection for native Alpha display
   - [ ] Use a labeled placeholder visual for now
   - [ ] Preserve reversed metadata in the native model
-- [ ] Update hierarchy grouping/display for the new native element kinds
-  - [ ] Backgrounds
-  - [ ] Lamps
-  - [ ] Reels
-  - [ ] Seven Segments
-  - [ ] Alphas
+- [x] Update hierarchy grouping/display for the new native element kinds
+  - [x] Backgrounds
+  - [x] Lamps
+  - [x] Reels
+  - [x] Seven Segments
+  - [x] Alphas
 - [ ] Verify selection, hierarchy selection, inspector display, save/load, and undo/redo still work for new native kinds
 - [ ] Build and run tests
 


### PR DESCRIPTION
### Motivation
- Expose newly-introduced native Panel2D element kinds in the editor hierarchy so imported MFME components (Background, Lamp, Reel, SevenSegment, Alpha) appear as first-class groups.
- Keep the hierarchy consistent with the Phase Q goals in `TASKS.md` for visual projection and native-kind support.

### Description
- Updated `Panel2DHierarchyProvider.Build` to add groups for `Background`, `Lamp`, `Reel`, `SevenSegment`, and `Alpha` so they appear alongside existing Image/Rectangle/Anchor/Zone groups (`WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs`).
- Added a unit test `HierarchyProvider_IncludesNativeComponentGroups` to `Panel2DRoundTripTests.cs` that verifies the new groups emit the expected group labels and counts (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs`).
- Marked the Phase Q hierarchy checklist item and its sub-items as complete in `TASKS.md` to reflect the implemented grouping update (`WindowsNetProjects/OasisEditor/TASKS.md`).

### Testing
- Added the unit test `HierarchyProvider_IncludesNativeComponentGroups` (not yet run in this environment).
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the execution failed in the current container because the `dotnet` CLI is not installed (error: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef675626688327a0e9e82c97d3dad6)