### PR TITLE
Refine MAME preferences to editor-managed runtime paths

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PreferencesWindow.xaml
@@ -61,11 +61,17 @@
                                                 <Button Grid.Column="1" Padding="10,4" Content="Browse..." Command="{Binding BrowseMameExecutableCommand}" />
                                             </Grid>
 
-                                            <TextBlock Margin="0,8,0,4" Text="Managed Runtime Root" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <TextBox IsReadOnly="True" Text="{Binding MameInstallRootDirectory, Mode=OneWay}" />
-
-                                            <TextBlock Margin="0,8,0,4" Text="Managed Lua Plugin Source" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <TextBox IsReadOnly="True" Text="{Binding MameLuaPluginPath, Mode=OneWay}" />
+                                            <Border Margin="0,12,0,0" Padding="12" CornerRadius="4" Background="#22000000">
+                                                <StackPanel>
+                                                    <TextBlock FontWeight="SemiBold" Text="Editor-managed runtime paths" />
+                                                    <TextBlock Margin="0,6,0,0"
+                                                               Foreground="{DynamicResource TextSecondaryBrush}"
+                                                               Text="MAME runtime root is managed automatically at %LOCALAPPDATA%\OasisEditor\MAME\." />
+                                                    <TextBlock Margin="0,4,0,0"
+                                                               Foreground="{DynamicResource TextSecondaryBrush}"
+                                                               Text="Lua plugin deployment is automatic and no longer configured per-user." />
+                                                </StackPanel>
+                                            </Border>
 
                                             <StackPanel Margin="0,12,0,0" Orientation="Horizontal">
                                                 <Button Padding="10,4" Content="Validate Setup" Command="{Binding ValidateMamePreferencesCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -63,11 +63,17 @@
                     <Button Grid.Column="1" Padding="10,4" Content="Browse..." Command="{Binding BrowseMameExecutableCommand}" />
                 </Grid>
 
-                <TextBlock Margin="0,8,0,4" Text="Managed Runtime Root" Foreground="{DynamicResource TextSecondaryBrush}" />
-                <TextBox IsReadOnly="True" Text="{Binding MameInstallRootDirectory, Mode=OneWay}" />
-
-                <TextBlock Margin="0,8,0,4" Text="Managed Lua Plugin Source" Foreground="{DynamicResource TextSecondaryBrush}" />
-                <TextBox IsReadOnly="True" Text="{Binding MameLuaPluginPath, Mode=OneWay}" />
+                <Border Margin="0,12,0,0" Padding="12" CornerRadius="4" Background="#22000000">
+                    <StackPanel>
+                        <TextBlock FontWeight="SemiBold" Text="Editor-managed runtime paths" />
+                        <TextBlock Margin="0,6,0,0"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   Text="MAME runtime root is managed automatically at %LOCALAPPDATA%\OasisEditor\MAME\." />
+                        <TextBlock Margin="0,4,0,0"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   Text="Lua plugin deployment is automatic and no longer configured per-user." />
+                    </StackPanel>
+                </Border>
 
                 <StackPanel Margin="0,12,0,0" Orientation="Horizontal">
                     <Button Padding="10,4" Content="Validate Setup" Command="{Binding ValidateMamePreferencesCommand}" />


### PR DESCRIPTION
### Motivation
- Align the Preferences UI with the current project direction to treat MAME runtime paths and Lua plugin deployment as editor-managed infrastructure rather than user-editable fields.
- Keep the Appearance category and existing MAME actions (version, executable selection, validation) intact while removing editable path fields that were confusing and error-prone.

### Description
- Replaced the editable/read-only path fields for the managed MAME install root and Lua plugin directory with a consolidated informational panel in `OasisEditor/Views/PreferencesView.xaml` and `OasisEditor/PreferencesWindow.xaml` that explains the editor-managed locations and behavior.
- Preserved MAME controls for `MameVersion`, `MameExecutablePath`, `Validate Setup`, and the version/download/action buttons so functionality remains available while ownership of runtime paths is moved to the editor.
- Updated the displayed messaging to explicitly reference the managed runtime root at `%LOCALAPPDATA%\OasisEditor\MAME\` and to state that Lua plugin deployment is automatic and not configurable per-user.

### Testing
- No automated tests were executed in this environment due to the repository's Windows/.NET/WPF toolchain constraints and the local testing policy; automated build/tests should be run locally and verified (see PR notes for manual checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a008b566bcc832791b7418dc55da1c1)