### PR TITLE
Add Lua plugin asset validation for MAME preferences

### DIFF
--- a/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
+++ b/WindowsNetProjects/OasisEditor/MameEmulationPort.TestLog.md
@@ -21,3 +21,21 @@ Date: 2026-05-05
 - Download archive format `mame####b_64bit.zip` / `mame####b_x64.zip` remains valid for target versions and GitHub release layout.
 - `ZipFile.ExtractToDirectory` can extract archives produced by MAME releases without additional staging logic.
 - `explorer.exe` launch is acceptable for target Windows environments.
+
+## Phase E (Lua plugin asset staging validation) - Codex notes
+
+Date: 2026-05-06
+
+### Manual test steps for maintainer
+
+1. Launch `OasisEditor` and open the Preferences pane.
+2. Leave **Lua Plugin Directory** empty, click **Validate Paths**, and confirm validation reports the plugin directory as missing.
+3. Set **Lua Plugin Directory** to a folder that exists but does not contain the full `oasis` plugin tree, click **Validate Paths**, and confirm validation reports specific missing files.
+4. Set **Lua Plugin Directory** to a complete `oasis` plugin directory and click **Validate Paths**.
+5. Confirm validation passes and output log includes the success message.
+6. Restart editor and verify that if no plugin path was explicitly saved, the app auto-detects the repo default path `UnityProjects/LayoutEditor_ExternalAssets/Windows/MameLuaPlugins/oasis` when it exists.
+
+### Untested assumptions
+
+- Relative default-path probing from `AppContext.BaseDirectory` to the repo root remains stable for maintainer build/debug layouts.
+- Required file list is sufficient for startup command support currently expected by the editor (excluding optional `snapshot_pixels`).

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -45,6 +45,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool _isRefreshingHierarchy;
     private readonly MfmeImportService _mfmeImportService = new();
     private readonly MameDownloadService _mameDownloadService = new();
+    private readonly MamePluginAssetValidator _mamePluginAssetValidator = new();
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -120,7 +121,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameExecutablePath = preferences.Mame.ExecutablePath;
         _mameInstallRootDirectory = preferences.Mame.InstallRootDirectory;
         _mameReleaseSource = preferences.Mame.ReleaseSource;
-        _mameLuaPluginPath = preferences.Mame.LuaPluginPath;
+        _mameLuaPluginPath = string.IsNullOrWhiteSpace(preferences.Mame.LuaPluginPath)
+            ? GetDefaultLuaPluginPath()
+            : preferences.Mame.LuaPluginPath;
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
@@ -874,7 +877,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             errors.Add("MAME install root directory is missing or does not exist.");
 
         if (string.IsNullOrWhiteSpace(MameLuaPluginPath) || !Directory.Exists(MameLuaPluginPath))
+        {
             errors.Add("Lua plugin directory is missing or does not exist.");
+        }
+        else
+        {
+            var missingPluginFiles = _mamePluginAssetValidator.GetMissingFiles(MameLuaPluginPath);
+            if (missingPluginFiles.Count > 0)
+            {
+                errors.Add($"Lua plugin directory is missing required files: {string.Join(", ", missingPluginFiles)}.");
+            }
+        }
 
         if (string.IsNullOrWhiteSpace(MameVersion) || MameVersion.Any(c => !char.IsDigit(c)))
             errors.Add("MAME version must be numeric (example: 0267).");
@@ -891,6 +904,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+
+    private static string GetDefaultLuaPluginPath()
+    {
+        var appBaseDirectory = AppContext.BaseDirectory;
+        var candidate = Path.GetFullPath(Path.Combine(appBaseDirectory, "..", "..", "..", "..", "..", "UnityProjects", "LayoutEditor_ExternalAssets", "Windows", "MameLuaPlugins", "oasis"));
+        return Directory.Exists(candidate) ? candidate : string.Empty;
+    }
 
     private async void RefreshMameVersions()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MamePluginAssetValidator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MamePluginAssetValidator.cs
@@ -1,0 +1,45 @@
+using System.IO;
+
+namespace OasisEditor;
+
+public sealed class MamePluginAssetValidator
+{
+    private static readonly string[] RequiredRelativePaths =
+    [
+        "plugin.json",
+        "init.lua",
+        "system/utility.lua",
+        "system/stdin_thread.lua",
+        "system/command_processor.lua",
+        "system/commands/exit.lua",
+        "system/commands/pause.lua",
+        "system/commands/resume.lua",
+        "system/commands/soft_reset.lua",
+        "system/commands/hard_reset.lua",
+        "system/commands/throttled.lua",
+        "system/commands/state_load.lua",
+        "system/commands/state_save.lua",
+        "system/commands/state_save_and_exit.lua",
+        "system/commands/set_input_value.lua"
+    ];
+
+    public IReadOnlyList<string> GetMissingFiles(string pluginRootDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(pluginRootDirectory))
+        {
+            return ["<plugin root directory is empty>"];
+        }
+
+        var missing = new List<string>();
+        foreach (var relativePath in RequiredRelativePaths)
+        {
+            var absolutePath = Path.Combine(pluginRootDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(absolutePath))
+            {
+                missing.Add(relativePath);
+            }
+        }
+
+        return missing;
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement Phase E of the MAME emulation port by ensuring the editor can detect and validate the required `oasis` Lua plugin assets before any MAME launch work is attempted.
- Provide better diagnostics for maintainers so missing plugin files are reported precisely and a sensible repo-default plugin path is auto-detected when possible.

### Description

- Added `MamePluginAssetValidator` with `GetMissingFiles(string)` to enumerate required relative plugin files (e.g. `plugin.json`, `init.lua`, `system/*`, and required `system/commands/*`).
- Injected `_mamePluginAssetValidator` into `MainWindowViewModel`, added `GetDefaultLuaPluginPath()` to probe a repo-default `UnityProjects/LayoutEditor_ExternalAssets/.../oasis` path, and used it when no saved plugin path exists.
- Extended `ValidateMamePreferences()` in `MainWindowViewModel` to check for missing plugin files and include list of missing entries in the validation error summary.
- Appended Phase E manual test steps and untested assumptions to `MameEmulationPort.TestLog.md` to guide maintainer-side validation on Windows/.NET.

### Testing

- No automated build or unit tests were run in this environment due to the documented lack of a Windows/.NET/WPF toolchain; automated build/test execution is deferred to the maintainer.
- Repository-level verification performed: added files and changes were staged and committed successfully (`git commit` succeeded).
- File inspection commands used during development (for review) completed successfully (reading `MainWindowViewModel.cs`, `MamePluginAssetValidator.cs`, and `MameEmulationPort.TestLog.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb23437ecc8327b7c3ed0bc2f16d79)