### PR TITLE
docs: record Phase S build/test attempt in container

### DIFF
--- a/WindowsNetProjects/OasisEditor/PhaseS.BuildAndTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseS.BuildAndTestAttempt.md
@@ -1,0 +1,22 @@
+# Phase S Build and Test Attempt
+
+Date: 2026-04-27
+
+## Goal
+
+Attempt the pending `Build and run tests` checkpoint in Phase S of `TASKS.md`.
+
+## Commands attempted
+
+- `dotnet --info`
+- `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`
+
+## Result
+
+The .NET CLI is not available in this container environment:
+
+- `/bin/bash: line 1: dotnet: command not found`
+
+## Impact on TASKS
+
+The Phase S `Build and run tests` item cannot be completed in this environment and remains unchecked. Run the above commands on a machine with the .NET SDK installed (Windows dev environment expected for this WPF solution).

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -231,6 +231,7 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [x] Ensure import into an empty Panel2D document is the first supported flow
 - [x] Add a clear message for unsupported active document types
 - [ ] Build and run tests
+  - [ ] Blocked in current container; see `PhaseS.BuildAndTestAttempt.md`
 
 ### Phase T — End-to-End Validation and Cleanup
 - [ ] Create or identify a small MFME extract fixture for manual smoke testing


### PR DESCRIPTION
### Motivation
- Document the Phase S "Build and run tests" checkpoint attempt and record why it cannot be completed in this container environment.

### Description
- Add `WindowsNetProjects/OasisEditor/PhaseS.BuildAndTestAttempt.md` documenting the attempted commands and the environment limitation.
- Update `WindowsNetProjects/OasisEditor/TASKS.md` to mark the Phase S build/test item as blocked in this container and reference the new attempt log.

### Testing
- Ran `dotnet --info` which failed with `/bin/bash: line 1: dotnet: command not found` in this environment.
- Ran `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` which could not run because the .NET CLI is missing; no test suite executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef829ca838832784d9689d4f388a98)