### PR TITLE
Filter no-op panel updates, detect import-source metadata changes, and add unit tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1231,6 +1231,117 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void UpdateElementCommand_GeometryOnlyChange_EmitsPanelChangeWithoutHierarchyRefreshFlag()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        updated.X = 42;
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+        var panelChange = Assert.Single(events);
+        Assert.Equal("rect-1", panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Geometry));
+        Assert.False(panelChange.AffectsHierarchy);
+    }
+
+    [Fact]
+    public void UpdateElementCommand_NameChange_EmitsPanelChangeWithHierarchyRefreshFlag()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20
+            });
+        var workspace = CreateWorkspace(document, document);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        updated.Name = "Rect Renamed";
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+        var panelChange = Assert.Single(events);
+        Assert.Equal("rect-1", panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Name));
+        Assert.True(panelChange.AffectsHierarchy);
+    }
+
+    [Fact]
+    public void UpdateElementCommand_ImportSourceChange_EmitsMetadataPanelChange()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel
+            {
+                ObjectId = "rect-1",
+                Name = "Rect 1",
+                Kind = PanelElementKind.Rectangle,
+                X = 10,
+                Y = 10,
+                Width = 20,
+                Height = 20,
+                ImportSource = new PanelElementImportSourceModel
+                {
+                    Format = "LegacyImport",
+                    Reference = "layout.json#rect-1"
+                }
+            });
+        var workspace = CreateWorkspace(document, document);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        updated.ImportSource = new PanelElementImportSourceModel
+        {
+            Format = "LegacyImport",
+            Reference = "layout.json#rect-1-updated"
+        };
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "rect-1",
+            updated,
+            "Inspector update");
+
+        Assert.True(workspace.ExecuteDocumentCanvasCommand(document.DocumentId, command));
+        var panelChange = Assert.Single(events);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Metadata));
+        Assert.False(panelChange.AffectsHierarchy);
+    }
+
+    [Fact]
     public void ExecuteDocumentCanvasCommand_TargetingInactiveDocument_ReturnsFalseAndDoesNotMutate()
     {
         var firstDocument = CreatePanelDocument(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -750,9 +750,15 @@ internal static class CanvasMutationCommands
             _previousElement = PanelElementModelCloner.Clone(existing);
             elements[index] = PanelElementModelCloner.Clone(_updatedElement);
             var changedProperties = GetChangedProperties(existing, _updatedElement);
+            if (changedProperties is PanelChangeProperties.None)
+            {
+                return;
+            }
+
             var affectsHierarchy = changedProperties.HasFlag(PanelChangeProperties.Name)
                 || changedProperties.HasFlag(PanelChangeProperties.Visibility)
-                || changedProperties.HasFlag(PanelChangeProperties.LockState);
+                || changedProperties.HasFlag(PanelChangeProperties.LockState)
+                || changedProperties.HasFlag(PanelChangeProperties.Ordering);
 
             _document.SetPanelElements(elements, CreateElementChange(_document, _objectId, changedProperties, affectsHierarchy: affectsHierarchy));
             _document.MarkDirty();
@@ -780,9 +786,15 @@ internal static class CanvasMutationCommands
 
             var current = elements[index];
             var changedProperties = GetChangedProperties(current, _previousElement);
+            if (changedProperties is PanelChangeProperties.None)
+            {
+                return;
+            }
+
             var affectsHierarchy = changedProperties.HasFlag(PanelChangeProperties.Name)
                 || changedProperties.HasFlag(PanelChangeProperties.Visibility)
-                || changedProperties.HasFlag(PanelChangeProperties.LockState);
+                || changedProperties.HasFlag(PanelChangeProperties.LockState)
+                || changedProperties.HasFlag(PanelChangeProperties.Ordering);
 
             elements[index] = PanelElementModelCloner.Clone(_previousElement);
             _document.SetPanelElements(elements, CreateElementChange(_document, _objectId, changedProperties, affectsHierarchy: affectsHierarchy));
@@ -831,9 +843,13 @@ internal static class CanvasMutationCommands
                 changed |= PanelChangeProperties.Metadata;
             }
 
-            return changed is PanelChangeProperties.None
-                ? PanelChangeProperties.Metadata
-                : changed;
+            if (!string.Equals(before.ImportSource?.Format, after.ImportSource?.Format, StringComparison.Ordinal)
+                || !string.Equals(before.ImportSource?.Reference, after.ImportSource?.Reference, StringComparison.Ordinal))
+            {
+                changed |= PanelChangeProperties.Metadata;
+            }
+
+            return changed;
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/TASKS.md
+++ b/WindowsNetProjects/OasisEditor/TASKS.md
@@ -101,16 +101,16 @@ Create a new, explicit change notification mechanism for Panel2D documents.
 
 ## Phase AE — Incremental Hierarchy Updates
 
-- [ ] Modify hierarchy refresh logic so that:
-  - [ ] full `RefreshHierarchy()` is NOT called for simple property changes
-- [ ] Only refresh hierarchy when:
-  - [ ] element added/removed
-  - [ ] reorder/z-index change
+- [x] Modify hierarchy refresh logic so that:
+  - [x] full `RefreshHierarchy()` is NOT called for simple property changes
+- [x] Only refresh hierarchy when:
+  - [x] element added/removed
+  - [x] reorder/z-index change
   - [ ] parent/group change
-  - [ ] name change
-  - [ ] visibility/lock IF shown in hierarchy UI
-- [ ] For non-structural changes:
-  - [ ] skip hierarchy rebuild entirely
+  - [x] name change
+  - [x] visibility/lock IF shown in hierarchy UI
+- [x] For non-structural changes:
+  - [x] skip hierarchy rebuild entirely
 
 ---
 


### PR DESCRIPTION
### Motivation
- Prevent emitting redundant panel change events for inspector updates that do not actually change element properties.
- Ensure import source changes are treated as metadata changes so the UI and persistence reflect them.
- Verify change-detection and hierarchy-affecting flags via unit tests.

### Description
- Added early return in `CanvasMutationCommands` execution and undo paths to skip creating events when `GetChangedProperties` returns `None` by not emitting no-op changes.
- Extended `GetChangedProperties` to check `ImportSource.Format` and `ImportSource.Reference` and include them under `PanelChangeProperties.Metadata` when they differ.
- Included `PanelChangeProperties.Ordering` in the computation of `affectsHierarchy` so ordering changes trigger hierarchy refreshes.
- Added three tests to `Panel2DRoundTripTests`: `UpdateElementCommand_GeometryOnlyChange_EmitsPanelChangeWithoutHierarchyRefreshFlag`, `UpdateElementCommand_NameChange_EmitsPanelChangeWithHierarchyRefreshFlag`, and `UpdateElementCommand_ImportSourceChange_EmitsMetadataPanelChange` and minor `TASKS.md` checkbox updates.

### Testing
- Ran the `OasisEditor.Tests` suite including the new `Panel2DRoundTripTests` additions; all tests including the three new tests passed.
- Verified that geometry-only updates emit a panel change without `AffectsHierarchy` and that name and import-source changes set the appropriate flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1a153df208327960b5fad003c49a5)