### PR TITLE
Add vertical scrolling to Inspector pane

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -115,20 +115,23 @@
                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                 BorderThickness="1"
                 CornerRadius="4">
-            <StackPanel>
-                <TextBlock FontWeight="SemiBold"
-                           FontSize="14"
-                           Text="{Binding InspectorTitle}" />
-                <Button Margin="0,8,0,0"
-                        HorizontalAlignment="Left"
-                        Content="Test"
-                        Visibility="{Binding ShowLampTestButton, Converter={StaticResource BoolToVisibility}}"
-                        PreviewMouseLeftButtonDown="OnLampTestMouseDown"
-                        PreviewMouseLeftButtonUp="OnLampTestMouseUp"
-                        MouseLeave="OnLampTestMouseLeave" />
-                <ItemsControl Margin="0,10,0,0"
-                              ItemsSource="{Binding InspectorPropertyRows}" />
-            </StackPanel>
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <StackPanel>
+                    <TextBlock FontWeight="SemiBold"
+                               FontSize="14"
+                               Text="{Binding InspectorTitle}" />
+                    <Button Margin="0,8,0,0"
+                            HorizontalAlignment="Left"
+                            Content="Test"
+                            Visibility="{Binding ShowLampTestButton, Converter={StaticResource BoolToVisibility}}"
+                            PreviewMouseLeftButtonDown="OnLampTestMouseDown"
+                            PreviewMouseLeftButtonUp="OnLampTestMouseUp"
+                            MouseLeave="OnLampTestMouseLeave" />
+                    <ItemsControl Margin="0,10,0,0"
+                                  ItemsSource="{Binding InspectorPropertyRows}" />
+                </StackPanel>
+            </ScrollViewer>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- The Inspector pane did not show a vertical scrollbar when its content exceeded the available height, unlike other editor panes such as Hierarchy.
- All inspector content is rendered through the same `ItemsControl` in the view, so fixing the container ensures scrolling for every inspector variation.

### Description
- Wrapped the Inspector pane content in a `ScrollViewer` in `WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml`.
- Set `VerticalScrollBarVisibility="Auto"` so a vertical scrollbar appears only when needed.
- Set `HorizontalScrollBarVisibility="Disabled"` to preserve the intended horizontal layout and avoid horizontal scrolling.

### Testing
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore`, but the command could not run because `dotnet` is not installed in this environment.
- No automated UI/unit tests were executed in this environment; the change is limited to XAML layout and should be validated in a local build/runtime that has `.NET` and the application UI available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fce2b2b5388327b6c480193282e1ed)