### PR TITLE
Add Inspector property row model foundation and render rows in UI

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
@@ -63,6 +63,55 @@ public sealed class InspectorViewModelTests
         Assert.Contains("Reel number: 3, stops: 24.", viewModel.InspectorSummary);
     }
 
+    [Fact]
+    public void InspectorPropertyRows_SelectedLamp_IncludesCommonAndLampFields()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Lamp 7",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    DisplayNumber = 7,
+                    OnColorHex = "#FFFFFF",
+                    IsLocked = true,
+                    IsVisible = false
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("lamp-1", "lamp", 10, 20, 30, 40));
+
+        var viewModel = CreateInspectorViewModel(selectedDocument, context);
+        viewModel.NotifyContextChanged();
+
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Name");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Locked");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Visible");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Display Number");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "On Color");
+    }
+
+    [Fact]
+    public void InspectorPropertyRows_NoSelection_AreEmpty()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+
+        var viewModel = CreateInspectorViewModel(selectedDocument, context);
+        viewModel.NotifyContextChanged();
+
+        Assert.Empty(viewModel.InspectorPropertyRows);
+    }
+
     private static InspectorViewModel CreateInspectorViewModel(
         DocumentTabViewModel selectedDocument,
         ActiveDocumentContextService context)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -343,6 +343,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public bool CanEditInspectorSummary => _inspector.CanEditInspectorSummary;
 
+    public IReadOnlyList<InspectorPropertyRowViewModel> InspectorPropertyRows => _inspector.InspectorPropertyRows;
+
     public IReadOnlyList<HierarchyItemViewModel> HierarchyItems => _hierarchy.Items;
 
     public bool HasHierarchyItems => _hierarchy.HasItems;
@@ -1118,6 +1120,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(InspectorEditableSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
+        OnPropertyChanged(nameof(InspectorPropertyRows));
     }
 
     private void RefreshHierarchy()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace OasisEditor;
