### PR TITLE
Separate runtime panel visual updates from persisted layout JSON

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -74,6 +74,13 @@ public static class CanvasPanBehavior
             typeof(CanvasPanBehavior),
             new PropertyMetadata(false));
 
+    private static readonly DependencyProperty SubscribedDocumentTabProperty =
+        DependencyProperty.RegisterAttached(
+            "SubscribedDocumentTab",
+            typeof(DocumentTabViewModel),
+            typeof(CanvasPanBehavior),
+            new PropertyMetadata(null));
+
     public static bool GetIsEnabled(DependencyObject dependencyObject)
     {
         return (bool)dependencyObject.GetValue(IsEnabledProperty);
@@ -172,6 +179,8 @@ public static class CanvasPanBehavior
             element.MouseUp += OnMouseUp;
             element.MouseWheel += OnMouseWheel;
             element.LostMouseCapture += OnLostMouseCapture;
+            element.DataContextChanged += OnCanvasDataContextChanged;
+            AttachVisualStateSubscription(element);
         }
         else
         {
@@ -181,6 +190,75 @@ public static class CanvasPanBehavior
             element.MouseUp -= OnMouseUp;
             element.MouseWheel -= OnMouseWheel;
             element.LostMouseCapture -= OnLostMouseCapture;
+            element.DataContextChanged -= OnCanvasDataContextChanged;
+            DetachVisualStateSubscription(element);
+        }
+    }
+
+    private static void OnCanvasDataContextChanged(object sender, DependencyPropertyChangedEventArgs _)
+    {
+        if (sender is not FrameworkElement element)
+        {
+            return;
+        }
+
+        DetachVisualStateSubscription(element);
+        AttachVisualStateSubscription(element);
+    }
+
+    private static void AttachVisualStateSubscription(FrameworkElement element)
+    {
+        if (element.DataContext is not DocumentTabViewModel tab)
+        {
+            return;
+        }
+
+        tab.PanelVisualStateChanged += OnPanelVisualStateChanged;
+        element.SetValue(SubscribedDocumentTabProperty, tab);
+    }
+
+    private static void DetachVisualStateSubscription(FrameworkElement element)
+    {
+        if (element.GetValue(SubscribedDocumentTabProperty) is not DocumentTabViewModel tab)
+        {
+            return;
+        }
+
+        tab.PanelVisualStateChanged -= OnPanelVisualStateChanged;
+        element.ClearValue(SubscribedDocumentTabProperty);
+    }
+
+    private static void OnPanelVisualStateChanged(PanelVisualStateChangedEvent visualStateChanged)
+    {
+        foreach (Window window in Application.Current.Windows)
+        {
+            foreach (var canvas in FindVisualChildren<Canvas>(window))
+            {
+                if (canvas.DataContext is not DocumentTabViewModel tab || tab.DocumentId != visualStateChanged.DocumentId)
+                {
+                    continue;
+                }
+
+                PanelLayoutMapper.ApplyVisualState(canvas, tab, visualStateChanged);
+            }
+        }
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject root) where T : DependencyObject
+    {
+        var childCount = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < childCount; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T typed)
+            {
+                yield return typed;
+            }
+
+            foreach (var nested in FindVisualChildren<T>(child))
+            {
+                yield return nested;
+            }
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -105,6 +105,54 @@ public static class PanelLayoutMapper
         }
     }
 
