### PR TITLE
Preferences: two-pane category UI and managed MAME path ownership

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -13,9 +13,7 @@ public sealed class MamePreferences
 {
     public string Version { get; init; } = "0267";
     public string ExecutablePath { get; init; } = string.Empty;
-    public string InstallRootDirectory { get; init; } = string.Empty;
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
-    public string LuaPluginPath { get; init; } = string.Empty;
     public string CommandLineOverrides { get; init; } = string.Empty;
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -121,7 +121,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _selectedThemePreference = preferences.ThemePreference;
         _mameVersion = preferences.Mame.Version;
         _mameExecutablePath = preferences.Mame.ExecutablePath;
-        _mameInstallRootDirectory = GetManagedMameRuntimeRootDirectory();
+        _mameInstallRootDirectory = EnsureManagedMameRuntimeRootDirectory();
         _mameReleaseSource = preferences.Mame.ReleaseSource;
         _mameLuaPluginPath = GetDefaultLuaPluginPath();
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
@@ -893,19 +893,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         else if (!string.Equals(Path.GetFileName(MameExecutablePath), "mame.exe", StringComparison.OrdinalIgnoreCase))
             errors.Add("MAME executable path must point to mame.exe.");
 
-        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory) || !Directory.Exists(MameInstallRootDirectory))
-            errors.Add("MAME install root directory is missing or does not exist.");
+        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory))
+            errors.Add("Managed MAME runtime root could not be resolved.");
+        else if (!Directory.Exists(MameInstallRootDirectory))
+            Directory.CreateDirectory(MameInstallRootDirectory);
 
         if (string.IsNullOrWhiteSpace(MameLuaPluginPath) || !Directory.Exists(MameLuaPluginPath))
         {
-            errors.Add("Lua plugin directory is missing or does not exist.");
+            errors.Add("Managed Lua plugin source could not be located in editor assets.");
         }
         else
         {
             var missingPluginFiles = _mamePluginAssetValidator.GetMissingFiles(MameLuaPluginPath);
             if (missingPluginFiles.Count > 0)
             {
-                errors.Add($"Lua plugin directory is missing required files: {string.Join(", ", missingPluginFiles)}.");
+                errors.Add($"Managed Lua plugin source is missing required files: {string.Join(", ", missingPluginFiles)}.");
             }
         }
 
@@ -932,12 +934,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return Directory.Exists(candidate) ? candidate : string.Empty;
     }
 
-    private static string GetManagedMameRuntimeRootDirectory()
+    private static string EnsureManagedMameRuntimeRootDirectory()
     {
-        return Path.Combine(
+        var root = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "OasisEditor",
             "MAME");
+        Directory.CreateDirectory(root);
+        return root;
     }
 
     private async void RefreshMameVersions()
@@ -1013,9 +1017,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             {
                 Version = MameVersion,
                 ExecutablePath = MameExecutablePath,
-                InstallRootDirectory = MameInstallRootDirectory,
                 ReleaseSource = MameReleaseSource,
-                LuaPluginPath = MameLuaPluginPath,
                 CommandLineOverrides = MameCommandLineOverrides
             }
         });

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
@@ -2,47 +2,83 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Preferences"
-        Width="630"
-        Height="220"
-        MinWidth="380"
-        MinHeight="200"
+        Width="760"
+        Height="460"
+        MinWidth="540"
+        MinHeight="360"
         WindowStartupLocation="CenterOwner"
         Background="{DynamicResource PanelBackgroundBrush}"
         Foreground="{DynamicResource TextPrimaryBrush}">
     <Grid Margin="16">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="170" />
+            <ColumnDefinition Width="16" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0"
-                   FontSize="18"
-                   FontWeight="SemiBold"
-                   Foreground="{DynamicResource TextPrimaryBrush}"
-                   Text="Editor Preferences" />
+        <Border Grid.Column="0" Padding="8">
+            <ListBox ItemsSource="{Binding PreferencesCategories}"
+                     SelectedItem="{Binding SelectedPreferencesCategory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </Border>
 
