### PR TITLE
Add hierarchy reorder (bring/send front/back/forward) with undo and UI commands

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -306,6 +306,49 @@ public sealed class HierarchyPanelCommandServiceTests
         Assert.Single(document.CommandService.History.Entries);
     }
 
+    [Fact]
+    public void ReorderCanExecute_ReflectsSelectedElementPosition()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "back", Name = "Back", Kind = PanelElementKind.Rectangle, X = 0, Y = 0, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "middle", Name = "Middle", Kind = PanelElementKind.Rectangle, X = 20, Y = 0, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "front", Name = "Front", Kind = PanelElementKind.Rectangle, X = 40, Y = 0, Width = 10, Height = 10 });
+        var workspace = CreateWorkspace(document, document);
+        var service = CreateService(document, workspace);
+
+        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("middle", "rectangle", 20, 0, 10, 10);
+        Assert.True(service.CanBringToFrontSelected());
+        Assert.True(service.CanBringForwardSelected());
+        Assert.True(service.CanSendToBackSelected());
+        Assert.True(service.CanSendBackwardSelected());
+
+        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("front", "rectangle", 40, 0, 10, 10);
+        Assert.False(service.CanBringToFrontSelected());
+        Assert.False(service.CanBringForwardSelected());
+        Assert.True(service.CanSendToBackSelected());
+        Assert.True(service.CanSendBackwardSelected());
+    }
+
+    [Fact]
+    public void ExecuteBringToFrontSelected_ReordersElement_AndUndoRestoresOrder()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "first", Name = "First", Kind = PanelElementKind.Rectangle, X = 0, Y = 0, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "second", Name = "Second", Kind = PanelElementKind.Rectangle, X = 20, Y = 0, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "third", Name = "Third", Kind = PanelElementKind.Rectangle, X = 40, Y = 0, Width = 10, Height = 10 });
+        var workspace = CreateWorkspace(document, document);
+        var service = CreateService(document, workspace);
+        document.HierarchySelectedPanelSelection = new PanelSelectionInfo("first", "rectangle", 0, 0, 10, 10);
+
+        service.ExecuteBringToFrontSelected();
+
+        Assert.Equal(["second", "third", "first"], document.GetPanelElements().Select(element => element.ObjectId));
+        Assert.Single(document.CommandService.History.Entries);
+
+        Assert.True(workspace.UndoActiveDocument());
+        Assert.Equal(["first", "second", "third"], document.GetPanelElements().Select(element => element.ObjectId));
+    }
+
     private static HierarchyPanelCommandService CreateService(
         DocumentTabViewModel selectedDocument,
         DocumentWorkspaceViewModel workspace)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -42,6 +42,38 @@ internal static class CanvasMutationCommands
         return new PasteElementMutationCommand(documentId, document, sourceElement);
     }
 
+    public static Commands.ICommand CreateBringToFrontCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelSelectionInfo selection)
+    {
+        return new ReorderElementMutationCommand(documentId, document, selection, ReorderDirection.BringToFront);
+    }
+
+    public static Commands.ICommand CreateSendToBackCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelSelectionInfo selection)
+    {
+        return new ReorderElementMutationCommand(documentId, document, selection, ReorderDirection.SendToBack);
+    }
+
+    public static Commands.ICommand CreateBringForwardCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelSelectionInfo selection)
+    {
+        return new ReorderElementMutationCommand(documentId, document, selection, ReorderDirection.BringForward);
+    }
+
+    public static Commands.ICommand CreateSendBackwardCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        PanelSelectionInfo selection)
+    {
+        return new ReorderElementMutationCommand(documentId, document, selection, ReorderDirection.SendBackward);
+    }
+
     private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
@@ -401,6 +433,97 @@ internal static class CanvasMutationCommands
         }
     }
 
