### PR TITLE
Use PanelChangeEvent for selected document UI refresh

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -282,6 +282,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (_selectedDocument is not null)
             {
                 _selectedDocument.PropertyChanged -= OnSelectedDocumentPropertyChanged;
+                _selectedDocument.PanelChanged -= OnSelectedDocumentPanelChanged;
             }
 
             if (SetProperty(ref _selectedDocument, value))
@@ -289,6 +290,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 if (_selectedDocument is not null)
                 {
                     _selectedDocument.PropertyChanged += OnSelectedDocumentPropertyChanged;
+                    _selectedDocument.PanelChanged += OnSelectedDocumentPanelChanged;
                 }
 
                 _activeDocumentContext.SetActiveDocument(value);
@@ -1150,18 +1152,30 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(DocumentTabViewModel.PanelLayoutJson))
-        {
-            RefreshHierarchy();
-            NotifyInspectorChanged();
-        }
-
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
             _hierarchy.SyncSelection(SelectedDocument?.HierarchySelectedPanelSelection);
             OnPropertyChanged(nameof(HierarchyItems));
             NotifyInspectorChanged();
             NotifyHierarchyCommands();
+        }
+    }
+
+    private void OnSelectedDocumentPanelChanged(PanelChangeEvent panelChange)
+    {
+        if (SelectedDocument is null || panelChange.DocumentId != SelectedDocument.DocumentId)
+        {
+            return;
+        }
+
+        if (panelChange.AffectsHierarchy)
+        {
+            RefreshHierarchy();
+        }
+
+        if (panelChange.AffectsInspectorRows)
+        {
+            NotifyInspectorChanged();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Reduce reliance on `PanelLayoutJson` as a broad live UI update trigger to avoid full Inspector/Hierarchy rebuilds for small edits and improve high-frequency interaction performance.
- Move toward scoped notifications (Phase AC) so only affected panes update on element changes.

### Description
- Subscribe/unsubscribe `DocumentTabViewModel.PanelChanged` alongside `PropertyChanged` when the `SelectedDocument` changes by wiring `PanelChanged` in `MainWindowViewModel.SelectedDocument`.
- Remove the `PanelLayoutJson` branch from `OnSelectedDocumentPropertyChanged` so `PanelLayoutJson` no longer forces hierarchy/inspector refreshes.
- Add `OnSelectedDocumentPanelChanged(PanelChangeEvent)` that applies updates only to the active document and conditionally calls `RefreshHierarchy()` when `AffectsHierarchy` is true and `NotifyInspectorChanged()` when `AffectsInspectorRows` is true.

### Testing
- Ran repository inspections and file reads (`rg`, `sed`, `cat`) to verify code locations and updated wiring, and these commands completed successfully in the environment.
- Committed the change and verified the commit summary via `git commit`/`git show`, and the commit completed successfully.
- No unit/integration test runs were performed in this environment due to the project environment constraints; please run the full local build and test suite (including inspector/hierarchy regression tests and color-picker interaction checks) on a Windows/.NET machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1976155a4832786f957a86f52106c)