-        <TextBlock Grid.Row="1"
-                   Margin="0,16,0,6"
-                   Foreground="{DynamicResource TextSecondaryBrush}"
-                   Text="Theme" />
+        <ContentControl Grid.Column="2">
+            <ContentControl.Style>
+                <Style TargetType="ContentControl">
+                    <Setter Property="Content" Value="{x:Null}" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding SelectedPreferencesCategory}" Value="Appearance">
+                            <Setter Property="ContentTemplate">
+                                <Setter.Value>
+                                    <DataTemplate>
+                                        <StackPanel>
+                                            <TextBlock FontSize="18" FontWeight="SemiBold" Text="Appearance" />
+                                            <TextBlock Margin="0,16,0,6" Foreground="{DynamicResource TextSecondaryBrush}" Text="Theme" />
+                                            <ComboBox Width="180"
+                                                      HorizontalAlignment="Left"
+                                                      ItemsSource="{Binding ThemePreferences}"
+                                                      SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding SelectedPreferencesCategory}" Value="MAME">
+                            <Setter Property="ContentTemplate">
+                                <Setter.Value>
+                                    <DataTemplate>
+                                        <StackPanel>
+                                            <TextBlock FontSize="18" FontWeight="SemiBold" Text="MAME" />
+                                            <TextBlock Margin="0,16,0,4" Text="MAME Version" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <TextBox Text="{Binding MameVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-        <ComboBox Grid.Row="2"
-                  Width="180"
-                  HorizontalAlignment="Left"
-                  ItemsSource="{Binding ThemePreferences}"
-                  SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBlock Margin="0,8,0,4" Text="MAME Executable" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <TextBox Grid.Column="0" Margin="0,0,8,0" Text="{Binding MameExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                <Button Grid.Column="1" Padding="10,4" Content="Browse..." Command="{Binding BrowseMameExecutableCommand}" />
+                                            </Grid>
 
-        <StackPanel Grid.Row="4"
-                    Margin="0,16,0,0"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right">
-            <Button MinWidth="96"
-                    Padding="12,6"
-                    Command="{Binding ClosePreferencesCommand}"
-                    Content="Close" />
-        </StackPanel>
+                                            <TextBlock Margin="0,8,0,4" Text="Managed Runtime Root" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <TextBox IsReadOnly="True" Text="{Binding MameInstallRootDirectory, Mode=OneWay}" />
+
+                                            <TextBlock Margin="0,8,0,4" Text="Managed Lua Plugin Source" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <TextBox IsReadOnly="True" Text="{Binding MameLuaPluginPath, Mode=OneWay}" />
+
+                                            <StackPanel Margin="0,12,0,0" Orientation="Horizontal">
+                                                <Button Padding="10,4" Content="Validate Setup" Command="{Binding ValidateMamePreferencesCommand}" />
+                                                <TextBlock Margin="12,4,0,0" Text="{Binding MameValidationSummary}" TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ContentControl.Style>
+        </ContentControl>
     </Grid>
 </Window>


### PR DESCRIPTION
### Motivation
- Move Preferences to a category-driven two-pane layout so future categories can be added cleanly and the UI matches the MAME redesign direction.
- Remove end-user filesystem configuration for MAME runtime/plugin paths and make the editor own those paths to reduce invalid setup states.
- Prepare the codebase for automatic MAME plugin deployment and managed per-version installs under LocalAppData.

### Description
- Reworked the Preferences UI into a two-pane layout with a left `ListBox` of categories (`Appearance`, `MAME`) and right-side category templates in `PreferencesWindow.xaml`, keeping theme selection in `Appearance` bound to `ThemePreferences`/`SelectedThemePreference`.
- Removed `InstallRootDirectory` and `LuaPluginPath` from the persisted `MamePreferences` model in `EditorPreferences.cs` so those are no longer user-editable persisted fields.
- Updated `MainWindowViewModel` to ensure a managed runtime root via `EnsureManagedMameRuntimeRootDirectory()` (targets `%LOCALAPPDATA%\OasisEditor\MAME`), to use `GetDefaultLuaPluginPath()` as the editor-owned plugin source, and to change validation/messages to reflect managed ownership; also removed saving of install/plugin paths in `SavePreferences`.
- Made the managed runtime root directory auto-created when preferences are loaded to avoid requiring a user-configured install-root value.

### Testing
- Applied the file updates and performed repository-level checks to verify the changes were written and the workspace is in a clean state; those checks completed successfully.
- No compile, unit, or UI integration tests were executed in this environment because the Windows/.NET/WPF toolchain is not available here per project constraints, so build/test runs must be performed locally by the maintainer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a008a4960e083279aeea415480c5ad5)