### PR TITLE
Add document-scoped MFME import command with unit tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
@@ -1,0 +1,148 @@
+using OasisEditor.Features.MfmeImport;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class ImportMfmeExtractCommandTests
+{
+    [Fact]
+    public void Execute_WithImportedElements_AddsAllAsSingleUndoableMutation()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "existing",
+                    Name = "Existing",
+                    Kind = PanelElementKind.Rectangle,
+                    X = 0,
+                    Y = 0,
+                    Width = 20,
+                    Height = 20
+                }
+            ]);
+
+        var command = new ImportMfmeExtractCommand(
+            document.DocumentId,
+            document,
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "import-a",
+                    Name = "Lamp 1",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "import-b",
+                    Name = "Reel 1",
+                    Kind = PanelElementKind.Reel,
+                    X = 50,
+                    Y = 60,
+                    Width = 70,
+                    Height = 80
+                }
+            ]);
+
+        document.CommandService.Execute(command);
+
+        Assert.Equal(3, document.GetPanelElements().Count);
+        Assert.Single(document.CommandService.History.Entries);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Single(document.GetPanelElements());
+
+        Assert.True(document.CommandService.TryRedo());
+        Assert.Equal(3, document.GetPanelElements().Count);
+        Assert.Contains(document.GetPanelElements(), element => element.ObjectId == "import-a");
+        Assert.Contains(document.GetPanelElements(), element => element.ObjectId == "import-b");
+    }
+
+    [Fact]
+    public void Execute_WithNoElements_DoesNotMutateOrRecordHistory()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        var command = new ImportMfmeExtractCommand(document.DocumentId, document, []);
+
+        document.CommandService.Execute(command);
+
+        Assert.Empty(document.GetPanelElements());
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void Execute_WithWrongDocumentId_ThrowsAndDoesNotMutateTargetDocument()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        var command = new ImportMfmeExtractCommand(
+            Guid.NewGuid(),
+            document,
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "import-a",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    X = 0,
+                    Y = 0,
+                    Width = 100,
+                    Height = 100
+                }
+            ]);
+
+        Assert.Throws<InvalidOperationException>(() => document.CommandService.Execute(command));
+        Assert.Empty(document.GetPanelElements());
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void Execute_WithConflictingSourceObjectId_RewritesIdAndKeepsItStableAcrossUndoRedo()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "collision",
+                    Name = "Existing",
+                    Kind = PanelElementKind.Rectangle,
+                    X = 1,
+                    Y = 2,
+                    Width = 3,
+                    Height = 4
+                }
+            ]);
+
+        var command = new ImportMfmeExtractCommand(
+            document.DocumentId,
+            document,
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "collision",
+                    Name = "Imported",
+                    Kind = PanelElementKind.Alpha,
+                    X = 5,
+                    Y = 6,
+                    Width = 7,
+                    Height = 8
+                }
+            ]);
+
+        document.CommandService.Execute(command);
+        var importedId = document.GetPanelElements().Single(element => element.Name == "Imported").ObjectId;
+        Assert.NotEqual("collision", importedId);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.DoesNotContain(document.GetPanelElements(), element => element.ObjectId == importedId);
+
+        Assert.True(document.CommandService.TryRedo());
+        var redoneImportedId = document.GetPanelElements().Single(element => element.Name == "Imported").ObjectId;
+        Assert.Equal(importedId, redoneImportedId);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
@@ -95,7 +95,8 @@ public sealed class ImportMfmeExtractCommandTests
                 }
             ]);
 
