### PR TITLE
Fix vertical alignment in Preferences and Project Settings panes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
@@ -13,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -34,7 +35,7 @@
                   ItemsSource="{Binding ThemePreferences}"
                   SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <StackPanel Grid.Row="3"
+        <StackPanel Grid.Row="4"
                     Margin="0,16,0,0"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -36,7 +37,7 @@
         <TextBlock Grid.Row="5" Margin="0,12,0,4" Text="Assets folder" Foreground="{DynamicResource TextSecondaryBrush}" />
         <TextBlock Grid.Row="6" TextWrapping="Wrap" Text="{Binding LoadedProject.AssetsDirectory, TargetNullValue=Open or create a project first.}" />
 
-        <StackPanel Grid.Row="7"
+        <StackPanel Grid.Row="8"
                     Margin="0,16,0,0"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -16,6 +16,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 


### PR DESCRIPTION
### Motivation
- The last control in the Preferences and Project Settings windows was being vertically centered because a star-sized (`*`) row was placed before the final `Auto` row, causing the final content to sit in remaining space instead of being anchored. 
- Ensure the UI content uses `Auto` rows and reserve the expanding `*` row as a spacer so the final buttons and controls stay pinned to the expected positions.

### Description
- Adjusted `Grid.RowDefinitions` in `WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml` so content rows are `Auto` and the expanding `*` row is a spacer before the Close button, and moved the `StackPanel` Close button to `Grid.Row="4"`.
- Updated `WindowsNetProjects/OasisEditor/OasisEditor/ProjectSettingsWindow.xaml` to add the missing `Auto` row for content and moved the Close `StackPanel` to `Grid.Row="8"` so only a trailing `*` row expands.
- Updated `WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml` to insert an additional `Auto` row for the `Fruit machine platform` label and make the final `*` row a trailing spacer, keeping the ComboBox in `Grid.Row="8"`.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not installed (build not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcd4d236488327b85f8009417386c5)