+    private sealed class ReorderElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly PanelSelectionInfo _selection;
+        private readonly ReorderDirection _direction;
+        private int? _fromIndex;
+        private int? _toIndex;
+        private string? _objectId;
+
+        public ReorderElementMutationCommand(
+            Guid documentId,
+            DocumentTabViewModel document,
+            PanelSelectionInfo selection,
+            ReorderDirection direction)
+        {
+            _documentId = documentId;
+            _document = document;
+            _selection = selection;
+            _direction = direction;
+        }
+
+        public Guid DocumentId => _documentId;
+
+        public string Description => _direction switch
+        {
+            ReorderDirection.BringToFront => "Bring to front",
+            ReorderDirection.SendToBack => "Send to back",
+            ReorderDirection.BringForward => "Bring forward",
+            ReorderDirection.SendBackward => "Send backward",
+            _ => "Reorder element"
+        };
+
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetPanelElements().ToList();
+            if (!TryFindMatchingElementIndex(elements, _selection, out var fromIndex))
+            {
+                return;
+            }
+
+            var toIndex = ResolveTargetIndex(fromIndex, elements.Count, _direction);
+            if (toIndex == fromIndex)
+            {
+                return;
+            }
+
+            var selected = elements[fromIndex];
+            elements.RemoveAt(fromIndex);
+            var insertIndex = toIndex > fromIndex ? toIndex - 1 : toIndex;
+            elements.Insert(insertIndex, selected);
+
+            _fromIndex = fromIndex;
+            _toIndex = insertIndex;
+            _objectId = selected.ObjectId;
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_fromIndex is not int fromIndex || _toIndex is not int toIndex || string.IsNullOrWhiteSpace(_objectId))
+            {
+                return;
+            }
+
+            var elements = _document.GetPanelElements().ToList();
+            if (toIndex < 0 || toIndex >= elements.Count)
+            {
+                return;
+            }
+
+            var currentIndex = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
+            if (currentIndex < 0)
+            {
+                return;
+            }
+
+            var selected = elements[currentIndex];
+            elements.RemoveAt(currentIndex);
+            var restoreIndex = Math.Clamp(fromIndex, 0, elements.Count);
+            elements.Insert(restoreIndex, selected);
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+        }
+    }
+
     private static bool TryFindMatchingElementIndex(IReadOnlyList<PanelElementModel> elements, PanelSelectionInfo selection, out int index)
     {
         var hasObjectId = !string.IsNullOrWhiteSpace(selection.ObjectId);
@@ -515,5 +638,25 @@ internal static class CanvasMutationCommands
 
             suffix++;
         }
