### PR TITLE
Add MAME preferences model and Preferences UI with path validation (Phase B)

### DIFF
--- a/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
+++ b/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
@@ -1,0 +1,21 @@
+# MAME Emulation Port Test Log
+
+## Phase B (Preferences model and UI) - Codex notes
+
+Date: 2026-05-05
+
+### Manual test steps for maintainer
+
+1. Launch `OasisEditor` and open the Preferences tool window.
+2. Confirm new MAME fields are visible: Version, Executable Path (with Browse), Install Root, Lua Plugin Directory, and Validate Paths status.
+3. Click **Browse...** and select a local `mame.exe`.
+4. Click **Validate Paths**.
+5. Confirm validation feedback appears in the preferences UI and output log.
+6. Set an invalid executable path and invalid plugin directory, click **Validate Paths**, and confirm clear warning output without crashes.
+7. Close and restart the editor; verify values entered in the MAME fields persist.
+
+### Untested assumptions
+
+- Preferences tool window uses `Views/PreferencesView.xaml` bindings from `MainWindowViewModel` in all runtime entry paths.
+- Output log warning/info statuses for validation are surfaced as expected by existing output infrastructure.
+- Existing preferences JSON files without a `Mame` object continue to load with defaults via model initialization.

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -4,7 +4,19 @@ public sealed class EditorPreferences
 {
     public ThemePreference ThemePreference { get; init; } = ThemePreference.Dark;
 
+    public MamePreferences Mame { get; init; } = new();
+
     public Dictionary<string, ProjectWindowState> ProjectWindowStates { get; init; } = new();
+}
+
+public sealed class MamePreferences
+{
+    public string Version { get; init; } = "0267";
+    public string ExecutablePath { get; init; } = string.Empty;
+    public string InstallRootDirectory { get; init; } = string.Empty;
+    public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
+    public string LuaPluginPath { get; init; } = string.Empty;
+    public string CommandLineOverrides { get; init; } = string.Empty;
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -26,6 +26,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private EditorProject? _loadedProject;
     private DocumentTabViewModel? _selectedDocument;
     private ThemePreference _selectedThemePreference;
+    private string _mameVersion = "0267";
+    private string _mameExecutablePath = string.Empty;
+    private string _mameInstallRootDirectory = string.Empty;
+    private string _mameReleaseSource = string.Empty;
+    private string _mameLuaPluginPath = string.Empty;
+    private string _mameCommandLineOverrides = string.Empty;
+    private string _mameValidationSummary = "Not validated.";
     private readonly AssetBrowserViewModel _assetBrowser;
     private readonly OutputLogViewModel _outputLog;
     private readonly InspectorViewModel _inspector;
@@ -67,6 +74,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenPreferencesCommand = new RelayCommand(OpenPreferences);
         OpenProjectSettingsCommand = new RelayCommand(OpenProjectSettings);
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
+        BrowseMameExecutableCommand = new RelayCommand(BrowseMameExecutable);
+        ValidateMamePreferencesCommand = new RelayCommand(ValidateMamePreferences);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
@@ -101,6 +110,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         var preferences = _preferencesStore.Load();
         _selectedThemePreference = preferences.ThemePreference;
+        _mameVersion = preferences.Mame.Version;
+        _mameExecutablePath = preferences.Mame.ExecutablePath;
+        _mameInstallRootDirectory = preferences.Mame.InstallRootDirectory;
+        _mameReleaseSource = preferences.Mame.ReleaseSource;
+        _mameLuaPluginPath = preferences.Mame.LuaPluginPath;
+        _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
@@ -210,6 +225,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenPreferencesCommand { get; }
     public ICommand OpenProjectSettingsCommand { get; }
     public ICommand ClosePreferencesCommand { get; }
+    public ICommand BrowseMameExecutableCommand { get; }
+    public ICommand ValidateMamePreferencesCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
@@ -234,10 +251,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             }
 
             _applicationThemeService.ApplyTheme(Application.Current ?? throw new InvalidOperationException("Application is not initialized."), value);
-            _preferencesStore.Save(new EditorPreferences { ThemePreference = value });
+            SavePreferences();
             AddOutputEntry($"Theme preference changed: {value}", OutputLogStatus.Info);
         }
     }
