### PR TITLE
Refresh inspector/hierarchy from PanelChangeEvent instead of PanelLayoutJson

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -282,6 +282,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (_selectedDocument is not null)
             {
                 _selectedDocument.PropertyChanged -= OnSelectedDocumentPropertyChanged;
+                _selectedDocument.PanelChanged -= OnSelectedDocumentPanelChanged;
             }
 
             if (SetProperty(ref _selectedDocument, value))
@@ -289,6 +290,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 if (_selectedDocument is not null)
                 {
                     _selectedDocument.PropertyChanged += OnSelectedDocumentPropertyChanged;
+                    _selectedDocument.PanelChanged += OnSelectedDocumentPanelChanged;
                 }
 
                 _activeDocumentContext.SetActiveDocument(value);
@@ -1150,18 +1152,31 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(DocumentTabViewModel.PanelLayoutJson))
-        {
-            RefreshHierarchy();
-            NotifyInspectorChanged();
-        }
-
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
             _hierarchy.SyncSelection(SelectedDocument?.HierarchySelectedPanelSelection);
             OnPropertyChanged(nameof(HierarchyItems));
             NotifyInspectorChanged();
             NotifyHierarchyCommands();
+        }
+    }
+
+    private void OnSelectedDocumentPanelChanged(PanelChangeEvent panelChange)
+    {
+        if (SelectedDocument is null || panelChange.DocumentId != SelectedDocument.DocumentId)
+        {
+            return;
+        }
+
+        if (panelChange.AffectsHierarchy)
+        {
+            RefreshHierarchy();
+            NotifyHierarchyCommands();
+        }
+
+        if (panelChange.AffectsInspectorRows)
+        {
+            NotifyInspectorChanged();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1105,15 +1105,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         NotifyUndoRedoStateChanged();
         _assetBrowser.NotifyRefreshCommand();
-        RefreshHierarchy();
     }
 
     private void NotifyUndoRedoStateChanged()
     {
         OnPropertyChanged(nameof(UndoMenuHeader));
         OnPropertyChanged(nameof(RedoMenuHeader));
-        RefreshHierarchy();
-        NotifyInspectorChanged();
         CommandManager.InvalidateRequerySuggested();
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1176,7 +1176,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         if (panelChange.AffectsInspectorRows)
         {
-            NotifyInspectorChanged();
+            _inspector.NotifyPanelChanged(panelChange);
+            OnPropertyChanged(nameof(InspectorSummary));
+            OnPropertyChanged(nameof(InspectorPropertyRows));
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -99,6 +99,14 @@ public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRo
         _committedValue = _value;
     }
 
+    public void SetCommittedValue(string? value)
+    {
+        ErrorText = string.Empty;
+        _value = value ?? string.Empty;
+        _committedValue = _value;
+        RaisePropertyChanged(nameof(Value));
+    }
+
 }
 
 public sealed class InspectorDoublePropertyViewModel : InspectorEditablePropertyRowViewModel
@@ -148,6 +156,14 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
 
         ErrorText = string.Empty;
         _committedValue = parsed.ToString("0.###", CultureInfo.InvariantCulture);
+        _value = _committedValue;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetCommittedValue(double value)
+    {
+        ErrorText = string.Empty;
+        _committedValue = value.ToString("0.###", CultureInfo.InvariantCulture);
         _value = _committedValue;
         RaisePropertyChanged(nameof(Value));
     }
@@ -218,6 +234,14 @@ public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRow
 
         ErrorText = string.Empty;
         _committedValue = parsedValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        _value = _committedValue;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetCommittedValue(int? value)
+    {
+        ErrorText = string.Empty;
+        _committedValue = value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         _value = _committedValue;
         RaisePropertyChanged(nameof(Value));
     }
@@ -351,6 +375,26 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
         parsedColor = color;
         return InspectorColorHex.Format(color);
     }
+
+    public void SetCommittedValue(string? value)
+    {
+        ErrorText = string.Empty;
+        if (InspectorColorHex.TryParse(value, out var parsedColor))
+        {
+            _selectedColor = parsedColor;
+            _committedColor = parsedColor;
+            _hexValue = InspectorColorHex.Format(parsedColor);
+            _committedHexValue = _hexValue;
+        }
+        else
+        {
+            _hexValue = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+            _committedHexValue = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        }
+
+        RaisePropertyChanged(nameof(HexValue));
+        RaisePropertyChanged(nameof(SelectedColor));
+    }
 }
 
 public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewModel
@@ -389,6 +433,13 @@ public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewMod
             _isApplyingChange = false;
         }
     }
+
+    public void SetCommittedValue(bool value)
+    {
+        ErrorText = string.Empty;
+        _value = value;
+        RaisePropertyChanged(nameof(Value));
+    }
 }
 
 public sealed class InspectorInfoPropertyViewModel : InspectorPropertyRowViewModel
@@ -405,5 +456,10 @@ public sealed class InspectorInfoPropertyViewModel : InspectorPropertyRowViewMod
     {
         get => _value;
         set => SetProperty(ref _value, value);
+    }
+
+    public void SetCommittedValue(string value)
+    {
+        Value = value;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -204,6 +204,38 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         NotifyInspectorEditCommand();
     }
 
