### PR TITLE
Record generic LegacyImport provenance for MFME-imported elements and update tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -116,7 +116,7 @@ public sealed class HierarchyPanelCommandServiceTests
                 DisplayText = "HOLD",
                 ImportSource = new PanelElementImportSourceModel
                 {
-                    Format = "MFME",
+                    Format = "LegacyImport",
                     Reference = "layout:lamp:7"
                 }
             });
@@ -142,7 +142,7 @@ public sealed class HierarchyPanelCommandServiceTests
         Assert.Equal("#FFFFFFFF", pasted.TextColorHex);
         Assert.Equal("HOLD", pasted.DisplayText);
         Assert.NotNull(pasted.ImportSource);
-        Assert.Equal("MFME", pasted.ImportSource!.Format);
+        Assert.Equal("LegacyImport", pasted.ImportSource!.Format);
         Assert.Equal("layout:lamp:7", pasted.ImportSource.Reference);
         Assert.Single(document.CommandService.History.Entries);
     }
@@ -205,7 +205,7 @@ public sealed class HierarchyPanelCommandServiceTests
                 IsReversed = true,
                 ImportSource = new PanelElementImportSourceModel
                 {
-                    Format = "MFME",
+                    Format = "LegacyImport",
                     Reference = "layout:alpha:1"
                 }
             });
@@ -224,7 +224,7 @@ public sealed class HierarchyPanelCommandServiceTests
         Assert.Equal("#FF00FF00", updated.TextColorHex);
         Assert.True(updated.IsReversed);
         Assert.NotNull(updated.ImportSource);
-        Assert.Equal("MFME", updated.ImportSource!.Format);
+        Assert.Equal("LegacyImport", updated.ImportSource!.Format);
         Assert.Equal("layout:alpha:1", updated.ImportSource.Reference);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -61,6 +61,57 @@ public sealed class MfmeImportServiceTests
         Assert.Equal(480, imported.Height);
     }
 
+
+    [Fact]
+    public void Import_WithMixedLegacyComponents_ReturnsNativeElementsAndGenericImportBoundary()
+    {
+        var extract = new MfmeLegacyExtractData
+        {
+            ExtractRootPath = @"C:\extract",
+            ManifestPath = @"C:\extract\layout.json",
+            LayoutName = "Layout",
+            Components =
+            [
+                new MfmeLegacyLampComponent(
+                    new MfmeLegacyPoint(10, 20),
+                    new MfmeLegacyPoint(30, 40),
+                    "HOLD",
+                    null,
+                    null,
+                    null,
+                    new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp"),
+                    new MfmeLegacyColor(0f, 0f, 0f, 1f),
+                    new MfmeLegacyColor(1f, 1f, 1f, 1f),
+                    NoOutline: false),
+                new UnsupportedLegacyComponent()
+            ]
+        };
+
+        var service = new MfmeImportService(
+            new StubReader(
+                new MfmeExtractReadResult
+                {
+                    Extract = extract,
+                    Warnings = [],
+                    Errors = []
+                }));
+
+        var result = service.Import(CreateContext(copyAssets: false));
+
+        Assert.True(result.Succeeded);
+        var lamp = Assert.Single(result.ImportedElements);
+        Assert.Equal(PanelElementKind.Lamp, lamp.Kind);
+        Assert.Equal(7, lamp.DisplayNumber);
+        Assert.Equal("HOLD", lamp.DisplayText);
+        Assert.NotNull(lamp.ImportSource);
+        Assert.Equal("LegacyImport", lamp.ImportSource!.Format);
+        Assert.Equal("Lamp:7", lamp.ImportSource.Reference);
+
+        Assert.Single(result.SkippedLegacyComponentTypes);
+        Assert.Equal("ExtractComponentButton", result.SkippedLegacyComponentTypes[0]);
+        Assert.Contains(result.Warnings, warning => warning.Code == "mfme.import.component.unsupported");
+    }
+
     private static MfmeImportContext CreateContext(bool copyAssets = true)
     {
         return new MfmeImportContext
@@ -71,6 +122,17 @@ public sealed class MfmeImportServiceTests
             CopyAssets = copyAssets
         };
     }
+
+
+    private sealed record UnsupportedLegacyComponent()
+        : MfmeLegacyComponentBase(
+            "ExtractComponentButton",
+            new MfmeLegacyPoint(0, 0),
+            new MfmeLegacyPoint(1, 1),
+            null,
+            null,
+            null,
+            null);
 
     private sealed class StubReader : IMfmeExtractReader
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -105,6 +105,12 @@ public sealed class MfmeToOasisComponentMapperTests
 
         Assert.All(result.Elements, element => Assert.NotEqual(PanelElementKind.Unknown, element.Kind));
         Assert.All(result.Elements, element => Assert.False(string.IsNullOrWhiteSpace(element.ObjectId)));
+        Assert.All(result.Elements, element =>
+        {
+            Assert.NotNull(element.ImportSource);
+            Assert.Equal("LegacyImport", element.ImportSource!.Format);
+            Assert.False(string.IsNullOrWhiteSpace(element.ImportSource.Reference));
+        });
     }
 
     [Fact]