+
+    public string MameVersion { get => _mameVersion; set { if (SetProperty(ref _mameVersion, value)) SavePreferences(); } }
+    public string MameExecutablePath { get => _mameExecutablePath; set { if (SetProperty(ref _mameExecutablePath, value)) SavePreferences(); } }
+    public string MameInstallRootDirectory { get => _mameInstallRootDirectory; set { if (SetProperty(ref _mameInstallRootDirectory, value)) SavePreferences(); } }
+    public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
+    public string MameLuaPluginPath { get => _mameLuaPluginPath; set { if (SetProperty(ref _mameLuaPluginPath, value)) SavePreferences(); } }
+    public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
+    public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
 
     public string StatusMessage
     {
@@ -781,6 +806,77 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         ToolWindowOpenRequested?.Invoke(EditorToolWindowId.Preferences);
         AddOutputEntry("Opened Preferences pane.", OutputLogStatus.Info);
+    }
+
+    private void BrowseMameExecutable()
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Select mame.exe",
+            Filter = "MAME Executable|mame.exe|Executable Files|*.exe|All Files|*.*",
+            CheckFileExists = true,
+            Multiselect = false,
+            FileName = Path.GetFileName(MameExecutablePath)
+        };
+
+        if (dialog.ShowDialog(_ownerWindow) == true)
+        {
+            MameExecutablePath = dialog.FileName;
+            if (string.IsNullOrWhiteSpace(MameInstallRootDirectory))
+            {
+                MameInstallRootDirectory = Path.GetDirectoryName(dialog.FileName) ?? string.Empty;
+            }
+
+            AddOutputEntry($"Selected MAME executable: {dialog.FileName}", OutputLogStatus.Info);
+            ValidateMamePreferences();
+        }
+    }
+
+    private void ValidateMamePreferences()
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(MameExecutablePath) || !File.Exists(MameExecutablePath))
+            errors.Add("MAME executable is missing or does not exist.");
+        else if (!string.Equals(Path.GetFileName(MameExecutablePath), "mame.exe", StringComparison.OrdinalIgnoreCase))
+            errors.Add("MAME executable path must point to mame.exe.");
+
+        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory) || !Directory.Exists(MameInstallRootDirectory))
+            errors.Add("MAME install root directory is missing or does not exist.");
+
+        if (string.IsNullOrWhiteSpace(MameLuaPluginPath) || !Directory.Exists(MameLuaPluginPath))
+            errors.Add("Lua plugin directory is missing or does not exist.");
+
+        if (string.IsNullOrWhiteSpace(MameVersion) || MameVersion.Any(c => !char.IsDigit(c)))
+            errors.Add("MAME version must be numeric (example: 0267).");
+
+        if (errors.Count == 0)
+        {
+            MameValidationSummary = "MAME preferences validation passed.";
+            AddOutputEntry(MameValidationSummary, OutputLogStatus.Info);
+        }
+        else
+        {
+            MameValidationSummary = string.Join(" ", errors);
+            AddOutputEntry($"MAME preferences validation failed: {MameValidationSummary}", OutputLogStatus.Warning);
+        }
+    }
+
+    private void SavePreferences()
+    {
+        _preferencesStore.Save(new EditorPreferences
+        {
+            ThemePreference = SelectedThemePreference,
+            Mame = new MamePreferences
+            {
+                Version = MameVersion,
+                ExecutablePath = MameExecutablePath,
+                InstallRootDirectory = MameInstallRootDirectory,
+                ReleaseSource = MameReleaseSource,
+                LuaPluginPath = MameLuaPluginPath,
+                CommandLineOverrides = MameCommandLineOverrides
+            }
+        });
     }
 
     private void OpenProjectSettings()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -4,10 +4,19 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             d:DesignHeight="220"
-             d:DesignWidth="420">
+             d:DesignHeight="560"
+             d:DesignWidth="620">
     <Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -30,5 +39,29 @@
                   HorizontalAlignment="Left"
                   ItemsSource="{Binding ThemePreferences}"
                   SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Grid.Row="3" Margin="0,16,0,4" Text="MAME Version" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBox Grid.Row="4" Text="{Binding MameVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Grid.Row="5" Margin="0,8,0,4" Text="MAME Executable" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <Grid Grid.Row="6">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Column="0" Margin="0,0,8,0" Text="{Binding MameExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Grid.Column="1" Padding="10,4" Content="Browse..." Command="{Binding BrowseMameExecutableCommand}" />
+        </Grid>
+
+        <TextBlock Grid.Row="7" Margin="0,8,0,4" Text="MAME Install Root" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBox Grid.Row="8" Text="{Binding MameInstallRootDirectory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <TextBlock Grid.Row="9" Margin="0,8,0,4" Text="Lua Plugin Directory" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBox Grid.Row="10" Text="{Binding MameLuaPluginPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <StackPanel Grid.Row="11" Margin="0,12,0,0" Orientation="Horizontal">
+            <Button Padding="10,4" Content="Validate Paths" Command="{Binding ValidateMamePreferencesCommand}" />
+            <TextBlock Margin="12,4,0,0" Text="{Binding MameValidationSummary}" TextWrapping="Wrap" />
+        </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation

- Implement Phase B from the MAME emulation port tasks: add editor-stored MAME configuration and a Preferences UI to select/validate a local `mame.exe` without adding any launch/process logic.

### Description

- Added `MamePreferences` and embedded it in `EditorPreferences` to persist version, `ExecutablePath`, `InstallRootDirectory`, `ReleaseSource`, `LuaPluginPath`, and `CommandLineOverrides` (`WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs`).
- Exposed new bindable properties and persistence in `MainWindowViewModel`: load/save MAME prefs from the existing `EditorPreferencesStore`, added `Mame*` properties, `SavePreferences()` helper, `BrowseMameExecutableCommand`, and `ValidateMamePreferencesCommand` which validates paths/version and emits messages to the existing output log (`WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).
- Extended the Preferences view with MAME controls and bindings: version, executable field + `Browse...`, install root, Lua plugin directory, `Validate Paths` button, and inline validation summary (`WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml`).
- Added `MameEmulationPort.TestLog.md` documenting manual test steps and untested assumptions for the maintainer to follow when running the app locally.

### Testing

- Attempted automated build: ran `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` but it failed in this environment because the `dotnet` CLI is not installed (`/bin/bash: line 1: dotnet: command not found`).
- No unit tests were added or executed as part of this change; validation logic is exercised via the UI-bound `ValidateMamePreferencesCommand` and documented manual steps in `MameEmulationPort.TestLog.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa4dffceec832782212465a16381b5)