+
+public abstract class InspectorPropertyRowViewModel : INotifyPropertyChanged
+{
+    private string _errorText = string.Empty;
+
+    protected InspectorPropertyRowViewModel(string displayName, string groupName, bool isReadOnly)
+    {
+        DisplayName = displayName;
+        GroupName = groupName;
+        IsReadOnly = isReadOnly;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string DisplayName { get; }
+
+    public string GroupName { get; }
+
+    public bool IsReadOnly { get; }
+
+    public string ErrorText
+    {
+        get => _errorText;
+        set => SetProperty(ref _errorText, value);
+    }
+
+    protected bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+}
+
+public sealed class InspectorTextPropertyViewModel : InspectorPropertyRowViewModel
+{
+    private string _value;
+
+    public InspectorTextPropertyViewModel(string displayName, string groupName, string value, bool isReadOnly = false)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value;
+    }
+
+    public string Value
+    {
+        get => _value;
+        set => SetProperty(ref _value, value);
+    }
+}
+
+public sealed class InspectorDoublePropertyViewModel : InspectorPropertyRowViewModel
+{
+    private double _value;
+
+    public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value;
+    }
+
+    public double Value
+    {
+        get => _value;
+        set => SetProperty(ref _value, value);
+    }
+}
+
+public sealed class InspectorIntPropertyViewModel : InspectorPropertyRowViewModel
+{
+    private int? _value;
+
+    public InspectorIntPropertyViewModel(string displayName, string groupName, int? value, bool isReadOnly = false)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value;
+    }
+
+    public int? Value
+    {
+        get => _value;
+        set => SetProperty(ref _value, value);
+    }
+}
+
+public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewModel
+{
+    private bool _value;
+
+    public InspectorBoolPropertyViewModel(string displayName, string groupName, bool value, bool isReadOnly = false)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value;
+    }
+
+    public bool Value
+    {
+        get => _value;
+        set => SetProperty(ref _value, value);
+    }
+}
+
+public sealed class InspectorInfoPropertyViewModel : InspectorPropertyRowViewModel
+{
+    private string _value;
+
+    public InspectorInfoPropertyViewModel(string displayName, string groupName, string value)
+        : base(displayName, groupName, true)
+    {
+        _value = value;
+    }
+
+    public string Value
+    {
+        get => _value;
+        set => SetProperty(ref _value, value);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -193,7 +193,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         var selectedDocument = _selectedDocumentAccessor();
         var selection = _activeDocumentContext.ActivePanelSelection;
-        if (selectedDocument is null || selection is null || !selectedDocument.TryGetPanelElement(selection, out var selectedElement))
+        if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
         {
             OnPropertyChanged(nameof(InspectorPropertyRows));
             return;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
@@ -13,6 +13,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private readonly Func<EditorProject?> _loadedProjectAccessor;
     private readonly ActiveDocumentContextService _activeDocumentContext;
     private readonly Func<DocumentTabViewModel, string, DocumentTabViewModel?> _applySummary;
+    private readonly ObservableCollection<InspectorPropertyRowViewModel> _propertyRows = [];
     private string _inspectorEditableSummary = string.Empty;
 
     public InspectorViewModel(
@@ -33,6 +34,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public ICommand ApplyInspectorSummaryCommand { get; }
+
+    public IReadOnlyList<InspectorPropertyRowViewModel> InspectorPropertyRows => _propertyRows;
 
     public string InspectorTitle
     {
@@ -178,8 +181,96 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
 
+        RebuildPropertyRows();
+
         InspectorEditableSummary = _selectedDocumentAccessor()?.ContentSummary ?? string.Empty;
         NotifyInspectorEditCommand();
+    }
+
+    private void RebuildPropertyRows()
+    {
+        _propertyRows.Clear();
+
+        var selectedDocument = _selectedDocumentAccessor();
+        var selection = _activeDocumentContext.ActivePanelSelection;
+        if (selectedDocument is null || selection is null || !selectedDocument.TryGetPanelElement(selection, out var selectedElement))
+        {
+            OnPropertyChanged(nameof(InspectorPropertyRows));
+            return;
+        }
+
+        _propertyRows.Add(new InspectorTextPropertyViewModel("Name", "Common", selectedElement.Name));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Object ID", "Metadata", selectedElement.ObjectId));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Kind", "Metadata", selectedElement.Kind.ToString()));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel("X", "Transform", selectedElement.X));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel("Y", "Transform", selectedElement.Y));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel("Width", "Transform", selectedElement.Width));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel("Height", "Transform", selectedElement.Height));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel("Locked", "Common", selectedElement.IsLocked));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel("Visible", "Common", selectedElement.IsVisible));
+
+        AddTypeSpecificRows(selectedElement);
+
+        OnPropertyChanged(nameof(InspectorPropertyRows));
+    }
+
+    private void AddTypeSpecificRows(PanelElementModel selectedElement)
+    {
+        if (selectedElement.DisplayNumber.HasValue)
+        {
+            _propertyRows.Add(new InspectorIntPropertyViewModel("Display Number", "Type-specific", selectedElement.DisplayNumber));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.AssetPath))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("Asset Path", "Type-specific", selectedElement.AssetPath));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.SecondaryAssetPath))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("Secondary Asset", "Type-specific", selectedElement.SecondaryAssetPath));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.OnColorHex))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("On Color", "Type-specific", selectedElement.OnColorHex));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.OffColorHex))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("Off Color", "Type-specific", selectedElement.OffColorHex));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.TextColorHex))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("Text Color", "Type-specific", selectedElement.TextColorHex));
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedElement.DisplayText))
+        {
+            _propertyRows.Add(new InspectorTextPropertyViewModel("Display Text", "Type-specific", selectedElement.DisplayText));
+        }
+
+        if (selectedElement.Stops.HasValue)
+        {
+            _propertyRows.Add(new InspectorIntPropertyViewModel("Stops", "Type-specific", selectedElement.Stops));
+        }
+
+        if (selectedElement.VisibleScale.HasValue)
+        {
+            _propertyRows.Add(new InspectorDoublePropertyViewModel("Visible Scale", "Type-specific", selectedElement.VisibleScale.Value));
+        }
+
+        if (selectedElement.IsReversed.HasValue)
+        {
+            _propertyRows.Add(new InspectorBoolPropertyViewModel("Reversed", "Type-specific", selectedElement.IsReversed.Value));
+        }
+
+        if (selectedElement.ImportSource is not null)
+        {
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference));
+        }
     }
 
     private bool CanApplyInspectorSummary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -3,9 +3,81 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:OasisEditor"
              mc:Ignorable="d"
              d:DesignHeight="300"
              d:DesignWidth="260">
