### PR TITLE
Scope panel lamp runtime state by document

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ActiveDocumentContextService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ActiveDocumentContextService.cs
@@ -53,3 +53,30 @@ public readonly record struct PanelSelectionInfo(
     double Y,
     double Width,
     double Height);
+
+
+public sealed class PanelRuntimeStateStore
+{
+    private readonly Dictionary<Guid, PanelRuntimeState> _statesByDocument = new();
+
+    public PanelRuntimeState GetOrCreate(Guid documentId)
+    {
+        if (!_statesByDocument.TryGetValue(documentId, out var state))
+        {
+            state = new PanelRuntimeState();
+            _statesByDocument[documentId] = state;
+        }
+
+        return state;
+    }
+
+    public void ClearDocumentState(Guid documentId)
+    {
+        _statesByDocument.Remove(documentId);
+    }
+
+    public void ClearAll()
+    {
+        _statesByDocument.Clear();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasPanBehavior.cs
@@ -239,7 +239,7 @@ public static class CanvasPanBehavior
                     continue;
                 }
 
-                PanelLayoutMapper.ApplyVisualState(canvas, tab, visualStateChanged);
+                PanelLayoutMapper.ApplyVisualState(canvas, tab, visualStateChanged, tab.RuntimeState);
             }
         }
     }
@@ -415,7 +415,10 @@ public static class CanvasPanBehavior
             return;
         }
 
-        PanelLayoutMapper.ApplyPersistedLayout(canvas, eventArgs.NewValue as string);
+        var runtimeState = canvas.DataContext is DocumentTabViewModel tab
+            ? tab.RuntimeState
+            : new PanelRuntimeState();
+        PanelLayoutMapper.ApplyPersistedLayout(canvas, eventArgs.NewValue as string, runtimeState);
     }
 
     private static void OnSelectedPanelSelectionChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -32,6 +32,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly HierarchyViewModel _hierarchy;
     private readonly DocumentWorkspaceViewModel _documentWorkspace;
     private readonly ActiveDocumentContextService _activeDocumentContext;
+    private readonly PanelRuntimeStateStore _panelRuntimeStates;
     private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
     private bool _isRefreshingHierarchy;
     private readonly MfmeImportService _mfmeImportService = new();
@@ -73,6 +74,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
         _activeDocumentContext = new ActiveDocumentContextService();
+        _panelRuntimeStates = new PanelRuntimeStateStore();
         _assetBrowser = new AssetBrowserViewModel(
             () => LoadedProject,
             () => OnPropertyChanged(nameof(SelectedAsset)),
@@ -111,7 +113,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             NotifyUndoRedoStateChanged,
             value => StatusMessage = value,
             AddOutputEntry,
-            documentId => _activeDocumentContext.ClearDocumentState(documentId));
+            _panelRuntimeStates,
+            documentId =>
+            {
+                _activeDocumentContext.ClearDocumentState(documentId);
+                _panelRuntimeStates.ClearDocumentState(documentId);
+            });
         AssetBrowserItems = _assetBrowser.AssetBrowserItems;
         AssetBrowserItems.CollectionChanged += OnAssetBrowserItemsChanged;
         OutputEntries = _outputLog.OutputEntries;
@@ -821,6 +828,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         _documentWorkspace.ClearProjectSessionState();
         _activeDocumentContext.ClearAll();
+        _panelRuntimeStates.ClearAll();
         PanelElementFactory.ProjectDirectoryPath = null;
 
         AssetBrowserItems.Clear();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -9,9 +9,6 @@ namespace OasisEditor;
 
 internal static class PanelElementFactory
 {
-    public static bool IsLampTestActive { get; set; }
-    public static string? LampTestObjectId { get; set; }
-
     private static string? _projectDirectoryPath;
     private static readonly Dictionary<string, FontFamily> MfmeFontFamilies = new(StringComparer.OrdinalIgnoreCase);
 
@@ -74,14 +71,14 @@ internal static class PanelElementFactory
         };
     }
 
