### PR TITLE
Add MAME download/cache workflow and Preferences actions (Phase C)

### DIFF
--- a/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
+++ b/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
@@ -1,21 +1,23 @@
 # MAME Emulation Port Test Log
 
-## Phase B (Preferences model and UI) - Codex notes
+## Phase C (Download/cache service) - Codex notes
 
 Date: 2026-05-05
 
 ### Manual test steps for maintainer
 
 1. Launch `OasisEditor` and open the Preferences tool window.
-2. Confirm new MAME fields are visible: Version, Executable Path (with Browse), Install Root, Lua Plugin Directory, and Validate Paths status.
-3. Click **Browse...** and select a local `mame.exe`.
-4. Click **Validate Paths**.
-5. Confirm validation feedback appears in the preferences UI and output log.
-6. Set an invalid executable path and invalid plugin directory, click **Validate Paths**, and confirm clear warning output without crashes.
-7. Close and restart the editor; verify values entered in the MAME fields persist.
+2. Set **MAME Install Root** to a writable local directory.
+3. Click **Refresh Versions** and confirm known versions are written to output log.
+4. Set **MAME Version** (for example `0267`) and verify **MAME Release Source** points to the MAME GitHub releases base URL.
+5. Click **Download Selected** and verify progress log entries for download and extraction appear.
+6. Confirm `mame.exe` is extracted under `<install-root>/mame####/mame.exe`, and that **MAME Executable** is auto-filled.
+7. Click **Open Install Folder** and verify Explorer opens at install root.
+8. Click **Remove Cached Version** and verify the version folder is deleted and a corresponding log entry is produced.
+9. Try download with an invalid URL or unwritable install root and confirm failure is logged clearly without editor crash.
 
 ### Untested assumptions
 
-- Preferences tool window uses `Views/PreferencesView.xaml` bindings from `MainWindowViewModel` in all runtime entry paths.
-- Output log warning/info statuses for validation are surfaced as expected by existing output infrastructure.
-- Existing preferences JSON files without a `Mame` object continue to load with defaults via model initialization.
+- Download archive format `mame####b_64bit.zip` / `mame####b_x64.zip` remains valid for target versions and GitHub release layout.
+- `ZipFile.ExtractToDirectory` can extract archives produced by MAME releases without additional staging logic.
+- `explorer.exe` launch is acceptable for target Windows environments.

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -43,6 +43,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly HierarchyPanelCommandService _hierarchyPanelCommands;
     private bool _isRefreshingHierarchy;
     private readonly MfmeImportService _mfmeImportService = new();
+    private readonly MameDownloadService _mameDownloadService = new();
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -76,6 +77,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
         BrowseMameExecutableCommand = new RelayCommand(BrowseMameExecutable);
         ValidateMamePreferencesCommand = new RelayCommand(ValidateMamePreferences);
+        RefreshMameVersionsCommand = new RelayCommand(RefreshMameVersions);
+        DownloadMameVersionCommand = new RelayCommand(DownloadMameVersion);
+        OpenMameInstallRootCommand = new RelayCommand(OpenMameInstallRoot);
+        RemoveCachedMameVersionCommand = new RelayCommand(RemoveCachedMameVersion);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
@@ -227,6 +232,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ClosePreferencesCommand { get; }
     public ICommand BrowseMameExecutableCommand { get; }
     public ICommand ValidateMamePreferencesCommand { get; }
