### PR TITLE
Preferences: display editor-managed MAME paths and add disabled Re-sync action

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -68,7 +68,16 @@
                         <TextBlock FontWeight="SemiBold" Text="Editor-managed runtime paths" />
                         <TextBlock Margin="0,6,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
-                                   Text="MAME runtime root is managed automatically at %LOCALAPPDATA%\OasisEditor\MAME\." />
+                                   Text="MAME runtime root (editor-managed)" />
+                        <TextBox Margin="0,4,0,0"
+                                 IsReadOnly="True"
+                                 Text="{Binding MameInstallRootDirectory}" />
+                        <TextBlock Margin="0,4,0,0"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   Text="Lua plugin source (editor-managed)" />
+                        <TextBox Margin="0,4,0,0"
+                                 IsReadOnly="True"
+                                 Text="{Binding MameLuaPluginPath}" />
                         <TextBlock Margin="0,4,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    Text="Lua plugin deployment is automatic and no longer configured per-user." />
@@ -84,6 +93,7 @@
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Refresh Versions" Command="{Binding RefreshMameVersionsCommand}" />
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Download Selected" Command="{Binding DownloadMameVersionCommand}" />
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Open Install Folder" Command="{Binding OpenMameInstallRootCommand}" />
+                    <Button Padding="10,4" Margin="0,0,8,0" Content="Re-sync Lua Plugins (TODO)" IsEnabled="False" ToolTip="Planned editor-managed plugin deployment action." />
                     <Button Padding="10,4" Content="Remove Cached Version" Command="{Binding RemoveCachedMameVersionCommand}" />
                 </StackPanel>
             </StackPanel>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -71,13 +71,13 @@
                                    Text="MAME runtime root (editor-managed)" />
                         <TextBox Margin="0,4,0,0"
                                  IsReadOnly="True"
-                                 Text="{Binding MameInstallRootDirectory}" />
+                                 Text="{Binding MameInstallRootDirectory, Mode=OneWay}" />
                         <TextBlock Margin="0,4,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    Text="Lua plugin source (editor-managed)" />
                         <TextBox Margin="0,4,0,0"
                                  IsReadOnly="True"
-                                 Text="{Binding MameLuaPluginPath}" />
+                                 Text="{Binding MameLuaPluginPath, Mode=OneWay}" />
                         <TextBlock Margin="0,4,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    Text="Lua plugin deployment is automatic and no longer configured per-user." />


### PR DESCRIPTION
### Motivation
- Make MAME preferences align with the editor-managed runtime model by surfacing the managed runtime root and Lua plugin source as read-only fields and by signaling a planned plugin sync action without exposing user-editable runtime paths.

### Description
- Updated `Views/PreferencesView.xaml` to show read-only `TextBox` bindings for `MameInstallRootDirectory` and `MameLuaPluginPath`, replaced the prior static explanatory text with these explicit fields, and added a disabled `Re-sync Lua Plugins (TODO)` button while keeping existing MAME controls and commands intact.

### Testing
- Verified the XAML change via automated file inspection commands (`sed`/`nl`) to confirm `Views/PreferencesView.xaml` now contains the read-only bindings to `MameInstallRootDirectory` and `MameLuaPluginPath` and the disabled re-sync button; no unit or integration tests were executed in this environment due to toolchain constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a008ca85dc083278b0d9c869e6ba051)