### PR TITLE
Use bundled MFME fonts for imported lamp text

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -14,4 +14,10 @@
     <PackageReference Include="PixiEditor.ColorPicker" Version="3.4.2.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="MfmeFonts\*.ttf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -317,8 +317,8 @@ internal static class PanelElementFactory
 
     private static LampFontSettings CreateFontSettings(string? fontName, string? fontStyle, string? fontSize)
     {
-        var family = ResolveFontFamily(fontName);
         var styleToken = string.IsNullOrWhiteSpace(fontStyle) ? "Regular" : fontStyle.Trim();
+        var family = ResolveFontFamily(fontName, styleToken);
         var style = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase) ? FontStyles.Italic : FontStyles.Normal;
         var weight = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase) ? FontWeights.Bold : FontWeights.Normal;
         var size = double.TryParse(fontSize, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
@@ -327,7 +327,7 @@ internal static class PanelElementFactory
         return new LampFontSettings(family, style, weight, size);
     }
 
-    private static FontFamily ResolveFontFamily(string? fontName)
+    private static FontFamily ResolveFontFamily(string? fontName, string styleToken)
     {
         if (string.IsNullOrWhiteSpace(fontName))
         {
@@ -335,7 +335,7 @@ internal static class PanelElementFactory
         }
 
         var trimmedName = fontName.Trim();
-        if (TryResolveMfmeFontFamily(trimmedName, out var mfmeFontFamily))
+        if (TryResolveMfmeFontFamily(trimmedName, styleToken, out var mfmeFontFamily))
         {
             return mfmeFontFamily;
         }
@@ -343,9 +343,10 @@ internal static class PanelElementFactory
         return new FontFamily(trimmedName);
     }
 
