### PR TITLE
Open non-document assets with Windows file association

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -706,7 +706,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         try
         {
-            OpenDocumentFromPath(asset.FullPath);
+            if (ShouldOpenAssetInEditor(asset.FullPath))
+            {
+                OpenDocumentFromPath(asset.FullPath);
+                return;
+            }
+
+            Process.Start(new ProcessStartInfo(asset.FullPath)
+            {
+                UseShellExecute = true
+            });
+            StatusMessage = $"Opened external asset: {asset.DisplayPath}";
+            AddOutputEntry($"Opened asset via Windows association: {asset.FullPath}", OutputLogStatus.Info);
         }
         catch (Exception ex)
         {
@@ -714,6 +725,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Open asset failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Open Asset Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+    private static bool ShouldOpenAssetInEditor(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return string.Equals(extension, ".panel2d", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".cabinet3d", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".machine", StringComparison.OrdinalIgnoreCase);
     }
 
     private void OpenDocumentFromPath(string path)


### PR DESCRIPTION
### Motivation
- Double-clicking non-editor assets in the Assets pane (e.g. `.png`, `.bmp`, `.ttf`) should be handled by the OS default application rather than opened as an OasisEditor document tab.

### Description
- Route asset open logic in `MainWindowViewModel.OpenAssetDocument` to open only Oasis document types (`.panel2d`, `.cabinet3d`, `.machine`) in-editor via `OpenDocumentFromPath`, and launch all other file types using `ProcessStart(new ProcessStartInfo(...){ UseShellExecute = true })` so Windows file associations handle them; added helper `ShouldOpenAssetInEditor` to encapsulate the extension check.

### Testing
- No automated tests were executed in this environment due to the repository constraint against running the Windows/.NET/WPF toolchain here; locally run `dotnet test` for the test suite and manually verify that double-clicking a `.panel2d` still opens an editor tab while double-clicking `.png`, `.bmp`, `.ttf` (and other non-editor types) opens in the OS-associated application and that status/output messages reflect the action.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcdf5fcf88832786a3d6014375b306)