### PR TITLE
Differentiate inactive tree selection highlighting in Assets/Hierarchy panes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ApplicationThemeService.cs
@@ -50,6 +50,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
         var panelBackground = palette["PanelBackgroundBrush"];
         var textPrimary = palette["TextPrimaryBrush"];
         var selection = palette["SelectionBrush"];
+        var inactiveSelection = palette["InactiveSelectionBrush"];
         var borderSubtle = palette["BorderSubtleBrush"];
         var borderStrong = palette["BorderStrongBrush"];
         var hover = palette["ControlHoverBrush"];
@@ -61,7 +62,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
         application.Resources[SystemColors.ControlTextBrushKey] = new SolidColorBrush(textPrimary);
         application.Resources[SystemColors.HighlightBrushKey] = new SolidColorBrush(selection);
         application.Resources[SystemColors.HighlightTextBrushKey] = new SolidColorBrush(textPrimary);
-        application.Resources[SystemColors.InactiveSelectionHighlightBrushKey] = new SolidColorBrush(selection);
+        application.Resources[SystemColors.InactiveSelectionHighlightBrushKey] = new SolidColorBrush(inactiveSelection);
         application.Resources[SystemColors.InactiveSelectionHighlightTextBrushKey] = new SolidColorBrush(textPrimary);
 
         application.Resources["ComboBox.Static.Background"] = new SolidColorBrush(panelBackground);
@@ -121,6 +122,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
             ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FFD9E0EE"),
             ["BorderStrongBrush"] = (Color)ColorConverter.ConvertFromString("#FFB9C7DA"),
             ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FFCCE0FF"),
+            ["InactiveSelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FFE4E7ED"),
             ["DisabledBrush"] = (Color)ColorConverter.ConvertFromString("#FFB7BFCC")
         };
     }
@@ -142,6 +144,7 @@ public sealed class ApplicationThemeService : IApplicationThemeService
             ["BorderSubtleBrush"] = (Color)ColorConverter.ConvertFromString("#FF3B3F45"),
             ["BorderStrongBrush"] = (Color)ColorConverter.ConvertFromString("#FF50555C"),
             ["SelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF294859"),
+            ["InactiveSelectionBrush"] = (Color)ColorConverter.ConvertFromString("#FF4A4E53"),
             ["DisabledBrush"] = (Color)ColorConverter.ConvertFromString("#FF6B7077")
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -78,7 +78,7 @@
                                     <Condition Property="Selector.IsSelectionActive" Value="False" />
                                 </MultiTrigger.Conditions>
                                 <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
-                                <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
                             </MultiTrigger>
                         </Style.Triggers>
                     </Style>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -87,7 +87,7 @@
                                 <Condition Property="Selector.IsSelectionActive" Value="False" />
                             </MultiTrigger.Conditions>
                             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource SelectionBrush}" />
+                            <Setter Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
                         </MultiTrigger>
                     </Style.Triggers>
                 </Style>


### PR DESCRIPTION
### Motivation
- Improve visual clarity by showing a distinct (grey) selection highlight when an AvalonDock pane is inactive while keeping the existing blue highlight when the pane is active.
- Ensure the inactive/active selection distinction works in both Light and Dark editor themes.

### Description
- Introduced a new theme color key `InactiveSelectionBrush` in both the Light and Dark palettes in `ApplicationThemeService`.
- Wire `SystemColors.InactiveSelectionHighlightBrushKey` to `InactiveSelectionBrush` so system inactive-selection resources use the dedicated color.
- Updated `TreeViewItem` style triggers in `Views/AssetBrowserView.xaml` to use `InactiveSelectionBrush` when `Selector.IsSelectionActive` is `False` so inactive-pane selections render gray.
- Updated `TreeViewItem` style triggers in `Views/HierarchyView.xaml` to use `InactiveSelectionBrush` under the same inactive-selection condition.

### Testing
- Attempted to run `dotnet build OasisEditor.sln -v minimal` but the build could not run in this environment because `dotnet` is not installed (build not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff3981ad188327acdbb9fa13f1e0ed)