@@ -161,6 +167,13 @@ public sealed class MfmeToOasisComponentMapperTests
         var reel = result.Elements[1];
         Assert.Null(reel.VisibleScale);
         Assert.Equal("Reel 2", reel.Name);
+
+        Assert.All(result.Elements, element =>
+        {
+            Assert.NotNull(element.ImportSource);
+            Assert.Equal("LegacyImport", element.ImportSource!.Format);
+            Assert.False(string.IsNullOrWhiteSpace(element.ImportSource.Reference));
+        });
     }
 
     private sealed record UnsupportedLegacyComponent()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -119,7 +119,7 @@ public sealed class Panel2DRoundTripTests
                     VisibleScale = 0.75,
                     ImportSource = new PanelElementImportSourceFile
                     {
-                        Format = "MFME",
+                        Format = "LegacyImport",
                         Reference = "layout.json#lamp-8"
                     }
                 }
@@ -148,7 +148,7 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal(24, element.Stops);
         Assert.Equal(0.75, element.VisibleScale);
         Assert.NotNull(element.ImportSource);
-        Assert.Equal("MFME", element.ImportSource!.Format);
+        Assert.Equal("LegacyImport", element.ImportSource!.Format);
         Assert.Equal("layout.json#lamp-8", element.ImportSource.Reference);
     }
 
@@ -370,7 +370,7 @@ public sealed class Panel2DRoundTripTests
               "AssetPath": "  Assets/alpha.png  ",
               "DisplayText": "  HELLO  ",
               "ImportSource": {
-                "Format": "  MFME  ",
+                "Format": "  LegacyImport  ",
                 "Reference": "  layout.json#alpha-1  "
               }
             }
@@ -386,7 +386,7 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal("Assets/alpha.png", element.AssetPath);
         Assert.Equal("HELLO", element.DisplayText);
         Assert.NotNull(element.ImportSource);
-        Assert.Equal("MFME", element.ImportSource!.Format);
+        Assert.Equal("LegacyImport", element.ImportSource!.Format);
         Assert.Equal("layout.json#alpha-1", element.ImportSource.Reference);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelImportBoundaryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelImportBoundaryTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PanelElementModelImportBoundaryTests
+{
+    [Fact]
+    public void PanelElementModel_DoesNotExposeMfmeSpecificPropertyNames()
+    {
+        var properties = typeof(PanelElementModel).GetProperties();
+
+        Assert.DoesNotContain(properties, property =>
+            property.Name.Contains("Mfme", StringComparison.OrdinalIgnoreCase)
+            || property.Name.Contains("ExtractComponent", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void PanelElementImportSourceModel_UsesGenericProvenanceFields()
+    {
+        var properties = typeof(PanelElementImportSourceModel)
+            .GetProperties()
+            .Select(property => property.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(new[] { "Format", "Reference" }, properties);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -4,6 +4,8 @@ namespace OasisEditor.Features.MfmeImport;
 
 internal sealed class MfmeToOasisComponentMapper
 {
+    private const string ImportSourceFormat = "LegacyImport";
+
     public MfmeToOasisMapResult Map(MfmeLegacyExtractData extract)
     {
         ArgumentNullException.ThrowIfNull(extract);
@@ -61,7 +63,8 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             AssetPath = BuildExtractRelativePath("background", component.BmpImageFilename),
-            OnColorHex = ToHex(component.Color)
+            OnColorHex = ToHex(component.Color),
+            ImportSource = CreateImportSource(component.SourceType)
         };
     }
 
@@ -97,7 +100,8 @@ internal sealed class MfmeToOasisComponentMapper
             OnColorHex = ToHex(component.FirstLampElement?.OnColor),
             OffColorHex = ToHex(component.OffImageColor),
             TextColorHex = ToHex(component.TextColor),
-            DisplayText = NormalizeOptional(component.TextBoxText)
+            DisplayText = NormalizeOptional(component.TextBoxText),
+            ImportSource = CreateImportSource(number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType)
         };
     }
 
@@ -135,7 +139,8 @@ internal sealed class MfmeToOasisComponentMapper
                 : null,
             Stops = component.Stops,
             IsReversed = component.Reversed,
-            VisibleScale = visibleScale
+            VisibleScale = visibleScale,
+            ImportSource = CreateImportSource($"{component.SourceType}:{mappedNumber}")
         };
     }
 
@@ -151,7 +156,8 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             DisplayNumber = component.Number,
-            OnColorHex = ToHex(component.SegmentOnColor)
+            OnColorHex = ToHex(component.SegmentOnColor),
+            ImportSource = CreateImportSource($"{component.SourceType}:{component.Number}")
         };
     }
 
@@ -166,7 +172,17 @@ internal sealed class MfmeToOasisComponentMapper
             Y = component.Position.Y,
             Width = component.Size.X,
             Height = component.Size.Y,
