### PR TITLE
Render reels using visible vertical window in WPF editor

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -239,14 +239,42 @@ internal static class PanelElementFactory
         var surface = CreatePlaceholderComponentVisual(element, label, "#1E293B");
         if (TryCreateImageSource(element.AssetPath, out var source))
         {
-            surface.Child = new Image
+            var width = element.Width <= 0 ? NewRectangleWidth : element.Width;
+            var height = element.Height <= 0 ? NewRectangleHeight : element.Height;
+            var visibleScale = ResolveVisibleScale(element.VisibleScale);
+
+            var reelImage = new Image
             {
                 Stretch = Stretch.Fill,
-                Source = source
+                Source = source,
+                Width = width,
+                Height = height / visibleScale,
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            surface.Child = new Grid
+            {
+                ClipToBounds = true,
+                Children =
+                {
+                    reelImage
+                }
             };
         }
 
         return surface;
+    }
+
+
+    private static double ResolveVisibleScale(double? visibleScale)
+    {
+        if (!visibleScale.HasValue || double.IsNaN(visibleScale.Value) || double.IsInfinity(visibleScale.Value))
+        {
+            return 1d;
+        }
+
+        return Math.Clamp(visibleScale.Value, 0.01d, 1d);
     }
 
     private static Border CreateSevenSegmentVisual(PanelElementFile element)


### PR DESCRIPTION
### Motivation
- Reel elements were rendering the entire reel band squashed into the element bounds rather than showing a vertical viewport of the band as the legacy Unity editor did, and this must be corrected to support future emulator-driven scrolling.

### Description
- Updated `PanelElementFactory.CreateReelVisual` to render the reel `Image` taller (based on element size and `VisibleScale`) and place it inside a clipped `Grid` so only a vertical window of the band is visible.
- Added `ResolveVisibleScale` helper to safely default and clamp `VisibleScale` values to prevent NaN/infinite/out-of-range geometry.
- Changes are contained in `OasisEditor/PanelElementFactory.cs`.

### Testing
- No automated tests were run in this environment because the WPF/.NET toolchain is unavailable; automated build/test should be executed locally against the solution to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9e0d445188327ada1cdcdf854d1fd)