### PR TITLE
Remove per-item outlines from editor menu rows

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
@@ -25,7 +25,7 @@
         <Setter Property="BorderBrush"
                 Value="{DynamicResource BorderSubtleBrush}" />
         <Setter Property="BorderThickness"
-                Value="1" />
+                Value="0" />
         <Setter Property="Padding"
                 Value="8,4" />
         <Setter Property="FontSize"
@@ -38,7 +38,7 @@
                                 Padding="{TemplateBinding Padding}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="1"
+                                BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="4">
                             <DockPanel LastChildFill="True"
                                        TextElement.Foreground="{TemplateBinding Foreground}">
@@ -80,9 +80,6 @@
                             <Setter TargetName="MenuItemBorder"
                                     Property="Background"
                                     Value="{DynamicResource ControlPressedBrush}" />
-                            <Setter TargetName="MenuItemBorder"
-                                    Property="BorderBrush"
-                                    Value="{DynamicResource BorderStrongBrush}" />
                         </Trigger>
                         <Trigger Property="Role"
                                  Value="TopLevelHeader">


### PR DESCRIPTION
### Motivation
- Menu rows in both the top OS menus and right-click context menus were drawing a visible outline around each item; the intent is to make hover/selection appear as a background-only highlight and keep only a single outer menu border.

### Description
- Set `EditorMenuItemStyle` `BorderThickness` to `0` in `WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml` so individual menu rows no longer draw an outline.
- Changed the per-item container `Border` (`MenuItemBorder`) to use `BorderThickness="{TemplateBinding BorderThickness}"` so row borders follow the style value.
- Removed the `IsHighlighted` trigger that set the item `BorderBrush` to `BorderStrongBrush` so highlight is applied only via background (`ControlPressedBrush`).
- Left the popup/context menu outer `Border` intact (its `BorderThickness` remains non-zero) so the menu surface still has a clear outer boundary.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj` to validate XAML/resource changes, but the build could not run because `dotnet` is not installed (`dotnet: command not found`).
- No other automated tests were executed in this environment due to the missing `dotnet` SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff3ca037e883278070c54418df066b)