### PR TITLE
Fix dark-mode inactive selection styling in Hierarchy and Assets tree views

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -10,6 +10,11 @@
                 <ResourceDictionary Source="Styles/AvalonDockVs2013Palette.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"
+                             Color="{Binding Source={StaticResource SelectionBrush}, Path=Color}" />
+            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}"
+                             Color="{Binding Source={StaticResource TextPrimaryBrush}, Path=Color}" />
+
             <Style TargetType="TextBox">
                 <Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/App.xaml
@@ -10,11 +10,6 @@
                 <ResourceDictionary Source="Styles/AvalonDockVs2013Palette.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"
-                             Color="{Binding Source={StaticResource SelectionBrush}, Path=Color}" />
-            <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}"
-                             Color="{Binding Source={StaticResource TextPrimaryBrush}, Path=Color}" />
-
             <Style TargetType="TextBox">
                 <Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
@@ -141,7 +141,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
             ["TextMutedBrush"] = (Color)ColorConverter.ConvertFromString("#FFA6ABB1"),
             ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FF3B3F45"),
             ["BorderStrongBrush"] = (Color)ColorConverter.ConvertFromString("#FF50555C"),
-            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF3B82F6"),
+            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF294859"),
             ["DisabledBrush"] = (Color)ColorConverter.ConvertFromString("#FF6B7077")
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
@@ -61,6 +61,8 @@ public sealed class ApplicationThemeService : IApplicationThemeService
         application.Resources[SystemColors.ControlTextBrushKey] = new SolidColorBrush(textPrimary);
         application.Resources[SystemColors.HighlightBrushKey] = new SolidColorBrush(selection);
         application.Resources[SystemColors.HighlightTextBrushKey] = new SolidColorBrush(textPrimary);
+        application.Resources[SystemColors.InactiveSelectionHighlightBrushKey] = new SolidColorBrush(selection);
+        application.Resources[SystemColors.InactiveSelectionHighlightTextBrushKey] = new SolidColorBrush(textPrimary);
 
         application.Resources["ComboBox.Static.Background"] = new SolidColorBrush(panelBackground);
         application.Resources["ComboBox.Static.Foreground"] = new SolidColorBrush(textPrimary);
@@ -139,7 +141,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
             ["TextMutedBrush"] = (Color)ColorConverter.ConvertFromString("#FFA6ABB1"),
             ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FF3B3F45"),
             ["BorderStrongBrush"] = (Color)ColorConverter.ConvertFromString("#FF50555C"),
-            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF555A62"),
+            ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF3B82F6"),
             ["DisabledBrush"] = (Color)ColorConverter.ConvertFromString("#FF6B7077")
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -68,8 +68,19 @@
                 </TreeView.ContextMenu>
                 <TreeView.ItemContainerStyle>
                     <Style TargetType="{x:Type TreeViewItem}">
+                        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                         <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                        <Style.Triggers>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsSelected" Value="True" />
+                                    <Condition Property="Selector.IsSelectionActive" Value="False" />
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />
+                            </MultiTrigger>
+                        </Style.Triggers>
                     </Style>
                 </TreeView.ItemContainerStyle>
                 <TreeView.Resources>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -79,6 +79,16 @@
                     <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Style.Triggers>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="True" />
+                                <Condition Property="Selector.IsSelectionActive" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />
+                        </MultiTrigger>
+                    </Style.Triggers>
                     <EventSetter Event="Selected" Handler="OnTreeViewItemSelected" />
                 </Style>
                 <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -79,6 +79,7 @@
                     <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <EventSetter Event="Selected" Handler="OnTreeViewItemSelected" />
                     <Style.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -89,7 +90,6 @@
                             <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />
                         </MultiTrigger>
                     </Style.Triggers>
-                    <EventSetter Event="Selected" Handler="OnTreeViewItemSelected" />
                 </Style>
                 <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"
                                           ItemsSource="{Binding Children}">


### PR DESCRIPTION
### Motivation
- In Dark mode, selected items in the Hierarchy pane and the left Assets tree were reverting to system/light inactive-selection colors when the control lost focus (e.g. after right-click or switching panes), making text and selection appear wrong for the theme.

### Description
- Updated `HierarchyView.xaml` to add a `MultiTrigger` for `IsSelected=True` and `Selector.IsSelectionActive=False` that forces the `Foreground` to `TextPrimaryBrush` and `Background` to `SelectionBrush` so unfocused selected items keep editor theme colors.
- Updated `AssetBrowserView.xaml` `TreeView.ItemContainerStyle` with the same `MultiTrigger` and added a default `Foreground` setter to ensure consistent text color when selection becomes inactive.

### Testing
- No automated tests were executed in this environment due to the repository's environment constraints; visual verification of inactive selection colors should be performed locally (open the editor in Dark mode, select an item, then remove focus or open the context menu to confirm the selection retains `TextPrimaryBrush` and `SelectionBrush`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff32f173fc83278200404c2b581539)