### PR TITLE
Parse MFME lamp mask filename and map to SecondaryAssetPath

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -153,6 +153,7 @@ public sealed class MfmeExtractReaderTests
         Directory.CreateDirectory(Path.Combine(extractDirectory, "reels"));
         File.WriteAllText(Path.Combine(extractDirectory, "background", "bg.png"), "placeholder");
         File.WriteAllText(Path.Combine(extractDirectory, "lamps", "lamp.png"), "placeholder");
+        File.WriteAllText(Path.Combine(extractDirectory, "lamps", "lamp-mask.png"), "placeholder");
         File.WriteAllText(Path.Combine(extractDirectory, "reels", "band.png"), "placeholder");
         File.WriteAllText(Path.Combine(extractDirectory, "reels", "overlay.png"), "placeholder");
         File.WriteAllText(manifestPath, CreateSupportedComponentsManifestJson());
@@ -182,6 +183,7 @@ public sealed class MfmeExtractReaderTests
             var lamp = Assert.IsType<MfmeLegacyLampComponent>(components[1]);
             Assert.Equal(12, lamp.FirstLampElement!.Number);
             Assert.Equal("lamp.png", lamp.FirstLampElement.BmpImageFilename);
+            Assert.Equal("lamp-mask.png", lamp.FirstLampElement.BmpMaskImageFilename);
 
             var reel = Assert.IsType<MfmeLegacyReelComponent>(components[2]);
             Assert.Equal(3, reel.Number);
@@ -230,7 +232,7 @@ public sealed class MfmeExtractReaderTests
 
             Assert.True(result.Succeeded);
             Assert.Empty(result.Errors);
-            Assert.Equal(4, result.Warnings.Count);
+            Assert.Equal(5, result.Warnings.Count);
             Assert.All(result.Warnings, warning => Assert.Equal("mfme.extract.asset.missing", warning.Code));
             Assert.Equal(7, result.Extract!.Components.Count);
         }
@@ -323,7 +325,8 @@ public sealed class MfmeExtractReaderTests
                 {
                   "NumberAsText": "12",
                   "OnColor": { "R": 1, "G": 0, "B": 0, "A": 1 },
-                  "BmpImageFilename": "lamp.png"
+                  "BmpImageFilename": "lamp.png",
+                  "BmpMaskImageFilename": "lamp-mask.png"
                 }
               ]
             },

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class MfmeImportServiceTests
                     null,
                     null,
                     null,
-                    new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp"),
+                    new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp", null),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
                     NoOutline: false),

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -27,7 +27,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     "Arial",
                     "Regular",
                     "12",
-                    new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png"),
+                    new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png"),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
                     NoOutline: false),
@@ -77,6 +77,7 @@ public sealed class MfmeToOasisComponentMapperTests
         Assert.Equal("Lamp 8", lamp.Name);
         Assert.Equal(8, lamp.DisplayNumber);
         Assert.Equal("lamps/lamp.png", lamp.AssetPath);
+        Assert.Equal("lamps/lamp-mask.png", lamp.SecondaryAssetPath);
         Assert.Equal("#FF00FF00", lamp.OnColorHex);
         Assert.Equal("#FF000000", lamp.OffColorHex);
         Assert.Equal("#FFFFFFFF", lamp.TextColorHex);
@@ -130,7 +131,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     null,
                     null,
                     null,
-                    new MfmeLegacyLampElement("NaN", null, null, null),
+                    new MfmeLegacyLampElement("NaN", null, null, null, null),
                     null,
                     null,
                     NoOutline: true),

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1248,7 +1248,7 @@ public sealed class Panel2DRoundTripTests
         var events = new List<PanelChangeEvent>();
         document.PanelChanged += panelChange => events.Add(panelChange);
 
