### PR TITLE
Add MAME Lua plugin re-sync action and deployment service

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -48,6 +48,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly MfmeImportService _mfmeImportService = new();
     private readonly MameDownloadService _mameDownloadService = new();
     private readonly MamePluginAssetValidator _mamePluginAssetValidator = new();
+    private readonly MamePluginDeploymentService _mamePluginDeploymentService = new();
     private readonly IMameSetupOrchestrator _mameSetupOrchestrator;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
 
@@ -86,6 +87,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RefreshMameVersionsCommand = new RelayCommand(RefreshMameVersions);
         DownloadMameVersionCommand = new RelayCommand(DownloadMameVersion);
         OpenMameInstallRootCommand = new RelayCommand(OpenMameInstallRoot);
+        ResyncMamePluginsCommand = new RelayCommand(ResyncMamePlugins);
         RemoveCachedMameVersionCommand = new RelayCommand(RemoveCachedMameVersion);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
@@ -244,6 +246,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand RefreshMameVersionsCommand { get; }
     public ICommand DownloadMameVersionCommand { get; }
     public ICommand OpenMameInstallRootCommand { get; }
+    public ICommand ResyncMamePluginsCommand { get; }
     public ICommand RemoveCachedMameVersionCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
@@ -986,6 +989,20 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         System.Diagnostics.Process.Start("explorer.exe", MameInstallRootDirectory);
     }
 
+
+    private void ResyncMamePlugins()
+    {
+        try
+        {
+            var copied = _mamePluginDeploymentService.SyncPluginFiles(MameLuaPluginPath, MameExecutablePath);
+            AddOutputEntry($"Re-synced Oasis Lua plugins into active MAME install ({copied} files copied).", OutputLogStatus.Info);
+            ValidateMamePreferences();
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Failed to re-sync Oasis Lua plugins: {ex.Message}", OutputLogStatus.Warning);
+        }
+    }
     private void RemoveCachedMameVersion()
     {
         try

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MamePluginDeploymentService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MamePluginDeploymentService.cs
@@ -1,0 +1,47 @@
+using System.IO;
+
+namespace OasisEditor;
+
+public sealed class MamePluginDeploymentService
+{
+    public int SyncPluginFiles(string pluginSourceDirectory, string mameExecutablePath)
+    {
+        if (string.IsNullOrWhiteSpace(pluginSourceDirectory) || !Directory.Exists(pluginSourceDirectory))
+        {
+            throw new DirectoryNotFoundException($"Plugin source directory not found: {pluginSourceDirectory}");
+        }
+
+        if (string.IsNullOrWhiteSpace(mameExecutablePath) || !File.Exists(mameExecutablePath))
+        {
+            throw new FileNotFoundException("MAME executable not found.", mameExecutablePath);
+        }
+
+        var mameRoot = Path.GetDirectoryName(mameExecutablePath);
+        if (string.IsNullOrWhiteSpace(mameRoot))
+        {
+            throw new InvalidOperationException("Unable to resolve MAME installation directory from executable path.");
+        }
+
+        var destinationRoot = Path.Combine(mameRoot, "plugins", "oasis");
+        Directory.CreateDirectory(destinationRoot);
+
+        var files = Directory.GetFiles(pluginSourceDirectory, "*", SearchOption.AllDirectories);
+        var copiedCount = 0;
+
+        foreach (var sourceFile in files)
+        {
+            var relativePath = Path.GetRelativePath(pluginSourceDirectory, sourceFile);
+            var destinationFile = Path.Combine(destinationRoot, relativePath);
+            var destinationDirectory = Path.GetDirectoryName(destinationFile);
+            if (!string.IsNullOrWhiteSpace(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(sourceFile, destinationFile, overwrite: true);
+            copiedCount++;
+        }
+
+        return copiedCount;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -111,7 +111,7 @@
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Refresh Versions" Command="{Binding RefreshMameVersionsCommand}" />
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Download Selected" Command="{Binding DownloadMameVersionCommand}" />
                     <Button Padding="10,4" Margin="0,0,8,0" Content="Open Install Folder" Command="{Binding OpenMameInstallRootCommand}" />
-                    <Button Padding="10,4" Margin="0,0,8,0" Content="Re-sync Lua Plugins (TODO)" IsEnabled="False" ToolTip="Planned editor-managed plugin deployment action." />
+                    <Button Padding="10,4" Margin="0,0,8,0" Content="Re-sync Lua Plugins" Command="{Binding ResyncMamePluginsCommand}" ToolTip="Copy bundled Oasis Lua plugin files into the active MAME install." />
                     <Button Padding="10,4" Content="Remove Cached Version" Command="{Binding RemoveCachedMameVersionCommand}" />
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
### Motivation
- Align Preferences with the MAME architecture redesign by making plugin deployment editor-managed and providing a manual fallback to re-sync bundled Oasis Lua plugins into an active MAME install.
- Replace the prior disabled TODO in the MAME Preferences UI with a usable command so users (and background plumbing) can ensure plugins are present without exposing raw runtime paths for editing.

### Description
- Added `MamePluginDeploymentService` with `SyncPluginFiles(string pluginSourceDirectory, string mameExecutablePath)` to recursively copy bundled plugin assets into `<mame root>/plugins/oasis` with overwrite semantics and input validation (`OasisEditor/MamePluginDeploymentService.cs`).
- Wired a new `ResyncMamePluginsCommand` and the `ResyncMamePlugins()` handler into `MainWindowViewModel`, instantiated a `_mamePluginDeploymentService` field, and added logging plus a post-sync call to `ValidateMamePreferences()` to refresh setup state (`OasisEditor/MainWindowViewModel.cs`).
- Updated the Preferences UI to replace the disabled TODO button with an enabled `Re-sync Lua Plugins` button bound to the new command and a tooltip explaining the action (`OasisEditor/Views/PreferencesView.xaml`).

### Testing
- No automated unit or integration tests were executed in this environment due to the Windows/.NET/WPF toolchain constraint; compilation and runtime tests must be run locally by the maintainer as described in the manual test steps. 
- Repository verification commands (`git status`, `git diff`, `git add`, `git commit`) used during the change process completed successfully in the rollout environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00a105ab4c8327905d734b31114d1a)