-    public static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
+    public static FrameworkElement? CreateVisualFromElement(PanelElementFile element, PanelRuntimeState runtimeState)
     {
         FrameworkElement? visual = element.ElementKind switch
         {
             PanelElementKind.Rectangle => CreateRectangleVisual(element),
             PanelElementKind.Image => CreateImageVisual(element),
             PanelElementKind.Background => CreateBackgroundVisual(element),
-            PanelElementKind.Lamp => CreateLampVisual(element),
+            PanelElementKind.Lamp => CreateLampVisual(element, runtimeState),
             PanelElementKind.Reel => CreateReelVisual(element),
             PanelElementKind.SevenSegment => CreateSevenSegmentVisual(element),
             PanelElementKind.Alpha => CreateAlphaVisual(element),
@@ -192,12 +189,12 @@ internal static class PanelElementFactory
         return surface;
     }
 
-    private static FrameworkElement CreateLampVisual(PanelElementFile element)
+    private static FrameworkElement CreateLampVisual(PanelElementFile element, PanelRuntimeState runtimeState)
     {
         var hasGraphic = TryCreateImageSource(element.AssetPath, out var source);
-        var isLampOn = IsLampTestActive
-            && !string.IsNullOrWhiteSpace(LampTestObjectId)
-            && string.Equals(element.ObjectId, LampTestObjectId, StringComparison.Ordinal);
+        var isLampOn = runtimeState.IsLampTestActive
+            && !string.IsNullOrWhiteSpace(runtimeState.LampTestObjectId)
+            && string.Equals(element.ObjectId, runtimeState.LampTestObjectId, StringComparison.Ordinal);
 
         if (hasGraphic)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -40,7 +40,7 @@ public static class PanelLayoutMapper
         return (bool)canvas.GetValue(IsApplyingLayoutProperty);
     }
 
-    public static void ApplyPersistedLayout(Canvas canvas, string? layoutJson)
+    public static void ApplyPersistedLayout(Canvas canvas, string? layoutJson, PanelRuntimeState runtimeState)
     {
         canvas.SetValue(IsApplyingLayoutProperty, true);
         try
@@ -63,7 +63,7 @@ public static class PanelLayoutMapper
                     continue;
                 }
 
-                var visual = PanelElementFactory.CreateVisualFromElement(element);
+                var visual = PanelElementFactory.CreateVisualFromElement(element, runtimeState);
                 if (visual is null)
                 {
                     continue;
@@ -122,7 +122,7 @@ public static class PanelLayoutMapper
         }
     }
 
