### PR TITLE
Implement inspector property commit pipeline for Panel2D element editing

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using EditorCommands = OasisEditor.Commands;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -112,15 +114,86 @@ public sealed class InspectorViewModelTests
         Assert.Empty(viewModel.InspectorPropertyRows);
     }
 
+    [Fact]
+    public void InspectorPropertyRows_EditName_CommitsThroughCanvasCommand()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "rect-1",
+                    Name = "Original",
+                    Kind = PanelElementKind.Rectangle,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("rect-1", "rectangle", 10, 20, 30, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var row = Assert.IsType<InspectorTextPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Name"));
+        row.Value = "Renamed";
+        row.Commit();
+
+        Assert.Equal("Renamed", selectedDocument.GetPanelElements().Single().Name);
+    }
+
+    [Fact]
+    public void InspectorPropertyRows_WidthRejectsNonPositiveValue()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "rect-1",
+                    Name = "Original",
+                    Kind = PanelElementKind.Rectangle,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("rect-1", "rectangle", 10, 20, 30, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var row = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Width"));
+        row.Value = "0";
+        row.Commit();
+
+        Assert.Equal("Width must be greater than zero.", row.ErrorText);
+        Assert.Equal(30, selectedDocument.GetPanelElements().Single().Width);
+    }
+
     private static InspectorViewModel CreateInspectorViewModel(
         DocumentTabViewModel selectedDocument,
-        ActiveDocumentContextService context)
+        ActiveDocumentContextService context,
+        Func<Guid, EditorCommands.ICommand, bool>? executeCanvasCommand = null)
     {
         return new InspectorViewModel(
             selectedAssetAccessor: () => null,
             selectedDocumentAccessor: () => selectedDocument,
             loadedProjectAccessor: () => null,
             activeDocumentContext: context,
+            executeCanvasCommand: executeCanvasCommand ?? ((_, _) => true),
             applySummary: (document, summary) => document);
+    }
+
+    private static bool ExecuteImmediately(Guid _, EditorCommands.ICommand command)
+    {
+        command.Execute();
+        return command is not EditorCommands.IExecutionTrackedCommand tracked || tracked.WasExecuted;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -33,6 +33,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
     private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
+    private bool _isRefreshingHierarchy;
     private readonly MfmeImportService _mfmeImportService = new();
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -1126,11 +1127,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void RefreshHierarchy()
     {
-        _hierarchy.Refresh();
-        OnPropertyChanged(nameof(HierarchyItems));
-        OnPropertyChanged(nameof(HasHierarchyItems));
-        OnPropertyChanged(nameof(HierarchyEmptyStateMessage));
-        NotifyHierarchyCommands();
+        if (_isRefreshingHierarchy)
+        {
+            return;
+        }
+
+        _isRefreshingHierarchy = true;
+        try
+        {
+            _hierarchy.Refresh();
+            OnPropertyChanged(nameof(HierarchyItems));
+            OnPropertyChanged(nameof(HasHierarchyItems));
+            OnPropertyChanged(nameof(HierarchyEmptyStateMessage));
+        }
+        finally
+        {
+            _isRefreshingHierarchy = false;
+        }
     }
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -85,6 +85,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => SelectedDocument,
             () => LoadedProject,
             _activeDocumentContext,
+            ExecuteDocumentCanvasCommand,
             ApplyInspectorSummary);
         _hierarchy = new HierarchyViewModel(
             () => SelectedDocument,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1139,11 +1139,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             or nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
             RefreshHierarchy();
+            NotifyInspectorChanged();
         }
 
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
-            NotifyInspectorChanged();
             NotifyHierarchyCommands();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -924,8 +924,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         _activeDocumentContext.SetPanelSelection(documentId, selection);
+        _hierarchy.SyncSelection(selection);
         NotifyInspectorChanged();
-        RefreshHierarchy();
+        OnPropertyChanged(nameof(HierarchyItems));
     }
 
 
@@ -1148,8 +1149,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(DocumentTabViewModel.PanelLayoutJson)
-            or nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
+        if (e.PropertyName is nameof(DocumentTabViewModel.PanelLayoutJson))
         {
             RefreshHierarchy();
             NotifyInspectorChanged();
@@ -1157,6 +1157,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
+            _hierarchy.SyncSelection(SelectedDocument?.HierarchySelectedPanelSelection);
+            OnPropertyChanged(nameof(HierarchyItems));
+            NotifyInspectorChanged();
             NotifyHierarchyCommands();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
@@ -73,6 +73,11 @@ public sealed class HierarchyViewModel : INotifyPropertyChanged
         NotifyCollectionStateChanged();
     }
 
