### PR TITLE
Scale MFME lamp text rendering by 1.25 in PanelElementFactory

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -317,6 +317,8 @@ internal static class PanelElementFactory
         }
     }
 
+    private const double MfmeLampTextScaleFactor = 1.25d;
+
     private static LampFontSettings CreateFontSettings(string? fontName, string? fontStyle, string? fontSize)
     {
         var styleToken = string.IsNullOrWhiteSpace(fontStyle) ? "Regular" : fontStyle.Trim();
@@ -326,6 +328,7 @@ internal static class PanelElementFactory
         var size = double.TryParse(fontSize, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
             ? parsed
             : 8d;
+        size *= MfmeLampTextScaleFactor;
         return new LampFontSettings(family, style, weight, size);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -317,7 +317,7 @@ internal static class PanelElementFactory
         }
     }
 
-    private const double MfmeLampTextScaleFactor = 1.25d;
+    private const double MfmeLampTextScaleFactor = 1.33333333d;
 
     private static LampFontSettings CreateFontSettings(string? fontName, string? fontStyle, string? fontSize)
     {


### PR DESCRIPTION
### Motivation
- MFME-imported Lamp text rendered smaller in OasisEditor than in MFME, so apply a simple scale factor (1.25) to bring editor text sizing closer to MFME.

### Description
- Added a `MfmeLampTextScaleFactor = 1.25d` constant to `PanelElementFactory.cs`.
- Applied the scale factor to parsed lamp font sizes in `CreateFontSettings`, which affects non-graphic lamp text rendering.

### Testing
- Executed `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj`, which failed in this environment because `dotnet` is not installed, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f774c5de1c83279202996a339fece3)