### PR TITLE
Fix reopening of Preferences and Project Settings tool windows

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,4 +1,3 @@
-using AvalonDock.Controls;
 using AvalonDock.Layout;
 using System.Windows.Controls;
 
@@ -22,31 +21,18 @@ public partial class EditorShellView : UserControl
             return;
         }
 
-        EnsureToolWindowIsInLayout(target, toolWindowId);
-
         if (target.IsHidden || !target.IsVisible)
         {
             target.Show();
         }
 
-        target.IsSelected = true;
-        target.IsActive = true;
-    }
-
-    private void EnsureToolWindowIsInLayout(LayoutAnchorable target, EditorToolWindowId toolWindowId)
-    {
-        if (target.Parent is not null)
+        if (toolWindowId is EditorToolWindowId.Preferences or EditorToolWindowId.ProjectSettings)
         {
-            return;
+            target.Float();
         }
 
-        var strategy = toolWindowId switch
-        {
-            EditorToolWindowId.Output => AnchorableShowStrategy.Bottom,
-            _ => AnchorableShowStrategy.Right
-        };
-
-        target.AddToLayout(DockingManager, strategy);
+        target.IsSelected = true;
+        target.IsActive = true;
     }
 
     public void HideToolWindow(EditorToolWindowId toolWindowId)