+    public void SyncSelection(PanelSelectionInfo? selection)
+    {
+        ApplySelection(selection);
+    }
+
     public HierarchyItemViewModel? GetSelectedEntity()
     {
         return Flatten(Items).FirstOrDefault(item =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Globalization;
 
 namespace OasisEditor;
 
@@ -37,19 +38,38 @@ public abstract class InspectorPropertyRowViewModel : INotifyPropertyChanged
         }
 
         field = value;
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        RaisePropertyChanged(propertyName);
         return true;
+    }
+
+    protected void RaisePropertyChanged(string? propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }
 
-public sealed class InspectorTextPropertyViewModel : InspectorPropertyRowViewModel
+public abstract class InspectorEditablePropertyRowViewModel : InspectorPropertyRowViewModel
 {
-    private string _value;
-
-    public InspectorTextPropertyViewModel(string displayName, string groupName, string value, bool isReadOnly = false)
+    protected InspectorEditablePropertyRowViewModel(string displayName, string groupName, bool isReadOnly)
         : base(displayName, groupName, isReadOnly)
     {
-        _value = value;
+    }
+
+    public abstract void Commit();
+}
+
+public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRowViewModel
+{
+    private string _value;
+    private string _committedValue;
+    private readonly Func<string, string?>? _commit;
+
+    public InspectorTextPropertyViewModel(string displayName, string groupName, string value, bool isReadOnly = false, Func<string, string?>? commit = null)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value ?? string.Empty;
+        _committedValue = _value;
+        _commit = commit;
     }
 
     public string Value
@@ -57,56 +77,186 @@ public sealed class InspectorTextPropertyViewModel : InspectorPropertyRowViewMod
         get => _value;
         set => SetProperty(ref _value, value);
     }
-}
 
-public sealed class InspectorDoublePropertyViewModel : InspectorPropertyRowViewModel
-{
-    private double _value;
-
-    public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false)
-        : base(displayName, groupName, isReadOnly)
+    public override void Commit()
     {
-        _value = value;
+        if (IsReadOnly || string.Equals(_value, _committedValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var error = _commit?.Invoke(_value);
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            ErrorText = error;
+            _value = _committedValue;
+            RaisePropertyChanged(nameof(Value));
+            return;
+        }
+
+        ErrorText = string.Empty;
+        _committedValue = _value;
     }
 
-    public double Value
+}
+
+public sealed class InspectorDoublePropertyViewModel : InspectorEditablePropertyRowViewModel
+{
+    private string _value;
+    private string _committedValue;
+    private readonly Func<double, string?>? _commit;
+
+    public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false, Func<double, string?>? commit = null)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _value = value.ToString("0.###", CultureInfo.InvariantCulture);
+        _committedValue = _value;
+        _commit = commit;
+    }
+
+    public string Value
     {
         get => _value;
         set => SetProperty(ref _value, value);
     }
+
+    public override void Commit()
+    {
+        if (IsReadOnly || string.Equals(_value, _committedValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (!double.TryParse(_value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var parsed)
+            || !PanelElementValidation.IsFinite(parsed))
+        {
+            ErrorText = "Enter a valid number.";
+            _value = _committedValue;
+            RaisePropertyChanged(nameof(Value));
+            return;
+        }
+
+        var error = _commit?.Invoke(parsed);
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            ErrorText = error;
+            _value = _committedValue;
+            RaisePropertyChanged(nameof(Value));
+            return;
+        }
+
+        ErrorText = string.Empty;
+        _committedValue = parsed.ToString("0.###", CultureInfo.InvariantCulture);
+        _value = _committedValue;
+        RaisePropertyChanged(nameof(Value));
+    }
 }
 