+    public ICommand RefreshMameVersionsCommand { get; }
+    public ICommand DownloadMameVersionCommand { get; }
+    public ICommand OpenMameInstallRootCommand { get; }
+    public ICommand RemoveCachedMameVersionCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
@@ -862,6 +871,71 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+
+    private async void RefreshMameVersions()
+    {
+        try
+        {
+            var versions = await _mameDownloadService.GetKnownVersionsAsync(CancellationToken.None);
+            AddOutputEntry($"Known MAME versions: {string.Join(", ", versions)}", OutputLogStatus.Info);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Failed to refresh MAME versions: {ex.Message}", OutputLogStatus.Warning);
+        }
+    }
+
+    private async void DownloadMameVersion()
+    {
+        try
+        {
+            ValidateMamePreferences();
+            if (MameValidationSummary.StartsWith("MAME preferences validation failed", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var executablePath = await _mameDownloadService.DownloadAndExtractAsync(
+                MameReleaseSource,
+                MameVersion,
+                MameInstallRootDirectory,
+                new Progress<string>(message => AddOutputEntry(message, OutputLogStatus.Info)),
+                CancellationToken.None);
+            MameExecutablePath = executablePath;
+            AddOutputEntry($"MAME download completed. Executable: {executablePath}", OutputLogStatus.Info);
+            ValidateMamePreferences();
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"MAME download failed: {ex.Message}", OutputLogStatus.Warning);
+        }
+    }
+
+    private void OpenMameInstallRoot()
+    {
+        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory) || !Directory.Exists(MameInstallRootDirectory))
+        {
+            AddOutputEntry("MAME install root directory does not exist.", OutputLogStatus.Warning);
+            return;
+        }
+
+        System.Diagnostics.Process.Start("explorer.exe", MameInstallRootDirectory);
+    }
+
+    private void RemoveCachedMameVersion()
+    {
+        try
+        {
+            var removed = _mameDownloadService.RemoveCachedVersion(MameInstallRootDirectory, MameVersion);
+            AddOutputEntry(removed
+                ? $"Removed cached MAME version {MameVersion}."
+                : $"No cached MAME version directory found for {MameVersion}.", removed ? OutputLogStatus.Info : OutputLogStatus.Warning);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Failed to remove cached MAME version: {ex.Message}", OutputLogStatus.Warning);
+        }
+    }
     private void SavePreferences()
     {
         _preferencesStore.Save(new EditorPreferences

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
@@ -1,0 +1,90 @@
+using System.IO.Compression;
+using System.Net.Http;
+
+namespace OasisEditor;
+
+public sealed class MameDownloadService
+{
+    private static readonly HttpClient HttpClient = new();
+
+    public Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken)
+    {
+        // Phase C seed list aligned with legacy default and current branch conventions.
+        IReadOnlyList<string> versions = ["0258", "0267", "0281"];
+        return Task.FromResult(versions);
+    }
+
+    public string GetArchiveUrl(string releaseSource, string version)
+    {
+        var normalizedVersion = NormalizeVersion(version);
+        var archiveName = BuildArchiveFileName(normalizedVersion);
+        return $"{releaseSource.TrimEnd('/')}/download/mame{normalizedVersion}/{archiveName}";
+    }
+
+    public string GetInstallDirectory(string installRootDirectory, string version)
+        => Path.Combine(installRootDirectory, $"mame{NormalizeVersion(version)}");
+
+    public async Task<string> DownloadAndExtractAsync(
+        string releaseSource,
+        string version,
+        string installRootDirectory,
+        IProgress<string>? progress,
+        CancellationToken cancellationToken)
+    {
+        var normalizedVersion = NormalizeVersion(version);
+        var installDirectory = GetInstallDirectory(installRootDirectory, normalizedVersion);
+        var archiveName = BuildArchiveFileName(normalizedVersion);
+        var archiveUrl = GetArchiveUrl(releaseSource, normalizedVersion);
+        var downloadsDirectory = Path.Combine(installRootDirectory, "downloads");
+        Directory.CreateDirectory(downloadsDirectory);
+        Directory.CreateDirectory(installRootDirectory);
+
+        var archivePath = Path.Combine(downloadsDirectory, archiveName);
+        progress?.Report($"Downloading {archiveUrl}");
+        await using (var sourceStream = await HttpClient.GetStreamAsync(archiveUrl, cancellationToken))
+        await using (var targetStream = File.Create(archivePath))
+        {
+            await sourceStream.CopyToAsync(targetStream, cancellationToken);
+        }
+
+        progress?.Report($"Extracting {archiveName} to {installDirectory}");
+        if (Directory.Exists(installDirectory))
+        {
+            Directory.Delete(installDirectory, recursive: true);
+        }
+
+        ZipFile.ExtractToDirectory(archivePath, installDirectory, overwriteFiles: true);
+        return Path.Combine(installDirectory, "mame.exe");
+    }
+
+    public bool RemoveCachedVersion(string installRootDirectory, string version)
+    {
+        var installDirectory = GetInstallDirectory(installRootDirectory, version);
+        if (!Directory.Exists(installDirectory))
+        {
+            return false;
+        }
+
+        Directory.Delete(installDirectory, recursive: true);
+        return true;
+    }
+
+    private static string BuildArchiveFileName(string normalizedVersion)
+    {
+        var numericVersion = int.Parse(normalizedVersion);
+        var suffix = numericVersion >= 281 ? "x64" : "64bit";
+        return $"mame{normalizedVersion}b_{suffix}.zip";
+    }
+
+    private static string NormalizeVersion(string version)
+    {
+        var numericOnly = new string(version.Where(char.IsDigit).ToArray());
+        if (string.IsNullOrWhiteSpace(numericOnly))
+        {
+            throw new InvalidOperationException("MAME version must contain digits.");
+        }
+
+        var numericVersion = int.Parse(numericOnly);
+        return numericVersion.ToString("0000");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
@@ -1,7 +1,7 @@
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Diagnostics;
 
 namespace OasisEditor;
 
@@ -55,7 +55,8 @@ public sealed class MameDownloadService
             Directory.Delete(installDirectory, recursive: true);
         }
 
-        ZipFile.ExtractToDirectory(archivePath, installDirectory, overwriteFiles: true);
+        Directory.CreateDirectory(installDirectory);
+        await ExtractArchiveAsync(archivePath, installDirectory, cancellationToken).ConfigureAwait(false);
         return Path.Combine(installDirectory, "mame.exe");
     }
 
@@ -75,7 +76,29 @@ public sealed class MameDownloadService
     {
         var numericVersion = int.Parse(normalizedVersion);
         var suffix = numericVersion >= 281 ? "x64" : "64bit";
-        return $"mame{normalizedVersion}b_{suffix}.zip";
+        return $"mame{normalizedVersion}b_{suffix}.exe";
+    }
+
+    private static async Task ExtractArchiveAsync(string archivePath, string installDirectory, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = archivePath,
+            Arguments = $"-y -o\"{installDirectory}\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = installDirectory
+        };
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start MAME extractor executable.");
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            var error = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"MAME extraction failed with code {process.ExitCode}: {error}");
+        }
     }
 
     private static string NormalizeVersion(string version)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 
 namespace OasisEditor;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -19,6 +19,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -62,6 +63,13 @@
         <StackPanel Grid.Row="11" Margin="0,12,0,0" Orientation="Horizontal">
             <Button Padding="10,4" Content="Validate Paths" Command="{Binding ValidateMamePreferencesCommand}" />
             <TextBlock Margin="12,4,0,0" Text="{Binding MameValidationSummary}" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="12" Margin="0,8,0,0" Orientation="Horizontal">
