### PR TITLE
Refactor OasisEditor document hosting to native AvalonDock documents

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -199,7 +199,7 @@ public sealed class HierarchyPanelCommandServiceTests
 
         Assert.Equal(2, document.GetPanelElements().Count);
         Assert.Contains(document.GetPanelElements(), element => element.ObjectId == "dup-source");
-        var duplicate = Assert.Single(document.GetPanelElements().Where(element => element.ObjectId != "dup-source"));
+        var duplicate = Assert.Single(document.GetPanelElements(), element => element.ObjectId != "dup-source");
         Assert.Equal(PanelElementKind.Reel, duplicate.Kind);
         Assert.Equal("Assets/MfmeImport/layout/Reels/reel2.png", duplicate.AssetPath);
         Assert.Equal("Assets/MfmeImport/layout/Reels/reel2-overlay.png", duplicate.SecondaryAssetPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportLampPostProcessorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportLampPostProcessorTests.cs
@@ -28,7 +28,7 @@ public sealed class MfmeImportLampPostProcessorTests
             ]);
 
             Assert.True(result.Succeeded);
-            var lampAsset = Assert.Single(result.Elements.Where(e => e.Kind == PanelElementKind.Lamp));
+            var lampAsset = Assert.Single(result.Elements, e => e.Kind == PanelElementKind.Lamp);
             Assert.EndsWith(".png", lampAsset.AssetPath, StringComparison.OrdinalIgnoreCase);
             Assert.NotNull(lampAsset.SecondaryAssetPath);
 
@@ -42,7 +42,7 @@ public sealed class MfmeImportLampPostProcessorTests
             Assert.Equal(2, alphas.Count(a => a == 0)); // transparent palette entries remain transparent
             Assert.Contains((byte)255, alphas); // at least one masked-on pixel remains opaque
 
-            var imageAsset = Assert.Single(result.Elements.Where(e => e.Kind == PanelElementKind.Image));
+            var imageAsset = Assert.Single(result.Elements, e => e.Kind == PanelElementKind.Image);
             Assert.EndsWith("symbol.png", imageAsset.AssetPath, StringComparison.OrdinalIgnoreCase);
         }
         finally

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -838,7 +838,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         PanelElementFactory.ProjectDirectoryPath = project.ProjectDirectory;
         ProjectFilePath = project.ProjectFilePath;
         UpdateRecentProjects(project.ProjectFilePath);
-        _documentWorkspace.EnsureProjectOverviewDocument();
         _assetBrowser.RefreshAssetBrowser();
         StatusMessage = $"Project opened: {project.Name} ({project.ProjectFilePath})";
         AddOutputEntry($"Loaded startup project '{project.Name}' from {project.ProjectFilePath}", OutputLogStatus.Info);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -53,7 +53,7 @@ public sealed class DocumentWorkspaceViewModel
     public bool CanSaveSelectedDocument()
     {
         var selectedDocument = _getSelectedDocument();
-        return selectedDocument is not null && selectedDocument.Document.DocumentType != EditorDocumentType.ProjectOverview;
+        return selectedDocument is not null;
     }
 
     public void OpenUntitledDocument()
@@ -143,17 +143,6 @@ public sealed class DocumentWorkspaceViewModel
         ExecuteDocumentMutation(new ReplaceDocumentTabMutationCommand(this, original, updated));
     }
 
