### PR TITLE
Fix lamp text color rendering for text-only MFME imports

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -170,6 +170,35 @@ public sealed class PanelElementFactoryTests
     }
 
     [Fact]
+    public void CreateVisualFromElement_LampWithoutImage_UsesTextColorForLabel()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "lamp-1",
+                Name = "Lamp",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Lamp),
+                Width = 80,
+                Height = 36,
+                DisplayText = "HOLD",
+                OnColorHex = "#FFAA3300",
+                TextColorHex = "#FF00FF00"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+            var foreground = Assert.IsType<SolidColorBrush>(title.Foreground);
+
+            Assert.Equal("HOLD", title.Text);
+            Assert.Equal(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00), foreground.Color);
+        });
+    }
+
+    [Fact]
     public void CreateVisualFromElement_ReelWithoutImage_UsesFallbackLabel()
     {
         RunInSta(() =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -191,7 +191,8 @@ internal static class PanelElementFactory
             element,
             label,
             hasGraphic ? null : element.OnColorHex ?? element.OffColorHex,
-            null);
+            null,
+            hasGraphic ? null : element.TextColorHex);
         if (hasGraphic)
         {
             surface.Child = new Image
@@ -239,7 +240,12 @@ internal static class PanelElementFactory
         return CreatePlaceholderComponentVisual(element, label, null, null);
     }
 
-    private static Border CreatePlaceholderComponentVisual(PanelElementFile element, string label, string? backgroundColorHex, string? detailText = null)
+    private static Border CreatePlaceholderComponentVisual(
+        PanelElementFile element,
+        string label,
+        string? backgroundColorHex,
+        string? detailText = null,
+        string? labelColorHex = null)
     {
         var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
         var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
@@ -262,7 +268,7 @@ internal static class PanelElementFactory
                         Text = label,
                         HorizontalAlignment = HorizontalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
-                        Foreground = Brushes.LightSteelBlue
+                        Foreground = TryCreateBrush(labelColorHex, Brushes.LightSteelBlue)
                     },
                     new TextBlock
                     {


### PR DESCRIPTION
### Motivation
- MFME-derived, text-heavy Panel2D layouts rendered lamp labels but ignored the lamp `Text color` property, always falling back to a hard-coded brush.

### Description
- `CreateLampVisual` in `PanelElementFactory` now passes `TextColorHex` for non-graphic lamps into the placeholder visual creation path.
- `CreatePlaceholderComponentVisual` signature was extended with an optional `labelColorHex` parameter and the primary `TextBlock` foreground now uses `TryCreateBrush(labelColorHex, Brushes.LightSteelBlue)`.
- A regression unit test `CreateVisualFromElement_LampWithoutImage_UsesTextColorForLabel` was added to `OasisEditor.Tests/PanelElementFactoryTests.cs` to assert the label text and foreground color.

### Testing
- Added automated test `CreateVisualFromElement_LampWithoutImage_UsesTextColorForLabel` in `OasisEditor.Tests/PanelElementFactoryTests.cs` to cover the regression.
- No tests were executed in this environment due to the project guidance in `AGENT.md` regarding the missing Windows/.NET/WPF toolchain; please run `dotnet test` locally to validate the new test passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f759680e688327969be4f119cee6f2)