+    <UserControl.Resources>
+        <DataTemplate DataType="{x:Type vm:InspectorTextPropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <TextBox Grid.Column="1"
+                         IsReadOnly="{Binding IsReadOnly}"
+                         Text="{Binding Value, UpdateSourceTrigger=LostFocus}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:InspectorDoublePropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <TextBox Grid.Column="1"
+                         IsReadOnly="{Binding IsReadOnly}"
+                         Text="{Binding Value, StringFormat=0.###, UpdateSourceTrigger=LostFocus}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:InspectorIntPropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <TextBox Grid.Column="1"
+                         IsReadOnly="{Binding IsReadOnly}"
+                         Text="{Binding Value, UpdateSourceTrigger=LostFocus}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:InspectorBoolPropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <CheckBox Grid.Column="1"
+                          IsChecked="{Binding Value}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:InspectorInfoPropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <TextBlock Grid.Column="1"
+                           TextWrapping="Wrap"
+                           Text="{Binding Value}" />
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+
     <Grid>
         <StackPanel>
             <TextBlock FontWeight="SemiBold"
@@ -25,6 +97,10 @@
                 <StackPanel>
                     <TextBlock TextWrapping="Wrap"
                                Text="{Binding InspectorSummary}" />
+
+                    <ItemsControl Margin="0,10,0,0"
+                                  ItemsSource="{Binding InspectorPropertyRows}" />
+
                     <TextBlock Margin="0,10,0,0"
                                FontWeight="SemiBold"
                                Text="Edit Summary" />


### PR DESCRIPTION
### Motivation
- Implement the Phase V inspector foundation so selected Panel2D elements can be rendered as Unity-style property rows in the Inspector without changing mutation/command behavior yet.
- Provide a strongly-typed, testable layer for property rows to enable later work that will commit edits via document-scoped commands (Phase V2/V3).

### Description
- Added a new typed property-row ViewModel layer in `ViewModels/InspectorPropertyRowViewModels.cs` with `InspectorPropertyRowViewModel` and concrete row types (`Text`, `Double`, `Int`, `Bool`, `Info`).
- Updated `InspectorViewModel` to build and expose a `InspectorPropertyRows` collection and to populate common, metadata, and conditional type-specific rows for the active Panel2D selection (`ViewModels/InspectorViewModel.cs`).
- Updated `MainWindowViewModel` to forward `InspectorPropertyRows` and to notify property changes so the view can bind to the new rows (`MainWindowViewModel.cs`).
- Updated the Inspector view XAML to render rows using typed `DataTemplate`s and an `ItemsControl` bound to `InspectorPropertyRows` (`Views/InspectorView.xaml`).
- Added/updated unit tests to assert row projection behavior for a selected lamp and to assert empty rows when no selection exists (`OasisEditor.Tests/InspectorViewModelTests.cs`).
- This change focuses on UI projection only and does not yet wire row edits into document mutation commands (Phase V2/V3 work remains).

### Testing
- No automated builds or tests were executed in this environment because the container lacks the .NET SDK/CLI, per project guidance; therefore no test run results are available here.
- Added unit test assertions in `OasisEditor.Tests/InspectorViewModelTests.cs` covering row creation for a selected lamp and empty-row behavior, but those tests were not executed in this rollout.
- Recommended local verification (on a Windows dev machine): run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` and `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` to validate the new tests and ensure no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0c485a7388327a8ac82a073ccc9f0)