### PR TITLE
Auto-scroll Hierarchy tree to selected panel object

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -17,6 +17,7 @@
                   ItemsSource="{Binding HierarchyItems}"
                   SelectedItemChanged="OnTreeViewSelectedItemChanged"
                   PreviewKeyDown="OnTreeViewPreviewKeyDown"
+                  PreviewMouseLeftButtonDown="OnTreeViewPreviewMouseLeftButtonDown"
                   PreviewMouseRightButtonDown="OnTreeViewPreviewMouseRightButtonDown"
                   Visibility="{Binding HasHierarchyItems, Converter={StaticResource BoolToVisibility}}"
                   Foreground="{DynamicResource TextPrimaryBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -78,6 +78,7 @@
                     <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <EventSetter Event="Selected" Handler="OnTreeViewItemSelected" />
                 </Style>
                 <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"
                                           ItemsSource="{Binding Children}">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -83,7 +83,26 @@ public partial class HierarchyView : UserControl
             return;
         }
 
+        if (IsVerticallyVisible(treeViewItem))
+        {
+            return;
+        }
+
         treeViewItem.BringIntoView();
+    }
+
+    private static bool IsVerticallyVisible(TreeViewItem treeViewItem)
+    {
+        var scrollViewer = FindAncestor<ScrollViewer>(treeViewItem);
+        if (scrollViewer is null || scrollViewer.ViewportHeight <= 0)
+        {
+            return false;
+        }
+
+        var bounds = treeViewItem.TransformToAncestor(scrollViewer)
+            .TransformBounds(new Rect(new Point(0, 0), treeViewItem.RenderSize));
+
+        return bounds.Top >= 0 && bounds.Bottom <= scrollViewer.ViewportHeight;
     }
 
     private static T? FindAncestor<T>(DependencyObject current)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -114,6 +114,18 @@ public partial class HierarchyView : UserControl
             return;
         }
 
+        Dispatcher.BeginInvoke(
+            DispatcherPriority.Loaded,
+            new Action(() => EnsureTreeViewItemIsVisible(treeViewItem)));
+    }
+
+    private static void EnsureTreeViewItemIsVisible(TreeViewItem treeViewItem)
+    {
+        if (!treeViewItem.IsSelected || !treeViewItem.IsVisible)
+        {
+            return;
+        }
+
         if (IsVerticallyVisible(treeViewItem))
         {
             return;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -2,11 +2,14 @@ using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace OasisEditor.Views;
 
 public partial class HierarchyView : UserControl
 {
+    private bool _suppressAutoScrollForUserTreeSelection;
+
     public HierarchyView()
     {
         InitializeComponent();
@@ -76,9 +79,37 @@ public partial class HierarchyView : UserControl
         viewModel.SelectHierarchyItemForContextMenu(hierarchyItem);
     }
 
+    private void OnTreeViewPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs eventArgs)
+    {
+        if (eventArgs.OriginalSource is not DependencyObject source)
+        {
+            return;
+        }
+
+        if (FindAncestor<TreeViewItem>(source) is null)
+        {
+            return;
+        }
+
+        _suppressAutoScrollForUserTreeSelection = true;
+        Dispatcher.BeginInvoke(
+            DispatcherPriority.Input,
+            new Action(() => _suppressAutoScrollForUserTreeSelection = false));
+    }
+
     private void OnTreeViewItemSelected(object sender, RoutedEventArgs eventArgs)
     {
         if (sender is not TreeViewItem treeViewItem)
+        {
+            return;
+        }
+
+        if (!ReferenceEquals(sender, eventArgs.OriginalSource))
+        {
+            return;
+        }
+
+        if (_suppressAutoScrollForUserTreeSelection)
         {
             return;
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -76,6 +76,16 @@ public partial class HierarchyView : UserControl
         viewModel.SelectHierarchyItemForContextMenu(hierarchyItem);
     }
 
+    private void OnTreeViewItemSelected(object sender, RoutedEventArgs eventArgs)
+    {
+        if (sender is not TreeViewItem treeViewItem)
+        {
+            return;
+        }
+
+        treeViewItem.BringIntoView();
+    }
+
     private static T? FindAncestor<T>(DependencyObject current)
         where T : DependencyObject
     {


### PR DESCRIPTION
### Motivation
- Ensure Hierarchy view scrolls to reveal the item when selection is changed from the panel2d canvas so users can always see the synced item in large trees.

### Description
- Hook the `TreeViewItem.Selected` event by adding an `EventSetter` in `WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml` so item selection raises a handler.
- Implement `OnTreeViewItemSelected` in `WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs` and call `BringIntoView()` on the selected `TreeViewItem` so the tree scrolls to the selected node.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln -v minimal` but the build could not run in this environment because the `dotnet` CLI is not installed, so automated build tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0b50a1f0883279af0f154611ce86b)