### PR TITLE
Mark ordering changes as hierarchy-affecting and update Phase AE task status

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1231,6 +1231,74 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void UpdateElementCommand_GeometryOnlyChange_EmitsPanelChangeWithoutHierarchyRefreshFlag()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        updated.X = 42;
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+        var panelChange = Assert.Single(events);
+        Assert.Equal("rect-1", panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Geometry));
+        Assert.False(panelChange.AffectsHierarchy);
+    }
+
+    [Fact]
+    public void UpdateElementCommand_NameChange_EmitsPanelChangeWithHierarchyRefreshFlag()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        updated.Name = "Rect Renamed";
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+        var panelChange = Assert.Single(events);
+        Assert.Equal("rect-1", panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Name));
+        Assert.True(panelChange.AffectsHierarchy);
+    }
+
+    [Fact]
     public void ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate()
     {
         var firstDocument = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -752,7 +752,8 @@ internal static class CanvasMutationCommands
             var changedProperties = GetChangedProperties(existing, _updatedElement);
             var affectsHierarchy = changedProperties.HasFlag(PanelChangeProperties.Name)
                 || changedProperties.HasFlag(PanelChangeProperties.Visibility)
-                || changedProperties.HasFlag(PanelChangeProperties.LockState);
+                || changedProperties.HasFlag(PanelChangeProperties.LockState)
+                || changedProperties.HasFlag(PanelChangeProperties.Ordering);
 
             _document.SetPanelElements(elements, CreateElementChange(_document, _objectId, changedProperties, affectsHierarchy: affectsHierarchy));
             _document.MarkDirty();
@@ -782,7 +783,8 @@ internal static class CanvasMutationCommands
             var changedProperties = GetChangedProperties(current, _previousElement);
             var affectsHierarchy = changedProperties.HasFlag(PanelChangeProperties.Name)
                 || changedProperties.HasFlag(PanelChangeProperties.Visibility)
-                || changedProperties.HasFlag(PanelChangeProperties.LockState);
+                || changedProperties.HasFlag(PanelChangeProperties.LockState)
+                || changedProperties.HasFlag(PanelChangeProperties.Ordering);
 
             elements[index] = PanelElementModelCloner.Clone(_previousElement);
             _document.SetPanelElements(elements, CreateElementChange(_document, _objectId, changedProperties, affectsHierarchy: affectsHierarchy));

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -101,16 +101,16 @@ Create a new, explicit change notification mechanism for Panel2D documents.
 
 ## Phase AE — Incremental Hierarchy Updates
 
-- [ ] Modify hierarchy refresh logic so that:
-  - [ ] full `RefreshHierarchy()` is NOT called for simple property changes
-- [ ] Only refresh hierarchy when:
-  - [ ] element added/removed
-  - [ ] reorder/z-index change
+- [x] Modify hierarchy refresh logic so that:
+  - [x] full `RefreshHierarchy()` is NOT called for simple property changes
+- [x] Only refresh hierarchy when:
+  - [x] element added/removed
+  - [x] reorder/z-index change
   - [ ] parent/group change
-  - [ ] name change
-  - [ ] visibility/lock IF shown in hierarchy UI
-- [ ] For non-structural changes:
-  - [ ] skip hierarchy rebuild entirely
+  - [x] name change
+  - [x] visibility/lock IF shown in hierarchy UI
+- [x] For non-structural changes:
+  - [x] skip hierarchy rebuild entirely
 
 ---
 


### PR DESCRIPTION
### Motivation

- Ensure that reordering/z-index changes are treated as structural/hierarchy-affecting so the UI can refresh the hierarchy when an element's ordering changes.
- Reflect completed work for Phase AE in the project task list so the roadmap accurately records that hierarchy refreshes are now incremental.

### Description

- Treat `PanelChangeProperties.Ordering` as a hierarchy-affecting change by including it in the `affectsHierarchy` calculation in both the command `Execute()` and `Undo()` paths.
- Update `TASKS.md` to mark Phase AE hierarchy-refresh items (including suppressing full `RefreshHierarchy()` for simple changes and only refreshing on add/remove and reorder) as completed.

### Testing

- Built the solution to validate there are no compile errors after the change and the build succeeded.
- Ran the repository's automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1a153df208327960b5fad003c49a5)