### PR TITLE
Add seven-segment vector rendering and shared segment visual base

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -250,7 +250,7 @@ public sealed class PanelElementFactoryTests
     }
 
     [Fact]
-    public void CreateVisualFromElement_SevenSegment_UsesDisplayColorAndLabel()
+    public void CreateVisualFromElement_SevenSegment_RendersSevenSegmentDisplay()
     {
         RunInSta(() =>
         {
@@ -262,20 +262,19 @@ public sealed class PanelElementFactoryTests
                 Width = 90,
                 Height = 40,
                 DisplayNumber = 4,
+                DisplayText = "2",
                 OnColorHex = "#FFCC2200"
             };
 
             var visual = PanelElementFactory.CreateVisualFromElement(source);
 
             var border = Assert.IsType<Border>(visual);
-            var stack = Assert.IsType<StackPanel>(border.Child);
-            var title = Assert.IsType<TextBlock>(stack.Children[0]);
-            var background = Assert.IsType<SolidColorBrush>(border.Background);
-
-            Assert.Equal("7 Segment 4", title.Text);
-            Assert.Equal(Color.FromArgb(0xFF, 0xCC, 0x22, 0x00), background.Color);
+            var display = Assert.IsType<SevenSegmentDisplayVisual>(border.Child);
+            Assert.Equal("2", display.DisplayText);
+            Assert.True(display.ShowDecimalPoint);
         });
     }
+
 
     [Fact]
     public void CreateVisualFromElement_AlphaReversed_RendersSegmentDisplayWithoutLabel()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/AlphaSixteenSegmentDisplayVisual.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/AlphaSixteenSegmentDisplayVisual.cs
@@ -1,88 +1,13 @@
-using System.Windows;
-using System.Windows.Media;
-
 namespace OasisEditor;
 
