### PR TITLE
Add Inspector color picker rows for Panel2D color fields

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
@@ -93,6 +93,28 @@ public sealed class InspectorColorTests
         Assert.Equal(string.Empty, row.HexValue);
     }
 
+
+    [Fact]
+    public void InspectorColorProperty_SelectedColor_DoesNotAutoCommit()
+    {
+        var commits = new List<string?>();
+        var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#112233", commit: value =>
+        {
+            commits.Add(value);
+            return null;
+        });
+
+        row.SelectedColor = Color.FromArgb(255, 0x22, 0x33, 0x44);
+
+        Assert.Equal("#223344", row.HexValue);
+        Assert.Empty(commits);
+
+        row.Commit();
+
+        Assert.Single(commits);
+        Assert.Equal("#223344", commits[0]);
+    }
+
     [Fact]
     public void InspectorColorProperty_SelectingSameColor_DoesNotCommit()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
@@ -95,7 +95,7 @@ public sealed class InspectorColorTests
 
 
     [Fact]
-    public void InspectorColorProperty_SelectedColor_DoesNotAutoCommit()
+    public void InspectorColorProperty_SelectedColor_AutoCommits()
     {
         var commits = new List<string?>();
         var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#112233", commit: value =>
@@ -107,10 +107,6 @@ public sealed class InspectorColorTests
         row.SelectedColor = Color.FromArgb(255, 0x22, 0x33, 0x44);
 
         Assert.Equal("#223344", row.HexValue);
-        Assert.Empty(commits);
-
-        row.Commit();
-
         Assert.Single(commits);
         Assert.Equal("#223344", commits[0]);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorColorTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InspectorColorTests
+{
+    [Theory]
+    [InlineData("#112233", 255, 0x11, 0x22, 0x33)]
+    [InlineData("112233", 255, 0x11, 0x22, 0x33)]
+    [InlineData("#AA112233", 0xAA, 0x11, 0x22, 0x33)]
+    [InlineData("AA112233", 0xAA, 0x11, 0x22, 0x33)]
+    public void InspectorColorHex_TryParse_AcceptsSupportedFormats(string value, byte a, byte r, byte g, byte b)
+    {
+        Assert.True(InspectorColorHex.TryParse(value, out var color));
+        Assert.Equal(a, color.A);
+        Assert.Equal(r, color.R);
+        Assert.Equal(g, color.G);
+        Assert.Equal(b, color.B);
+    }
+
+    [Fact]
+    public void InspectorColorHex_TryParse_RejectsInvalid()
+    {
+        Assert.False(InspectorColorHex.TryParse("#XYZXYZ", out _));
+    }
+
+    [Fact]
+    public void InspectorColorHex_Format_PreservesOpaqueAsRgb()
+    {
+        var color = Color.FromArgb(255, 0x11, 0x22, 0x33);
+        Assert.Equal("#112233", InspectorColorHex.Format(color));
+    }
+
+    [Fact]
+    public void InspectorColorHex_Format_UsesArgbWhenTransparent()
+    {
+        var color = Color.FromArgb(0xAA, 0x11, 0x22, 0x33);
+        Assert.Equal("#AA112233", InspectorColorHex.Format(color));
+    }
+
+    [Fact]
+    public void InspectorColorProperty_Commit_UsesCanonicalHex()
+    {
+        string? committed = null;
+        var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#FFFFFF", commit: value =>
+        {
+            committed = value;
+            return null;
+        });
+
+        row.HexValue = "aa112233";
+        row.Commit();
+
+        Assert.Equal("#AA112233", committed);
+        Assert.Equal("#AA112233", row.HexValue);
+    }
+
+    [Fact]
+    public void InspectorColorProperty_Commit_InvalidHexRestoresValue()
+    {
+        var commits = new List<string?>();
+        var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#112233", commit: value =>
+        {
+            commits.Add(value);
+            return null;
+        });
+
+        row.HexValue = "invalid";
+        row.Commit();
+
+        Assert.Equal("Enter a valid hex color (RRGGBB or AARRGGBB).", row.ErrorText);
+        Assert.Equal("#112233", row.HexValue);
+        Assert.Empty(commits);
+    }
+
+    [Fact]
+    public void InspectorColorProperty_Commit_BlankAllowedCommitsNull()
+    {
+        string? committed = "seed";
+        var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#112233", allowEmpty: true, commit: value =>
+        {
+            committed = value;
+            return null;
+        });
+
+        row.HexValue = "  ";
+        row.Commit();
+
+        Assert.Null(committed);
+        Assert.Equal(string.Empty, row.HexValue);
+    }
+
+    [Fact]
+    public void InspectorColorProperty_SelectingSameColor_DoesNotCommit()
+    {
+        var commits = new List<string?>();
+        var row = new InspectorColorPropertyViewModel("On Color", "Type-specific", "#112233", commit: value =>
+        {
+            commits.Add(value);
+            return null;
+        });
+
+        row.SelectedColor = Color.FromArgb(255, 0x11, 0x22, 0x33);
+
+        Assert.Empty(commits);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
@@ -231,8 +231,8 @@ public sealed class InspectorViewModelTests
         var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
         viewModel.NotifyContextChanged();
 
-        var row = Assert.IsType<InspectorTextPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "On Color"));
-        row.Value = "#00FF00";
+        var row = Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "On Color"));
+        row.HexValue = "#00FF00";
         row.Commit();
 
         Assert.Equal("#00FF00", selectedDocument.GetPanelElements().Single().OnColorHex);