+    public void NotifyPanelChanged(PanelChangeEvent panelChange)
+    {
+        var selectedDocument = _selectedDocumentAccessor();
+        var selection = _activeDocumentContext.ActivePanelSelection;
+        if (selectedDocument is null || selection is not PanelSelectionInfo panelSelection)
+        {
+            NotifyContextChanged();
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(panelChange.ObjectId)
+            && !string.Equals(panelChange.ObjectId, panelSelection.ObjectId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Structure))
+        {
+            RebuildPropertyRows();
+            return;
+        }
+
+        if (!selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
+        {
+            RebuildPropertyRows();
+            return;
+        }
+
+        RefreshPropertyRowValues(selectedElement);
+        OnPropertyChanged(nameof(InspectorSummary));
+    }
+
     private void RebuildPropertyRows()
     {
         _propertyRows.Clear();
@@ -357,6 +389,73 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference));
+        }
+    }
+
+    private void RefreshPropertyRowValues(PanelElementModel selectedElement)
+    {
+        foreach (var row in _propertyRows)
+        {
+            switch (row.DisplayName)
+            {
+                case "Name" when row is InspectorTextPropertyViewModel textRow:
+                    textRow.SetCommittedValue(selectedElement.Name);
+                    break;
+                case "X" when row is InspectorDoublePropertyViewModel doubleRow:
+                    doubleRow.SetCommittedValue(selectedElement.X);
+                    break;
+                case "Y" when row is InspectorDoublePropertyViewModel yRow:
+                    yRow.SetCommittedValue(selectedElement.Y);
+                    break;
+                case "Width" when row is InspectorDoublePropertyViewModel widthRow:
+                    widthRow.SetCommittedValue(selectedElement.Width);
+                    break;
+                case "Height" when row is InspectorDoublePropertyViewModel heightRow:
+                    heightRow.SetCommittedValue(selectedElement.Height);
+                    break;
+                case "Locked" when row is InspectorBoolPropertyViewModel lockedRow:
+                    lockedRow.SetCommittedValue(selectedElement.IsLocked);
+                    break;
+                case "Visible" when row is InspectorBoolPropertyViewModel visibleRow:
+                    visibleRow.SetCommittedValue(selectedElement.IsVisible);
+                    break;
+                case "Display Number" when row is InspectorIntPropertyViewModel displayRow:
+                    displayRow.SetCommittedValue(selectedElement.DisplayNumber);
+                    break;
+                case "Asset Path" when row is InspectorTextPropertyViewModel assetPathRow:
+                    assetPathRow.SetCommittedValue(selectedElement.AssetPath);
+                    break;
+                case "Secondary Asset" when row is InspectorTextPropertyViewModel secondaryRow:
+                    secondaryRow.SetCommittedValue(selectedElement.SecondaryAssetPath);
+                    break;
+                case "On Color" when row is InspectorColorPropertyViewModel onColorRow:
+                    onColorRow.SetCommittedValue(selectedElement.OnColorHex);
+                    break;
+                case "Off Color" when row is InspectorColorPropertyViewModel offColorRow:
+                    offColorRow.SetCommittedValue(selectedElement.OffColorHex);
+                    break;
+                case "Text Color" when row is InspectorColorPropertyViewModel textColorRow:
+                    textColorRow.SetCommittedValue(selectedElement.TextColorHex);
+                    break;
+                case "Display Text" when row is InspectorTextPropertyViewModel displayTextRow:
+                    displayTextRow.SetCommittedValue(selectedElement.DisplayText);
+                    break;
+                case "Stops" when row is InspectorIntPropertyViewModel stopsRow:
+                    stopsRow.SetCommittedValue(selectedElement.Stops);
+                    break;
+                case "Visible Scale" when row is InspectorDoublePropertyViewModel scaleRow && selectedElement.VisibleScale.HasValue:
+                    scaleRow.SetCommittedValue(selectedElement.VisibleScale.Value);
+                    break;
+                case "Reversed" when row is InspectorBoolPropertyViewModel reversedRow:
+                    reversedRow.SetCommittedValue(selectedElement.IsReversed ?? false);
+                    break;
+                case "Import Format" when row is InspectorInfoPropertyViewModel importFormatRow:
+                    importFormatRow.SetCommittedValue(selectedElement.ImportSource?.Format ?? string.Empty);
+                    break;
+                case "Import Reference" when row is InspectorInfoPropertyViewModel importReferenceRow:
+                    importReferenceRow.SetCommittedValue(selectedElement.ImportSource?.Reference ?? string.Empty);
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Reduce broad UI refreshes driven by `PanelLayoutJson` updates and move to scoped change notifications to address Inspector/Hierarchy performance issues.
- Ensure UI panes update only for relevant panel mutations using explicit `PanelChangeEvent` metadata.

### Description
- Subscribed and unsubscribed `DocumentTabViewModel.PanelChanged` on `SelectedDocument` so selected-document wiring listens for panel-scoped change events. 
- Removed the `PanelLayoutJson` branch from `OnSelectedDocumentPropertyChanged` so JSON assignment no longer drives routine UI refreshes. 
- Added `OnSelectedDocumentPanelChanged(PanelChangeEvent)` that guards by `DocumentId` and calls `RefreshHierarchy()` and/or `NotifyInspectorChanged()` conditionally based on `AffectsHierarchy` and `AffectsInspectorRows` flags.

### Testing
- No automated tests were executed in this environment because the .NET SDK/CLI is not available here. 
- Locally run `dotnet build` and `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` on a Windows dev machine with the .NET SDK to validate compilation and unit tests. 
- Expect the existing test suite to pass and verify UI behavior manually: non-structural edits should not trigger full hierarchy/inspector rebuilds while structural edits still update both panes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f199798320832791d8b7cd0ccbe3a6)