+            <Button Padding="10,4" Margin="0,0,8,0" Content="Refresh Versions" Command="{Binding RefreshMameVersionsCommand}" />
+            <Button Padding="10,4" Margin="0,0,8,0" Content="Download Selected" Command="{Binding DownloadMameVersionCommand}" />
+            <Button Padding="10,4" Margin="0,0,8,0" Content="Open Install Folder" Command="{Binding OpenMameInstallRootCommand}" />
+            <Button Padding="10,4" Content="Remove Cached Version" Command="{Binding RemoveCachedMameVersionCommand}" />
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation

- Implement Phase C of the MAME emulation port plan to provide a focused download and cache workflow so maintainers can install and manage local MAME versions for later process integration.
- Surface MAME version discovery, download, extraction, and cached-version removal through the existing Preferences UI and output log without touching process-launch code yet.

### Description

- Added a new `MameDownloadService` providing known-version discovery, release URL construction, archive download + extraction, and cached-version removal with normalized install folder layout and archive-name logic (`WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs`).
- Wired new preferences commands and handlers into `MainWindowViewModel` including `RefreshMameVersionsCommand`, `DownloadMameVersionCommand`, `OpenMameInstallRootCommand`, and `RemoveCachedMameVersionCommand`, and added asynchronous download/extract flow that reports progress to the output log (`WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).
- Extended MAME preferences validation to check `MameReleaseSource` as a valid absolute URL and updated the Preferences view to expose action buttons (`Refresh Versions`, `Download Selected`, `Open Install Folder`, `Remove Cached Version`) (`WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml`).
- Updated `MameEmulationPort.TestLog.md` with Phase C manual test steps and untested assumptions to guide the maintainer during local verification (`WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md`).

### Testing

- No automated tests were executed in this environment due to the project constraint that the Codex execution environment lacks the required Windows/.NET/WPF toolchain as described in `AGENT.md`.
- Suggested automated checks for the maintainer to run locally are `dotnet build` for the solution and `dotnet test` for the `OasisEditor.Tests` project, plus unit tests validating `MameDownloadService` behaviors (URL construction, normalize/version parsing, download/extract handling) and `MainWindowViewModel` command flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa75fc1fe48327888b78e6cb35fbd7)