@@ -299,6 +299,39 @@ public sealed class InspectorViewModelTests
 
         Assert.Equal("Width must be greater than zero.", row.ErrorText);
         Assert.Equal(30, selectedDocument.GetPanelElements().Single().Width);
+    }
+
+
+    [Fact]
+    public void InspectorPropertyRows_ColorFields_UseColorRows()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    OnColorHex = "#00FF00",
+                    OffColorHex = "#000000",
+                    TextColorHex = "#FFFFFF"
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("lamp-1", "lamp", 10, 20, 30, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "On Color"));
+        Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Off Color"));
+        Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Text Color"));
     }
 
     private static InspectorViewModel CreateInspectorViewModel(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.1" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.0" />
+    <PackageReference Include="PixiEditor.ColorPicker" Version="3.4.2.3" />
   </ItemGroup>
 
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorColorHex.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorColorHex.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Globalization;
+using System.Windows.Media;
+
+namespace OasisEditor;
+
+public static class InspectorColorHex
+{
+    public static bool TryParse(string? value, out Color color)
+    {
+        color = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith('#'))
+        {
+            normalized = normalized[1..];
+        }
+
+        if (normalized.Length == 6 && byte.TryParse(normalized[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var r)
+            && byte.TryParse(normalized.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var g)
+            && byte.TryParse(normalized.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b))
+        {
+            color = Color.FromArgb(255, r, g, b);
+            return true;
+        }
+
+        if (normalized.Length == 8 && byte.TryParse(normalized[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var a)
+            && byte.TryParse(normalized.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out r)
+            && byte.TryParse(normalized.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out g)
+            && byte.TryParse(normalized.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out b))
+        {
+            color = Color.FromArgb(a, r, g, b);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static string Format(Color color)
+    {
+        if (color.A == 255)
+        {
+            return $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+        }
+
+        return $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}";
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Globalization;
+using System.Windows.Media;
 
 namespace OasisEditor;
 
@@ -219,6 +220,136 @@ public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRow
         _committedValue = parsedValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         _value = _committedValue;
         RaisePropertyChanged(nameof(Value));
+    }
+}
+
+
+public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyRowViewModel
+{
+    private Color _selectedColor;
+    private Color _committedColor;
+    private string _hexValue;
+    private readonly Func<string?, string?>? _commit;
+    private readonly bool _allowEmpty;
+
+    public InspectorColorPropertyViewModel(string displayName, string groupName, string? value, bool isReadOnly = false, bool allowEmpty = true, Func<string?, string?>? commit = null)
+        : base(displayName, groupName, isReadOnly)
+    {
+        _allowEmpty = allowEmpty;
+        _commit = commit;
+
+        if (InspectorColorHex.TryParse(value, out var parsedColor))
+        {
+            _selectedColor = parsedColor;
+            _committedColor = parsedColor;
+            _hexValue = InspectorColorHex.Format(parsedColor);
+            _committedHexValue = _hexValue;
+        }
+        else
+        {
+            _selectedColor = Colors.White;
+            _committedColor = _selectedColor;
+            _hexValue = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+            _committedHexValue = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+    }
+
+    public Color SelectedColor
+    {
+        get => _selectedColor;
+        set
+        {
+            if (IsReadOnly || !SetProperty(ref _selectedColor, value))
+            {
+                return;
+            }
+
+            _hexValue = InspectorColorHex.Format(value);
+            RaisePropertyChanged(nameof(HexValue));
+            Commit();
+        }
+    }
+
+    public string HexValue
+    {
+        get => _hexValue;
+        set => SetProperty(ref _hexValue, value);
+    }
+
+    public override void Commit()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        var normalizedHex = NormalizeHex(_hexValue, out var parsedColor, out var parseError);
+        if (!string.IsNullOrWhiteSpace(parseError))
+        {
+            ErrorText = parseError;
+            _hexValue = _committedHexValue ?? string.Empty;
+            _selectedColor = _committedColor;
+            RaisePropertyChanged(nameof(HexValue));
+            RaisePropertyChanged(nameof(SelectedColor));
+            return;
+        }
+
+        if (string.Equals(normalizedHex, _committedHexValue, StringComparison.Ordinal))
+        {
+            ErrorText = string.Empty;
+            return;
+        }
+
+        var error = _commit?.Invoke(normalizedHex);
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            ErrorText = error;
+            _hexValue = _committedHexValue ?? string.Empty;
+            _selectedColor = _committedColor;
+            RaisePropertyChanged(nameof(HexValue));
+            RaisePropertyChanged(nameof(SelectedColor));
+            return;
+        }
+
+        ErrorText = string.Empty;
+        _hexValue = normalizedHex ?? string.Empty;
+        RaisePropertyChanged(nameof(HexValue));
+
+        if (parsedColor.HasValue)
+        {
+            _selectedColor = parsedColor.Value;
+            RaisePropertyChanged(nameof(SelectedColor));
+            _committedColor = parsedColor.Value;
+        }
+
+        _committedHexValue = normalizedHex;
+    }
+
+    private string? _committedHexValue;
+
+    private string? NormalizeHex(string? value, out Color? parsedColor, out string? error)
+    {
+        parsedColor = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (_allowEmpty)
+            {
+                return null;
+            }
+
+            error = "A color value is required.";
+            return null;
+        }
+
+        if (!InspectorColorHex.TryParse(value, out var color))
+        {
+            error = "Enter a valid hex color (RRGGBB or AARRGGBB).";
+            return null;
+        }
+
+        parsedColor = color;
+        return InspectorColorHex.Format(color);
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -266,7 +266,7 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
 
             _hexValue = InspectorColorHex.Format(value);
             RaisePropertyChanged(nameof(HexValue));
-            ErrorText = string.Empty;
+            Commit();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -266,7 +266,7 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
 
             _hexValue = InspectorColorHex.Format(value);
             RaisePropertyChanged(nameof(HexValue));
-            Commit();
+            ErrorText = string.Empty;
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -19,6 +19,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private readonly Func<DocumentTabViewModel, string, DocumentTabViewModel?> _applySummary;
     private readonly ObservableCollection<InspectorPropertyRowViewModel> _propertyRows = [];
     private string _inspectorEditableSummary = string.Empty;
+    private bool _suppressPropertyRowRefresh;
 
     public InspectorViewModel(
         Func<AssetBrowserItemViewModel?> selectedAssetAccessor,
@@ -194,7 +195,14 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
 
-        RebuildPropertyRows();
+        if (_suppressPropertyRowRefresh)
+        {
+            _suppressPropertyRowRefresh = false;
+        }
+        else
+        {
+            RebuildPropertyRows();
+        }
 
         InspectorEditableSummary = _selectedDocumentAccessor()?.ContentSummary ?? string.Empty;
         NotifyInspectorEditCommand();
@@ -292,7 +300,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 "On Color",
                 "Type-specific",
                 selectedElement.OnColorHex ?? string.Empty,
-                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) })));
+                commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) })));
         }
 
         if (selectedElement.Kind is PanelElementKind.Lamp)