-internal sealed class AlphaSixteenSegmentDisplayVisual : FrameworkElement
+internal sealed class AlphaSixteenSegmentDisplayVisual : SegmentDisplayVisualBase
 {
-    private static readonly Pen SegmentPen = CreateSegmentPen();
-    private readonly SegmentDisplayDefinition? _definition;
-
     public AlphaSixteenSegmentDisplayVisual()
+        : base(LoadDefinition())
     {
-        SegmentDisplayDefinitionLoader.TryGetDefinition(out var definition);
-        _definition = definition;
-        ClipToBounds = true;
-        SnapsToDevicePixels = true;
     }
 
-    public int CellCount { get; set; } = 16;
-
-    public Brush LitBrush { get; set; } = Brushes.OrangeRed;
-
-    public Brush UnlitBrush { get; set; } = new SolidColorBrush(Color.FromArgb(120, 255, 69, 0));
-
-    public string? DisplayText { get; set; }
-
-    public bool ShowDecimalPoint { get; set; }
-
-    protected override void OnRender(DrawingContext drawingContext)
-    {
-        base.OnRender(drawingContext);
-
-        if (_definition?.Cell?.Size is null || _definition.Cell.Segments is null)
-        {
-            return;
-        }
-
-        var cellSize = _definition.Cell.Size.AsSize;
-        if (cellSize.Width <= 0 || cellSize.Height <= 0 || ActualWidth <= 0 || ActualHeight <= 0)
-        {
-            return;
-        }
-
-        var pitch = _definition.Cell.RecommendedPitch <= 0 ? cellSize.Width : _definition.Cell.RecommendedPitch;
-        var sourceWidth = pitch * CellCount;
-        var scale = Math.Min(ActualWidth / sourceWidth, ActualHeight / cellSize.Height);
-        var offsetX = (ActualWidth - (sourceWidth * scale)) * 0.5;
-        var offsetY = (ActualHeight - (cellSize.Height * scale)) * 0.5;
-
-        for (var i = 0; i < CellCount; i++)
-        {
-            var charIndex = i < (DisplayText?.Length ?? 0) ? i : -1;
-            var segmentMask = charIndex >= 0 ? GetBasicMaskForChar(DisplayText![charIndex]) : 0;
-            var cellTransform = new MatrixTransform(scale, 0, 0, scale, offsetX + (i * pitch * scale), offsetY);
-
-            foreach (var segment in _definition.Cell.Segments)
-            {
-                if (segment.Geometry is null)
-                {
-                    continue;
-                }
-
-                var lit = (segmentMask & (1 << segment.Index)) != 0;
-                drawingContext.PushTransform(cellTransform);
-                drawingContext.DrawGeometry(lit ? LitBrush : UnlitBrush, SegmentPen, segment.Geometry);
-                drawingContext.Pop();
-            }
-
-            if (ShowDecimalPoint && _definition.Cell.DecimalPoint?.Geometry is not null)
-            {
-                drawingContext.PushTransform(cellTransform);
-                drawingContext.DrawGeometry(UnlitBrush, SegmentPen, _definition.Cell.DecimalPoint.Geometry);
-                drawingContext.Pop();
-            }
-        }
-    }
-
-    private static Pen CreateSegmentPen()
-    {
-        var pen = new Pen(new SolidColorBrush(Color.FromArgb(120, 18, 18, 18)), 0.4);
-        pen.Freeze();
-        return pen;
-    }
-
-    private static int GetBasicMaskForChar(char c)
+    protected override int GetSegmentMaskForChar(char c)
     {
         return char.ToUpperInvariant(c) switch
         {
@@ -90,5 +15,11 @@ internal sealed class AlphaSixteenSegmentDisplayVisual : FrameworkElement
             >= 'A' and <= 'Z' => 0b1111_1111_0000_1111,
             _ => 0
         };
+    }
+
+    private static SegmentDisplayDefinition? LoadDefinition()
+    {
+        SegmentDisplayDefinitionLoader.TryGetSixteenSegmentDefinition(out var definition);
+        return definition;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -251,10 +251,29 @@ internal static class PanelElementFactory
 
     private static Border CreateSevenSegmentVisual(PanelElementFile element)
     {
-        var label = element.DisplayNumber.HasValue
-            ? $"7 Segment {element.DisplayNumber.Value}"
-            : "7 Segment";
-        return CreatePlaceholderComponentVisual(element, label, element.OnColorHex, element.DisplayText);
+        var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
+        var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
+
+        return new Border
+        {
+            Uid = element.ObjectId,
+            Width = width,
+            Height = height,
+            BorderThickness = new Thickness(1),
+            BorderBrush = Brushes.SlateGray,
+            Background = TryCreateBrush("#111827", Brushes.Black),
+            Padding = new Thickness(4),
+            Child = new SevenSegmentDisplayVisual
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                CellCount = 1,
+                DisplayText = string.IsNullOrWhiteSpace(element.DisplayText) ? "8" : element.DisplayText,
+                LitBrush = TryCreateBrush(element.OnColorHex, Brushes.OrangeRed),
+                UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(160, 70, 70, 70))),
+                ShowDecimalPoint = true
+            }
+        };
     }
 
     private static Border CreateAlphaVisual(PanelElementFile element)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinitionLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinitionLoader.cs
