### PR TITLE
Honor MFME 'Graphic' flag for Lamp import and rendering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -322,13 +322,13 @@ public sealed class MfmeExtractReaderTests
               "NoOutline": true,
               "TextColor": { "R": 1, "G": 1, "B": 1, "A": 1 },
               "OffImageColor": { "R": 0, "G": 0, "B": 0, "A": 1 },
+              "Graphic": true,
               "LampElements": [
                 {
                   "NumberAsText": "12",
                   "OnColor": { "R": 1, "G": 0, "B": 0, "A": 1 },
                   "BmpImageFilename": "lamp.png",
-                  "BmpMaskImageFilename": "lamp-mask.png",
-                  "Graphic": true
+                  "BmpMaskImageFilename": "lamp-mask.png"
                 }
               ]
             },

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -184,6 +184,7 @@ public sealed class MfmeExtractReaderTests
             Assert.Equal(12, lamp.FirstLampElement!.Number);
             Assert.Equal("lamp.png", lamp.FirstLampElement.BmpImageFilename);
             Assert.Equal("lamp-mask.png", lamp.FirstLampElement.BmpMaskImageFilename);
+            Assert.True(lamp.FirstLampElement.Graphic);
 
             var reel = Assert.IsType<MfmeLegacyReelComponent>(components[2]);
             Assert.Equal(3, reel.Number);
@@ -326,7 +327,8 @@ public sealed class MfmeExtractReaderTests
                   "NumberAsText": "12",
                   "OnColor": { "R": 1, "G": 0, "B": 0, "A": 1 },
                   "BmpImageFilename": "lamp.png",
-                  "BmpMaskImageFilename": "lamp-mask.png"
+                  "BmpMaskImageFilename": "lamp-mask.png",
+                  "Graphic": true
                 }
               ]
             },

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class MfmeImportServiceTests
                     null,
                     null,
                     null,
-                    new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp", null),
+                    new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp", null, Graphic: true),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
                     NoOutline: false),

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -27,7 +27,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     "Arial",
                     "Regular",
                     "12",
-                    new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png"),
+                    new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png", Graphic: true),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
                     NoOutline: false),
@@ -114,6 +114,40 @@ public sealed class MfmeToOasisComponentMapperTests
         });
     }
 
+
+    [Fact]
+    public void Map_LampWithGraphicFalse_DoesNotMapLampImages()
+    {
+        var extract = new MfmeLegacyExtractData
+        {
+            LayoutName = "layout",
+            Components =
+            [
+                new MfmeLegacyLampComponent(
+                    new MfmeLegacyPoint(100, 200),
+                    new MfmeLegacyPoint(30, 40),
+                    null,
+                    null,
+                    null,
+                    null,
+                    new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png", Graphic: false),
+                    new MfmeLegacyColor(0f, 0f, 0f, 1f),
+                    null,
+                    NoOutline: false)
+            ]
+        };
+
+        var mapper = new MfmeToOasisComponentMapper();
+
+        var result = mapper.Map(extract);
+
+        var lamp = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, lamp.Kind);
+        Assert.Null(lamp.AssetPath);
+        Assert.Null(lamp.SecondaryAssetPath);
+        Assert.Equal("#FF00FF00", lamp.OnColorHex);
+        Assert.Equal("#FF000000", lamp.OffColorHex);
+    }
     [Fact]
     public void Map_WithInvalidNumbersAndUnsupportedComponent_AddsWarnings()
     {
@@ -131,7 +165,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     null,
                     null,
                     null,
-                    new MfmeLegacyLampElement("NaN", null, null, null, null),
+                    new MfmeLegacyLampElement("NaN", null, null, null, null, Graphic: false),
                     null,
                     null,
                     NoOutline: true),

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -120,6 +120,8 @@ public sealed class MfmeToOasisComponentMapperTests
     {
         var extract = new MfmeLegacyExtractData
         {
+            ExtractRootPath = "C:/extract",
+            ManifestPath = "C:/extract/layout.json",
             LayoutName = "layout",
             Components =
             [

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -197,7 +197,7 @@ internal static class MfmeExtractManifestParser
                     ReadString(component, "TextBoxFontName"),
                     ReadString(component, "TextBoxFontStyle"),
                     ReadString(component, "TextBoxFontSize"),
-                    ReadFirstLampElement(component),
+                    ReadFirstLampElement(component, ReadOptionalBool(component, "Graphic")),
                     ReadColor(component, "OffImageColor"),
                     ReadColor(component, "TextColor"),
                     ReadBool(component, "NoOutline"));
@@ -240,7 +240,7 @@ internal static class MfmeExtractManifestParser
         }
     }
 