-        Assert.Throws<InvalidOperationException>(() => document.CommandService.Execute(command));
+        Action execute = () => document.CommandService.Execute(command);
+        Assert.Throws<InvalidOperationException>(execute);
         Assert.Empty(document.GetPanelElements());
         Assert.Empty(document.CommandService.History.Entries);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -32,6 +32,7 @@ public sealed class MfmeImportServiceTests
         var extract = new MfmeLegacyExtractData
         {
             ExtractRootPath = @"C:\extract",
+            ManifestPath = @"C:\extract\layout.json",
             LayoutName = "Layout",
             Components =
             [

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -1,0 +1,88 @@
+using OasisEditor.Features.MfmeImport;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeImportServiceTests
+{
+    [Fact]
+    public void Import_WhenReaderFails_ReturnsErrorsAndNoElements()
+    {
+        var service = new MfmeImportService(
+            new StubReader(
+                new MfmeExtractReadResult
+                {
+                    Extract = null,
+                    Warnings = [new MfmeImportWarning("warn", "warning")],
+                    Errors = ["bad extract"]
+                }));
+
+        var result = service.Import(CreateContext());
+
+        Assert.False(result.Succeeded);
+        Assert.Single(result.Errors);
+        Assert.Equal("bad extract", result.Errors[0]);
+        Assert.Empty(result.ImportedElements);
+        Assert.Single(result.Warnings);
+    }
+
+    [Fact]
+    public void Import_WhenReaderSucceeds_MapsElements()
+    {
+        var extract = new MfmeLegacyExtractData
+        {
+            ExtractRootPath = @"C:\extract",
+            LayoutName = "Layout",
+            Components =
+            [
+                new MfmeLegacyBackgroundComponent(
+                    new MfmeLegacyPoint(0, 0),
+                    new MfmeLegacyPoint(640, 480),
+                    "bg.bmp",
+                    null)
+            ]
+        };
+        var service = new MfmeImportService(
+            new StubReader(
+                new MfmeExtractReadResult
+                {
+                    Extract = extract,
+                    Warnings = [],
+                    Errors = []
+                }));
+
+        var result = service.Import(CreateContext(copyAssets: false));
+
+        Assert.True(result.Succeeded);
+        var imported = Assert.Single(result.ImportedElements);
+        Assert.Equal(PanelElementKind.Background, imported.Kind);
+        Assert.Equal(640, imported.Width);
+        Assert.Equal(480, imported.Height);
+    }
+
+    private static MfmeImportContext CreateContext(bool copyAssets = true)
+    {
+        return new MfmeImportContext
+        {
+            SourceExtractPath = @"C:\extract\layout.json",
+            ProjectRootPath = @"C:\project",
+            ProjectAssetsPath = @"C:\project\Assets",
+            CopyAssets = copyAssets
+        };
+    }
+
+    private sealed class StubReader : IMfmeExtractReader
+    {
+        private readonly MfmeExtractReadResult _result;
+
+        public StubReader(MfmeExtractReadResult result)
+        {
+            _result = result;
+        }
+
+        public MfmeExtractReadResult Read(MfmeImportContext context)
+        {
+            return _result;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -54,7 +54,7 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
         }
 
         var insertIndex = Math.Clamp(_insertIndex, 0, currentElements.Count);
-        currentElements.InsertRange(insertIndex, _importedElements.Select(CloneElement));
+        currentElements.InsertRange(insertIndex, _importedElements.Select(static element => CloneElement(element)));
         _document.SetPanelElements(currentElements);
         _document.MarkDirty();
         WasExecuted = true;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -1,0 +1,143 @@
+using OasisEditor.Commands;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTrackedCommand
+{
+    private readonly Guid _documentId;
+    private readonly DocumentTabViewModel _document;
+    private readonly IReadOnlyList<PanelElementModel> _sourceElements;
+    private IReadOnlyList<PanelElementModel>? _importedElements;
+    private int _insertIndex;
+
+    public ImportMfmeExtractCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        IReadOnlyList<PanelElementModel> sourceElements)
+    {
+        _documentId = documentId;
+        _document = document;
+        _sourceElements = sourceElements ?? [];
+    }
+
+    public Guid DocumentId => _documentId;
+
+    public string Description => "Import MFME extract";
+
+    public bool WasExecuted { get; private set; }
+
+    public void Execute()
+    {
+        WasExecuted = false;
+
+        if (_sourceElements.Count == 0)
+        {
+            return;
+        }
+
+        var currentElements = _document.GetPanelElements().ToList();
+        if (_importedElements is null)
+        {
+            _importedElements = MaterializeImportedElements(_sourceElements, currentElements);
+            _insertIndex = currentElements.Count;
+        }
+
+        if (_importedElements.Count == 0)
+        {
+            return;
+        }
+
+        var importedIds = new HashSet<string>(_importedElements.Select(element => element.ObjectId), StringComparer.Ordinal);
+        if (currentElements.Any(element => importedIds.Contains(element.ObjectId)))
+        {
+            return;
+        }
+
+        var insertIndex = Math.Clamp(_insertIndex, 0, currentElements.Count);
+        currentElements.InsertRange(insertIndex, _importedElements.Select(CloneElement));
+        _document.SetPanelElements(currentElements);
+        _document.MarkDirty();
+        WasExecuted = true;
+    }
+
+    public void Undo()
+    {
+        if (_importedElements is null || _importedElements.Count == 0)
+        {
+            return;
+        }
+
+        var importedIds = new HashSet<string>(_importedElements.Select(element => element.ObjectId), StringComparer.Ordinal);
+        var elements = _document.GetPanelElements().ToList();
+        var removed = elements.RemoveAll(element => importedIds.Contains(element.ObjectId)) > 0;
+        if (!removed)
+        {
+            return;
+        }
+
+        _document.SetPanelElements(elements);
+        _document.MarkDirty();
+    }
+
+    private static IReadOnlyList<PanelElementModel> MaterializeImportedElements(
+        IReadOnlyList<PanelElementModel> sourceElements,
+        IReadOnlyList<PanelElementModel> existingElements)
+    {
+        var existingIds = new HashSet<string>(existingElements.Select(element => element.ObjectId), StringComparer.Ordinal);
+        var imported = new List<PanelElementModel>(sourceElements.Count);
+
+        foreach (var source in sourceElements)
+        {
+            var objectId = string.IsNullOrWhiteSpace(source.ObjectId) || existingIds.Contains(source.ObjectId)
+                ? BuildUniqueObjectId(existingIds)
+                : source.ObjectId;
+
+            existingIds.Add(objectId);
+            imported.Add(CloneElement(source, objectId));
+        }
+
+        return imported;
+    }
+
+    private static string BuildUniqueObjectId(IReadOnlySet<string> existingIds)
+    {
+        string candidate;
+        do
+        {
+            candidate = Guid.NewGuid().ToString("N");
+        } while (existingIds.Contains(candidate));
+
+        return candidate;
+    }
+
+    private static PanelElementModel CloneElement(PanelElementModel source, string? objectId = null)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = objectId ?? source.ObjectId,
+            Name = source.Name,
+            Kind = source.Kind,
+            X = source.X,
+            Y = source.Y,
+            Width = source.Width,
+            Height = source.Height,
+            AssetPath = source.AssetPath,
+            SecondaryAssetPath = source.SecondaryAssetPath,
+            DisplayNumber = source.DisplayNumber,
+            OnColorHex = source.OnColorHex,
+            OffColorHex = source.OffColorHex,
+            TextColorHex = source.TextColorHex,
+            DisplayText = source.DisplayText,
+            IsReversed = source.IsReversed,
+            Stops = source.Stops,
+            VisibleScale = source.VisibleScale,
+            ImportSource = source.ImportSource is null
+                ? null
+                : new PanelElementImportSourceModel
+                {
+                    Format = source.ImportSource.Format,
+                    Reference = source.ImportSource.Reference
+                }
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportService.cs
@@ -1,0 +1,60 @@
+namespace OasisEditor.Features.MfmeImport;
+
+internal sealed class MfmeImportService
+{
+    private readonly IMfmeExtractReader _extractReader;
+    private readonly MfmeToOasisComponentMapper _componentMapper;
+    private readonly MfmeImportAssetCopier _assetCopier;
+
+    public MfmeImportService(
+        IMfmeExtractReader? extractReader = null,
+        MfmeToOasisComponentMapper? componentMapper = null,
+        MfmeImportAssetCopier? assetCopier = null)
+    {
+        _extractReader = extractReader ?? new FileSystemMfmeExtractReader();
+        _componentMapper = componentMapper ?? new MfmeToOasisComponentMapper();
+        _assetCopier = assetCopier ?? new MfmeImportAssetCopier();
+    }
+
+    public MfmeImportResult Import(MfmeImportContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var readResult = _extractReader.Read(context);
+        var warnings = new List<MfmeImportWarning>(readResult.Warnings);
+        var errors = new List<string>(readResult.Errors);
+
+        if (!readResult.Succeeded || readResult.Extract is null)
+        {
+            if (readResult.Extract is null && errors.Count == 0)
+            {
+                errors.Add("MFME extract could not be read.");
+            }
+
+            return new MfmeImportResult
+            {
+                ImportedElements = [],
+                CopiedAssetRelativePaths = [],
+                SkippedLegacyComponentTypes = [],
+                Warnings = warnings,
+                Errors = errors
+            };
+        }
+
+        var mapResult = _componentMapper.Map(readResult.Extract);
+        warnings.AddRange(mapResult.Warnings);
+
+        var copyResult = _assetCopier.CopyAssets(context, readResult.Extract, mapResult.Elements);
+        warnings.AddRange(copyResult.Warnings);
+        errors.AddRange(copyResult.Errors);
+
+        return new MfmeImportResult
+        {
+            ImportedElements = copyResult.Elements,
+            CopiedAssetRelativePaths = copyResult.CopiedAssetRelativePaths,
+            SkippedLegacyComponentTypes = mapResult.SkippedLegacyComponentTypes,
+            Warnings = warnings,
+            Errors = errors
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -58,6 +58,10 @@
                 <Separator />
                 <MenuItem Header="Open _Document"
                           Command="{Binding OpenDocumentCommand}" />
+                <MenuItem Header="_Import">
+                    <MenuItem Header="_MFME Extract..."
+                              Command="{Binding ImportMfmeExtractCommand}" />
+                </MenuItem>
                 <MenuItem Header="_Save Document"
                           Command="{Binding SaveSelectedDocumentCommand}" />
                 <MenuItem Header="_Close Project"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Collections.Specialized;
 using Microsoft.Win32;
+using OasisEditor.Features.MfmeImport;
 using EditorCommands = OasisEditor.Commands;
 using OasisEditor.Views;
 
@@ -32,6 +33,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
     private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
+    private readonly MfmeImportService _mfmeImportService = new();
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -57,6 +59,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
+        ImportMfmeExtractCommand = new RelayCommand(ImportMfmeExtract, CanImportMfmeExtract);
         SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         OpenPreferencesCommand = new RelayCommand(OpenPreferences);
@@ -148,6 +151,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenCabinet3DStubCommand { get; }
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
+    public ICommand ImportMfmeExtractCommand { get; }
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
@@ -489,6 +493,104 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Open document failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Open Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private bool CanImportMfmeExtract()
+    {
+        return LoadedProject is not null
+               && SelectedDocument?.Document.DocumentType == EditorDocumentType.Panel2D;
+    }
+
+    private void ImportMfmeExtract()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        if (SelectedDocument?.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            AddOutputEntry("MFME import is supported only when a Panel2D document is active.", OutputLogStatus.Warning);
+            MessageBox.Show(
+                "MFME import is currently supported only for Panel2D documents.",
+                "Import MFME Extract",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
+        var dialog = new OpenFileDialog
+        {
+            Title = "Import MFME Extract Manifest",
+            Filter = "MFME Extract Manifest|*.json|All Files|*.*",
+            InitialDirectory = LoadedProject.ProjectDirectory,
+            CheckFileExists = true
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var context = new MfmeImportContext
+        {
+            SourceExtractPath = dialog.FileName,
+            ProjectRootPath = LoadedProject.ProjectDirectory,
+            ProjectAssetsPath = LoadedProject.AssetsDirectory,
+            CopyAssets = true
+        };
+
+        var result = _mfmeImportService.Import(context);
+        foreach (var warning in result.Warnings)
+        {
+            AddOutputEntry($"MFME import warning ({warning.Code}): {warning.Message}", OutputLogStatus.Warning);
+        }
+
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+            {
+                AddOutputEntry($"MFME import failed: {error}", OutputLogStatus.Error);
+            }
+
+            MessageBox.Show(
+                "MFME import failed. See Output for details.",
+                "Import MFME Extract",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            return;
+        }
+
+        var activeDocument = SelectedDocument;
+        if (activeDocument is null)
+        {
+            return;
+        }
+
+        var importCommand = new ImportMfmeExtractCommand(
+            activeDocument.DocumentId,
+            activeDocument,
+            result.ImportedElements);
+        var inserted = _documentWorkspace.ExecuteDocumentCanvasCommand(activeDocument.DocumentId, importCommand);
+        if (!inserted)
+        {
+            AddOutputEntry("MFME import completed but no elements were inserted.", OutputLogStatus.Warning);
+            return;
+        }
+
+        _assetBrowser.RefreshAssetBrowser();
+        RefreshHierarchy();
+        NotifyInspectorChanged();
+
+        var grouped = result.ImportedElements
+            .GroupBy(element => element.Kind)
+            .OrderBy(group => group.Key.ToString(), StringComparer.Ordinal)
+            .Select(group => $"{group.Key}: {group.Count()}");
+
+        AddOutputEntry($"MFME import completed. Imported {result.ImportedElements.Count} elements.", OutputLogStatus.Info);
+        AddOutputEntry($"MFME import kinds -> {string.Join(", ", grouped)}", OutputLogStatus.Info);
+        AddOutputEntry($"MFME import skipped {result.SkippedLegacyComponentTypes.Count} unsupported components.", OutputLogStatus.Info);
+        AddOutputEntry($"MFME import copied {result.CopiedAssetRelativePaths.Count} assets.", OutputLogStatus.Info);
     }
 
     private void OpenAssetDocument(AssetBrowserItemViewModel? asset)
@@ -900,6 +1002,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (OpenDocumentCommand is RelayCommand openDocumentRelayCommand)
         {
             openDocumentRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (ImportMfmeExtractCommand is RelayCommand importMfmeRelayCommand)
+        {
+            importMfmeRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (SaveSelectedDocumentCommand is RelayCommand saveRelayCommand)

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -172,7 +172,7 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
   - [x] Import the native Oasis component anyway when possible
   - [x] Add a warning listing the missing file
   - [x] Use placeholder visuals later in the visual projection phase
-- [ ] Refresh the Assets pane after successful import/copy
+- [x] Refresh the Assets pane after successful import/copy
 - [x] Add tests for root containment, duplicate names, missing files, and project-relative path generation
 - [ ] Build and run tests
 
@@ -206,30 +206,30 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [ ] Build and run tests
 
 ### Phase R — Undoable Import Command
-- [ ] Add `ImportMfmeExtractCommand` or equivalent document-scoped command
-  - [ ] Target a specific document ID at creation time
-  - [ ] Insert all converted native Oasis Panel2D elements as one undoable operation
-  - [ ] Record copied assets/import warnings outside undo only if necessary and documented
-  - [ ] Mark the document dirty only when native elements are actually added
-  - [ ] Do not record no-op imports in undo history
-- [ ] Ensure undo removes all imported native elements from the active document only
-- [ ] Ensure redo restores the same logical native elements without reusing stale command state incorrectly
-- [ ] Ensure object IDs remain stable through undo/redo of the same command
-- [ ] Add command tests for import, undo, redo, no-op import, and wrong-document safety
+- [x] Add `ImportMfmeExtractCommand` or equivalent document-scoped command
+  - [x] Target a specific document ID at creation time
+  - [x] Insert all converted native Oasis Panel2D elements as one undoable operation
+  - [x] Record copied assets/import warnings outside undo only if necessary and documented
+  - [x] Mark the document dirty only when native elements are actually added
+  - [x] Do not record no-op imports in undo history
+- [x] Ensure undo removes all imported native elements from the active document only
+- [x] Ensure redo restores the same logical native elements without reusing stale command state incorrectly
+- [x] Ensure object IDs remain stable through undo/redo of the same command
+- [x] Add command tests for import, undo, redo, no-op import, and wrong-document safety
 - [ ] Build and run tests
 
 ### Phase S — Import UI Entry Point
-- [ ] Add a user-facing import command to the WPF editor shell
-  - [ ] Suggested menu: `File > Import > MFME Extract...`
-  - [ ] Enable only when a project is open and a Panel2D document is active or can be created intentionally
-  - [ ] Use a folder picker or file picker appropriate to the extract contract identified in Phase K
-- [ ] Route UI command through ViewModel/service code, not direct import logic in code-behind
-- [ ] Display import results in the output log
-  - [ ] Count imported native components by kind
-  - [ ] Count skipped unsupported legacy MFME components
-  - [ ] List warnings for missing images or unsupported fields
-- [ ] Ensure import into an empty Panel2D document is the first supported flow
-- [ ] Add a clear message for unsupported active document types
+- [x] Add a user-facing import command to the WPF editor shell
+  - [x] Suggested menu: `File > Import > MFME Extract...`
+  - [x] Enable only when a project is open and a Panel2D document is active or can be created intentionally
+  - [x] Use a folder picker or file picker appropriate to the extract contract identified in Phase K
+- [x] Route UI command through ViewModel/service code, not direct import logic in code-behind
+- [x] Display import results in the output log
+  - [x] Count imported native components by kind
+  - [x] Count skipped unsupported legacy MFME components
+  - [x] List warnings for missing images or unsupported fields
+- [x] Ensure import into an empty Panel2D document is the first supported flow
+- [x] Add a clear message for unsupported active document types
 - [ ] Build and run tests
 
 ### Phase T — End-to-End Validation and Cleanup


### PR DESCRIPTION
### Motivation
- Implement an undoable, document-scoped import operation for MFME extracts to satisfy the Phase R requirement to insert converted native Panel2D elements as a single undoable mutation.  
- Ensure imported elements become Oasis-native and obey document-scoped command/undo semantics and dirty-state rules.  
- Provide deterministic ID conflict handling so imported elements never reuse existing object IDs and remain stable across undo/redo.

### Description
- Added `ImportMfmeExtractCommand` (`Features/MfmeImport/ImportMfmeExtractCommand.cs`) which implements `IDocumentCommand` and `IExecutionTrackedCommand` and inserts a set of `PanelElementModel` instances into the target `DocumentTabViewModel` as one undoable mutation, with no-op protection when nothing is inserted.  
- The command materializes imported elements once, rewrites blank or colliding `ObjectId` values to unique IDs, clones all relevant model fields including `ImportSource`, and uses the same generated IDs on redo to keep undo/redo stable.  
- Added unit tests (`OasisEditor.Tests/ImportMfmeExtractCommandTests.cs`) that cover successful execute/undo/redo as a single history entry, empty-import no-op behavior, wrong-document safety, and ID collision rewriting and stability across undo/redo.

### Testing
- Added focused automated tests in `ImportMfmeExtractCommandTests` exercising execute/undo/redo, no-op, wrong-document, and ID-collision scenarios.  
- Attempted to run `dotnet test OasisEditor.sln` in the rollout environment, but the run failed because the container does not have the .NET CLI installed (`dotnet: command not found`).  
- The tests are present and expected to run successfully on a developer machine with the .NET SDK (Windows dev environment) installed; no runtime/WPF UI launches were attempted in this headless container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef7f2fa1f88327bc302150d38ae83b)