### PR TITLE
Inspector: use InspectorBackgroundBrush for pane background

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -111,7 +111,7 @@
 
     <Grid>
         <Border Padding="8"
-                Background="{DynamicResource SelectionBrush}"
+                Background="{DynamicResource InspectorBackgroundBrush}"
                 BorderBrush="{DynamicResource BorderSubtleBrush}"
                 BorderThickness="1"
                 CornerRadius="4">


### PR DESCRIPTION
### Motivation
- The Inspector view was using the `SelectionBrush` which produced an unintended blue selection tint; the pane should use a semantic theme brush that works in both Light and Dark modes.

### Description
- Replaced `Background="{DynamicResource SelectionBrush}"` with `Background="{DynamicResource InspectorBackgroundBrush}"` in `OasisEditor/Views/InspectorView.xaml` so the Inspector pane uses the intended theme brush.

### Testing
- No automated tests were executed in this environment because the WPF/.NET toolchain is unavailable; please run `dotnet test` for the solution locally and visually verify the Inspector in both Light and Dark themes to confirm the blue tint is removed and that selection highlighting in Hierarchy/Assets still behaves correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff4f21ad1c8327b7cdf7e24ce6a20b)