-    private static bool TryResolveMfmeFontFamily(string fontName, out FontFamily fontFamily)
+    private static bool TryResolveMfmeFontFamily(string fontName, string styleToken, out FontFamily fontFamily)
     {
-        if (MfmeFontFamilies.TryGetValue(fontName, out fontFamily!))
+        var cacheKey = $"{fontName}|{styleToken}";
+        if (MfmeFontFamilies.TryGetValue(cacheKey, out fontFamily!))
         {
             return true;
         }
@@ -358,14 +359,29 @@ internal static class PanelElementFactory
 
         foreach (var fontPath in System.IO.Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
         {
-            if (!string.Equals(System.IO.Path.GetFileNameWithoutExtension(fontPath), fontName, StringComparison.OrdinalIgnoreCase))
+            var fontUri = new Uri(fontPath, UriKind.Absolute);
+            if (!GlyphTypeface.TryCreateFromUri(fontUri, out var glyphTypeface))
             {
                 continue;
             }
 
-            var fontUri = new Uri(fontsDirectory + System.IO.Path.DirectorySeparatorChar);
-            fontFamily = new FontFamily(fontUri, $"./#{fontName}");
-            MfmeFontFamilies[fontName] = fontFamily;
+            var familyNameMatches = glyphTypeface.Win32FamilyNames.Values.Any(v => string.Equals(v, fontName, StringComparison.OrdinalIgnoreCase));
+            if (!familyNameMatches)
+            {
+                continue;
+            }
+
+            var wantsBold = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase);
+            var faceName = glyphTypeface.FaceNames.Values.FirstOrDefault() ?? string.Empty;
+            var isBoldFace = faceName.Contains("Bold", StringComparison.OrdinalIgnoreCase);
+            if (wantsBold != isBoldFace)
+            {
+                continue;
+            }
+
+            var fontFolderUri = new Uri(System.IO.Path.GetDirectoryName(fontPath)! + System.IO.Path.DirectorySeparatorChar, UriKind.Absolute);
+            fontFamily = new FontFamily(fontFolderUri, $"./#{fontName}");
+            MfmeFontFamilies[cacheKey] = fontFamily;
             return true;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -4,7 +4,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using System.Globalization;
-using System.IO;
 
 namespace OasisEditor;
 
@@ -351,20 +350,20 @@ internal static class PanelElementFactory
             return true;
         }
 
-        var fontsDirectory = Path.Combine(AppContext.BaseDirectory, "MfmeFonts");
-        if (!Directory.Exists(fontsDirectory))
+        var fontsDirectory = System.IO.Path.Combine(AppContext.BaseDirectory, "MfmeFonts");
+        if (!System.IO.Directory.Exists(fontsDirectory))
         {
             return false;
         }
 
-        foreach (var fontPath in Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
+        foreach (var fontPath in System.IO.Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
         {
-            if (!string.Equals(Path.GetFileNameWithoutExtension(fontPath), fontName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(System.IO.Path.GetFileNameWithoutExtension(fontPath), fontName, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
 
-            var fontUri = new Uri(fontsDirectory + Path.DirectorySeparatorChar, UriKind.Absolute);
+            var fontUri = new Uri(fontsDirectory + System.IO.Path.DirectorySeparatorChar);
             fontFamily = new FontFamily(fontUri, $"./#{fontName}");
             MfmeFontFamilies[fontName] = fontFamily;
             return true;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -360,7 +360,12 @@ internal static class PanelElementFactory
         foreach (var fontPath in System.IO.Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
         {
             var fontUri = new Uri(fontPath, UriKind.Absolute);
-            if (!GlyphTypeface.TryCreateFromUri(fontUri, out var glyphTypeface))
+            GlyphTypeface glyphTypeface;
+            try
+            {
+                glyphTypeface = new GlyphTypeface(fontUri);
+            }
+            catch
             {
                 continue;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -4,12 +4,14 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using System.Globalization;
+using System.IO;
 
 namespace OasisEditor;
 
 internal static class PanelElementFactory
 {
     private static string? _projectDirectoryPath;
+    private static readonly Dictionary<string, FontFamily> MfmeFontFamilies = new(StringComparer.OrdinalIgnoreCase);
 
     public static readonly DependencyProperty ElementNameProperty =
         DependencyProperty.RegisterAttached(
@@ -316,7 +318,7 @@ internal static class PanelElementFactory
 
     private static LampFontSettings CreateFontSettings(string? fontName, string? fontStyle, string? fontSize)
     {
-        var family = string.IsNullOrWhiteSpace(fontName) ? new FontFamily("Tahoma") : new FontFamily(fontName.Trim());
+        var family = ResolveFontFamily(fontName);
         var styleToken = string.IsNullOrWhiteSpace(fontStyle) ? "Regular" : fontStyle.Trim();
         var style = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase) ? FontStyles.Italic : FontStyles.Normal;
         var weight = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase) ? FontWeights.Bold : FontWeights.Normal;
@@ -324,6 +326,51 @@ internal static class PanelElementFactory
             ? parsed
             : 8d;
         return new LampFontSettings(family, style, weight, size);
+    }
+
+    private static FontFamily ResolveFontFamily(string? fontName)
+    {
+        if (string.IsNullOrWhiteSpace(fontName))
+        {
+            return new FontFamily("Tahoma");
+        }
+
+        var trimmedName = fontName.Trim();
+        if (TryResolveMfmeFontFamily(trimmedName, out var mfmeFontFamily))
+        {
+            return mfmeFontFamily;
+        }
+
+        return new FontFamily(trimmedName);
+    }
+
+    private static bool TryResolveMfmeFontFamily(string fontName, out FontFamily fontFamily)
+    {
+        if (MfmeFontFamilies.TryGetValue(fontName, out fontFamily!))
+        {
+            return true;
+        }
+
+        var fontsDirectory = Path.Combine(AppContext.BaseDirectory, "MfmeFonts");
+        if (!Directory.Exists(fontsDirectory))
+        {
+            return false;
+        }
+
+        foreach (var fontPath in Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
+        {
+            if (!string.Equals(Path.GetFileNameWithoutExtension(fontPath), fontName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var fontUri = new Uri(fontsDirectory + Path.DirectorySeparatorChar, UriKind.Absolute);
+            fontFamily = new FontFamily(fontUri, $"./#{fontName}");
+            MfmeFontFamilies[fontName] = fontFamily;
+            return true;
+        }
+
+        return false;
     }
 
     private sealed record LampFontSettings(FontFamily FontFamily, FontStyle FontStyle, FontWeight FontWeight, double FontSize);


### PR DESCRIPTION
### Motivation
- Imported MFME extracts can reference MFME-specific fonts (e.g. Lithograph) that may not be installed on the host system, causing text lamps to render incorrectly.
- The project includes an `MfmeFonts` directory with the original MFME font files that should be used when a lamp layout specifies one of those fonts.

### Description
- Resolve lamp `FontFamily` from a bundled `MfmeFonts` directory before falling back to system fonts by adding `ResolveFontFamily` and `TryResolveMfmeFontFamily` helpers.
- Cache resolved MFME `FontFamily` instances in a `MfmeFontFamilies` dictionary to avoid repeated disk enumeration.
- Use the new font resolution in `CreateFontSettings` so lamp text uses bundled fonts when specified.
- Include `MfmeFonts\*.ttf` in the project file with `CopyToOutputDirectory` so the font files are available at runtime via `AppContext.BaseDirectory`.

### Testing
- Attempted `dotnet build OasisEditor.sln`, which could not be executed in this environment because the `dotnet` CLI is not available (build failed for that reason).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7650e4e308327be5f2ffedf481cb6)