### PR TITLE
Add delta lamp visual updates using object-to-visual cache

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -309,6 +309,17 @@ internal static class PanelElementFactory
         return border;
     }
 
+
+    public static Brush TryCreateBrushForRuntime(string? colorHex, Brush fallback)
+    {
+        return TryCreateBrush(colorHex, fallback);
+    }
+
+    public static ImageSource? TryCreateImageSourceForRuntime(string? assetPath)
+    {
+        return TryCreateImageSource(assetPath, out var source) ? source : null;
+    }
+
     private static Brush TryCreateBrush(string? colorHex, Brush fallback)
     {
         if (string.IsNullOrWhiteSpace(colorHex))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -198,26 +198,35 @@ internal static class PanelElementFactory
         var isLampOn = IsLampTestActive
             && !string.IsNullOrWhiteSpace(LampTestObjectId)
             && string.Equals(element.ObjectId, LampTestObjectId, StringComparison.Ordinal);
-        var label = hasGraphic ? (element.DisplayNumber.HasValue ? $"Lamp {element.DisplayNumber.Value}" : "Lamp") : (element.DisplayText ?? string.Empty);
-        var surface = CreatePlaceholderComponentVisual(
-            element,
-            label,
-            hasGraphic ? null : (isLampOn ? element.OnColorHex : element.OffColorHex ?? element.OnColorHex),
-            null,
-            hasGraphic ? null : element.TextColorHex,
-            hasGraphic
-                ? null
-                : CreateFontSettings(element.TextBoxFontName, element.TextBoxFontStyle, element.TextBoxFontSize));
-        if (hasGraphic && isLampOn)
+
+        if (hasGraphic)
         {
-            surface.Child = new Image
+            var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
+            var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
+            return new Border
             {
-                Stretch = Stretch.Fill,
-                Source = source
+                Uid = element.ObjectId,
+                Width = width,
+                Height = height,
+                BorderThickness = new Thickness(1),
+                BorderBrush = Brushes.SlateGray,
+                Background = Brushes.Transparent,
+                Child = new Image
+                {
+                    Stretch = Stretch.Fill,
+                    Source = source,
+                    Opacity = isLampOn ? 1d : 0d
+                }
             };
         }
 
-        return surface;
+        return CreatePlaceholderComponentVisual(
+            element,
+            element.DisplayText ?? string.Empty,
+            isLampOn ? element.OnColorHex : element.OffColorHex ?? element.OnColorHex,
+            null,
+            element.TextColorHex,
+            CreateFontSettings(element.TextBoxFontName, element.TextBoxFontStyle, element.TextBoxFontSize));
     }
 
     private static FrameworkElement CreateReelVisual(PanelElementFile element)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -182,16 +182,20 @@ public static class PanelLayoutMapper
 
         if (visual is Border border)
         {
-            var backgroundHex = isOn ? onColorHex : offColorHex ?? onColorHex;
-            border.Background = PanelElementFactory.TryCreateBrushForRuntime(backgroundHex, Brushes.Transparent);
             if (border.Child is Image image)
             {
-                image.Opacity = effectiveOpacity;
                 if (!string.IsNullOrWhiteSpace(assetPath) && image.Source is null)
                 {
                     image.Source = PanelElementFactory.TryCreateImageSourceForRuntime(assetPath);
                 }
+
+                image.Opacity = effectiveOpacity;
+                border.Background = Brushes.Transparent;
+                return;
             }
+
+            var backgroundHex = isOn ? onColorHex : offColorHex ?? onColorHex;
+            border.Background = PanelElementFactory.TryCreateBrushForRuntime(backgroundHex, Brushes.Transparent);
         }
         else if (visual is Image image)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace OasisEditor;
 
@@ -18,6 +20,20 @@ public static class PanelLayoutMapper
             typeof(bool),
             typeof(PanelLayoutMapper),
             new PropertyMetadata(false));
+
+    private static readonly DependencyProperty ObjectVisualMapProperty =
+        DependencyProperty.RegisterAttached(
+            "ObjectVisualMap",
+            typeof(Dictionary<string, FrameworkElement>),
+            typeof(PanelLayoutMapper),
+            new PropertyMetadata(null));
+
+    private static readonly DependencyProperty MissingVisualLogSetProperty =
+        DependencyProperty.RegisterAttached(
+            "MissingVisualLogSet",
+            typeof(HashSet<string>),
+            typeof(PanelLayoutMapper),
+            new PropertyMetadata(null));
 
     public static bool IsApplyingLayout(Canvas canvas)
     {
@@ -61,6 +77,7 @@ public static class PanelLayoutMapper
                 canvas.Children.Add(visual);
             }
 
+            RebuildObjectVisualMap(canvas);
             CanvasSelectionBehavior.ClearSelection(canvas);
             if (canvas.DataContext is DocumentTabViewModel tab)
             {
@@ -116,40 +133,69 @@ public static class PanelLayoutMapper
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId))
             .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
 