-    public static void ApplyVisualState(Canvas canvas, DocumentTabViewModel tab, PanelVisualStateChangedEvent visualStateChange)
+    public static void ApplyVisualState(Canvas canvas, DocumentTabViewModel tab, PanelVisualStateChangedEvent visualStateChange, PanelRuntimeState runtimeState)
     {
         if (visualStateChange.ValuesByObjectId.Count == 0)
         {
@@ -144,11 +144,12 @@ public static class PanelLayoutMapper
             UpdateLampVisual(
                 canvas,
                 objectId,
-                1.0,
+                runtimeState.GetLampIntensity(objectId),
                 visualStateChange.ValuesByObjectId[objectId] is true,
                 sourceModel.OnColorHex,
                 sourceModel.OffColorHex,
                 sourceModel.AssetPath);
+            runtimeState.SetLampIntensity(objectId, runtimeState.GetLampIntensity(objectId));
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -1,0 +1,46 @@
+namespace OasisEditor;
+
+public sealed class PanelRuntimeState
+{
+    private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
+
+    public string? LampTestObjectId { get; set; }
+
+    public bool IsLampTestActive => !string.IsNullOrWhiteSpace(LampTestObjectId);
+
+    public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
+
+    public void SetLampIntensity(string objectId, double intensity)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return;
+        }
+
+        _lampIntensityByObjectId[objectId.Trim()] = Math.Clamp(intensity, 0d, 1d);
+    }
+
+    public double GetLampIntensity(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return 0d;
+        }
+
+        return _lampIntensityByObjectId.GetValueOrDefault(objectId.Trim(), 1d);
+    }
+
+    public void ClearLampIntensity(string objectId)
+    {
+        if (!string.IsNullOrWhiteSpace(objectId))
+        {
+            _lampIntensityByObjectId.Remove(objectId.Trim());
+        }
+    }
+
+    public void Clear()
+    {
+        LampTestObjectId = null;
+        _lampIntensityByObjectId.Clear();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -15,6 +15,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private double _panelPanX;
     private double _panelPanY;
     private Dictionary<string, object>? _lastVisualStateByObjectId;
+    private readonly PanelRuntimeState _runtimeState;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
@@ -24,12 +25,14 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         EditorDocument document,
         string? panelLayoutJson = null,
         Guid? documentId = null,
-        CommandService? commandService = null)
+        CommandService? commandService = null,
+        PanelRuntimeState? runtimeState = null)
     {
         _document = document;
         DocumentId = documentId ?? Guid.NewGuid();
         _commandService = commandService ?? new CommandService(new CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
+        _runtimeState = runtimeState ?? new PanelRuntimeState();
         _panelDocumentModel = new Panel2DDocumentModel
         {
             Elements = Panel2DDocumentStorage.DeserializeLayout(panelLayoutJson)
@@ -41,6 +44,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public EditorDocument Document => _document;
     public Guid DocumentId { get; }
     public CommandService CommandService => _commandService;
+    public PanelRuntimeState RuntimeState => _runtimeState;
     public string Title => Document.IsDirty ? $"{Document.Title}*" : Document.Title;
     public string TypeLabel => Document.DocumentType switch
     {
@@ -136,9 +140,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 && element.Kind == PanelElementKind.Lamp)
             .ToDictionary(
                 element => element.ObjectId,
-                element => (object)(PanelElementFactory.IsLampTestActive
-                    && !string.IsNullOrWhiteSpace(PanelElementFactory.LampTestObjectId)
-                    && string.Equals(element.ObjectId, PanelElementFactory.LampTestObjectId, StringComparison.Ordinal)));
+                element => (object)(_runtimeState.IsLampTestActive
+                    && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
+                    && string.Equals(element.ObjectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal)));
 
         var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
         foreach (var kvp in visualStateByObjectId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -18,6 +18,7 @@ public sealed class DocumentWorkspaceViewModel
     private readonly Action<string> _setStatusMessage;
     private readonly Action<string, OutputLogStatus> _addOutputEntry;
     private readonly Action<Guid> _onDocumentClosed;
+    private readonly PanelRuntimeStateStore _runtimeStateStore;
 
     private int _untitledDocumentCounter = 1;
     private int _panelDocumentCounter = 1;
@@ -33,6 +34,7 @@ public sealed class DocumentWorkspaceViewModel
         Action notifyUndoRedoStateChanged,
         Action<string> setStatusMessage,
         Action<string, OutputLogStatus> addOutputEntry,
+        PanelRuntimeStateStore runtimeStateStore,
         Action<Guid>? onDocumentClosed = null)
     {
         _getLoadedProject = getLoadedProject;
@@ -44,6 +46,7 @@ public sealed class DocumentWorkspaceViewModel
         _setStatusMessage = setStatusMessage;
         _addOutputEntry = addOutputEntry;
         _onDocumentClosed = onDocumentClosed ?? (_ => { });
+        _runtimeStateStore = runtimeStateStore;
     }
 
     public bool CanOpenUntitledDocument() => _getLoadedProject() is not null;
@@ -63,7 +66,7 @@ public sealed class DocumentWorkspaceViewModel
             return;
         }
 
-        var document = new DocumentTabViewModel(EditorDocument.CreateUntitled($"Untitled {_untitledDocumentCounter++}"));
+        var document = CreateDocumentTab(EditorDocument.CreateUntitled($"Untitled {_untitledDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened document tab: {document.Title}");
         _addOutputEntry($"Opened document tab: {document.Title}", OutputLogStatus.Info);
@@ -76,7 +79,7 @@ public sealed class DocumentWorkspaceViewModel
             return;
         }
 
-        var document = new DocumentTabViewModel(
+        var document = CreateDocumentTab(
             EditorDocument.CreatePanel2DStub($"Panel {_panelDocumentCounter++}"),
             panelLayoutJson: Panel2DDocumentStorage.SerializeLayout([]));
 
@@ -92,7 +95,7 @@ public sealed class DocumentWorkspaceViewModel
             return;
         }
 
-        var document = new DocumentTabViewModel(EditorDocument.CreateCabinet3DStub($"Cabinet {_cabinetDocumentCounter++}"));
+        var document = CreateDocumentTab(EditorDocument.CreateCabinet3DStub($"Cabinet {_cabinetDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened cabinet document stub: {document.Title}");
         _addOutputEntry($"Opened cabinet document stub: {document.Title}", OutputLogStatus.Info);
@@ -105,7 +108,7 @@ public sealed class DocumentWorkspaceViewModel
             return;
         }
 
-        var document = new DocumentTabViewModel(EditorDocument.CreateMachineStub($"Machine {_machineDocumentCounter++}"));
+        var document = CreateDocumentTab(EditorDocument.CreateMachineStub($"Machine {_machineDocumentCounter++}"));
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened machine document stub: {document.Title}");
         _addOutputEntry($"Opened machine document stub: {document.Title}", OutputLogStatus.Info);
@@ -133,7 +136,7 @@ public sealed class DocumentWorkspaceViewModel
             return false;
         }
 
-        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson);
+        var document = CreateDocumentTab(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         return true;
     }
@@ -224,7 +227,8 @@ public sealed class DocumentWorkspaceViewModel
             selectedDocument.Document.WithContentSummary(summary).MarkDirty(),
             selectedDocument.PanelLayoutJson,
             selectedDocument.DocumentId,
