### PR TITLE
Add inspector element update infrastructure and UpdateElement document command

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1054,6 +1054,183 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void UpdateElementCommand_UpdatesTargetedElementAndSupportsUndoRedo()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "target-id",
+                Name = "Target",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 20,
+                Width = 30,
+                Height = 40
+            },
+            new PanelElementModel
+            {
+                ObjectId = "other-id",
+                Name = "Other",
+                Kind = PanelElementKind.Rectangle,
+                X = 1,
+                Y = 2,
+                Width = 3,
+                Height = 4
+            });
+        var workspace = CreateWorkspace(document, document);
+        var updated = new PanelElementModel
+        {
+            ObjectId = "target-id",
+            Name = "Target Renamed",
+            Kind = PanelElementKind.Rectangle,
+            X = 50,
+            Y = 60,
+            Width = 70,
+            Height = 80
+        };
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "target-id",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+
+        var mutatedTarget = document.GetPanelElements().Single(element => element.ObjectId == "target-id");
+        var untouched = document.GetPanelElements().Single(element => element.ObjectId == "other-id");
+        Assert.Equal("Target Renamed", mutatedTarget.Name);
+        Assert.Equal(50, mutatedTarget.X);
+        Assert.Equal(60, mutatedTarget.Y);
+        Assert.Equal(70, mutatedTarget.Width);
+        Assert.Equal(80, mutatedTarget.Height);
+        Assert.Equal("Other", untouched.Name);
+
+        Assert.True(workspace.UndoActiveDocument());
+        var restoredTarget = document.GetPanelElements().Single(element => element.ObjectId == "target-id");
+        Assert.Equal("Target", restoredTarget.Name);
+        Assert.Equal(10, restoredTarget.X);
+        Assert.Equal(20, restoredTarget.Y);
+        Assert.Equal(30, restoredTarget.Width);
+        Assert.Equal(40, restoredTarget.Height);
+
+        Assert.True(workspace.RedoActiveDocument());
+        var redoneTarget = document.GetPanelElements().Single(element => element.ObjectId == "target-id");
+        Assert.Equal("Target Renamed", redoneTarget.Name);
+    }
+
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_UpdateElementNoOp_DoesNotRecordHistory()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var unchanged = document.GetPanelElements().Single();
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            PanelElementModelCloner.Clone(unchanged),
+            "Inspector update");
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command);
+
+        Assert.False(executed);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Equal("Rect 1", document.GetPanelElements().Single().Name);
+    }
+
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_UpdateElementMissingObject_DoesNotRecordHistory()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var updated = new PanelElementModel
+        {
+            ObjectId = "missing-id",
+            Name = "Renamed",
+            Kind = PanelElementKind.Rectangle,
+            X = 1,
+            Y = 2,
+            Width = 3,
+            Height = 4
+        };
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "missing-id",
+            updated,
+            "Inspector update");
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command);
+
+        Assert.False(executed);
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void ExecuteDocumentCanvasCommand_UpdateElementInvalidWidth_DoesNotExecute()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+
+        var invalid = new PanelElementModel
+        {
+            ObjectId = "rect-1",
+            Name = "Rect Invalid",
+            Kind = PanelElementKind.Rectangle,
+            X = 10,
+            Y = 10,
+            Width = 0,
+            Height = 20
+        };
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            invalid,
+            "Inspector update");
+
+        var executed = workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command);
+
+        Assert.False(executed);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Equal(20, document.GetPanelElements().Single().Width);
+    }
+
+    [Fact]
     public void ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate()
     {
         var firstDocument = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelUpdaterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelUpdaterTests.cs
@@ -1,3 +1,5 @@
+using Xunit;
+
 namespace OasisEditor.Tests;
 
 public sealed class PanelElementModelUpdaterTests

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelUpdaterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementModelUpdaterTests.cs
@@ -1,0 +1,76 @@
+namespace OasisEditor.Tests;
+
+public sealed class PanelElementModelUpdaterTests
+{
+    [Fact]
+    public void Apply_UpdatesRequestedFields_AndCanClearNullableValues()
+    {
+        var source = new PanelElementModel
+        {
+            ObjectId = "element-1",
+            Name = "Source",
+            Kind = PanelElementKind.Lamp,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            AssetPath = "Assets/lamp.png",
+            SecondaryAssetPath = "Assets/mask.png",
+            DisplayNumber = 7,
+            OnColorHex = "#FFFFFF",
+            OffColorHex = "#111111",
+            TextColorHex = "#FF0000",
+            DisplayText = "ABC",
+            IsReversed = true,
+            Stops = 24,
+            VisibleScale = 1.5,
+            IsLocked = false,
+            IsVisible = true
+        };
+
+        var updated = PanelElementModelUpdater.Apply(
+            source,
+            new PanelElementModelUpdate
+            {
+                Name = "Updated",
+                X = 99.5,
+                AssetPath = (string?)null,
+                DisplayNumber = (int?)null,
+                IsLocked = true,
+                IsVisible = false
+            });
+
+        Assert.Equal("element-1", updated.ObjectId);
+        Assert.Equal(PanelElementKind.Lamp, updated.Kind);
+        Assert.Equal("Updated", updated.Name);
+        Assert.Equal(99.5, updated.X);
+        Assert.Equal(20, updated.Y);
+        Assert.Null(updated.AssetPath);
+        Assert.Null(updated.DisplayNumber);
+        Assert.True(updated.IsLocked);
+        Assert.False(updated.IsVisible);
+        Assert.Equal("#111111", updated.OffColorHex);
+    }
+
+    [Theory]
+    [InlineData(1, 1, 1, 1, true)]
+    [InlineData(double.NaN, 1, 1, 1, false)]
+    [InlineData(1, double.PositiveInfinity, 1, 1, false)]
+    [InlineData(1, 1, 0, 1, false)]
+    [InlineData(1, 1, 1, -5, false)]
+    public void IsValidForInspectorUpdate_ValidatesNumericRequirements(double x, double y, double width, double height, bool expected)
+    {
+        var element = new PanelElementModel
+        {
+            ObjectId = "element-1",
+            Name = "Element",
+            Kind = PanelElementKind.Rectangle,
+            X = x,
+            Y = y,
+            Width = width,
+            Height = height
+        };
+
+        Assert.Equal(expected, PanelElementValidation.IsValidForInspectorUpdate(element));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -92,6 +92,16 @@ internal static class CanvasMutationCommands
         return new SetElementVisibilityMutationCommand(documentId, document, selection, isVisible);
     }
 
+    public static Commands.ICommand CreateUpdateElementCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        string objectId,
+        PanelElementModel updatedElement,
+        string description)
+    {
+        return new UpdateElementMutationCommand(documentId, document, objectId, updatedElement, description);
+    }
+
     private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
@@ -677,6 +687,93 @@ internal static class CanvasMutationCommands
             }
 
             elements[index] = PanelElementModelCloner.Clone(elements[index], isVisible: _previousValue);
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+        }
+    }
+
+    private sealed class UpdateElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly string _objectId;
+        private readonly PanelElementModel _updatedElement;
+        private readonly string _description;
+        private PanelElementModel? _previousElement;
+
+        public UpdateElementMutationCommand(
+            Guid documentId,
+            DocumentTabViewModel document,
+            string objectId,
+            PanelElementModel updatedElement,
+            string description)
+        {
+            _documentId = documentId;
+            _document = document;
+            _objectId = objectId;
+            _updatedElement = updatedElement;
+            _description = string.IsNullOrWhiteSpace(description)
+                ? "Update element"
+                : description;
+        }
+
+        public Guid DocumentId => _documentId;
+
+        public string Description => _description;
+
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            if (string.IsNullOrWhiteSpace(_objectId))
+            {
+                return;
+            }
+
+            var elements = _document.GetPanelElements().ToList();
+            var index = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return;
+            }
+
+            var existing = elements[index];
+            if (!string.Equals(_updatedElement.ObjectId, _objectId, StringComparison.Ordinal)
+                || _updatedElement.Kind != existing.Kind
+                || !PanelElementValidation.IsValidForInspectorUpdate(_updatedElement)
+                || PanelElementModelComparer.AreEquivalent(existing, _updatedElement))
+            {
+                return;
+            }
+
+            _previousElement = PanelElementModelCloner.Clone(existing);
+            elements[index] = PanelElementModelCloner.Clone(_updatedElement);
+            _document.SetPanelElements(elements);
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_previousElement is null || string.IsNullOrWhiteSpace(_objectId))
+            {
+                return;
+            }
+
+            var elements = _document.GetPanelElements().ToList();
+            var index = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return;
+            }
+
+            if (PanelElementModelComparer.AreEquivalent(elements[index], _previousElement))
+            {
+                return;
+            }
+
+            elements[index] = PanelElementModelCloner.Clone(_previousElement);
             _document.SetPanelElements(elements);
             _document.MarkDirty();
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -1,0 +1,83 @@
+namespace OasisEditor;
+
+internal readonly struct PanelElementOptionalValue<T>
+{
+    private readonly T _value;
+
+    public PanelElementOptionalValue(T value)
+    {
+        HasValue = true;
+        _value = value;
+    }
+
+    public bool HasValue { get; }
+
+    public T Value => HasValue
+        ? _value
+        : throw new InvalidOperationException("No value has been assigned.");
+
+    public static implicit operator PanelElementOptionalValue<T>(T value)
+    {
+        return new PanelElementOptionalValue<T>(value);
+    }
+}
+
+internal sealed class PanelElementModelUpdate
+{
+    public PanelElementOptionalValue<string?> Name { get; init; }
+    public PanelElementOptionalValue<double> X { get; init; }
+    public PanelElementOptionalValue<double> Y { get; init; }
+    public PanelElementOptionalValue<double> Width { get; init; }
+    public PanelElementOptionalValue<double> Height { get; init; }
+    public PanelElementOptionalValue<string?> AssetPath { get; init; }
+    public PanelElementOptionalValue<string?> SecondaryAssetPath { get; init; }
+    public PanelElementOptionalValue<int?> DisplayNumber { get; init; }
+    public PanelElementOptionalValue<string?> OnColorHex { get; init; }
+    public PanelElementOptionalValue<string?> OffColorHex { get; init; }
+    public PanelElementOptionalValue<string?> TextColorHex { get; init; }
+    public PanelElementOptionalValue<string?> DisplayText { get; init; }
+    public PanelElementOptionalValue<bool?> IsReversed { get; init; }
+    public PanelElementOptionalValue<int?> Stops { get; init; }
+    public PanelElementOptionalValue<double?> VisibleScale { get; init; }
+    public PanelElementOptionalValue<bool> IsLocked { get; init; }
+    public PanelElementOptionalValue<bool> IsVisible { get; init; }
+}
+
+internal static class PanelElementModelUpdater
+{
+    public static PanelElementModel Apply(PanelElementModel source, PanelElementModelUpdate update)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(update);
+
+        return new PanelElementModel
+        {
+            ObjectId = source.ObjectId,
+            Name = update.Name.HasValue ? update.Name.Value ?? string.Empty : source.Name,
+            Kind = source.Kind,
+            X = update.X.HasValue ? update.X.Value : source.X,
+            Y = update.Y.HasValue ? update.Y.Value : source.Y,
+            Width = update.Width.HasValue ? update.Width.Value : source.Width,
+            Height = update.Height.HasValue ? update.Height.Value : source.Height,
+            AssetPath = update.AssetPath.HasValue ? update.AssetPath.Value : source.AssetPath,
+            SecondaryAssetPath = update.SecondaryAssetPath.HasValue ? update.SecondaryAssetPath.Value : source.SecondaryAssetPath,
+            DisplayNumber = update.DisplayNumber.HasValue ? update.DisplayNumber.Value : source.DisplayNumber,
+            OnColorHex = update.OnColorHex.HasValue ? update.OnColorHex.Value : source.OnColorHex,
+            OffColorHex = update.OffColorHex.HasValue ? update.OffColorHex.Value : source.OffColorHex,
+            TextColorHex = update.TextColorHex.HasValue ? update.TextColorHex.Value : source.TextColorHex,
+            DisplayText = update.DisplayText.HasValue ? update.DisplayText.Value : source.DisplayText,
+            IsReversed = update.IsReversed.HasValue ? update.IsReversed.Value : source.IsReversed,
+            Stops = update.Stops.HasValue ? update.Stops.Value : source.Stops,
+            VisibleScale = update.VisibleScale.HasValue ? update.VisibleScale.Value : source.VisibleScale,
+            IsLocked = update.IsLocked.HasValue ? update.IsLocked.Value : source.IsLocked,
+            IsVisible = update.IsVisible.HasValue ? update.IsVisible.Value : source.IsVisible,
+            ImportSource = source.ImportSource is null
+                ? null
+                : new PanelElementImportSourceModel
+                {
+                    Format = source.ImportSource.Format,
+                    Reference = source.ImportSource.Reference
+                }
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -1,0 +1,65 @@
+namespace OasisEditor;
+
+internal static class PanelElementValidation
+{
+    public static bool IsFinite(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    public static bool IsPositiveFinite(double value)
+    {
+        return IsFinite(value) && value > 0;
+    }
+
+    public static bool IsValidForInspectorUpdate(PanelElementModel element)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+
+        return IsFinite(element.X)
+               && IsFinite(element.Y)
+               && IsPositiveFinite(element.Width)
+               && IsPositiveFinite(element.Height);
+    }
+}
+
+internal static class PanelElementModelComparer
+{
+    public static bool AreEquivalent(PanelElementModel left, PanelElementModel right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        return string.Equals(left.ObjectId, right.ObjectId, StringComparison.Ordinal)
+               && string.Equals(left.Name, right.Name, StringComparison.Ordinal)
+               && left.Kind == right.Kind
+               && left.X.Equals(right.X)
+               && left.Y.Equals(right.Y)
+               && left.Width.Equals(right.Width)
+               && left.Height.Equals(right.Height)
+               && string.Equals(left.AssetPath, right.AssetPath, StringComparison.Ordinal)
+               && string.Equals(left.SecondaryAssetPath, right.SecondaryAssetPath, StringComparison.Ordinal)
+               && left.DisplayNumber == right.DisplayNumber
+               && string.Equals(left.OnColorHex, right.OnColorHex, StringComparison.Ordinal)
+               && string.Equals(left.OffColorHex, right.OffColorHex, StringComparison.Ordinal)
+               && string.Equals(left.TextColorHex, right.TextColorHex, StringComparison.Ordinal)
+               && string.Equals(left.DisplayText, right.DisplayText, StringComparison.Ordinal)
+               && left.IsReversed == right.IsReversed
+               && left.Stops == right.Stops
+               && left.VisibleScale == right.VisibleScale
+               && left.IsLocked == right.IsLocked
+               && left.IsVisible == right.IsVisible
+               && AreEquivalent(left.ImportSource, right.ImportSource);
+    }
+
+    private static bool AreEquivalent(PanelElementImportSourceModel? left, PanelElementImportSourceModel? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        return string.Equals(left.Format, right.Format, StringComparison.Ordinal)
+               && string.Equals(left.Reference, right.Reference, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide the foundation for Inspector-driven edits that must follow clone-and-replace semantics, validate numeric input, avoid no-op undo entries, and be scoped to a specific document/object ID.
- Prepare for wiring the Inspector UI so edits commit through a single, testable document-scoped command instead of mutating domain models directly.

### Description
- Added a selective-update representation `PanelElementModelUpdate` with `PanelElementOptionalValue<T>` to express field updates (including clearing nullable fields) without losing immutability semantics.
- Implemented `PanelElementModelUpdater.Apply(...)` to produce updated immutable `PanelElementModel` snapshots from a source + update.
- Added `PanelElementValidation` helpers (`IsFinite`, `IsPositiveFinite`, `IsValidForInspectorUpdate`) and `PanelElementModelComparer.AreEquivalent(...)` for numeric validation and no-op detection.
- Extended `CanvasMutationCommands` with `CreateUpdateElementCommand(...)` and a new `UpdateElementMutationCommand` that targets a specific `objectId`, enforces `objectId`/`Kind` invariants, validates geometry, prevents no-op history entries, marks the document dirty on real changes, and supports undo/redo by restoring the previous snapshot.
- Added unit tests: `PanelElementModelUpdaterTests` and new tests in `Panel2DRoundTripTests` covering update execution, undo/redo, no-op behavior, missing target, and invalid-width rejection.

### Testing
- No automated test runs were executed in this environment because the container lacks the .NET SDK and WPF runtime; local verification is required (per project AGENT constraints).
- Added tests to be executed locally: `PanelElementModelUpdaterTests` and the new update-related tests in `Panel2DRoundTripTests` (`UpdateElementCommand_UpdatesTargetedElementAndSupportsUndoRedo`, `ExecuteDocumentCanvasCommand_UpdateElementNoOp_DoesNotRecordHistory`, `ExecuteDocumentCanvasCommand_UpdateElementMissingObject_DoesNotRecordHistory`, `ExecuteDocumentCanvasCommand_UpdateElementInvalidWidth_DoesNotExecute`).
- Please run locally on Windows: `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` and `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` and confirm the new tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0c28b49408327ab611020f8af7583)