-public sealed class InspectorIntPropertyViewModel : InspectorPropertyRowViewModel
+public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRowViewModel
 {
-    private int? _value;
+    private string _value;
+    private string _committedValue;
+    private readonly bool _allowEmpty;
+    private readonly Func<int?, string?>? _commit;
 
-    public InspectorIntPropertyViewModel(string displayName, string groupName, int? value, bool isReadOnly = false)
+    public InspectorIntPropertyViewModel(string displayName, string groupName, int? value, bool isReadOnly = false, bool allowEmpty = true, Func<int?, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
     {
-        _value = value;
+        _value = value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        _committedValue = _value;
+        _allowEmpty = allowEmpty;
+        _commit = commit;
     }
 
-    public int? Value
+    public string Value
     {
         get => _value;
         set => SetProperty(ref _value, value);
+    }
+
+    public override void Commit()
+    {
+        if (IsReadOnly || string.Equals(_value, _committedValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        int? parsedValue;
+        if (string.IsNullOrWhiteSpace(_value))
+        {
+            if (!_allowEmpty)
+            {
+                ErrorText = "A value is required.";
+                _value = _committedValue;
+                RaisePropertyChanged(nameof(Value));
+                return;
+            }
+
+            parsedValue = null;
+        }
+        else if (!int.TryParse(_value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedInt))
+        {
+            ErrorText = "Enter a valid integer.";
+            _value = _committedValue;
+            RaisePropertyChanged(nameof(Value));
+            return;
+        }
+        else
+        {
+            parsedValue = parsedInt;
+        }
+
+        var error = _commit?.Invoke(parsedValue);
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            ErrorText = error;
+            _value = _committedValue;
+            RaisePropertyChanged(nameof(Value));
+            return;
+        }
+
+        ErrorText = string.Empty;
+        _committedValue = parsedValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        _value = _committedValue;
+        RaisePropertyChanged(nameof(Value));
     }
 }
 
 public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewModel
 {
     private bool _value;
+    private readonly Func<bool, string?>? _commit;
+    private bool _isApplyingChange;
 
-    public InspectorBoolPropertyViewModel(string displayName, string groupName, bool value, bool isReadOnly = false)
+    public InspectorBoolPropertyViewModel(string displayName, string groupName, bool value, bool isReadOnly = false, Func<bool, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
     {
         _value = value;
+        _commit = commit;
     }
 
     public bool Value
     {
         get => _value;
-        set => SetProperty(ref _value, value);
+        set
+        {
+            if (IsReadOnly || _isApplyingChange || !SetProperty(ref _value, value))
+            {
+                return;
+            }
+
+            var error = _commit?.Invoke(value);
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                ErrorText = string.Empty;
+                return;
+            }
+
+            ErrorText = error;
+            _isApplyingChange = true;
+            Value = !value;
+            _isApplyingChange = false;
+        }
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using EditorCommands = OasisEditor.Commands;
 
 namespace OasisEditor;
 
@@ -12,6 +14,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private readonly Func<DocumentTabViewModel?> _selectedDocumentAccessor;
     private readonly Func<EditorProject?> _loadedProjectAccessor;
     private readonly ActiveDocumentContextService _activeDocumentContext;
+    private readonly Func<Guid, EditorCommands.ICommand, bool> _executeCanvasCommand;
     private readonly Func<DocumentTabViewModel, string, DocumentTabViewModel?> _applySummary;
     private readonly ObservableCollection<InspectorPropertyRowViewModel> _propertyRows = [];
     private string _inspectorEditableSummary = string.Empty;
@@ -21,12 +24,14 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         Func<DocumentTabViewModel?> selectedDocumentAccessor,
         Func<EditorProject?> loadedProjectAccessor,
         ActiveDocumentContextService activeDocumentContext,
+        Func<Guid, EditorCommands.ICommand, bool> executeCanvasCommand,
         Func<DocumentTabViewModel, string, DocumentTabViewModel?> applySummary)
     {
         _selectedAssetAccessor = selectedAssetAccessor;
         _selectedDocumentAccessor = selectedDocumentAccessor;
         _loadedProjectAccessor = loadedProjectAccessor;
         _activeDocumentContext = activeDocumentContext;
+        _executeCanvasCommand = executeCanvasCommand;
         _applySummary = applySummary;
         ApplyInspectorSummaryCommand = new RelayCommand(ApplyInspectorSummary, CanApplyInspectorSummary);
     }
@@ -199,15 +204,47 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
-        _propertyRows.Add(new InspectorTextPropertyViewModel("Name", "Common", selectedElement.Name));
+        _propertyRows.Add(new InspectorTextPropertyViewModel(
+            "Name",
+            "Common",
+            selectedElement.Name,
+            commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update name", new PanelElementModelUpdate { Name = value })));
         _propertyRows.Add(new InspectorInfoPropertyViewModel("Object ID", "Metadata", selectedElement.ObjectId));
         _propertyRows.Add(new InspectorInfoPropertyViewModel("Kind", "Metadata", selectedElement.Kind.ToString()));
-        _propertyRows.Add(new InspectorDoublePropertyViewModel("X", "Transform", selectedElement.X));
-        _propertyRows.Add(new InspectorDoublePropertyViewModel("Y", "Transform", selectedElement.Y));
-        _propertyRows.Add(new InspectorDoublePropertyViewModel("Width", "Transform", selectedElement.Width));
-        _propertyRows.Add(new InspectorDoublePropertyViewModel("Height", "Transform", selectedElement.Height));
-        _propertyRows.Add(new InspectorBoolPropertyViewModel("Locked", "Common", selectedElement.IsLocked));
-        _propertyRows.Add(new InspectorBoolPropertyViewModel("Visible", "Common", selectedElement.IsVisible));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "X",
+            "Transform",
+            selectedElement.X,
+            commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update X", new PanelElementModelUpdate { X = value })));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Y",
+            "Transform",
+            selectedElement.Y,
+            commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update Y", new PanelElementModelUpdate { Y = value })));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Width",
+            "Transform",
+            selectedElement.Width,
+            commit: value => value > 0
+                ? TryApplyUpdate(selectedElement.ObjectId, "Update width", new PanelElementModelUpdate { Width = value })
+                : "Width must be greater than zero."));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Height",
+            "Transform",
+            selectedElement.Height,
+            commit: value => value > 0
+                ? TryApplyUpdate(selectedElement.ObjectId, "Update height", new PanelElementModelUpdate { Height = value })
+                : "Height must be greater than zero."));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel(
+            "Locked",
+            "Common",
+            selectedElement.IsLocked,
+            commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update lock state", new PanelElementModelUpdate { IsLocked = value })));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel(
+            "Visible",
+            "Common",
+            selectedElement.IsVisible,
+            commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update visibility", new PanelElementModelUpdate { IsVisible = value })));
 
         AddTypeSpecificRows(selectedElement);
 
@@ -218,17 +255,29 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     {
         if (selectedElement.DisplayNumber.HasValue)
         {
-            _propertyRows.Add(new InspectorIntPropertyViewModel("Display Number", "Type-specific", selectedElement.DisplayNumber));
+            _propertyRows.Add(new InspectorIntPropertyViewModel(
+                "Display Number",
+                "Type-specific",
+                selectedElement.DisplayNumber,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update display number", new PanelElementModelUpdate { DisplayNumber = value })));
         }
 
-        if (!string.IsNullOrWhiteSpace(selectedElement.AssetPath))
+        if (selectedElement.Kind is PanelElementKind.Image or PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel)
         {
-            _propertyRows.Add(new InspectorTextPropertyViewModel("Asset Path", "Type-specific", selectedElement.AssetPath));
+            _propertyRows.Add(new InspectorTextPropertyViewModel(
+                "Asset Path",
+                "Type-specific",
+                selectedElement.AssetPath ?? string.Empty,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update asset path", new PanelElementModelUpdate { AssetPath = NormalizeOptionalText(value) })));
         }
 
-        if (!string.IsNullOrWhiteSpace(selectedElement.SecondaryAssetPath))
+        if (selectedElement.Kind is PanelElementKind.Background or PanelElementKind.Reel)
         {
-            _propertyRows.Add(new InspectorTextPropertyViewModel("Secondary Asset", "Type-specific", selectedElement.SecondaryAssetPath));
+            _propertyRows.Add(new InspectorTextPropertyViewModel(
+                "Secondary Asset",
+                "Type-specific",
+                selectedElement.SecondaryAssetPath ?? string.Empty,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update secondary asset path", new PanelElementModelUpdate { SecondaryAssetPath = NormalizeOptionalText(value) })));
         }
 
         if (!string.IsNullOrWhiteSpace(selectedElement.OnColorHex))
@@ -271,6 +320,48 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference));
         }
+    }
+
+    private string? TryApplyUpdate(string objectId, string description, PanelElementModelUpdate update)
+    {
+        var selectedDocument = _selectedDocumentAccessor();
+        if (selectedDocument is null)
+        {
+            return "No active document.";
+        }
+
+        var existing = selectedDocument.GetPanelElements()
+            .FirstOrDefault(element => string.Equals(element.ObjectId, objectId, StringComparison.Ordinal));
+        if (existing is null)
+        {
+            return "Selected element no longer exists.";
+        }
+
+        var updated = PanelElementModelUpdater.Apply(existing, update);
+        if (!PanelElementValidation.IsValidForInspectorUpdate(updated))
+        {
+            return "Invalid element dimensions.";
+        }
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            selectedDocument.DocumentId,
+            selectedDocument,
+            objectId,
+            updated,
+            description);
+        _executeCanvasCommand(selectedDocument.DocumentId, command);
+        NotifyContextChanged();
+        return null;
+    }
+
+    private static string? NormalizeOptionalText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
     }
 
     private bool CanApplyInspectorSummary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -349,9 +349,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             objectId,
             updated,
             description);
-        _executeCanvasCommand(selectedDocument.DocumentId, command);
-        NotifyContextChanged();
-        return null;
+        return _executeCanvasCommand(selectedDocument.DocumentId, command)
+            ? null
+            : "Unable to apply update.";
     }
 
     private static string? NormalizeOptionalText(string? value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -18,7 +18,9 @@
                            Text="{Binding DisplayName}" />
                 <TextBox Grid.Column="1"
                          IsReadOnly="{Binding IsReadOnly}"
-                         Text="{Binding Value, UpdateSourceTrigger=LostFocus}" />
+                         LostFocus="OnEditableTextBoxLostFocus"
+                         KeyDown="OnEditableTextBoxKeyDown"
+                         Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
 
@@ -32,7 +34,9 @@
                            Text="{Binding DisplayName}" />
                 <TextBox Grid.Column="1"
                          IsReadOnly="{Binding IsReadOnly}"
-                         Text="{Binding Value, StringFormat=0.###, UpdateSourceTrigger=LostFocus}" />
+                         LostFocus="OnEditableTextBoxLostFocus"
+                         KeyDown="OnEditableTextBoxKeyDown"
+                         Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
 
@@ -46,7 +50,9 @@
                            Text="{Binding DisplayName}" />
                 <TextBox Grid.Column="1"
                          IsReadOnly="{Binding IsReadOnly}"
-                         Text="{Binding Value, UpdateSourceTrigger=LostFocus}" />
+                         LostFocus="OnEditableTextBoxLostFocus"
+                         KeyDown="OnEditableTextBoxKeyDown"
+                         Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -1,4 +1,6 @@
+using System.Windows.Input;
 using System.Windows.Controls;
+using System.Windows;
 
 namespace OasisEditor.Views;
 
@@ -7,5 +9,26 @@ public partial class InspectorView : UserControl
     public InspectorView()
     {
         InitializeComponent();
+    }
+
+    private void OnEditableTextBoxLostFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is not TextBox textBox || textBox.DataContext is not InspectorEditablePropertyRowViewModel row)
+        {
+            return;
+        }
+
+        row.Commit();
+    }
+
+    private void OnEditableTextBoxKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter || sender is not TextBox textBox || textBox.DataContext is not InspectorEditablePropertyRowViewModel row)
+        {
+            return;
+        }
+
+        row.Commit();
+        e.Handled = true;
     }
 }


