### PR TITLE
Wrap long single-line lamp text using WrapWithOverflow

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -105,6 +105,33 @@ public sealed class PanelElementFactoryTests
         });
     }
 
+
+    [Fact]
+    public void CreateVisualFromElement_LampWithoutImage_WithLongSingleLineText_UsesWrapWithOverflow()
+    {
+        RunInSta(() =>
+        {
+            var source = new PanelElementFile
+            {
+                ObjectId = "lamp-wrap-1",
+                Name = "Lamp",
+                Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Lamp),
+                Width = 40,
+                Height = 40,
+                DisplayText = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+                OnColorHex = "#FF00CC00"
+            };
+
+            var visual = PanelElementFactory.CreateVisualFromElement(source);
+
+            var border = Assert.IsType<Border>(visual);
+            var stack = Assert.IsType<StackPanel>(border.Child);
+            var title = Assert.IsType<TextBlock>(stack.Children[0]);
+
+            Assert.Equal(TextWrapping.WrapWithOverflow, title.TextWrapping);
+        });
+    }
+
     [Fact]
     public void CreateVisualFromElement_BackgroundWithoutImage_UsesConfiguredColor()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -274,6 +274,7 @@ internal static class PanelElementFactory
                         Text = label,
                         HorizontalAlignment = HorizontalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
+                        TextWrapping = TextWrapping.WrapWithOverflow,
                         Foreground = TryCreateBrush(labelColorHex, Brushes.LightSteelBlue),
                         FontFamily = labelFontSettings?.FontFamily ?? new FontFamily("Segoe UI"),
                         FontStyle = labelFontSettings?.FontStyle ?? FontStyles.Normal,
@@ -286,6 +287,7 @@ internal static class PanelElementFactory
                         Margin = new Thickness(0, 4, 0, 0),
                         HorizontalAlignment = HorizontalAlignment.Center,
                         TextAlignment = TextAlignment.Center,
+                        TextWrapping = TextWrapping.WrapWithOverflow,
                         Foreground = Brushes.Gainsboro,
                         FontSize = 10,
                         Visibility = string.IsNullOrWhiteSpace(detailText) ? Visibility.Collapsed : Visibility.Visible


### PR DESCRIPTION
### Motivation
- Long single-line `DisplayText` for text-based Lamp elements could overflow the panel visual because the `TextBlock` did not enable wrapping. 
- Lamp labels should wrap across multiple rows when a single unbroken line exceeds the element bounds so text remains visible and constrained.

### Description
- Set `TextWrapping = TextWrapping.WrapWithOverflow` on the primary label and the detail `TextBlock` in `CreatePlaceholderComponentVisual` in `OasisEditor/PanelElementFactory.cs` to enable wrapping for long single-line text. 
- Added a regression unit test `CreateVisualFromElement_LampWithoutImage_WithLongSingleLineText_UsesWrapWithOverflow` in `OasisEditor.Tests/PanelElementFactoryTests.cs` that asserts the title `TextBlock` uses `WrapWithOverflow`. 
- Files changed: `OasisEditor/PanelElementFactory.cs` and `OasisEditor.Tests/PanelElementFactoryTests.cs`.

### Testing
- No automated tests were executed in this environment because the required Windows/.NET/WPF toolchain is not available here. 
- Please run `dotnet test` for the `OasisEditor.Tests` project locally and verify the new test `CreateVisualFromElement_LampWithoutImage_WithLongSingleLineText_UsesWrapWithOverflow` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f76d2e17608327a1bfeb5f69ed1686)