-            IsReversed = component.Reversed
+            IsReversed = component.Reversed,
+            ImportSource = CreateImportSource(component.SourceType)
+        };
+    }
+
+    private static PanelElementImportSourceModel CreateImportSource(string reference)
+    {
+        return new PanelElementImportSourceModel
+        {
+            Format = ImportSourceFormat,
+            Reference = reference
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/PhaseQ.BuildAndTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseQ.BuildAndTestAttempt.md
@@ -1,0 +1,22 @@
+# Phase Q Build and Test Attempt
+
+Date: 2026-04-28
+
+## Goal
+
+Attempt the pending **Phase Q — Build and run tests** checkpoint in `TASKS.md` after native imported component visual projection updates.
+
+## Commands attempted
+
+- `dotnet --info`
+- `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`
+
+## Result
+
+Both commands failed in this container because the .NET SDK/CLI is unavailable:
+
+- `/bin/bash: line 1: dotnet: command not found`
+
+## Impact on TASKS
+
+The Phase Q `Build and run tests` checkbox remains pending in this environment and must be completed on a machine with the .NET SDK installed.

--- a/WindowsNetProjects/OasisEditor/PhaseR.BuildAndTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseR.BuildAndTestAttempt.md
@@ -1,0 +1,22 @@
+# Phase R Build and Test Attempt
+
+Date: 2026-04-28
+
+## Goal
+
+Attempt the pending **Phase R — Build and run tests** checkpoint in `TASKS.md` after the undoable MFME import command implementation.
+
+## Commands attempted
+
+- `dotnet --info`
+- `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`
+
+## Result
+
+Both commands failed in this container because the .NET SDK/CLI is unavailable:
+
+- `/bin/bash: line 1: dotnet: command not found`
+
+## Impact on TASKS
+
+The Phase R `Build and run tests` checkbox remains pending in this environment and must be completed on a machine with the .NET SDK installed.

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -202,8 +202,8 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
   - [x] Reels
   - [x] Seven Segments
   - [x] Alphas
-- [ ] Verify selection, hierarchy selection, inspector display, save/load, and undo/redo still work for new native kinds
-- [ ] Build and run tests
+- [ ] Verify selection, hierarchy selection, inspector display, save/load, and undo/redo still work for new native kinds *(blocked in current container; see `PhaseQ.VerificationAttempt.md`)*
+- [ ] Build and run tests *(blocked in current container; see `PhaseQ.BuildAndTestAttempt.md`)*
 
 ### Phase R — Undoable Import Command
 - [x] Add `ImportMfmeExtractCommand` or equivalent document-scoped command
@@ -216,7 +216,7 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 - [x] Ensure redo restores the same logical native elements without reusing stale command state incorrectly
 - [x] Ensure object IDs remain stable through undo/redo of the same command
 - [x] Add command tests for import, undo, redo, no-op import, and wrong-document safety
-- [ ] Build and run tests
+- [ ] Build and run tests *(blocked in current container; see `PhaseR.BuildAndTestAttempt.md`)*
 
 ### Phase S — Import UI Entry Point
 - [x] Add a user-facing import command to the WPF editor shell


### PR DESCRIPTION
### Motivation

- Preserve provenance for elements produced by the MFME legacy extract path using a generic import format identifier rather than MFME-specific strings.
- Ensure the PanelElement model surface does not expose MFME-specific property names and that import provenance uses generic `Format`/`Reference` fields.
- Update the import mapper and tests to assert and round-trip the new provenance values.

### Description

- Added an `ImportSourceFormat = "LegacyImport"` constant and introduced `CreateImportSource(string)` in `MfmeToOasisComponentMapper` to populate `PanelElementImportSourceModel.Format` and `Reference` for all mapped native elements.
- Updated mapping functions (`MapBackground`, `MapLamp`, `MapReel`, `MapSevenSegment`, `MapAlpha`) to attach `ImportSource` with appropriate references (e.g. `SourceType` or `SourceType:number`).
- Updated many unit tests to expect `ImportSource.Format == "LegacyImport"` and to assert `ImportSource.Reference` is populated, and added a new `PanelElementModelImportBoundaryTests` file that verifies the public model does not expose MFME-specific property names and that `PanelElementImportSourceModel` exposes only `Format` and `Reference`.
- Added small bookkeeping docs and task updates: `PhaseQ.BuildAndTestAttempt.md`, `PhaseR.BuildAndTestAttempt.md`, and updated `TASKS.md` to mark build/test steps as blocked in this container environment.

### Testing

- No automated test run could be completed in this environment because the .NET CLI is unavailable; `dotnet --info` and `dotnet test` failed with `/bin/bash: line 1: dotnet: command not found`.
- Unit tests were updated and new tests were added (`PanelElementModelImportBoundaryTests`, updates in `MfmeImportServiceTests`, `MfmeToOasisComponentMapperTests`, `HierarchyPanelCommandServiceTests`, and `Panel2DRoundTripTests`) and are intended to be executed with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` on a machine with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f07b7f79688327b4b60499dad723c9)