-    private static MfmeLegacyLampElement? ReadFirstLampElement(JsonElement component)
+    private static MfmeLegacyLampElement? ReadFirstLampElement(JsonElement component, bool? componentGraphic)
     {
         if (!component.TryGetProperty("LampElements", out var lampElements) || lampElements.ValueKind != JsonValueKind.Array)
         {
@@ -261,7 +261,7 @@ internal static class MfmeExtractManifestParser
                 ReadColor(lampElement, "OnColor"),
                 ReadString(lampElement, "BmpImageFilename"),
                 ReadString(lampElement, "BmpMaskImageFilename"),
-                ReadBool(lampElement, "Graphic"));
+                ReadOptionalBool(lampElement, "Graphic") ?? componentGraphic ?? false);
         }
 
         return null;
@@ -312,6 +312,33 @@ internal static class MfmeExtractManifestParser
         }
 
         return 0;
+    }
+
+
+    private static bool? ReadOptionalBool(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+        {
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.True)
+        {
+            return true;
+        }
+
+        if (property.ValueKind == JsonValueKind.False)
+        {
+            return false;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            bool.TryParse(property.GetString(), out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
     }
 
     private static bool ReadBool(JsonElement element, string propertyName)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -260,7 +260,8 @@ internal static class MfmeExtractManifestParser
                 TryParseNullableInt(numberAsText),
                 ReadColor(lampElement, "OnColor"),
                 ReadString(lampElement, "BmpImageFilename"),
-                ReadString(lampElement, "BmpMaskImageFilename"));
+                ReadString(lampElement, "BmpMaskImageFilename"),
+                ReadBool(lampElement, "Graphic"));
         }
 
         return null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -32,7 +32,8 @@ internal sealed record MfmeLegacyLampElement(
     int? Number,
     MfmeLegacyColor? OnColor,
     string? BmpImageFilename,
-    string? BmpMaskImageFilename);
+    string? BmpMaskImageFilename,
+    bool Graphic);
 
 internal sealed record MfmeLegacyLampComponent(
     MfmeLegacyPoint Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -96,8 +96,12 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             DisplayNumber = number,
-            AssetPath = BuildExtractRelativePath("lamps", component.FirstLampElement?.BmpImageFilename),
-            SecondaryAssetPath = BuildExtractRelativePath("lamps", component.FirstLampElement?.BmpMaskImageFilename),
+            AssetPath = component.FirstLampElement?.Graphic == true
+                ? BuildExtractRelativePath("lamps", component.FirstLampElement.BmpImageFilename)
+                : null,
+            SecondaryAssetPath = component.FirstLampElement?.Graphic == true
+                ? BuildExtractRelativePath("lamps", component.FirstLampElement.BmpMaskImageFilename)
+                : null,
             OnColorHex = ToHex(component.FirstLampElement?.OnColor),
             OffColorHex = ToHex(component.OffImageColor),
             TextColorHex = ToHex(component.TextColor),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -186,8 +186,13 @@ internal static class PanelElementFactory
     private static FrameworkElement CreateLampVisual(PanelElementFile element)
     {
         var label = element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp";
-        var surface = CreatePlaceholderComponentVisual(element, label, element.OnColorHex ?? element.OffColorHex, element.DisplayText);
-        if (TryCreateImageSource(element.AssetPath, out var source))
+        var hasGraphic = TryCreateImageSource(element.AssetPath, out var source);
+        var surface = CreatePlaceholderComponentVisual(
+            element,
+            label,
+            hasGraphic ? null : element.OnColorHex ?? element.OffColorHex,
+            hasGraphic ? null : element.DisplayText);
+        if (hasGraphic)
         {
             surface.Child = new Image
             {


### PR DESCRIPTION
### Motivation
- MFME lamp elements include a `Graphic` flag indicating whether a lamp is represented by an image or by solid on/off colors, and the editor was incorrectly rendering both for imported lamps. 
- The change ensures imported lamp data and Panel2D visuals follow the `Graphic` flag so a lamp renders either its graphic image or the solid color placeholder, not both.

### Description
- Added a `Graphic` boolean to the legacy MFME lamp DTO (`MfmeLegacyLampElement`) and updated the manifest parser to read `"Graphic"` from lamp elements. 
- Updated the MFME-to-Oasis mapper to populate `AssetPath`/`SecondaryAssetPath` only when `Graphic == true`, leaving image paths null when `Graphic == false`. 
- Changed `PanelElementFactory.CreateLampVisual` to detect whether a lamp has a graphic and render either the image alone or the color/text placeholder alone. 
- Updated/added unit test expectations and a new test (`Map_LampWithGraphicFalse_DoesNotMapLampImages`) plus sample manifest changes to cover parsing and mapping of the `Graphic` flag.

### Testing
- No automated tests were executed in this environment per project constraints, so there are no local test results to report here. 
- Unit tests were added or updated: `MfmeToOasisComponentMapperTests` (new `Map_LampWithGraphicFalse_DoesNotMapLampImages`), `MfmeExtractReaderTests` (assert `Graphic` parsed), and `MfmeImportServiceTests` (updated fixtures); these should be exercised by running `dotnet test` for the solution locally. 
- Please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` locally; the updated unit tests are expected to pass after a normal build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2cfeceb308327b69c8017f6de58a9)