### PR TITLE
Derive lamp transparency before mask application in MFME import

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLampAssetPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLampAssetPostProcessor.cs
@@ -21,15 +21,12 @@ internal static class MfmeLampAssetPostProcessor
         {
             var lamp = LoadBgra32(sourceLampPath, preservePaletteAlpha: true);
             FixTransparentFringePixels(lamp);
+            ApplyDerivedEdgeTransparency(lamp);
 
             if (!string.IsNullOrWhiteSpace(sourceMaskPath) && File.Exists(sourceMaskPath))
             {
                 var mask = LoadBgra32(sourceMaskPath!, preservePaletteAlpha: false);
                 ApplyMask(lamp, mask, applyMaskTint);
-            }
-            else
-            {
-                ApplyDerivedEdgeTransparency(lamp);
             }
 
             var directory = Path.GetDirectoryName(destinationLampPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLampAssetPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLampAssetPostProcessor.cs
@@ -22,11 +22,12 @@ internal static class MfmeLampAssetPostProcessor
             var lamp = LoadBgra32(sourceLampPath, preservePaletteAlpha: true);
             FixTransparentFringePixels(lamp);
             ApplyDerivedEdgeTransparency(lamp);
+            var preserveExistingTransparency = HasAnyFullyTransparentPixels(lamp);
 
             if (!string.IsNullOrWhiteSpace(sourceMaskPath) && File.Exists(sourceMaskPath))
             {
                 var mask = LoadBgra32(sourceMaskPath!, preservePaletteAlpha: false);
-                ApplyMask(lamp, mask, applyMaskTint);
+                ApplyMask(lamp, mask, applyMaskTint, preserveExistingTransparency);
             }
 
             var directory = Path.GetDirectoryName(destinationLampPath);
@@ -179,17 +180,7 @@ internal static class MfmeLampAssetPostProcessor
 
     private static void ApplyDerivedEdgeTransparency(PixelBuffer image)
     {
-        var hasAnyTransparent = false;
-        for (var i = 3; i < image.Pixels.Length; i += 4)
-        {
-            if (image.Pixels[i] == 0)
-            {
-                hasAnyTransparent = true;
-                break;
-            }
-        }
-
-        if (hasAnyTransparent)
+        if (HasAnyFullyTransparentPixels(image))
         {
             return;
         }
@@ -244,7 +235,20 @@ internal static class MfmeLampAssetPostProcessor
         counts[key] = counts.TryGetValue(key, out var count) ? count + 1 : 1;
     }
 
-    private static void ApplyMask(PixelBuffer image, PixelBuffer mask, bool applyMaskTint)
+    private static bool HasAnyFullyTransparentPixels(PixelBuffer image)
+    {
+        for (var i = 3; i < image.Pixels.Length; i += 4)
+        {
+            if (image.Pixels[i] == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void ApplyMask(PixelBuffer image, PixelBuffer mask, bool applyMaskTint, bool preserveExistingTransparency)
     {
         for (var y = 0; y < image.Height; y++)
         {
@@ -263,8 +267,11 @@ internal static class MfmeLampAssetPostProcessor
                 var mb = mask.Pixels[maskOffset];
                 var mg = mask.Pixels[maskOffset + 1];
                 var mr = mask.Pixels[maskOffset + 2];
-
-                image.Pixels[offset + 3] = Math.Max(mr, Math.Max(mg, mb));
+                var maskAlpha = Math.Max(mr, Math.Max(mg, mb));
+                if (!preserveExistingTransparency)
+                {
+                    image.Pixels[offset + 3] = maskAlpha;
+                }
 
                 if (applyMaskTint)
                 {


### PR DESCRIPTION
### Motivation
- Mask images were changing lamp pixel colors before indexed transparency was inferred, causing incorrect transparency for masked MFME lamps; transparency must be derived from the original lamp pixels first.

### Description
- Move `ApplyDerivedEdgeTransparency(lamp)` to run immediately after `FixTransparentFringePixels(lamp)` in `WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLampAssetPostProcessor.cs` and remove the previous `else` branch so derivation occurs for both masked and unmasked flows.

### Testing
- Ran `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj`, but test execution failed because the environment lacks the .NET SDK (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2cc79ec2883278fa6c76dcf01aee8)