@@ -6,32 +6,43 @@ namespace OasisEditor;
 
 internal static class SegmentDisplayDefinitionLoader
 {
-    private const string RelativePath = "Assets/SegmentDisplays/oasis_16_segment_display_definition.json";
-    private static readonly Lazy<SegmentDisplayDefinition?> LazyDefinition = new(TryLoadDefinition);
-
-    public static bool TryGetDefinition(out SegmentDisplayDefinition definition)
+    private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        definition = LazyDefinition.Value!;
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly Lazy<SegmentDisplayDefinition?> LazySixteenSegmentDefinition =
+        new(() => TryLoadDefinition("Assets/SegmentDisplays/oasis_16_segment_display_definition.json", 16));
+
+    private static readonly Lazy<SegmentDisplayDefinition?> LazySevenSegmentDefinition =
+        new(() => TryLoadDefinition("Assets/SegmentDisplays/oasis_7_segment_display_definition.json", 7));
+
+    public static bool TryGetSixteenSegmentDefinition(out SegmentDisplayDefinition definition)
+    {
+        definition = LazySixteenSegmentDefinition.Value!;
         return definition is not null;
     }
 
-    private static SegmentDisplayDefinition? TryLoadDefinition()
+    public static bool TryGetSevenSegmentDefinition(out SegmentDisplayDefinition definition)
     {
-        var definitionPath = Path.Combine(AppContext.BaseDirectory, RelativePath);
+        definition = LazySevenSegmentDefinition.Value!;
+        return definition is not null;
+    }
+
+    private static SegmentDisplayDefinition? TryLoadDefinition(string relativePath, int expectedSegmentCount)
+    {
+        var definitionPath = Path.Combine(AppContext.BaseDirectory, relativePath);
         if (!File.Exists(definitionPath))
         {
             return null;
         }
 
         var json = File.ReadAllText(definitionPath);
-        var definition = JsonSerializer.Deserialize<SegmentDisplayDefinition>(json, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var definition = JsonSerializer.Deserialize<SegmentDisplayDefinition>(json, JsonOptions);
 
         try
         {
-            Validate(definition);
+            Validate(definition, expectedSegmentCount);
             return definition!;
         }
         catch
@@ -40,7 +51,7 @@ internal static class SegmentDisplayDefinitionLoader
         }
     }
 
-    private static void Validate(SegmentDisplayDefinition? definition)
+    private static void Validate(SegmentDisplayDefinition? definition, int expectedSegmentCount)
     {
         if (definition?.Cell?.Size is null)
         {
@@ -48,9 +59,9 @@ internal static class SegmentDisplayDefinitionLoader
         }
 
         var segments = definition.Cell.Segments;
-        if (segments is null || segments.Count != 16)
+        if (segments is null || segments.Count != expectedSegmentCount)
         {
-            throw new InvalidOperationException("Segment definition must contain exactly 16 segments.");
+            throw new InvalidOperationException($"Segment definition must contain exactly {expectedSegmentCount} segments.");
         }
 
         foreach (var segment in segments)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -1,0 +1,81 @@
+using System.Windows;
+using System.Windows.Media;
+
+namespace OasisEditor;
+
+internal abstract class SegmentDisplayVisualBase : FrameworkElement
+{
+    private static readonly Pen SegmentPen = CreateSegmentPen();
+    private readonly SegmentDisplayDefinition? _definition;
+
+    protected SegmentDisplayVisualBase(SegmentDisplayDefinition? definition)
+    {
+        _definition = definition;
+        ClipToBounds = true;
+        SnapsToDevicePixels = true;
+    }
+
+    public int CellCount { get; set; } = 1;
+    public Brush LitBrush { get; set; } = Brushes.OrangeRed;
+    public Brush UnlitBrush { get; set; } = new SolidColorBrush(Color.FromArgb(120, 255, 69, 0));
+    public string? DisplayText { get; set; }
+    public bool ShowDecimalPoint { get; set; }
+
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        base.OnRender(drawingContext);
+
+        if (_definition?.Cell?.Size is null || _definition.Cell.Segments is null)
+        {
+            return;
+        }
+
+        var cellSize = _definition.Cell.Size.AsSize;
+        if (cellSize.Width <= 0 || cellSize.Height <= 0 || ActualWidth <= 0 || ActualHeight <= 0)
+        {
+            return;
+        }
+
+        var pitch = _definition.Cell.RecommendedPitch <= 0 ? cellSize.Width : _definition.Cell.RecommendedPitch;
+        var sourceWidth = pitch * CellCount;
+        var scale = Math.Min(ActualWidth / sourceWidth, ActualHeight / cellSize.Height);
+        var offsetX = (ActualWidth - (sourceWidth * scale)) * 0.5;
+        var offsetY = (ActualHeight - (cellSize.Height * scale)) * 0.5;
+
+        for (var i = 0; i < CellCount; i++)
+        {
+            var charIndex = i < (DisplayText?.Length ?? 0) ? i : -1;
+            var segmentMask = charIndex >= 0 ? GetSegmentMaskForChar(DisplayText![charIndex]) : 0;
+            var cellTransform = new MatrixTransform(scale, 0, 0, scale, offsetX + (i * pitch * scale), offsetY);
+
+            foreach (var segment in _definition.Cell.Segments)
+            {
+                if (segment.Geometry is null)
+                {
+                    continue;
+                }
+
+                var lit = (segmentMask & (1 << segment.Index)) != 0;
+                drawingContext.PushTransform(cellTransform);
+                drawingContext.DrawGeometry(lit ? LitBrush : UnlitBrush, SegmentPen, segment.Geometry);
+                drawingContext.Pop();
+            }
+
+            if (ShowDecimalPoint && _definition.Cell.DecimalPoint?.Geometry is not null)
+            {
+                drawingContext.PushTransform(cellTransform);
+                drawingContext.DrawGeometry(UnlitBrush, SegmentPen, _definition.Cell.DecimalPoint.Geometry);
+                drawingContext.Pop();
+            }
+        }
+    }
+
+    protected abstract int GetSegmentMaskForChar(char c);
+
+    private static Pen CreateSegmentPen()
+    {
+        var pen = new Pen(new SolidColorBrush(Color.FromArgb(120, 18, 18, 18)), 0.4);
+        pen.Freeze();
+        return pen;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SevenSegmentDisplayVisual.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SevenSegmentDisplayVisual.cs
@@ -1,0 +1,33 @@
+namespace OasisEditor;
+
+internal sealed class SevenSegmentDisplayVisual : SegmentDisplayVisualBase
+{
+    public SevenSegmentDisplayVisual()
+        : base(LoadDefinition())
+    {
+    }
+
+    protected override int GetSegmentMaskForChar(char c)
+    {
+        return char.ToUpperInvariant(c) switch
+        {
+            '0' => 0b0111111,
+            '1' => 0b0000110,
+            '2' => 0b1011011,
+            '3' => 0b1001111,
+            '4' => 0b1100110,
+            '5' => 0b1101101,
+            '6' => 0b1111101,
+            '7' => 0b0000111,
+            '8' => 0b1111111,
+            '9' => 0b1101111,
+            _ => 0
+        };
+    }
+
+    private static SegmentDisplayDefinition? LoadDefinition()
+    {
+        SegmentDisplayDefinitionLoader.TryGetSevenSegmentDefinition(out var definition);
+        return definition;
+    }
+}


### PR DESCRIPTION
### Motivation

- Add support for the new 7-segment (plus decimal point) vector definition asset and render it as geometry rather than a placeholder label.
- Reduce duplicate rendering logic between the existing 16-segment Alpha visual and the new 7-segment visual by extracting shared behavior.
- Integrate the new vector-backed seven-segment control into the panel element factory so panel2d documents can show a real seven-segment preview.

### Description

- Extended the segment loader into `SegmentDisplayDefinitionLoader` to support both the existing 16-segment JSON and the new `oasis_7_segment_display_definition.json`, with shared validation, parsing, and cached `Geometry` creation (including decimal point geometry). (`SegmentDisplayDefinitionLoader.cs`)
- Introduced `SegmentDisplayVisualBase` which centralizes scaling, pitch/spacing, per-cell rendering, segment draw loop, and decimal-point rendering to avoid duplicated rendering code. (`SegmentDisplayVisualBase.cs`)
- Refactored `AlphaSixteenSegmentDisplayVisual` to inherit from the new base and keep only the 16-segment-specific mask logic and definition selection. (`AlphaSixteenSegmentDisplayVisual.cs`)
- Added `SevenSegmentDisplayVisual` implementing seven-segment digit masks and loading the 7-segment definition, exposing the same properties as the base (lit/unlit brushes, `DisplayText`, `ShowDecimalPoint`). (`SevenSegmentDisplayVisual.cs`)
- Updated `PanelElementFactory` so SevenSegment elements now return a geometry-backed `SevenSegmentDisplayVisual` (with sensible defaults for text/brushes/DP) instead of the placeholder stack label. (`PanelElementFactory.cs`)
- Updated unit test to assert the panel factory now produces a `SevenSegmentDisplayVisual` for seven-segment elements (test update in `PanelElementFactoryTests.cs`).

### Testing

- No automated test runs were executed in this environment per repository policy because the Codex environment does not have the required Windows/.NET/WPF toolchain; therefore no `dotnet test` was run here. (See project AGENT.md constraints.)
- Please run the solution unit tests locally with `dotnet test` (or the test runner of choice) and confirm the `OasisEditor.Tests` test assembly including the updated `PanelElementFactoryTests` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9dbc8133883279599e7398c04c2b6)