### PR TITLE
Add MFME background color support in inspector and panel rendering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -172,8 +172,12 @@ internal static class PanelElementFactory
 
     private static FrameworkElement CreateBackgroundVisual(PanelElementFile element)
     {
-        var surface = CreatePlaceholderComponentVisual(element, "Background", element.OnColorHex ?? element.OffColorHex);
-        if (TryCreateImageSource(element.AssetPath, out var source))
+        var hasImage = TryCreateImageSource(element.AssetPath, out var source);
+        var surface = CreatePlaceholderComponentVisual(
+            element,
+            "Background",
+            hasImage ? null : element.OnColorHex ?? element.OffColorHex);
+        if (hasImage)
         {
             surface.Child = new Image
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -172,7 +172,7 @@ internal static class PanelElementFactory
 
     private static FrameworkElement CreateBackgroundVisual(PanelElementFile element)
     {
-        var surface = CreatePlaceholderComponentVisual(element, "Background", element.OffColorHex);
+        var surface = CreatePlaceholderComponentVisual(element, "Background", element.OnColorHex ?? element.OffColorHex);
         if (TryCreateImageSource(element.AssetPath, out var source))
         {
             surface.Child = new Image

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -349,7 +349,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update secondary asset path", new PanelElementModelUpdate { SecondaryAssetPath = NormalizeOptionalText(value) })));
         }
 
-        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
+        if (selectedElement.Kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
         {
             _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "On Color",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -349,7 +349,16 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update secondary asset path", new PanelElementModelUpdate { SecondaryAssetPath = NormalizeOptionalText(value) })));
         }
 
-        if (selectedElement.Kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
+        if (selectedElement.Kind is PanelElementKind.Background)
+        {
+            _propertyRows.Add(new InspectorColorPropertyViewModel(
+                "Color",
+                "Type-specific",
+                selectedElement.OnColorHex ?? string.Empty,
+                commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update background color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) })));
+        }
+
+        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
         {
             _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "On Color",
@@ -464,6 +473,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     break;
                 case "On Color" when row is InspectorColorPropertyViewModel onColorRow:
                     onColorRow.SetCommittedValue(selectedElement.OnColorHex);
+                    break;
+                case "Color" when row is InspectorColorPropertyViewModel colorRow:
+                    colorRow.SetCommittedValue(selectedElement.OnColorHex);
                     break;
                 case "Off Color" when row is InspectorColorPropertyViewModel offColorRow:
                     offColorRow.SetCommittedValue(selectedElement.OffColorHex);


### PR DESCRIPTION
### Motivation
- MFME background components include a `Color` value that is mapped into `OnColorHex` but was not exposed in the Oasis inspector nor used when a background image is missing, causing import/rendering mismatches.
- Make Background behave like Lamp elements so the imported color can be edited and used as a solid fill when no image asset is present.

### Description
- Added Background to the `On Color` inspector property group so Background elements show a color swatch/picker (change in `InspectorViewModel.cs`).
- Updated background visual creation to prefer `OnColorHex` with `OffColorHex` as fallback when painting a null-image background (change in `PanelElementFactory.cs`).

### Testing
- Attempted to run tests with `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` in `WindowsNetProjects/OasisEditor`, but the command failed because `dotnet` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a0c0cd9c832791b853a0831b00e2)