@@ -301,7 +309,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 "Off Color",
                 "Type-specific",
                 selectedElement.OffColorHex ?? string.Empty,
-                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update off color", new PanelElementModelUpdate { OffColorHex = NormalizeOptionalText(value) })));
+                commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update off color", new PanelElementModelUpdate { OffColorHex = NormalizeOptionalText(value) })));
         }
 
         if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.Alpha)
@@ -310,7 +318,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 "Text Color",
                 "Type-specific",
                 selectedElement.TextColorHex ?? string.Empty,
-                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update text color", new PanelElementModelUpdate { TextColorHex = NormalizeOptionalText(value) })));
+                commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update text color", new PanelElementModelUpdate { TextColorHex = NormalizeOptionalText(value) })));
         }
 
         if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.Alpha)
@@ -356,7 +364,12 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
     }
 
-    private string? TryApplyUpdate(string objectId, string description, PanelElementModelUpdate update)
+    private string? TryApplyColorUpdate(string objectId, string description, PanelElementModelUpdate update)
+    {
+        return TryApplyUpdate(objectId, description, update, suppressInspectorRefresh: true);
+    }
+
+    private string? TryApplyUpdate(string objectId, string description, PanelElementModelUpdate update, bool suppressInspectorRefresh = false)
     {
         var selectedDocument = _selectedDocumentAccessor();
         if (selectedDocument is null)
@@ -383,9 +396,19 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             objectId,
             updated,
             description);
