### PR TITLE
Prefer DisplayText for Lamp visuals without images and update tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -46,7 +46,7 @@ public sealed class PanelElementFactoryTests
     }
 
     [Fact]
-    public void CreateVisualFromElement_LampWithoutImage_UsesLampNumberAndDisplayText()
+    public void CreateVisualFromElement_LampWithoutImage_WithDisplayText_UsesDisplayTextOnly()
     {
         RunInSta(() =>
         {
@@ -69,9 +69,39 @@ public sealed class PanelElementFactoryTests
             var title = Assert.IsType<TextBlock>(stack.Children[0]);
             var detail = Assert.IsType<TextBlock>(stack.Children[1]);
 
-            Assert.Equal("Lamp 9", title.Text);
-            Assert.Equal("HOLD", detail.Text);
-            Assert.Equal(Visibility.Visible, detail.Visibility);
+            Assert.Equal("HOLD", title.Text);
+            Assert.Equal(string.Empty, detail.Text);
+            Assert.Equal(Visibility.Collapsed, detail.Visibility);
+        });
+    }
+
+    [Fact]
+    public void CreateVisualFromElement_LampWithoutImage_WithoutDisplayText_ShowsNoText()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "lamp-2",
+                Name = "Lamp 9",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Lamp),
+                Width = 90,
+                Height = 40,
+                DisplayNumber = 9,
+                DisplayText = null,
+                OnColorHex = "#FF00CC00"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            var detail = Assert.IsType<TextBlock>(stack.Children[1]);
+
+            Assert.Equal(string.Empty, title.Text);
+            Assert.Equal(string.Empty, detail.Text);
+            Assert.Equal(Visibility.Collapsed, detail.Visibility);
         });
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -185,13 +185,13 @@ internal static class PanelElementFactory
 
     private static FrameworkElement CreateLampVisual(PanelElementFile element)
     {
-        var label = element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp";
         var hasGraphic = TryCreateImageSource(element.AssetPath, out var source);
+        var label = hasGraphic ? (element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp") : (element.DisplayText ?? string.Empty);
         var surface = CreatePlaceholderComponentVisual(
             element,
             label,
             hasGraphic ? null : element.OnColorHex ?? element.OffColorHex,
-            hasGraphic ? null : element.DisplayText);
+            null);
         if (hasGraphic)
         {
             surface.Child = new Image


### PR DESCRIPTION
### Motivation
- Lamps that lack an image should display the configured `DisplayText` (or nothing) rather than falling back to a generated "Lamp {number}" title and a secondary detail line.

### Description
- Updated `CreateLampVisual` to choose the label as `DisplayText` (or an empty string) when no image is present, and to stop passing a separate detail text to the placeholder.
- Preserved existing image handling and color selection behavior for lamps that do have an image.
- Adjusted the existing test `CreateVisualFromElement_LampWithoutImage_...` to assert the new single-label behavior when `DisplayText` is present, and added `CreateVisualFromElement_LampWithoutImage_WithoutDisplayText_ShowsNoText` to assert behavior when `DisplayText` is `null`.
- No other visual creation paths were changed.

### Testing
- Ran the unit tests in `OasisEditor.Tests`, including `PanelElementFactoryTests`, and the updated tests `CreateVisualFromElement_LampWithoutImage_WithDisplayText_UsesDisplayTextOnly` and `CreateVisualFromElement_LampWithoutImage_WithoutDisplayText_ShowsNoText` passed.
- Executed the project's test suite locally and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f756b1abe88327b79c12acd8b84357)