+    }
+
+    private static int ResolveTargetIndex(int currentIndex, int count, ReorderDirection direction)
+    {
+        return direction switch
+        {
+            ReorderDirection.BringToFront => count - 1,
+            ReorderDirection.SendToBack => 0,
+            ReorderDirection.BringForward => Math.Min(currentIndex + 1, count - 1),
+            ReorderDirection.SendBackward => Math.Max(currentIndex - 1, 0),
+            _ => currentIndex
+        };
+    }
+
+    private enum ReorderDirection
+    {
+        BringToFront,
+        SendToBack,
+        BringForward,
+        SendBackward
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -440,7 +440,6 @@ internal static class CanvasMutationCommands
         private readonly PanelSelectionInfo _selection;
         private readonly ReorderDirection _direction;
         private int? _fromIndex;
-        private int? _toIndex;
         private string? _objectId;
 
         public ReorderElementMutationCommand(
@@ -477,19 +476,17 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            var toIndex = ResolveTargetIndex(fromIndex, elements.Count, _direction);
-            if (toIndex == fromIndex)
+            if (!CanReorder(fromIndex, elements.Count, _direction))
             {
                 return;
             }
 
             var selected = elements[fromIndex];
             elements.RemoveAt(fromIndex);
-            var insertIndex = toIndex > fromIndex ? toIndex - 1 : toIndex;
+            var insertIndex = ResolveInsertIndex(fromIndex, elements.Count + 1, _direction);
             elements.Insert(insertIndex, selected);
 
             _fromIndex = fromIndex;
-            _toIndex = insertIndex;
             _objectId = selected.ObjectId;
             _document.SetPanelElements(elements);
             _document.MarkDirty();
@@ -498,17 +495,12 @@ internal static class CanvasMutationCommands
 
         public void Undo()
         {
-            if (_fromIndex is not int fromIndex || _toIndex is not int toIndex || string.IsNullOrWhiteSpace(_objectId))
+            if (_fromIndex is not int fromIndex || string.IsNullOrWhiteSpace(_objectId))
             {
                 return;
             }
 
             var elements = _document.GetPanelElements().ToList();
-            if (toIndex < 0 || toIndex >= elements.Count)
-            {
-                return;
-            }
-
             var currentIndex = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
             if (currentIndex < 0)
             {
@@ -640,13 +632,25 @@ internal static class CanvasMutationCommands
         }
     }
 
-    private static int ResolveTargetIndex(int currentIndex, int count, ReorderDirection direction)
+    private static bool CanReorder(int currentIndex, int count, ReorderDirection direction)
     {
         return direction switch
         {
-            ReorderDirection.BringToFront => count - 1,
+            ReorderDirection.BringToFront => currentIndex < count - 1,
+            ReorderDirection.SendToBack => currentIndex > 0,
+            ReorderDirection.BringForward => currentIndex < count - 1,
+            ReorderDirection.SendBackward => currentIndex > 0,
+            _ => false
+        };
+    }
+
+    private static int ResolveInsertIndex(int currentIndex, int originalCount, ReorderDirection direction)
+    {
+        return direction switch
+        {
+            ReorderDirection.BringToFront => originalCount - 1,
             ReorderDirection.SendToBack => 0,
-            ReorderDirection.BringForward => Math.Min(currentIndex + 1, count - 1),
+            ReorderDirection.BringForward => Math.Min(currentIndex + 1, originalCount - 1),
             ReorderDirection.SendBackward => Math.Max(currentIndex - 1, 0),
             _ => currentIndex
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
@@ -133,6 +133,26 @@ internal sealed class HierarchyPanelCommandService
         return TryGetSelectionDocument(out var document, out var selection) && document.HasPanelElement(selection);
     }
 
+    public bool CanBringToFrontSelected()
+    {
+        return CanReorderSelected(ReorderAction.BringToFront);
+    }
+
+    public bool CanSendToBackSelected()
+    {
+        return CanReorderSelected(ReorderAction.SendToBack);
+    }
+
+    public bool CanBringForwardSelected()
+    {
+        return CanReorderSelected(ReorderAction.BringForward);
+    }
+
+    public bool CanSendBackwardSelected()
+    {
+        return CanReorderSelected(ReorderAction.SendBackward);
+    }
+
     public void ExecuteCutSelected()
     {
         if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
@@ -189,6 +209,26 @@ internal sealed class HierarchyPanelCommandService
         _executeCanvasCommand(document.DocumentId, command);
     }
 
+    public void ExecuteBringToFrontSelected()
+    {
+        ExecuteReorderSelected(ReorderAction.BringToFront);
+    }
+
+    public void ExecuteSendToBackSelected()
+    {
+        ExecuteReorderSelected(ReorderAction.SendToBack);
+    }
+
+    public void ExecuteBringForwardSelected()
+    {
+        ExecuteReorderSelected(ReorderAction.BringForward);
+    }
+
+    public void ExecuteSendBackwardSelected()
+    {
+        ExecuteReorderSelected(ReorderAction.SendBackward);
+    }
+
     private bool TryCopySelectedToClipboard()
     {
         if (!TryGetSelectionDocument(out var document, out var selection))
@@ -229,5 +269,71 @@ internal sealed class HierarchyPanelCommandService
         document = selectedDocument;
         selection = selected;
         return true;
+    }
+
+    private bool CanReorderSelected(ReorderAction action)
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        {
+            return false;
+        }
+
+        var elements = document.GetPanelElements();
+        if (elements.Count <= 1)
+        {
+            return false;
+        }
+
+        var selectedIndex = -1;
+        for (var i = 0; i < elements.Count; i++)
+        {
+            if (!PanelSelectionContract.IsMatch(Panel2DDocumentStorage.ToStorageElement(elements[i]), selection))
+            {
+                continue;
+            }
+
+            selectedIndex = i;
+            break;
+        }
+        if (selectedIndex < 0)
+        {
+            return false;
+        }
+
+        return action switch
+        {
+            ReorderAction.BringToFront => selectedIndex < elements.Count - 1,
+            ReorderAction.SendToBack => selectedIndex > 0,
+            ReorderAction.BringForward => selectedIndex < elements.Count - 1,
+            ReorderAction.SendBackward => selectedIndex > 0,
+            _ => false
+        };
+    }
+
+    private void ExecuteReorderSelected(ReorderAction action)
+    {
+        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        {
+            return;
+        }
+
+        Commands.ICommand command = action switch
+        {
+            ReorderAction.BringToFront => CanvasMutationCommands.CreateBringToFrontCommand(document.DocumentId, document, selection),
+            ReorderAction.SendToBack => CanvasMutationCommands.CreateSendToBackCommand(document.DocumentId, document, selection),
+            ReorderAction.BringForward => CanvasMutationCommands.CreateBringForwardCommand(document.DocumentId, document, selection),
+            ReorderAction.SendBackward => CanvasMutationCommands.CreateSendBackwardCommand(document.DocumentId, document, selection),
+            _ => throw new InvalidOperationException($"Unsupported reorder action '{action}'.")
+        };
+
+        _executeCanvasCommand(document.DocumentId, command);
+    }
+
+    private enum ReorderAction
+    {
+        BringToFront,
+        SendToBack,
+        BringForward,
+        SendBackward
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -137,6 +137,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         DuplicateSelectedHierarchyItemCommand = new RelayCommand(
             () => _hierarchyPanelCommands.ExecuteDuplicateSelected(),
             () => _hierarchyPanelCommands.CanDuplicateSelected());
+        BringToFrontHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteBringToFrontSelected(),
+            () => _hierarchyPanelCommands.CanBringToFrontSelected());
+        SendToBackHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteSendToBackSelected(),
+            () => _hierarchyPanelCommands.CanSendToBackSelected());
+        BringForwardHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteBringForwardSelected(),
+            () => _hierarchyPanelCommands.CanBringForwardSelected());
+        SendBackwardHierarchyItemCommand = new RelayCommand(
+            () => _hierarchyPanelCommands.ExecuteSendBackwardSelected(),
+            () => _hierarchyPanelCommands.CanSendBackwardSelected());
         ClearOutputCommand = _outputLog.ClearOutputCommand;
         ApplyInspectorSummaryCommand = _inspector.ApplyInspectorSummaryCommand;
         AddOutputEntry("Editor shell initialized.", OutputLogStatus.Info);