-            selectedDocument.CommandService)
+            selectedDocument.CommandService,
+            selectedDocument.RuntimeState)
         {
             PanelZoom = selectedDocument.PanelZoom,
             PanelPanX = selectedDocument.PanelPanX,
@@ -235,6 +239,16 @@ public sealed class DocumentWorkspaceViewModel
         _setStatusMessage($"Updated inspector summary for {updated.Title}");
         _addOutputEntry($"Inspector summary updated for {updated.Title}", OutputLogStatus.Info);
         return updated;
+    }
+
+    private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null)
+    {
+        var documentId = Guid.NewGuid();
+        return new DocumentTabViewModel(
+            document,
+            panelLayoutJson,
+            documentId,
+            runtimeState: _runtimeStateStore.GetOrCreate(documentId));
     }
 
     internal static OpenDocumentData BuildOpenDocumentData(string path, string content)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -205,11 +205,11 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     public void NotifyContextChanged()
     {
-        if (!ShowLampTestButton && PanelElementFactory.IsLampTestActive)
+        var selectedDocument = _selectedDocumentAccessor();
+        if (!ShowLampTestButton && selectedDocument is not null && selectedDocument.RuntimeState.IsLampTestActive)
         {
-            PanelElementFactory.IsLampTestActive = false;
-            PanelElementFactory.LampTestObjectId = null;
-            _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
+            selectedDocument.RuntimeState.LampTestObjectId = null;
+            selectedDocument.NotifyPanelVisualPreviewChanged();
         }
 
         OnPropertyChanged(nameof(InspectorTitle));
@@ -652,16 +652,21 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
 
         var targetObjectId = isActive ? selectedLampObjectId : null;
-        if (PanelElementFactory.IsLampTestActive == isActive
-            && string.Equals(PanelElementFactory.LampTestObjectId, targetObjectId, StringComparison.Ordinal))
+        var selectedDocument = _selectedDocumentAccessor();
+        if (selectedDocument is null)
         {
             return;
         }
 
-        PanelElementFactory.IsLampTestActive = isActive;
-        PanelElementFactory.LampTestObjectId = targetObjectId;
-        Debug.WriteLine($"[LampTest] SetLampTestActive={isActive}");
-        _selectedDocumentAccessor()?.NotifyPanelVisualPreviewChanged();
+        if (selectedDocument.RuntimeState.IsLampTestActive == isActive
+            && string.Equals(selectedDocument.RuntimeState.LampTestObjectId, targetObjectId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        selectedDocument.RuntimeState.LampTestObjectId = targetObjectId;
+        Debug.WriteLine($"[LampTest] SetLampTestActive={isActive} document={selectedDocument.DocumentId}");
+        selectedDocument.NotifyPanelVisualPreviewChanged();
     }
 
     private static string BuildSelectedElementSummary(PanelElementModel selectedElement)


### PR DESCRIPTION
### Motivation
- Remove use of global/static lamp-test state so lamp test target and intensities do not leak between open document tabs. 
- Store lamp-test target and per-lamp intensity per-document to enable independent runtime emulation per tab. 
- Thread the per-document runtime state through rendering and visual-update paths so UI actions operate on the active document only.

### Description
- Added a `PanelRuntimeState` class to hold `LampTestObjectId` and per-object lamp intensities and a `PanelRuntimeStateStore` keyed by `DocumentId` to manage per-document runtime instances. 
- Replaced static globals in `PanelElementFactory` with a `CreateVisualFromElement(PanelElementFile, PanelRuntimeState)` signature and updated lamp visual creation to query `runtimeState` instead of static fields. 
- Updated `PanelLayoutMapper` to accept `PanelRuntimeState` for `ApplyPersistedLayout` and `ApplyVisualState`, and to use `runtimeState.GetLampIntensity` when updating lamp visuals. 
- Added a `RuntimeState` property to `DocumentTabViewModel` and switched `NotifyPanelVisualPreviewChanged` to compute deltas from that runtime state. 
- Wired runtime state creation and propagation in `DocumentWorkspaceViewModel` (via `PanelRuntimeStateStore`), ensured `ReplaceDocument` preserves the tab runtime state, and added cleanup on document close/project clear in `MainWindowViewModel`. 
- Updated `CanvasPanBehavior` to use the tab `RuntimeState` when applying layout and visual-state updates. 
- Modified `InspectorViewModel` lamp-test flows to toggle the selected document's `RuntimeState.LampTestObjectId` and to call the document's `NotifyPanelVisualPreviewChanged` so lamp-test toggles are scoped to the active document.

### Testing
- Attempted an automated build with `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj -v minimal`, but the environment lacks the `dotnet` SDK so the build could not be executed (failure: `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7bf9c173c832796b7c708bcef94b6)