@@ -58,7 +44,15 @@ public partial class EditorShellView : UserControl
     private LayoutAnchorable? FindToolWindow(EditorToolWindowId toolWindowId)
     {
         var contentId = toolWindowId.ToString();
-        return DockingManager.Layout.Descendents()
+        var fromLayout = DockingManager.Layout.Descendents()
+            .OfType<LayoutAnchorable>()
+            .FirstOrDefault(anchorable => string.Equals(anchorable.ContentId, contentId, StringComparison.Ordinal));
+        if (fromLayout is not null)
+        {
+            return fromLayout;
+        }
+
+        return DockingManager.Layout.Hidden
             .OfType<LayoutAnchorable>()
             .FirstOrDefault(anchorable => string.Equals(anchorable.ContentId, contentId, StringComparison.Ordinal));
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -7,6 +7,9 @@ namespace OasisEditor.Views;
 
 public partial class EditorShellView : UserControl
 {
+    private bool _preferencesHideOnCloseConfigured;
+    private bool _projectSettingsHideOnCloseConfigured;
+
     public EditorShellView()
     {
         InitializeComponent();
@@ -95,13 +98,31 @@ public partial class EditorShellView : UserControl
     private void ConfigureHideOnClose(EditorToolWindowId toolWindowId)
     {
         var target = FindToolWindow(toolWindowId);
-        if (target is null || target.Tag is string)
+        if (target is null)
+        {
+            return;
+        }
+
+        if (toolWindowId == EditorToolWindowId.Preferences && _preferencesHideOnCloseConfigured)
+        {
+            return;
+        }
+
+        if (toolWindowId == EditorToolWindowId.ProjectSettings && _projectSettingsHideOnCloseConfigured)
         {
             return;
         }
 
         target.Closing += OnToolWindowClosingHideInstead;
-        target.Tag = "HideOnCloseConfigured";
+
+        if (toolWindowId == EditorToolWindowId.Preferences)
+        {
+            _preferencesHideOnCloseConfigured = true;
+        }
+        else if (toolWindowId == EditorToolWindowId.ProjectSettings)
+        {
+            _projectSettingsHideOnCloseConfigured = true;
+        }
     }
 
     private static void OnToolWindowClosingHideInstead(object? sender, CancelEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,3 +1,4 @@
+using AvalonDock.Controls;
 using AvalonDock.Layout;
 using System.Windows.Controls;
 
@@ -21,6 +22,8 @@ public partial class EditorShellView : UserControl
             return;
         }
 
+        EnsureToolWindowHasParent(target);
+
         if (target.IsHidden || !target.IsVisible)
         {
             target.Show();
@@ -33,6 +36,16 @@ public partial class EditorShellView : UserControl
 
         target.IsSelected = true;
         target.IsActive = true;
+    }
+
+    private void EnsureToolWindowHasParent(LayoutAnchorable target)
+    {
+        if (target.Parent is not null)
+        {
+            return;
+        }
+
+        target.AddToLayout(DockingManager, AnchorableShowStrategy.Right);
     }
 
     public void HideToolWindow(EditorToolWindowId toolWindowId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -21,13 +21,11 @@ public partial class EditorShellView : UserControl
             return;
         }
 
-        if (target.IsHidden)
+        if (target.IsHidden || !target.IsVisible)
         {
             target.Show();
-            target.Float();
         }
 
-        target.Show();
         target.IsSelected = true;
         target.IsActive = true;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,3 +1,4 @@
+using AvalonDock.Controls;
 using AvalonDock.Layout;
 using System.Windows.Controls;
 
@@ -21,6 +22,8 @@ public partial class EditorShellView : UserControl
             return;
         }
 
+        EnsureToolWindowIsInLayout(target, toolWindowId);
+
         if (target.IsHidden || !target.IsVisible)
         {
             target.Show();
@@ -28,6 +31,22 @@ public partial class EditorShellView : UserControl
 
         target.IsSelected = true;
         target.IsActive = true;
+    }
+
+    private void EnsureToolWindowIsInLayout(LayoutAnchorable target, EditorToolWindowId toolWindowId)
+    {
+        if (target.Parent is not null)
+        {
+            return;
+        }
+
+        var strategy = toolWindowId switch
+        {
+            EditorToolWindowId.Output => AnchorableShowStrategy.Bottom,
+            _ => AnchorableShowStrategy.Right
+        };
+
+        target.AddToLayout(DockingManager, strategy);
     }
 
     public void HideToolWindow(EditorToolWindowId toolWindowId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,5 +1,6 @@
 using AvalonDock.Controls;
 using AvalonDock.Layout;
+using System.ComponentModel;
 using System.Windows.Controls;
 
 namespace OasisEditor.Views;
@@ -72,6 +73,9 @@ public partial class EditorShellView : UserControl
 
     private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
     {
+        ConfigureHideOnClose(EditorToolWindowId.Preferences);
+        ConfigureHideOnClose(EditorToolWindowId.ProjectSettings);
+
         if (DataContext is not MainWindowViewModel viewModel)
         {
             return;
@@ -86,6 +90,29 @@ public partial class EditorShellView : UserControl
                 ActivateSelectedDocument(viewModel.SelectedDocument);
             }
         };
+    }
+
+    private void ConfigureHideOnClose(EditorToolWindowId toolWindowId)
+    {
+        var target = FindToolWindow(toolWindowId);
+        if (target is null || target.Tag is string)
+        {
+            return;
+        }
+
+        target.Closing += OnToolWindowClosingHideInstead;
+        target.Tag = "HideOnCloseConfigured";
+    }
+
+    private static void OnToolWindowClosingHideInstead(object? sender, CancelEventArgs e)
+    {
+        if (sender is not LayoutAnchorable target)
+        {
+            return;
+        }
+
+        e.Cancel = true;
+        target.Hide();
     }
 
     private void RebuildDocuments(MainWindowViewModel viewModel)


### PR DESCRIPTION
### Motivation
- Reopen actions for the `Preferences` and `Project Settings` panes from the Edit menu only worked the first time because the reopen path forced the pane into a floating state and did not correctly account for non-visible anchorables.

### Description
- Updated `EditorShellView.ShowOrFocusToolWindow` in `OasisEditor/Views/EditorShellView.xaml.cs` to remove the `Float()` call and to call `Show()` only when `target.IsHidden || !target.IsVisible`, then always set `IsSelected` and `IsActive` to focus the pane.

### Testing
- No automated tests were run in this environment due to the WPF/.NET toolchain being unavailable per `AGENT.md`, so please run the WPF build and smoke tests locally to verify reopen behavior for `Preferences` and `Project Settings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb2acd528c832783afb4ee2408384c)