-        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single()) with { X = 42 };
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single(), x: 42);
         var command = CanvasMutationCommands.CreateUpdateElementCommand(
             document.DocumentId,
             document,
@@ -1281,7 +1281,7 @@ public sealed class Panel2DRoundTripTests
         var events = new List<PanelChangeEvent>();
         document.PanelChanged += panelChange => events.Add(panelChange);
 
-        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single()) with { Name = "Rect Renamed" };
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single(), name: "Rect Renamed");
         var command = CanvasMutationCommands.CreateUpdateElementCommand(
             document.DocumentId,
             document,

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -1248,8 +1248,7 @@ public sealed class Panel2DRoundTripTests
         var events = new List<PanelChangeEvent>();
         document.PanelChanged += panelChange => events.Add(panelChange);
 
-        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
-        updated.X = 42;
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single()) with { X = 42 };
         var command = CanvasMutationCommands.CreateUpdateElementCommand(
             document.DocumentId,
             document,
@@ -1282,8 +1281,7 @@ public sealed class Panel2DRoundTripTests
         var events = new List<PanelChangeEvent>();
         document.PanelChanged += panelChange => events.Add(panelChange);
 
-        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
-        updated.Name = "Rect Renamed";
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single()) with { Name = "Rect Renamed" };
         var command = CanvasMutationCommands.CreateUpdateElementCommand(
             document.DocumentId,
             document,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -118,6 +118,13 @@ internal static class MfmeExtractManifestParser
                     "Lamp",
                     componentIndex,
                     warnings);
+                AddMissingImageWarningIfNeeded(
+                    extractDirectory,
+                    "lamps",
+                    lamp.FirstLampElement?.BmpMaskImageFilename,
+                    "Lamp mask",
+                    componentIndex,
+                    warnings);
                 break;
             case MfmeLegacyReelComponent reel:
                 AddMissingImageWarningIfNeeded(
@@ -252,7 +259,8 @@ internal static class MfmeExtractManifestParser
                 numberAsText,
                 TryParseNullableInt(numberAsText),
                 ReadColor(lampElement, "OnColor"),
-                ReadString(lampElement, "BmpImageFilename"));
+                ReadString(lampElement, "BmpImageFilename"),
+                ReadString(lampElement, "BmpMaskImageFilename"));
         }
 
         return null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -31,7 +31,8 @@ internal sealed record MfmeLegacyLampElement(
     string? NumberAsText,
     int? Number,
     MfmeLegacyColor? OnColor,
-    string? BmpImageFilename);
+    string? BmpImageFilename,
+    string? BmpMaskImageFilename);
 
 internal sealed record MfmeLegacyLampComponent(
     MfmeLegacyPoint Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -97,6 +97,7 @@ internal sealed class MfmeToOasisComponentMapper
             Height = component.Size.Y,
             DisplayNumber = number,
             AssetPath = BuildExtractRelativePath("lamps", component.FirstLampElement?.BmpImageFilename),
+            SecondaryAssetPath = BuildExtractRelativePath("lamps", component.FirstLampElement?.BmpMaskImageFilename),
             OnColorHex = ToHex(component.FirstLampElement?.OnColor),
             OffColorHex = ToHex(component.OffImageColor),
             TextColorHex = ToHex(component.TextColor),


### PR DESCRIPTION
### Motivation
- Carry lamp mask image references from MFME extract manifests through parsing and mapping so mask assets can be used or validated during import.
- Surface missing-mask asset warnings using the same component index context as other optional images.

### Description
- Added a `BmpMaskImageFilename` field to `MfmeLegacyLampElement` to hold mask filename metadata.
- Updated `MfmeExtractManifestParser.ReadFirstLampElement` to read `BmpMaskImageFilename` from the first `LampElements` entry and included an existence check for the mask under the `lamps` folder in `AddMissingOptionalImageWarnings`.
- Mapped lamp mask filenames into Oasis panel data by setting `PanelElementModel.SecondaryAssetPath` to `lamps/<mask-file>` for lamp elements in `MfmeToOasisComponentMapper`.
- Updated unit tests in `OasisEditor.Tests` (`MfmeExtractReaderTests` and `MfmeToOasisComponentMapperTests`) to validate mask parsing, mapped `SecondaryAssetPath`, and adjusted missing-asset warning expectations.

### Testing
- Updated tests: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs` and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs` were modified to cover the new mask behavior.
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --filter "FullyQualifiedName~MfmeExtractReaderTests|FullyQualifiedName~MfmeToOasisComponentMapperTests"` but the environment lacks the `dotnet` SDK and the command failed with `dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2bae438208327aaaae854c7970b76)