-        return _executeCanvasCommand(selectedDocument.DocumentId, command)
-            ? null
-            : "Unable to apply update.";
+        if (suppressInspectorRefresh)
+        {
+            _suppressPropertyRowRefresh = true;
+        }
+
+        var executed = _executeCanvasCommand(selectedDocument.DocumentId, command);
+        if (!executed)
+        {
+            _suppressPropertyRowRefresh = false;
+            return "Unable to apply update.";
+        }
+
+        return null;
     }
 
     private static string? NormalizeOptionalText(string? value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -288,7 +288,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
         {
-            _propertyRows.Add(new InspectorTextPropertyViewModel(
+            _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "On Color",
                 "Type-specific",
                 selectedElement.OnColorHex ?? string.Empty,
@@ -297,7 +297,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         if (selectedElement.Kind is PanelElementKind.Lamp)
         {
-            _propertyRows.Add(new InspectorTextPropertyViewModel(
+            _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "Off Color",
                 "Type-specific",
                 selectedElement.OffColorHex ?? string.Empty,
@@ -306,7 +306,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.Alpha)
         {
-            _propertyRows.Add(new InspectorTextPropertyViewModel(
+            _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "Text Color",
                 "Type-specific",
                 selectedElement.TextColorHex ?? string.Empty,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -19,7 +19,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private readonly Func<DocumentTabViewModel, string, DocumentTabViewModel?> _applySummary;
     private readonly ObservableCollection<InspectorPropertyRowViewModel> _propertyRows = [];
     private string _inspectorEditableSummary = string.Empty;
-    private bool _suppressPropertyRowRefresh;
+    private DateTime _suppressPropertyRowRefreshUntilUtc;
 
     public InspectorViewModel(
         Func<AssetBrowserItemViewModel?> selectedAssetAccessor,
@@ -195,11 +195,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
 
-        if (_suppressPropertyRowRefresh)
-        {
-            _suppressPropertyRowRefresh = false;
-        }
-        else
+        if (!ShouldSuppressPropertyRowRefresh())
         {
             RebuildPropertyRows();
         }
@@ -398,17 +394,23 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             description);
         if (suppressInspectorRefresh)
         {
-            _suppressPropertyRowRefresh = true;
+            _suppressPropertyRowRefreshUntilUtc = DateTime.UtcNow.AddSeconds(1);
         }
 
         var executed = _executeCanvasCommand(selectedDocument.DocumentId, command);
         if (!executed)
         {
-            _suppressPropertyRowRefresh = false;
+            _suppressPropertyRowRefreshUntilUtc = DateTime.MinValue;
             return "Unable to apply update.";
         }
 
         return null;
+    }
+
+
+    private bool ShouldSuppressPropertyRowRefresh()
+    {
+        return DateTime.UtcNow < _suppressPropertyRowRefreshUntilUtc;
     }
 
     private static string? NormalizeOptionalText(string? value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -72,7 +72,7 @@
                                                  Width="36"
                                                  Height="20"
                                                  SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 LostMouseCapture="OnEditableColorControlLostMouseCapture" />
+                                                 IsKeyboardFocusWithinChanged="OnEditableColorControlIsKeyboardFocusWithinChanged" />
                 <TextBox Grid.Column="3"
                          IsReadOnly="{Binding IsReadOnly}"
                          LostFocus="OnEditableTextBoxLostFocus"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:OasisEditor"
+             xmlns:colorPicker="clr-namespace:ColorPicker;assembly=ColorPicker"
              mc:Ignorable="d"
              d:DesignHeight="300"
              d:DesignWidth="260">
@@ -53,6 +54,29 @@
                          LostFocus="OnEditableTextBoxLostFocus"
                          KeyDown="OnEditableTextBoxKeyDown"
                          Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
+            </Grid>
+        </DataTemplate>
+
+
+        <DataTemplate DataType="{x:Type vm:InspectorColorPropertyViewModel}">
+            <Grid Margin="0,3,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="120" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center"
+                           Text="{Binding DisplayName}" />
+                <colorPicker:PortableColorPicker Grid.Column="1"
+                                                 Width="36"
+                                                 Height="20"
+                                                 SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBox Grid.Column="3"
+                         IsReadOnly="{Binding IsReadOnly}"
+                         LostFocus="OnEditableTextBoxLostFocus"
+                         KeyDown="OnEditableTextBoxKeyDown"
+                         Text="{Binding HexValue, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -71,7 +71,8 @@
                 <colorPicker:PortableColorPicker Grid.Column="1"
                                                  Width="36"
                                                  Height="20"
-                                                 SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                 SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 LostMouseCapture="OnEditableColorControlLostMouseCapture" />
                 <TextBox Grid.Column="3"
                          IsReadOnly="{Binding IsReadOnly}"
                          LostFocus="OnEditableTextBoxLostFocus"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -71,8 +71,7 @@
                 <colorPicker:PortableColorPicker Grid.Column="1"
                                                  Width="36"
                                                  Height="20"
-                                                 SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 IsKeyboardFocusWithinChanged="OnEditableColorControlIsKeyboardFocusWithinChanged" />
+                                                 SelectedColor="{Binding SelectedColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <TextBox Grid.Column="3"
                          IsReadOnly="{Binding IsReadOnly}"
                          LostFocus="OnEditableTextBoxLostFocus"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -11,19 +11,6 @@ public partial class InspectorView : UserControl
         InitializeComponent();
     }
 
-    private void OnEditableColorControlIsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
-    {
-        if (sender is not FrameworkElement element || element.DataContext is not InspectorEditablePropertyRowViewModel row)
-        {
-            return;
-        }
-
-        if (e.NewValue is bool hasFocusWithin && !hasFocusWithin)
-        {
-            row.Commit();
-        }
-    }
-
     private void OnEditableTextBoxLostFocus(object sender, RoutedEventArgs e)
     {
         if (sender is not TextBox textBox || textBox.DataContext is not InspectorEditablePropertyRowViewModel row)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -11,15 +11,17 @@ public partial class InspectorView : UserControl
         InitializeComponent();
     }
 
-
-    private void OnEditableColorControlLostMouseCapture(object sender, MouseEventArgs e)
+    private void OnEditableColorControlIsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
         if (sender is not FrameworkElement element || element.DataContext is not InspectorEditablePropertyRowViewModel row)
         {
             return;
         }
 
-        row.Commit();
+        if (e.NewValue is bool hasFocusWithin && !hasFocusWithin)
+        {
+            row.Commit();
+        }
     }
 
     private void OnEditableTextBoxLostFocus(object sender, RoutedEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -11,6 +11,17 @@ public partial class InspectorView : UserControl
         InitializeComponent();
     }
 
+
+    private void OnEditableColorControlLostMouseCapture(object sender, MouseEventArgs e)
+    {
+        if (sender is not FrameworkElement element || element.DataContext is not InspectorEditablePropertyRowViewModel row)
+        {
+            return;
+        }
+
+        row.Commit();
+    }
+
     private void OnEditableTextBoxLostFocus(object sender, RoutedEventArgs e)
     {
         if (sender is not TextBox textBox || textBox.DataContext is not InspectorEditablePropertyRowViewModel row)


### PR DESCRIPTION
### Motivation
- Implement Phase Z of the Inspector plan to provide a compact color picker for model-backed color fields (`OnColorHex`, `OffColorHex`, `TextColorHex`) so users can edit colors with a picker or hex input while preserving the existing command/update/undo flow.
- Ensure existing data formats are accepted and preserved by adding parsing/formatting helpers that accept common hex variants and emit a canonical representation.

### Description
- Added `PixiEditor.ColorPicker` package reference to `OasisEditor.csproj` and introduced an Inspector data-template that renders a `PortableColorPicker` swatch plus an adjacent hex `TextBox` bound to the same VM row.
- Added `InspectorColorHex` helper with `TryParse` and `Format` to accept `#RRGGBB`, `RRGGBB`, `#AARRGGBB`, and `AARRGGBB` and to emit `#RRGGBB` for opaque colors or `#AARRGGBB` when alpha is non-opaque.
- Implemented `InspectorColorPropertyViewModel` supporting `SelectedColor` and `HexValue`, validation, canonical formatting, no-op suppression, commit/rollback on error, and the existing commit callback pattern used by other rows.
- Replaced the inspector text rows for element color fields with `InspectorColorPropertyViewModel` in `InspectorViewModel`, updated `InspectorView.xaml` with a color row `DataTemplate`, and added unit tests covering parsing/formatting/validation and inspector integration.

### Testing
- Added unit tests: `OasisEditor.Tests/InspectorColorTests.cs` for color parsing/formatting/row commit behavior and updated `InspectorViewModelTests` to assert color rows and commit flows; these tests were added but not executed in this environment.
- No build or test commands were run here because the container lacks the .NET SDK and the project guidance disallows local builds in this environment; please run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` and `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` on a Windows dev machine to verify compilation and tests.
- Locally verify that `PortableColorPicker` resolves in XAML, that editing via the picker or hex input updates the model through the existing command path, that invalid hex shows the row error and does not mutate the model, and that undo/redo and save/load preserve expected hex formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0f78dcdfc8327b0b3ecd66ef0f59d)