### PR TITLE
Refactor MAME preferences setup state and orchestrator

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/IMameSetupOrchestrator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/IMameSetupOrchestrator.cs
@@ -1,0 +1,6 @@
+namespace OasisEditor;
+
+public interface IMameSetupOrchestrator
+{
+    Task<MameSetupState> ValidateAsync(MameSetupValidationRequest request, CancellationToken cancellationToken);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -48,9 +48,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly MfmeImportService _mfmeImportService = new();
     private readonly MameDownloadService _mameDownloadService = new();
     private readonly MamePluginAssetValidator _mamePluginAssetValidator = new();
-    private readonly IMameSetupValidationService _mameSetupValidationService;
-    private MameSetupPhase _mameSetupPhase = MameSetupPhase.NotStarted;
-    private string _mameSetupLatestKnownVersion = "Unknown";
+    private readonly IMameSetupOrchestrator _mameSetupOrchestrator;
+    private MameSetupState _mameSetupState = MameSetupState.NotStarted;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -128,7 +127,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameReleaseSource = preferences.Mame.ReleaseSource;
         _mameLuaPluginPath = GetDefaultLuaPluginPath();
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
-        _mameSetupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameDownloadService);
+        var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameDownloadService);
+        _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
@@ -301,8 +301,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
-    public string MameSetupPhaseDisplay => _mameSetupPhase.ToString();
-    public string MameSetupLatestKnownVersion { get => _mameSetupLatestKnownVersion; private set => SetProperty(ref _mameSetupLatestKnownVersion, value); }
+    public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
+    public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
+    public bool IsMameSetupInProgress => _mameSetupState.IsInProgress;
     public string SelectedPreferencesCategory
     {
         get => _selectedPreferencesCategory;
@@ -898,10 +899,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private async Task ValidateMamePreferencesAsync()
     {
-        _mameSetupPhase = MameSetupPhase.Validating;
+        _mameSetupState = new MameSetupState(MameSetupPhase.Validating, "Validating setup...", MameSetupLatestKnownVersion, true);
         OnPropertyChanged(nameof(MameSetupPhaseDisplay));
+        OnPropertyChanged(nameof(IsMameSetupInProgress));
 
-        var state = await _mameSetupValidationService.ValidateAsync(
+        var state = await _mameSetupOrchestrator.ValidateAsync(
             new MameSetupValidationRequest(
                 MameExecutablePath,
                 MameInstallRootDirectory,
@@ -910,11 +912,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 MameReleaseSource),
             CancellationToken.None);
 
-        _mameSetupPhase = state.Phase;
+        _mameSetupState = state;
         OnPropertyChanged(nameof(MameSetupPhaseDisplay));
-        MameSetupLatestKnownVersion = string.IsNullOrWhiteSpace(state.LatestKnownVersion)
-            ? "Unknown"
-            : state.LatestKnownVersion;
+        OnPropertyChanged(nameof(MameSetupLatestKnownVersion));
+        OnPropertyChanged(nameof(IsMameSetupInProgress));
         MameValidationSummary = state.Summary;
 
         if (state.Phase == MameSetupPhase.Ready)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupOrchestrator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupOrchestrator.cs
@@ -1,0 +1,21 @@
+namespace OasisEditor;
+
+public sealed class MameSetupOrchestrator : IMameSetupOrchestrator
+{
+    private readonly IMameSetupValidationService _validationService;
+
+    public MameSetupOrchestrator(IMameSetupValidationService validationService)
+    {
+        _validationService = validationService;
+    }
+
+    public async Task<MameSetupState> ValidateAsync(MameSetupValidationRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _validationService.ValidateAsync(request, cancellationToken);
+        return new MameSetupState(
+            result.Phase,
+            result.Summary,
+            string.IsNullOrWhiteSpace(result.LatestKnownVersion) ? "Unknown" : result.LatestKnownVersion,
+            false);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupState.cs
@@ -1,9 +1,17 @@
 namespace OasisEditor;
 
+public enum MameSetupPhase
+{
+    NotStarted,
+    Validating,
+    Ready,
+    NeedsAttention
+}
+
 public sealed record MameSetupState(
     MameSetupPhase Phase,
     string Summary,
-    string LatestKnownVersion,
+    string? LatestKnownVersion,
     bool IsInProgress)
 {
     public static MameSetupState NotStarted { get; } = new(MameSetupPhase.NotStarted, "Not started.", "Unknown", false);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupState.cs
@@ -1,16 +1,10 @@
 namespace OasisEditor;
 
-public enum MameSetupPhase
-{
-    NotStarted,
-    Validating,
-    Ready,
-    NeedsAttention,
-    Failed
-}
-
 public sealed record MameSetupState(
     MameSetupPhase Phase,
     string Summary,
-    string? LatestKnownVersion,
-    DateTimeOffset TimestampUtc);
+    string LatestKnownVersion,
+    bool IsInProgress)
+{
+    public static MameSetupState NotStarted { get; } = new(MameSetupPhase.NotStarted, "Not started.", "Unknown", false);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
@@ -61,13 +61,13 @@ public sealed class MameSetupValidationService : IMameSetupValidationService
                 MameSetupPhase.NeedsAttention,
                 string.Join(" ", issues),
                 latestVersion,
-                DateTimeOffset.UtcNow);
+                false);
         }
 
         return new MameSetupState(
             MameSetupPhase.Ready,
             "MAME setup is valid.",
             latestVersion,
-            DateTimeOffset.UtcNow);
+            false);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -94,6 +94,18 @@
                 <TextBlock Margin="0,2,0,0"
                            Foreground="{DynamicResource TextSecondaryBrush}"
                            Text="{Binding MameSetupLatestKnownVersion, StringFormat=Latest known MAME version: {0}}" />
+                <ProgressBar Margin="0,8,0,0" Height="6" IsIndeterminate="True">
+                    <ProgressBar.Style>
+                        <Style TargetType="ProgressBar">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsMameSetupInProgress}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ProgressBar.Style>
+                </ProgressBar>
 
                 <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Refresh Versions" Command="{Binding RefreshMameVersionsCommand}" />


### PR DESCRIPTION
### Motivation
- Centralize and simplify MAME setup/validation state so the Preferences UI can bind to a single cohesive state and show background progress without the view model directly managing validation service details.
- Prepare the codebase for future background provisioning and plugin-sync work by introducing a small orchestration abstraction and a binding-friendly state record.

### Description
- Added `MameSetupState` to represent phase, summary, latest-known-version, and in-progress flag. (OasisEditor/MameSetupState.cs)
- Introduced `IMameSetupOrchestrator` and `MameSetupOrchestrator` to wrap the existing validation service and provide a single async `ValidateAsync` entrypoint. (OasisEditor/IMameSetupOrchestrator.cs, OasisEditor/MameSetupOrchestrator.cs)
- Updated `MainWindowViewModel` to use the orchestrator and a `_mameSetupState` instance, and to expose `MameSetupPhaseDisplay`, `MameSetupLatestKnownVersion`, and `IsMameSetupInProgress` for bindings; adjusted the validation flow to publish in-progress state before validating and the final state after completion. (OasisEditor/MainWindowViewModel.cs)
- Updated the Preferences MAME UI to display an indeterminate progress bar while setup validation is in progress and wired it to the new `IsMameSetupInProgress` property. (OasisEditor/Views/PreferencesView.xaml)

### Testing
- No automated tests were executed in this codex environment due to toolchain constraints; please run `dotnet build` and the project test suite locally to verify compilation and regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a009cdaca3c832784f0ca1043266725)