-        var currentPersistedChildren = canvas.Children
-            .OfType<FrameworkElement>()
-            .Where(GetIsPersistedElement)
-            .ToArray();
-
-        foreach (var existingVisual in currentPersistedChildren)
+        foreach (var objectId in visualStateChange.ValuesByObjectId.Keys)
         {
-            var objectId = existingVisual.Uid?.Trim();
-            if (string.IsNullOrWhiteSpace(objectId)
-                || !visualStateChange.ValuesByObjectId.ContainsKey(objectId)
-                || !elementsByObjectId.TryGetValue(objectId, out var sourceModel))
+            if (!elementsByObjectId.TryGetValue(objectId, out var sourceModel))
             {
                 continue;
             }
 
-            var updatedVisual = PanelElementFactory.CreateVisualFromElement(Panel2DDocumentStorage.ToStorageElement(sourceModel));
-            if (updatedVisual is null)
+            UpdateLampVisual(
+                canvas,
+                objectId,
+                1.0,
+                visualStateChange.ValuesByObjectId[objectId] is true,
+                sourceModel.OnColorHex,
+                sourceModel.OffColorHex,
+                sourceModel.AssetPath);
+        }
+    }
+
+    public static void UpdateLampVisual(
+        Canvas canvas,
+        string objectId,
+        double intensity,
+        bool isOn,
+        string? onColorHex,
+        string? offColorHex,
+        string? assetPath)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return;
+        }
+
+        var objectVisualMap = GetOrCreateObjectVisualMap(canvas);
+        if (!objectVisualMap.TryGetValue(objectId, out var visual))
+        {
+            var missingIds = GetOrCreateMissingVisualLogSet(canvas);
+            if (missingIds.Add(objectId))
             {
-                continue;
+                Debug.WriteLine($"[PanelLayoutMapper] UpdateLampVisual skipped; visual not found for objectId '{objectId}'.");
             }
 
-            var childIndex = canvas.Children.IndexOf(existingVisual);
-            if (childIndex < 0)
-            {
-                continue;
-            }
+            return;
+        }
 
-            SetIsPersistedElement(updatedVisual, true);
-            CanvasSelectionBehavior.SetIsSelectable(updatedVisual, CanvasSelectionBehavior.GetIsSelectable(existingVisual));
-            CanvasSelectionBehavior.SetIsSelected(updatedVisual, CanvasSelectionBehavior.GetIsSelected(existingVisual));
-            Canvas.SetLeft(updatedVisual, Canvas.GetLeft(existingVisual));
-            Canvas.SetTop(updatedVisual, Canvas.GetTop(existingVisual));
-            canvas.Children.RemoveAt(childIndex);
-            canvas.Children.Insert(childIndex, updatedVisual);
+        var normalizedIntensity = Math.Clamp(intensity, 0d, 1d);
+        var effectiveOpacity = isOn ? Math.Max(0.1d, normalizedIntensity) : 0d;
+
+        if (visual is Border border)
+        {
+            var backgroundHex = isOn ? onColorHex : offColorHex ?? onColorHex;
+            border.Background = PanelElementFactory.TryCreateBrushForRuntime(backgroundHex, Brushes.Transparent);
+            if (border.Child is Image image)
+            {
+                image.Opacity = effectiveOpacity;
+                if (!string.IsNullOrWhiteSpace(assetPath) && image.Source is null)
+                {
+                    image.Source = PanelElementFactory.TryCreateImageSourceForRuntime(assetPath);
+                }
+            }
+        }
+        else if (visual is Image image)
+        {
+            image.Opacity = effectiveOpacity;
         }
     }
 
