### PR TITLE
Replace Hello World entrypoint with FML decoder CLI

### DIFF
--- a/WindowsNetProjects/MfmeFmlDecoder/MfmeFmlDecoder/Program.cs
+++ b/WindowsNetProjects/MfmeFmlDecoder/MfmeFmlDecoder/Program.cs
@@ -1,5 +1,30 @@
-﻿// See https://aka.ms/new-console-template for more information
 using MfmeFmlDecoder;
 
-Console.WriteLine("Hello, World!");
+if (args.Length != 1)
+{
+    Console.Error.WriteLine("Usage: MfmeFmlDecoder <path-to-file.fml>");
+    return 1;
+}
 
+string inputPath = args[0];
+
+if (!File.Exists(inputPath))
+{
+    Console.Error.WriteLine($"File not found: {inputPath}");
+    return 1;
+}
+
+try
+{
+    byte[] decodedBytes = MfmeLegacyLayoutDecoder.DecodeFile(inputPath);
+    string outputPath = Path.ChangeExtension(inputPath, ".decoded");
+
+    File.WriteAllBytes(outputPath, decodedBytes);
+    Console.WriteLine($"Decoded {decodedBytes.Length} bytes to: {outputPath}");
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Decoding failed: {ex.Message}");
+    return 1;
+}


### PR DESCRIPTION
### Motivation
- Replace the top-level placeholder program with a usable CLI that accepts a single `.fml` file path and invokes the existing decoder to produce a decoded output file.

### Description
- Updated `WindowsNetProjects/MfmeFmlDecoder/MfmeFmlDecoder/Program.cs` to require exactly one argument, validate the input file, call `MfmeLegacyLayoutDecoder.DecodeFile(inputPath)`, write the decoded bytes to a sibling file with the `.decoded` extension, and return non-zero exit codes and error messages on failure.

### Testing
- Ran `dotnet build` for the project, which failed in this environment because `dotnet` is not installed (build could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1dd43a4ec832780daa81a5b933426)