### PR TITLE
Simplify Inspector panel details for selected elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using EditorCommands = OasisEditor.Commands;
@@ -405,7 +406,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return kind.ToString();
         }
 
-        return char.ToUpperInvariant(serializedKind[0]) + serializedKind[1..];
+        var titleCased = char.ToUpperInvariant(serializedKind[0]) + serializedKind[1..];
+        return Regex.Replace(titleCased, "([a-z0-9])([A-Z])", "$1 $2");
     }
 
     private bool CanApplyInspectorSummary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -51,7 +51,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection
                 && selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
             {
-                return Panel2DDocumentStorage.SerializeElementKind(selectedElement.Kind);
+                return NicifyElementKind(selectedElement.Kind);
             }
 
             var selectedAsset = _selectedAssetAccessor();
@@ -395,6 +395,17 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
 
         return value.Trim();
+    }
+
+    private static string NicifyElementKind(PanelElementKind kind)
+    {
+        var serializedKind = Panel2DDocumentStorage.SerializeElementKind(kind);
+        if (string.IsNullOrWhiteSpace(serializedKind))
+        {
+            return kind.ToString();
+        }
+
+        return char.ToUpperInvariant(serializedKind[0]) + serializedKind[1..];
     }
 
     private bool CanApplyInspectorSummary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -46,13 +46,20 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     {
         get
         {
+            var selectedDocument = _selectedDocumentAccessor();
+            if (selectedDocument is not null
+                && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection
+                && selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
+            {
+                return Panel2DDocumentStorage.SerializeElementKind(selectedElement.Kind);
+            }
+
             var selectedAsset = _selectedAssetAccessor();
             if (selectedAsset is not null)
             {
                 return $"Asset: {selectedAsset.DisplayPath}";
             }
 
-            var selectedDocument = _selectedDocumentAccessor();
             if (selectedDocument is not null)
             {
                 return $"Document: {selectedDocument.Title}";
@@ -209,8 +216,6 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             "Common",
             selectedElement.Name,
             commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update name", new PanelElementModelUpdate { Name = value })));
-        _propertyRows.Add(new InspectorInfoPropertyViewModel("Object ID", "Metadata", selectedElement.ObjectId));
-        _propertyRows.Add(new InspectorInfoPropertyViewModel("Kind", "Metadata", selectedElement.Kind.ToString()));
         _propertyRows.Add(new InspectorDoublePropertyViewModel(
             "X",
             "Transform",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -85,45 +85,18 @@
     </UserControl.Resources>
 
     <Grid>
-        <StackPanel>
-            <TextBlock FontWeight="SemiBold"
-                       Text="{Binding InspectorTitle}" />
-            <TextBlock Margin="0,6,0,0"
-                       Foreground="{DynamicResource TextSecondaryBrush}"
-                       Text="{Binding InspectorType}" />
-            <TextBlock Margin="0,6,0,0"
-                       TextWrapping="Wrap"
-                       Text="{Binding InspectorPath}" />
-            <Border Margin="0,10,0,0"
-                    Padding="8"
-                    Background="{DynamicResource SelectionBrush}"
-                    BorderBrush="{DynamicResource BorderSubtleBrush}"
-                    BorderThickness="1"
-                    CornerRadius="4">
-                <StackPanel>
-                    <TextBlock TextWrapping="Wrap"
-                               Text="{Binding InspectorSummary}" />
-
-                    <ItemsControl Margin="0,10,0,0"
-                                  ItemsSource="{Binding InspectorPropertyRows}" />
-
-                    <TextBlock Margin="0,10,0,0"
-                               FontWeight="SemiBold"
-                               Text="Edit Summary" />
-                    <TextBox Margin="0,6,0,0"
-                             MinHeight="88"
-                             AcceptsReturn="True"
-                             VerticalScrollBarVisibility="Auto"
-                             IsEnabled="{Binding CanEditInspectorSummary}"
-                             Text="{Binding InspectorEditableSummary, UpdateSourceTrigger=PropertyChanged}" />
-                    <Button Margin="0,8,0,0"
-                            HorizontalAlignment="Left"
-                            Padding="10,4"
-                            IsEnabled="{Binding CanEditInspectorSummary}"
-                            Command="{Binding ApplyInspectorSummaryCommand}"
-                            Content="Apply Summary" />
-                </StackPanel>
-            </Border>
-        </StackPanel>
+        <Border Padding="8"
+                Background="{DynamicResource SelectionBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1"
+                CornerRadius="4">
+            <StackPanel>
+                <TextBlock FontWeight="SemiBold"
+                           FontSize="14"
+                           Text="{Binding InspectorTitle}" />
+                <ItemsControl Margin="0,10,0,0"
+                              ItemsSource="{Binding InspectorPropertyRows}" />
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- The Inspector pane displayed extra metadata, document/path, and an editable summary that added visual noise and duplicated information for selected Panel2D elements.
- When an element is selected the UI should behave like the Unity Inspector and focus on editable object properties with a clear object-kind heading.

### Description
- Updated `OasisEditor/Views/InspectorView.xaml` to remove the large type/path/summary/edit-summary blocks and render a compact bordered panel that shows only the header and the `InspectorPropertyRows` list.
- Modified `InspectorViewModel.InspectorTitle` to return the selected element kind (via `Panel2DDocumentStorage.SerializeElementKind`) when a panel element is selected so the header shows the object kind.
- Removed metadata-only rows (`Object ID`, `Kind`) from `InspectorViewModel.RebuildPropertyRows` so the property list emphasizes editable common fields and existing type-specific rows remain intact.

### Testing
- No automated tests were executed in this environment due to the project's Windows/.NET/WPF toolchain constraint described in `AGENT.md`.
- Please run the test suite locally (for example `dotnet test`) and pay special attention to `OasisEditor.Tests.InspectorViewModelTests` to confirm summaries, property-row composition, and commit/apply behavior still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0f0d52f588327a6ab82a2c7be3a9a)