-    public void EnsureProjectOverviewDocument()
-    {
-        var loadedProject = _getLoadedProject();
-        if (loadedProject is null)
-        {
-            return;
-        }
-
-        var overviewDocument = new DocumentTabViewModel(EditorDocument.CreateProjectOverview(loadedProject));
-        ExecuteDocumentMutation(new ReplaceOpenDocumentsMutationCommand(this, [overviewDocument], overviewDocument));
-    }
 
     public void ClearProjectSessionState()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -415,7 +415,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         if (selectedElement.ImportSource is not null)
         {
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
-            _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference));
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference ?? string.Empty));
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
@@ -1,0 +1,98 @@
+<UserControl x:Class="OasisEditor.Views.DocumentEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:OasisEditor"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="500"
+             d:DesignWidth="700">
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Margin="0,0,0,8"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="{Binding FilePath}" />
+
+        <Grid Grid.Row="1">
+            <Border x:Name="PanelCanvasContainer"
+                    Padding="12"
+                    Background="{DynamicResource EditorBackgroundBrush}"
+                    BorderBrush="{DynamicResource BorderSubtleBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Visibility="Collapsed">
+                <Grid MinHeight="280"
+                      ClipToBounds="True"
+                      Background="{DynamicResource PanelBackgroundBrush}">
+                    <Border BorderBrush="{DynamicResource BorderSubtleBrush}"
+                            BorderThickness="1"
+                            Background="{DynamicResource PanelBackgroundBrush}">
+                        <Canvas Width="1400"
+                                Height="900"
+                                Cursor="SizeAll"
+                                Focusable="True"
+                                local:CanvasPanBehavior.IsEnabled="True"
+                                local:CanvasPanBehavior.PanelLayoutJson="{Binding PanelLayoutJson, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                local:CanvasPanBehavior.SelectedPanelSelection="{Binding HierarchySelectedPanelSelection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                local:CanvasPanBehavior.PanelZoom="{Binding PanelZoom, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                local:CanvasPanBehavior.PanelPanX="{Binding PanelPanX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                local:CanvasPanBehavior.PanelPanY="{Binding PanelPanY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                Background="{DynamicResource PanelBackgroundBrush}">
+                            <Canvas.Resources>
+                                <Style TargetType="Rectangle">
+                                    <Setter Property="Stroke" Value="{DynamicResource BorderSubtleBrush}" />
+                                    <Setter Property="StrokeThickness" Value="1.5" />
+                                    <Setter Property="Fill" Value="{DynamicResource ToolBarBackgroundBrush}" />
+                                    <Style.Triggers>
+                                        <Trigger Property="local:CanvasSelectionBehavior.IsSelected" Value="True">
+                                            <Setter Property="Stroke" Value="{DynamicResource SelectionBrush}" />
+                                            <Setter Property="StrokeThickness" Value="2.5" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="BorderBrush" Value="SlateGray" />
+                                    <Setter Property="BorderThickness" Value="1" />
+                                    <Style.Triggers>
+                                        <Trigger Property="local:CanvasSelectionBehavior.IsSelected" Value="True">
+                                            <Setter Property="BorderBrush" Value="{DynamicResource SelectionBrush}" />
+                                            <Setter Property="BorderThickness" Value="2.5" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                                <Style TargetType="Image">
+                                    <Setter Property="Opacity" Value="0.88" />
+                                    <Style.Triggers>
+                                        <Trigger Property="local:CanvasSelectionBehavior.IsSelected" Value="True">
+                                            <Setter Property="Opacity" Value="1" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Canvas.Resources>
+                        </Canvas>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Border x:Name="DefaultSummaryContainer"
+                    Padding="10"
+                    CornerRadius="4"
+                    Background="{DynamicResource SelectionBrush}"
+                    BorderBrush="{DynamicResource BorderSubtleBrush}"
+                    BorderThickness="1">
+                <TextBlock TextWrapping="Wrap" Text="{Binding ContentSummary}" />
+            </Border>
+        </Grid>
+    </Grid>
+    <UserControl.Triggers>
+        <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
+            <Setter TargetName="PanelCanvasContainer" Property="Visibility" Value="Visible" />
+            <Setter TargetName="DefaultSummaryContainer" Property="Visibility" Value="Collapsed" />
+        </DataTrigger>
+    </UserControl.Triggers>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
@@ -19,13 +19,21 @@
                    Text="{Binding FilePath}" />
 
         <Grid Grid.Row="1">
-            <Border x:Name="PanelCanvasContainer"
-                    Padding="12"
+            <Border Padding="12"
                     Background="{DynamicResource EditorBackgroundBrush}"
                     BorderBrush="{DynamicResource BorderSubtleBrush}"
                     BorderThickness="1"
-                    CornerRadius="4"
-                    Visibility="Collapsed">
+                    CornerRadius="4">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
                 <Grid MinHeight="280"
                       ClipToBounds="True"
                       Background="{DynamicResource PanelBackgroundBrush}">
@@ -79,20 +87,23 @@
                 </Grid>
             </Border>
 
-            <Border x:Name="DefaultSummaryContainer"
-                    Padding="10"
+            <Border Padding="10"
                     CornerRadius="4"
                     Background="{DynamicResource SelectionBrush}"
                     BorderBrush="{DynamicResource BorderSubtleBrush}"
                     BorderThickness="1">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
                 <TextBlock TextWrapping="Wrap" Text="{Binding ContentSummary}" />
             </Border>
         </Grid>
     </Grid>
-    <UserControl.Triggers>
-        <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
-            <Setter TargetName="PanelCanvasContainer" Property="UIElement.Visibility" Value="Visible" />
-            <Setter TargetName="DefaultSummaryContainer" Property="UIElement.Visibility" Value="Collapsed" />
-        </DataTrigger>
-    </UserControl.Triggers>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
@@ -91,8 +91,8 @@
     </Grid>
     <UserControl.Triggers>
         <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
-            <Setter TargetName="PanelCanvasContainer" Property="Visibility" Value="Visible" />
-            <Setter TargetName="DefaultSummaryContainer" Property="Visibility" Value="Collapsed" />
+            <Setter TargetName="PanelCanvasContainer" Property="UIElement.Visibility" Value="Visible" />
+            <Setter TargetName="DefaultSummaryContainer" Property="UIElement.Visibility" Value="Collapsed" />
         </DataTrigger>
     </UserControl.Triggers>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Views;
+
+public partial class DocumentEditorView : UserControl
+{
+    public DocumentEditorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:layout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
              xmlns:themes="clr-namespace:AvalonDock.Themes;assembly=AvalonDock.Themes.VS2013"
-             xmlns:views="clr-namespace:OasisEditor.Views;assembly=OasisEditor"
+             xmlns:views="clr-namespace:OasisEditor.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="450"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -25,7 +25,6 @@
                 </ResourceDictionary>
             </avalonDock:DockingManager.Resources>
             
-                >
             <avalonDock:DockingManager.Theme>
                 <themes:Vs2013DarkTheme />
             </avalonDock:DockingManager.Theme>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -11,19 +11,20 @@
              d:DesignHeight="450"
              d:DesignWidth="900">
     <Grid Background="{DynamicResource EditorBackgroundBrush}">
+        <Grid.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />
+                </ResourceDictionary.MergedDictionaries>
+                <Style TargetType="{x:Type ContextMenu}"
+                       BasedOn="{StaticResource EditorContextMenuStyle}" />
+                <Style TargetType="{x:Type MenuItem}"
+                       BasedOn="{StaticResource EditorContextMenuItemStyle}" />
+            </ResourceDictionary>
+        </Grid.Resources>
+
         <avalonDock:DockingManager x:Name="DockingManager"
                                    Background="{DynamicResource EditorBackgroundBrush}">
-            <avalonDock:DockingManager.Resources>
-                <ResourceDictionary>
-                    <ResourceDictionary.MergedDictionaries>
-                        <ResourceDictionary Source="../Styles/AvalonDockVs2013Palette.xaml" />
-                    </ResourceDictionary.MergedDictionaries>
-                    <Style TargetType="{x:Type ContextMenu}"
-                           BasedOn="{StaticResource EditorContextMenuStyle}" />
-                    <Style TargetType="{x:Type MenuItem}"
-                           BasedOn="{StaticResource EditorContextMenuItemStyle}" />
-                </ResourceDictionary>
-            </avalonDock:DockingManager.Resources>
             <avalonDock:DockingManager.Theme>
                 <themes:Vs2013DarkTheme />
             </avalonDock:DockingManager.Theme>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -24,6 +24,8 @@
                            BasedOn="{StaticResource EditorContextMenuItemStyle}" />
                 </ResourceDictionary>
             </avalonDock:DockingManager.Resources>
+            
+                >
             <avalonDock:DockingManager.Theme>
                 <themes:Vs2013DarkTheme />
             </avalonDock:DockingManager.Theme>
@@ -42,16 +44,7 @@
                             </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>
 
-                        <layout:LayoutDocumentPane>
-                            <layout:LayoutDocument Title="Document Workspace"
-                                                   ContentId="DocumentWorkspace"
-                                                   CanClose="False">
-                                <Border Padding="10"
-                                        Background="{DynamicResource WorkspaceBackgroundBrush}">
-                                    <views:PanelCanvasView />
-                                </Border>
-                            </layout:LayoutDocument>
-                        </layout:LayoutDocumentPane>
+                        <layout:LayoutDocumentPane x:Name="DocumentPane" />
 
                         <layout:LayoutAnchorablePane DockWidth="280">
                             <layout:LayoutAnchorable Title="Inspector"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:layout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
              xmlns:themes="clr-namespace:AvalonDock.Themes;assembly=AvalonDock.Themes.VS2013"
-             xmlns:views="clr-namespace:OasisEditor.Views"
+             xmlns:views="clr-namespace:OasisEditor.Views;assembly=OasisEditor"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="450"
@@ -22,7 +22,6 @@
                        BasedOn="{StaticResource EditorContextMenuItemStyle}" />
             </ResourceDictionary>
         </Grid.Resources>
-
         <avalonDock:DockingManager x:Name="DockingManager"
                                    Background="{DynamicResource EditorBackgroundBrush}">
             <avalonDock:DockingManager.Theme>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -24,11 +24,9 @@
                            BasedOn="{StaticResource EditorContextMenuItemStyle}" />
                 </ResourceDictionary>
             </avalonDock:DockingManager.Resources>
-            
             <avalonDock:DockingManager.Theme>
                 <themes:Vs2013DarkTheme />
             </avalonDock:DockingManager.Theme>
-
             <layout:LayoutRoot>
                 <layout:LayoutPanel Orientation="Vertical">
                     <layout:LayoutPanel Orientation="Horizontal">
@@ -55,24 +53,23 @@
                                 </Border>
                             </layout:LayoutAnchorable>
 
-                        <layout:LayoutAnchorable Title="Preferences"
-                                                 ContentId="Preferences"
-                                                 CanClose="True">
-                            <Border Padding="10"
-                                    Background="{DynamicResource InspectorBackgroundBrush}">
-                                <views:PreferencesView />
-                            </Border>
-                        </layout:LayoutAnchorable>
+                            <layout:LayoutAnchorable Title="Preferences"
+                                                     ContentId="Preferences"
+                                                     CanClose="True">
+                                <Border Padding="10"
+                                        Background="{DynamicResource InspectorBackgroundBrush}">
+                                    <views:PreferencesView />
+                                </Border>
+                            </layout:LayoutAnchorable>
 
-                        <layout:LayoutAnchorable Title="Project Settings"
-                                                 ContentId="ProjectSettings"
-                                                 CanClose="True">
-                            <Border Padding="10"
-                                    Background="{DynamicResource InspectorBackgroundBrush}">
-                                <views:ProjectSettingsView />
-                            </Border>
-                        </layout:LayoutAnchorable>
-
+                            <layout:LayoutAnchorable Title="Project Settings"
+                                                     ContentId="ProjectSettings"
+                                                     CanClose="True">
+                                <Border Padding="10"
+                                        Background="{DynamicResource InspectorBackgroundBrush}">
+                                    <views:ProjectSettingsView />
+                                </Border>
+                            </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 
@@ -94,7 +91,6 @@
                                 <views:OutputLogView />
                             </Border>
                         </layout:LayoutAnchorable>
-
                     </layout:LayoutAnchorablePane>
                 </layout:LayoutPanel>
             </layout:LayoutRoot>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -8,6 +8,7 @@ public partial class EditorShellView : UserControl
     public EditorShellView()
     {
         InitializeComponent();
+        Loaded += OnLoaded;
         HideToolWindow(EditorToolWindowId.Preferences);
         HideToolWindow(EditorToolWindowId.ProjectSettings);
     }
@@ -43,5 +44,87 @@ public partial class EditorShellView : UserControl
         return DockingManager.Layout.Descendents()
             .OfType<LayoutAnchorable>()
             .FirstOrDefault(anchorable => string.Equals(anchorable.ContentId, contentId, StringComparison.Ordinal));
+    }
+
+    private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        RebuildDocuments(viewModel);
+        viewModel.OpenDocuments.CollectionChanged += (_, _) => RebuildDocuments(viewModel);
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(MainWindowViewModel.SelectedDocument))
+            {
+                ActivateSelectedDocument(viewModel.SelectedDocument);
+            }
+        };
+    }
+
+    private void RebuildDocuments(MainWindowViewModel viewModel)
+    {
+        DocumentPane.Children.Clear();
+
+        foreach (var document in viewModel.OpenDocuments)
+        {
+            var layoutDocument = new LayoutDocument
+            {
+                Title = document.Title,
+                ContentId = document.DocumentId.ToString(),
+                CanClose = true,
+                Content = new DocumentEditorView { DataContext = document }
+            };
+
+            document.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(DocumentTabViewModel.Title))
+                {
+                    layoutDocument.Title = document.Title;
+                }
+            };
+
+            layoutDocument.IsSelectedChanged += (_, _) =>
+            {
+                if (layoutDocument.IsSelected && viewModel.SelectedDocument != document)
+                {
+                    viewModel.SelectedDocument = document;
+                }
+            };
+
+            layoutDocument.Closing += (_, _) =>
+            {
+                if (viewModel.SelectedDocument != document)
+                {
+                    viewModel.SelectedDocument = document;
+                }
+
+                viewModel.CloseSelectedDocumentCommand.Execute(null);
+            };
+
+            DocumentPane.Children.Add(layoutDocument);
+        }
+
+        ActivateSelectedDocument(viewModel.SelectedDocument);
+    }
+
+    private void ActivateSelectedDocument(DocumentTabViewModel? selectedDocument)
+    {
+        if (selectedDocument is null)
+        {
+            return;
+        }
+
+        var target = DocumentPane.Children
+            .OfType<LayoutDocument>()
+            .FirstOrDefault(doc => string.Equals(doc.ContentId, selectedDocument.DocumentId.ToString(), StringComparison.Ordinal));
+
+        if (target is not null)
+        {
+            target.IsSelected = true;
+            target.IsActive = true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- removed the fixed `Document Workspace` wrapper document from `EditorShellView`
- introduced dynamic AvalonDock `LayoutDocument` creation for each open editor document tab
- added `DocumentEditorView` to render a single document's content inside each docked document window
- synchronized AvalonDock selection/close interactions back to `MainWindowViewModel.SelectedDocument` and close command
- stopped startup from creating the `Project Overview` document so it no longer appears in the Editor
- removed `DocumentWorkspaceViewModel.EnsureProjectOverviewDocument` and updated save gating to allow normal selected-document saves

## Why
This enables multiple document types (e.g. two `.panel2d` and one `.cabinet3d`) to be visible as independent AvalonDock document windows and removes the legacy `Project Overview`/`Document Workspace` UI model.

## Notes for local verification
- launch with a valid project and confirm there is no `Document Workspace` pane
- confirm no `Project Overview` tab is created on startup
- open multiple documents and verify each appears as its own AvalonDock document
- verify selecting and closing documents updates active Inspector/Hierarchy context correctly

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f35f4edb588327b52f629b299072b6)