@@ -165,6 +177,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand CopySelectedHierarchyItemCommand { get; }
     public ICommand PasteHierarchyItemCommand { get; }
     public ICommand DuplicateSelectedHierarchyItemCommand { get; }
+    public ICommand BringToFrontHierarchyItemCommand { get; }
+    public ICommand SendToBackHierarchyItemCommand { get; }
+    public ICommand BringForwardHierarchyItemCommand { get; }
+    public ICommand SendBackwardHierarchyItemCommand { get; }
     public ICommand ClearOutputCommand { get; }
     public ICommand OpenPreferencesCommand { get; }
     public ICommand OpenProjectSettingsCommand { get; }
@@ -923,6 +939,26 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (DuplicateSelectedHierarchyItemCommand is RelayCommand duplicateHierarchyCommand)
         {
             duplicateHierarchyCommand.RaiseCanExecuteChanged();
+        }
+
+        if (BringToFrontHierarchyItemCommand is RelayCommand bringToFrontCommand)
+        {
+            bringToFrontCommand.RaiseCanExecuteChanged();
+        }
+
+        if (SendToBackHierarchyItemCommand is RelayCommand sendToBackCommand)
+        {
+            sendToBackCommand.RaiseCanExecuteChanged();
+        }
+
+        if (BringForwardHierarchyItemCommand is RelayCommand bringForwardCommand)
+        {
+            bringForwardCommand.RaiseCanExecuteChanged();
+        }
+
+        if (SendBackwardHierarchyItemCommand is RelayCommand sendBackwardCommand)
+        {
+            sendBackwardCommand.RaiseCanExecuteChanged();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -41,6 +41,20 @@
                     <MenuItem Header="Duplicate"
                               Style="{StaticResource EditorContextMenuItemStyle}"
                               Command="{Binding DuplicateSelectedHierarchyItemCommand}" />
+                    <Separator />
+                    <MenuItem Header="Bring to Front"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Command="{Binding BringToFrontHierarchyItemCommand}" />
+                    <MenuItem Header="Send to Back"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Command="{Binding SendToBackHierarchyItemCommand}" />
+                    <MenuItem Header="Bring Forward"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Command="{Binding BringForwardHierarchyItemCommand}" />
+                    <MenuItem Header="Send Backward"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Command="{Binding SendBackwardHierarchyItemCommand}" />
+                    <Separator />
                     <MenuItem Header="Delete"
                               Style="{StaticResource EditorContextMenuItemStyle}"
                               Command="{Binding DeleteSelectedHierarchyItemCommand}" />

--- a/WindowsNetProjects/OasisEditor/PhaseT.FinalBuildAndTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseT.FinalBuildAndTestAttempt.md
@@ -1,6 +1,6 @@
 # Phase T Final Build and Test Attempt
 
-Date: 2026-04-27
+Date: 2026-04-28
 
 ## Goal
 

--- a/WindowsNetProjects/OasisEditor/PhaseT.SmokeTestAttempt.md
+++ b/WindowsNetProjects/OasisEditor/PhaseT.SmokeTestAttempt.md
@@ -1,6 +1,6 @@
 # Phase T Smoke Test Attempt
 
-Date: 2026-04-27
+Date: 2026-04-28
 
 ## Goal
 

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -235,9 +235,9 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
 ### Phase T — End-to-End Validation and Cleanup
 - [x] Create or identify a small MFME extract fixture for manual smoke testing
   - [x] Must include at least one Background, Lamp, Reel, SevenSegment, and Alpha if possible
-  - [ ] Keep fixture out of git if it is large or not redistributable
+  - [x] Keep fixture out of git if it is large or not redistributable
 - [ ] Smoke test importing into an empty project/document
-  - [ ] Blocked in current container; see `PhaseT.SmokeTestAttempt.md`
+  - [x] Blocked in current container; see `PhaseT.SmokeTestAttempt.md`
   - [ ] Imported assets are copied under the project's `Assets/MfmeImport/...` folder
   - [ ] Native Oasis Panel2D elements appear at expected positions/sizes
   - [ ] Hierarchy groups show imported native elements
@@ -254,7 +254,8 @@ Complete these tasks in order. Keep each task small enough for one Codex pass wh
   - [x] Alpha renderer
   - [x] Native button/input mapping
   - [x] Runtime/export mapping
-- [ ] Final build and test run *(blocked in current container; see `PhaseT.FinalBuildAndTestAttempt.md`)*
+- [ ] Final build and test run
+  - [x] Blocked in current container; see `PhaseT.FinalBuildAndTestAttempt.md`
 
 ---
 


### PR DESCRIPTION
### Motivation
- Enable reordering of Panel2D elements from the hierarchy (bring to front, send to back, bring forward, send backward) with undo/redo support and UI affordances.

### Description
- Add `ReorderElementMutationCommand` and supporting `ReorderDirection` and `ResolveTargetIndex` logic to `CanvasMutationCommands.cs` and expose factories `CreateBringToFrontCommand`, `CreateSendToBackCommand`, `CreateBringForwardCommand`, and `CreateSendBackwardCommand`.
- Extend `HierarchyPanelCommandService` with `CanBringToFrontSelected`, `CanSendToBackSelected`, `CanBringForwardSelected`, `CanSendBackwardSelected`, `Execute...` methods, and shared helpers `CanReorderSelected` and `ExecuteReorderSelected` plus `ReorderAction` enum.
- Wire new commands into the shell by adding RelayCommands to `MainWindowViewModel` and raising `CanExecute` updates, and add context-menu items in `HierarchyView.xaml` for the four reorder actions.
- Add unit tests in `HierarchyPanelCommandServiceTests.cs`: `ReorderCanExecute_ReflectsSelectedElementPosition` and `ExecuteBringToFrontSelected_ReordersElement_AndUndoRestoresOrder` to validate can-execute logic and undo behavior.
- Update task/phase documents to record smoke/build/test attempts and environment constraints.

### Testing
- Added unit tests `ReorderCanExecute_ReflectsSelectedElementPosition` and `ExecuteBringToFrontSelected_ReordersElement_AndUndoRestoresOrder` to `HierarchyPanelCommandServiceTests.cs` (not executed in this environment).
- Attempted `dotnet build` and `dotnet test` locally in the container, but the .NET CLI is unavailable and the commands failed with `/bin/bash: line 1: dotnet: command not found`, so automated tests were not run here and should be executed in a machine with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f07fa8943083278574e0265e8443c6)