@@ -161,5 +207,40 @@ public static class PanelLayoutMapper
     private static void SetIsPersistedElement(FrameworkElement element, bool value)
     {
         element.SetValue(IsPersistedElementProperty, value);
+    }
+
+    private static void RebuildObjectVisualMap(Canvas canvas)
+    {
+        var map = GetOrCreateObjectVisualMap(canvas);
+        map.Clear();
+        foreach (var element in canvas.Children.OfType<FrameworkElement>().Where(GetIsPersistedElement))
+        {
+            if (!string.IsNullOrWhiteSpace(element.Uid))
+            {
+                map[element.Uid.Trim()] = element;
+            }
+        }
+    }
+
+    private static Dictionary<string, FrameworkElement> GetOrCreateObjectVisualMap(Canvas canvas)
+    {
+        if (canvas.GetValue(ObjectVisualMapProperty) is not Dictionary<string, FrameworkElement> map)
+        {
+            map = new Dictionary<string, FrameworkElement>(StringComparer.Ordinal);
+            canvas.SetValue(ObjectVisualMapProperty, map);
+        }
+
+        return map;
+    }
+
+    private static HashSet<string> GetOrCreateMissingVisualLogSet(Canvas canvas)
+    {
+        if (canvas.GetValue(MissingVisualLogSetProperty) is not HashSet<string> missingIds)
+        {
+            missingIds = new HashSet<string>(StringComparer.Ordinal);
+            canvas.SetValue(MissingVisualLogSetProperty, missingIds);
+        }
+
+        return missingIds;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -135,7 +135,8 @@ public static class PanelLayoutMapper
 
         foreach (var objectId in visualStateChange.ValuesByObjectId.Keys)
         {
-            if (!elementsByObjectId.TryGetValue(objectId, out var sourceModel))
+            if (!elementsByObjectId.TryGetValue(objectId, out var sourceModel)
+                || Panel2DDocumentStorage.ParseElementKind(sourceModel.Kind) != PanelElementKind.Lamp)
             {
                 continue;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -136,7 +136,7 @@ public static class PanelLayoutMapper
         foreach (var objectId in visualStateChange.ValuesByObjectId.Keys)
         {
             if (!elementsByObjectId.TryGetValue(objectId, out var sourceModel)
-                || Panel2DDocumentStorage.ParseElementKind(sourceModel.Kind) != PanelElementKind.Lamp)
+                || sourceModel.Kind != PanelElementKind.Lamp)
             {
                 continue;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -132,7 +132,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     internal void NotifyPanelVisualPreviewChanged()
     {
         var visualStateByObjectId = _panelDocumentModel.Elements
-            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId))
+            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
+                && Panel2DDocumentStorage.ParseElementKind(element.Kind) == PanelElementKind.Lamp)
             .ToDictionary(
                 element => element.ObjectId,
                 element => (object)(PanelElementFactory.IsLampTestActive

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -133,7 +133,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     {
         var visualStateByObjectId = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && Panel2DDocumentStorage.ParseElementKind(element.Kind) == PanelElementKind.Lamp)
+                && element.Kind == PanelElementKind.Lamp)
             .ToDictionary(
                 element => element.ObjectId,
                 element => (object)(PanelElementFactory.IsLampTestActive

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -14,6 +14,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private double _panelZoom = 1.0;
     private double _panelPanX;
     private double _panelPanY;
+    private Dictionary<string, object>? _lastVisualStateByObjectId;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
@@ -138,7 +139,24 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                     && !string.IsNullOrWhiteSpace(PanelElementFactory.LampTestObjectId)
                     && string.Equals(element.ObjectId, PanelElementFactory.LampTestObjectId, StringComparison.Ordinal)));
 
-        PanelVisualStateChanged?.Invoke(new PanelVisualStateChangedEvent(DocumentId, visualStateByObjectId));
+        var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var kvp in visualStateByObjectId)
+        {
+            if (_lastVisualStateByObjectId is null
+                || !_lastVisualStateByObjectId.TryGetValue(kvp.Key, out var previous)
+                || !Equals(previous, kvp.Value))
+            {
+                deltaByObjectId[kvp.Key] = kvp.Value;
+            }
+        }
+
+        _lastVisualStateByObjectId = visualStateByObjectId;
+        if (deltaByObjectId.Count == 0)
+        {
+            return;
+        }
+
+        PanelVisualStateChanged?.Invoke(new PanelVisualStateChangedEvent(DocumentId, deltaByObjectId));
     }
 
     internal string GetPanelLayoutProjectionJson()


### PR DESCRIPTION
### Motivation

- Reduce cost of per-tick lamp updates by avoiding full visual remapping and child control replacement during emulation-style refreshes.
- Provide a fast-path API to mutate existing lamp visuals in place (brush / image / opacity) for smoother, lower-latency updates.
- Ensure missing or renamed object IDs are skipped safely and logged only once per canvas to avoid log spam.

### Description

- Added a per-canvas object -> visual cache via `ObjectVisualMapProperty` and a one-time missing-ID log set via `MissingVisualLogSetProperty` in `PanelLayoutMapper` and rebuild the map with `RebuildObjectVisualMap(Canvas)` after `ApplyPersistedLayout`.
- Replaced the previous replace-all visual strategy in `ApplyVisualState` with a delta-driven loop that calls the new `UpdateLampVisual(...)` API to mutate existing visuals in place (updates `Border.Background`, `Image.Opacity` and lazily sets `Image.Source`).
- Implemented `UpdateLampVisual(...)` which safely no-ops for unknown IDs and emits a single `Debug.WriteLine` per missing `objectId` per canvas the first time it is observed.
- Added runtime helper wrappers in `PanelElementFactory`: `TryCreateBrushForRuntime` and `TryCreateImageSourceForRuntime`, and changed `DocumentTabViewModel.NotifyPanelVisualPreviewChanged` to emit only changed object IDs (delta) each tick by tracking `_lastVisualStateByObjectId`.

### Testing

- Attempted an automated build with `dotnet build OasisEditor.sln`, but the environment lacks the `dotnet` CLI so the build could not be run (`dotnet: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7b88735b0832799032942a22b6069)