+    public static void ApplyVisualState(Canvas canvas, DocumentTabViewModel tab, PanelVisualStateChangedEvent visualStateChange)
+    {
+        if (visualStateChange.ValuesByObjectId.Count == 0)
+        {
+            return;
+        }
+
+        var elementsByObjectId = tab.GetPanelElements()
+            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+
+        var currentPersistedChildren = canvas.Children
+            .OfType<FrameworkElement>()
+            .Where(GetIsPersistedElement)
+            .ToArray();
+
+        foreach (var existingVisual in currentPersistedChildren)
+        {
+            var objectId = existingVisual.Uid?.Trim();
+            if (string.IsNullOrWhiteSpace(objectId)
+                || !visualStateChange.ValuesByObjectId.ContainsKey(objectId)
+                || !elementsByObjectId.TryGetValue(objectId, out var sourceModel))
+            {
+                continue;
+            }
+
+            var updatedVisual = PanelElementFactory.CreateVisualFromElement(Panel2DDocumentStorage.ToStorageElement(sourceModel));
+            if (updatedVisual is null)
+            {
+                continue;
+            }
+
+            var childIndex = canvas.Children.IndexOf(existingVisual);
+            if (childIndex < 0)
+            {
+                continue;
+            }
+
+            SetIsPersistedElement(updatedVisual, true);
+            CanvasSelectionBehavior.SetIsSelectable(updatedVisual, CanvasSelectionBehavior.GetIsSelectable(existingVisual));
+            CanvasSelectionBehavior.SetIsSelected(updatedVisual, CanvasSelectionBehavior.GetIsSelected(existingVisual));
+            Canvas.SetLeft(updatedVisual, Canvas.GetLeft(existingVisual));
+            Canvas.SetTop(updatedVisual, Canvas.GetTop(existingVisual));
+            canvas.Children.RemoveAt(childIndex);
+            canvas.Children.Insert(childIndex, updatedVisual);
+        }
+    }
+
     private static bool GetIsPersistedElement(FrameworkElement element)
     {
         return (bool)element.GetValue(IsPersistedElementProperty);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -17,6 +17,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
+    public event Action<PanelVisualStateChangedEvent>? PanelVisualStateChanged;
 
     public DocumentTabViewModel(
         EditorDocument document,
@@ -129,15 +130,15 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal void NotifyPanelVisualPreviewChanged()
     {
-        PanelLayoutJson = $"{GetPanelLayoutProjectionJson()}\n";
-        PanelChanged?.Invoke(new PanelChangeEvent(
-            DocumentId,
-            null,
-            PanelChangeProperties.Style,
-            AffectsCanvas: true,
-            AffectsHierarchy: false,
-            AffectsInspectorRows: false,
-            AffectsPersistence: false));
+        var visualStateByObjectId = _panelDocumentModel.Elements
+            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(
+                element => element.ObjectId,
+                element => (object)(PanelElementFactory.IsLampTestActive
+                    && !string.IsNullOrWhiteSpace(PanelElementFactory.LampTestObjectId)
+                    && string.Equals(element.ObjectId, PanelElementFactory.LampTestObjectId, StringComparison.Ordinal)));
+
+        PanelVisualStateChanged?.Invoke(new PanelVisualStateChangedEvent(DocumentId, visualStateByObjectId));
     }
 
     internal string GetPanelLayoutProjectionJson()
@@ -218,3 +219,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         return PanelSelectionContract.IsMatch(storageElement, selection);
     }
 }
+
+public sealed record PanelVisualStateChangedEvent(
+    Guid DocumentId,
+    IReadOnlyDictionary<string, object> ValuesByObjectId);


### PR DESCRIPTION
### Motivation
- Prevent transient visual changes (e.g. lamp test toggles) from mutating persisted layout serialization and keep `PanelLayoutJson` reserved for save/load/model edits.
- Provide a targeted runtime-only update path so canvas visuals can refresh without triggering persistence or structural update flows.

### Description
- Added a new `PanelVisualStateChanged` event and `PanelVisualStateChangedEvent` record to `DocumentTabViewModel` to carry visual-state values keyed by element object IDs instead of mutating `PanelLayoutJson`.
- Replaced the `PanelLayoutJson` newline-mutation in `NotifyPanelVisualPreviewChanged()` with composition and invocation of the new `PanelVisualStateChanged` payload.
- Implemented `PanelLayoutMapper.ApplyVisualState(...)` to update existing persisted canvas visuals in-place for affected object IDs while preserving selection/position/metadata.
- Updated `CanvasPanBehavior` to attach/detach subscriptions to `PanelVisualStateChanged`, handle `DataContextChanged`, and route visual-state updates to canvases bound to the matching `DocumentId`.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` but the environment lacks the `dotnet` SDK so the build could not be executed.
- No automated unit tests were run in this environment due to the missing SDK, so behavioral verification should be performed with a full local build and runtime.
- Local repository actions (staging/commit) were performed in the workspace to record the change set for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7b74a3760832788b4c633d597cb85)