### PR TITLE
Default lamps off; add hold-to-test lamp preview in Inspector

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -347,6 +347,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public bool CanEditInspectorSummary => _inspector.CanEditInspectorSummary;
 
+    public bool ShowLampTestButton => _inspector.ShowLampTestButton;
+
     public IReadOnlyList<InspectorPropertyRowViewModel> InspectorPropertyRows => _inspector.InspectorPropertyRows;
 
     public IReadOnlyList<HierarchyItemViewModel> HierarchyItems => _hierarchy.Items;
@@ -1122,7 +1124,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(InspectorEditableSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
+        OnPropertyChanged(nameof(ShowLampTestButton));
         OnPropertyChanged(nameof(InspectorPropertyRows));
+    }
+
+    public void SetLampTestActive(bool isActive)
+    {
+        _inspector.SetLampTestActive(isActive);
     }
 
     private void RefreshHierarchy()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -9,6 +9,8 @@ namespace OasisEditor;
 
 internal static class PanelElementFactory
 {
+    public static bool IsLampTestActive { get; set; }
+
     private static string? _projectDirectoryPath;
     private static readonly Dictionary<string, FontFamily> MfmeFontFamilies = new(StringComparer.OrdinalIgnoreCase);
 
@@ -192,17 +194,18 @@ internal static class PanelElementFactory
     private static FrameworkElement CreateLampVisual(PanelElementFile element)
     {
         var hasGraphic = TryCreateImageSource(element.AssetPath, out var source);
+        var isLampOn = IsLampTestActive;
         var label = hasGraphic ? (element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp") : (element.DisplayText ?? string.Empty);
         var surface = CreatePlaceholderComponentVisual(
             element,
             label,
-            hasGraphic ? null : element.OnColorHex ?? element.OffColorHex,
+            hasGraphic ? null : (isLampOn ? element.OnColorHex : element.OffColorHex ?? element.OnColorHex),
             null,
             hasGraphic ? null : element.TextColorHex,
             hasGraphic
                 ? null
                 : CreateFontSettings(element.TextBoxFontName, element.TextBoxFontStyle, element.TextBoxFontSize));
-        if (hasGraphic)
+        if (hasGraphic && isLampOn)
         {
             surface.Child = new Image
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -10,6 +10,7 @@ namespace OasisEditor;
 internal static class PanelElementFactory
 {
     public static bool IsLampTestActive { get; set; }
+    public static string? LampTestObjectId { get; set; }
 
     private static string? _projectDirectoryPath;
     private static readonly Dictionary<string, FontFamily> MfmeFontFamilies = new(StringComparer.OrdinalIgnoreCase);
@@ -194,7 +195,9 @@ internal static class PanelElementFactory
     private static FrameworkElement CreateLampVisual(PanelElementFile element)
     {
         var hasGraphic = TryCreateImageSource(element.AssetPath, out var source);
-        var isLampOn = IsLampTestActive;
+        var isLampOn = IsLampTestActive
+            && !string.IsNullOrWhiteSpace(LampTestObjectId)
+            && string.Equals(element.ObjectId, LampTestObjectId, StringComparison.Ordinal);
         var label = hasGraphic ? (element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp") : (element.DisplayText ?? string.Empty);
         var surface = CreatePlaceholderComponentVisual(
             element,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -131,10 +131,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     internal void NotifyPanelVisualPreviewChanged()
     {
         _panelPreviewRefreshFlip = !_panelPreviewRefreshFlip;
-        _panelLayoutJson = _panelPreviewRefreshFlip
+        PanelLayoutJson = _panelPreviewRefreshFlip
             ? $"{GetPanelLayoutProjectionJson()}\n"
             : GetPanelLayoutProjectionJson();
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
         PanelChanged?.Invoke(new PanelChangeEvent(
             DocumentId,
             null,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -14,7 +14,6 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private double _panelZoom = 1.0;
     private double _panelPanX;
     private double _panelPanY;
-    private bool _panelPreviewRefreshFlip;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
@@ -130,10 +129,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal void NotifyPanelVisualPreviewChanged()
     {
-        _panelPreviewRefreshFlip = !_panelPreviewRefreshFlip;
-        PanelLayoutJson = _panelPreviewRefreshFlip
-            ? $"{GetPanelLayoutProjectionJson()}\n"
-            : GetPanelLayoutProjectionJson();
+        PanelLayoutJson = $"{GetPanelLayoutProjectionJson()}\n";
         PanelChanged?.Invoke(new PanelChangeEvent(
             DocumentId,
             null,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -132,7 +132,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         PanelChanged?.Invoke(new PanelChangeEvent(
             DocumentId,
             null,
-            PanelChangeProperties.Appearance,
+            PanelChangeProperties.Style,
             AffectsCanvas: true,
             AffectsHierarchy: false,
             AffectsInspectorRows: false,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -14,6 +14,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private double _panelZoom = 1.0;
     private double _panelPanX;
     private double _panelPanY;
+    private bool _panelPreviewRefreshFlip;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
@@ -129,16 +130,19 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal void NotifyPanelVisualPreviewChanged()
     {
-        SetPanelElements(
-            _panelDocumentModel.Elements,
-            new PanelChangeEvent(
-                DocumentId,
-                null,
-                PanelChangeProperties.Style,
-                AffectsCanvas: true,
-                AffectsHierarchy: false,
-                AffectsInspectorRows: false,
-                AffectsPersistence: false));
+        _panelPreviewRefreshFlip = !_panelPreviewRefreshFlip;
+        _panelLayoutJson = _panelPreviewRefreshFlip
+            ? $"{GetPanelLayoutProjectionJson()}\n"
+            : GetPanelLayoutProjectionJson();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
+        PanelChanged?.Invoke(new PanelChangeEvent(
+            DocumentId,
+            null,
+            PanelChangeProperties.Style,
+            AffectsCanvas: true,
+            AffectsHierarchy: false,
+            AffectsInspectorRows: false,
+            AffectsPersistence: false));
     }
 
     internal string GetPanelLayoutProjectionJson()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -127,6 +127,18 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
     }
 
+    internal void NotifyPanelVisualPreviewChanged()
+    {
+        PanelChanged?.Invoke(new PanelChangeEvent(
+            DocumentId,
+            null,
+            PanelChangeProperties.Appearance,
+            AffectsCanvas: true,
+            AffectsHierarchy: false,
+            AffectsInspectorRows: false,
+            AffectsPersistence: false));
+    }
+
     internal string GetPanelLayoutProjectionJson()
     {
         return Panel2DDocumentStorage.SerializeLayout(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -129,14 +129,16 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal void NotifyPanelVisualPreviewChanged()
     {
-        PanelChanged?.Invoke(new PanelChangeEvent(
-            DocumentId,
-            null,
-            PanelChangeProperties.Style,
-            AffectsCanvas: true,
-            AffectsHierarchy: false,
-            AffectsInspectorRows: false,
-            AffectsPersistence: false));
+        SetPanelElements(
+            _panelDocumentModel.Elements,
+            new PanelChangeEvent(
+                DocumentId,
+                null,
+                PanelChangeProperties.Style,
+                AffectsCanvas: true,
+                AffectsHierarchy: false,
+                AffectsInspectorRows: false,
+                AffectsPersistence: false));
     }
 
     internal string GetPanelLayoutProjectionJson()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -651,13 +651,15 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
-        if (PanelElementFactory.IsLampTestActive == isActive)
+        var targetObjectId = isActive ? selectedLampObjectId : null;
+        if (PanelElementFactory.IsLampTestActive == isActive
+            && string.Equals(PanelElementFactory.LampTestObjectId, targetObjectId, StringComparison.Ordinal))
         {
             return;
         }
 
         PanelElementFactory.IsLampTestActive = isActive;
-        PanelElementFactory.LampTestObjectId = isActive ? selectedLampObjectId : null;
+        PanelElementFactory.LampTestObjectId = targetObjectId;
         Debug.WriteLine($"[LampTest] SetLampTestActive={isActive}");
         _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -205,6 +205,13 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     public void NotifyContextChanged()
     {
+        if (!ShowLampTestButton && PanelElementFactory.IsLampTestActive)
+        {
+            PanelElementFactory.IsLampTestActive = false;
+            PanelElementFactory.LampTestObjectId = null;
+            _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
+        }
+
         OnPropertyChanged(nameof(InspectorTitle));
         OnPropertyChanged(nameof(InspectorType));
         OnPropertyChanged(nameof(InspectorPath));
@@ -638,12 +645,19 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     public void SetLampTestActive(bool isActive)
     {
+        var selectedLampObjectId = _activeDocumentContext.ActivePanelSelection?.ObjectId;
+        if (isActive && string.IsNullOrWhiteSpace(selectedLampObjectId))
+        {
+            return;
+        }
+
         if (PanelElementFactory.IsLampTestActive == isActive)
         {
             return;
         }
 
         PanelElementFactory.IsLampTestActive = isActive;
+        PanelElementFactory.LampTestObjectId = isActive ? selectedLampObjectId : null;
         Debug.WriteLine($"[LampTest] SetLampTestActive={isActive}");
         _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using EditorCommands = OasisEditor.Commands;
@@ -643,6 +644,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
 
         PanelElementFactory.IsLampTestActive = isActive;
+        Debug.WriteLine($"[LampTest] SetLampTestActive={isActive}");
         _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -190,6 +190,18 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
     }
 
+    public bool ShowLampTestButton
+    {
+        get
+        {
+            var selectedDocument = _selectedDocumentAccessor();
+            return selectedDocument is not null
+                && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection
+                && selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement)
+                && selectedElement.Kind == PanelElementKind.Lamp;
+        }
+    }
+
     public void NotifyContextChanged()
     {
         OnPropertyChanged(nameof(InspectorTitle));
@@ -197,6 +209,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorPath));
         OnPropertyChanged(nameof(InspectorSummary));
         OnPropertyChanged(nameof(CanEditInspectorSummary));
+        OnPropertyChanged(nameof(ShowLampTestButton));
 
         if (!ShouldSuppressPropertyRowRefresh() && ShouldRebuildRowsForContextChange())
         {
@@ -620,6 +633,17 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             relayCommand.RaiseCanExecuteChanged();
         }
+    }
+
+    public void SetLampTestActive(bool isActive)
+    {
+        if (PanelElementFactory.IsLampTestActive == isActive)
+        {
+            return;
+        }
+
+        PanelElementFactory.IsLampTestActive = isActive;
+        _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
     }
 
     private static string BuildSelectedElementSummary(PanelElementModel selectedElement)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -9,6 +9,7 @@
              d:DesignHeight="300"
              d:DesignWidth="260">
     <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
         <DataTemplate DataType="{x:Type vm:InspectorTextPropertyViewModel}">
             <Grid Margin="0,3,0,0">
                 <Grid.ColumnDefinitions>
@@ -118,6 +119,13 @@
                 <TextBlock FontWeight="SemiBold"
                            FontSize="14"
                            Text="{Binding InspectorTitle}" />
+                <Button Margin="0,8,0,0"
+                        HorizontalAlignment="Left"
+                        Content="Test"
+                        Visibility="{Binding ShowLampTestButton, Converter={StaticResource BoolToVisibility}}"
+                        PreviewMouseLeftButtonDown="OnLampTestMouseDown"
+                        PreviewMouseLeftButtonUp="OnLampTestMouseUp"
+                        MouseLeave="OnLampTestMouseLeave" />
                 <ItemsControl Margin="0,10,0,0"
                               ItemsSource="{Binding InspectorPropertyRows}" />
             </StackPanel>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -34,25 +34,29 @@ public partial class InspectorView : UserControl
 
     private void OnLampTestMouseDown(object sender, MouseButtonEventArgs e)
     {
-        if (DataContext is InspectorViewModel viewModel)
-        {
-            viewModel.SetLampTestActive(true);
-        }
+        SetLampTestActive(true);
     }
 
     private void OnLampTestMouseUp(object sender, MouseButtonEventArgs e)
     {
-        if (DataContext is InspectorViewModel viewModel)
-        {
-            viewModel.SetLampTestActive(false);
-        }
+        SetLampTestActive(false);
     }
 
     private void OnLampTestMouseLeave(object sender, MouseEventArgs e)
     {
-        if (DataContext is InspectorViewModel viewModel)
+        SetLampTestActive(false);
+    }
+
+    private void SetLampTestActive(bool isActive)
+    {
+        switch (DataContext)
         {
-            viewModel.SetLampTestActive(false);
+            case InspectorViewModel inspectorViewModel:
+                inspectorViewModel.SetLampTestActive(isActive);
+                break;
+            case MainWindowViewModel mainWindowViewModel:
+                mainWindowViewModel.SetLampTestActive(isActive);
+                break;
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml.cs
@@ -31,4 +31,28 @@ public partial class InspectorView : UserControl
         row.Commit();
         e.Handled = true;
     }
+
+    private void OnLampTestMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is InspectorViewModel viewModel)
+        {
+            viewModel.SetLampTestActive(true);
+        }
+    }
+
+    private void OnLampTestMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is InspectorViewModel viewModel)
+        {
+            viewModel.SetLampTestActive(false);
+        }
+    }
+
+    private void OnLampTestMouseLeave(object sender, MouseEventArgs e)
+    {
+        if (DataContext is InspectorViewModel viewModel)
+        {
+            viewModel.SetLampTestActive(false);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Lamps were rendering their "on" appearance by default on panel2d canvases which makes it hard to see unlit state and to preview a lit state without emulator integration.
- Provide a lightweight, non-persistent preview so users can inspect what a lamp looks like when lit without wiring up MAME or other runtime control.

### Description
- Add a shared preview flag `PanelElementFactory.IsLampTestActive` and change lamp rendering so non-graphical lamps use `OffColor` by default (falling back to `OnColor` if `OffColor` is not set) and graphical lamp images only render when the preview flag is active (`PanelElementFactory.cs`).
- Expose `ShowLampTestButton` and `SetLampTestActive(bool)` on `InspectorViewModel` and wire toggling of the preview flag to those calls so the Inspector controls the transient preview state (`InspectorViewModel.cs`).
- Add a `Test` button to the Lamp inspector view that activates preview on mouse-down and deactivates on mouse-up / mouse-leave, with corresponding event handlers in the Inspector view code-behind (`InspectorView.xaml` and `InspectorView.xaml.cs`).
- Add `DocumentTabViewModel.NotifyPanelVisualPreviewChanged()` which raises an appearance-only `PanelChangeEvent` so the canvas repaints the visual preview without changing persisted panel data (`DocumentTabViewModel.cs`).

### Testing
- No automated tests were executed in this environment (per project AGENT.md constraints), so no test results are available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a595cc708327b48a80df0adfbc1e)