### PR DESCRIPTION
### Motivation
- Enable Unity-style inspector editing that updates Panel2D elements via the document-scoped command pipeline instead of direct model mutation.
- Preserve undo/redo, document-scoped behavior, and validation rules described in `Docs/InspectorEditingPlan.md` and project AGENT guidance.
- Provide a small, testable commit surface for inspector rows (text/number/bool) to avoid flooding undo history and to validate changes before applying.

### Description
- Added commit-capable inspector row types and a small editable base: `InspectorEditablePropertyRowViewModel` plus text/double/int/bool implementations that parse, validate, rollback on error, and optionally invoke a commit callback. (file: `ViewModels/InspectorPropertyRowViewModels.cs`)
- Wired `InspectorViewModel` to build inspector rows with commit callbacks that call `PanelElementModelUpdater.Apply(...)`, validate with `PanelElementValidation`, and dispatch a document-scoped update command via `CanvasMutationCommands.CreateUpdateElementCommand` using an injected `ExecuteDocumentCanvasCommand` delegate. (file: `ViewModels/InspectorViewModel.cs`)
- Updated `MainWindowViewModel` to pass `ExecuteDocumentCanvasCommand` into `InspectorViewModel` so inspector edits execute through the existing workspace/command routing. (file: `MainWindowViewModel.cs`)
- Made small UI changes to commit on Enter or LostFocus by delegating to row `Commit()` from lightweight code-behind event handlers; no business logic was moved into code-behind. (files: `Views/InspectorView.xaml`, `Views/InspectorView.xaml.cs`)
- Extended unit tests to cover inspector commit behavior and validation rejection (tests added/updated in `OasisEditor.Tests/InspectorViewModelTests.cs`).

### Testing
- No automated tests were executed in this Codex environment due to the project constraint prohibiting local WPF/.NET build/test execution here (per `AGENT.md`).
- Unit test changes: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs` was expanded with tests that assert name edits commit through the canvas command pipeline and that invalid width input is rejected; these tests were added but not run here.
- Please run locally: `dotnet build` then `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and verify tests pass, then smoke-test the WPF app by editing Inspector fields (Name, X, Y, Width, Height, Locked, Visible) to confirm canvas/hierarchy update, document dirty state, and undo/redo behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0c734c34883279ca46a45d9b308d6)