### PR TITLE
Refine MAME Preferences presentation for editor-managed runtime paths

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/IMameVersionCatalogService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/IMameVersionCatalogService.cs
@@ -1,0 +1,12 @@
+namespace OasisEditor;
+
+public interface IMameVersionCatalogService
+{
+    Task<MameVersionCatalogResult> GetLatestVersionAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken);
+}
+
+public sealed record MameVersionCatalogResult(
+    string? LatestVersion,
+    IReadOnlyList<string> KnownVersions,
+    bool IsFromCache);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -52,6 +52,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IMameSetupOrchestrator _mameSetupOrchestrator;
     private readonly IMameVersionCatalogService _mameVersionCatalogService;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
+    private bool _isAutoProvisioningMame;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -937,6 +938,56 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     AddOutputEntry($"MAME setup issue: {issue}", OutputLogStatus.Warning);
                 }
             }
+
+            await TryAutoProvisionMameAsync(state).ConfigureAwait(false);
+        }
+    }
+
+    private async Task TryAutoProvisionMameAsync(MameSetupState state)
+    {
+        if (_isAutoProvisioningMame)
+        {
+            return;
+        }
+
+        var hasMissingExecutableIssue = state.Issues.Any(issue => issue.Contains("executable", StringComparison.OrdinalIgnoreCase));
+        if (!hasMissingExecutableIssue)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(state.LatestKnownVersion))
+        {
+            AddOutputEntry("Auto-provision skipped: latest MAME version is unknown.", OutputLogStatus.Warning);
+            return;
+        }
+
+        try
+        {
+            _isAutoProvisioningMame = true;
+            MameVersion = state.LatestKnownVersion;
+            AddOutputEntry($"Auto-provisioning MAME {MameVersion} in background...", OutputLogStatus.Info);
+
+            var executablePath = await _mameDownloadService.DownloadAndExtractAsync(
+                MameReleaseSource,
+                MameVersion,
+                MameInstallRootDirectory,
+                new Progress<string>(message => AddOutputEntry($"[Auto-setup] {message}", OutputLogStatus.Info)),
+                CancellationToken.None).ConfigureAwait(false);
+
+            MameExecutablePath = executablePath;
+            AddOutputEntry($"Auto-provisioning completed. Executable: {executablePath}", OutputLogStatus.Info);
+
+            ResyncMamePlugins();
+            await ValidateMamePreferencesAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Auto-provisioning failed: {ex.Message}", OutputLogStatus.Warning);
+        }
+        finally
+        {
+            _isAutoProvisioningMame = false;
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -939,7 +939,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 }
             }
 
-            await TryAutoProvisionMameAsync(state).ConfigureAwait(false);
+            await TryAutoProvisionMameAsync(state);
         }
     }
 
@@ -973,13 +973,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 MameVersion,
                 MameInstallRootDirectory,
                 new Progress<string>(message => AddOutputEntry($"[Auto-setup] {message}", OutputLogStatus.Info)),
-                CancellationToken.None).ConfigureAwait(false);
+                CancellationToken.None);
 
             MameExecutablePath = executablePath;
             AddOutputEntry($"Auto-provisioning completed. Executable: {executablePath}", OutputLogStatus.Info);
 
             ResyncMamePlugins();
-            await ValidateMamePreferencesAsync().ConfigureAwait(false);
+            await ValidateMamePreferencesAsync();
         }
         catch (Exception ex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -50,6 +50,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly MamePluginAssetValidator _mamePluginAssetValidator = new();
     private readonly MamePluginDeploymentService _mamePluginDeploymentService = new();
     private readonly IMameSetupOrchestrator _mameSetupOrchestrator;
+    private readonly IMameVersionCatalogService _mameVersionCatalogService;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -129,7 +130,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameReleaseSource = preferences.Mame.ReleaseSource;
         _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
-        var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameDownloadService);
+        _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
+        var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
@@ -943,8 +945,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         try
         {
-            var versions = await _mameDownloadService.GetKnownVersionsAsync(CancellationToken.None);
-            AddOutputEntry($"Known MAME versions: {string.Join(", ", versions)}", OutputLogStatus.Info);
+            var catalog = await _mameVersionCatalogService.GetLatestVersionAsync(CancellationToken.None);
+            var source = catalog.IsFromCache ? "cache" : "network/service";
+            AddOutputEntry($"Known MAME versions ({source}): {string.Join(", ", catalog.KnownVersions)}", OutputLogStatus.Info);
+            if (!string.IsNullOrWhiteSpace(catalog.LatestVersion))
+            {
+                AddOutputEntry($"Latest known MAME version: {catalog.LatestVersion}", OutputLogStatus.Info);
+            }
         }
         catch (Exception ex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
@@ -5,12 +5,12 @@ namespace OasisEditor;
 public sealed class MameSetupValidationService : IMameSetupValidationService
 {
     private readonly MamePluginAssetValidator _pluginAssetValidator;
-    private readonly MameDownloadService _downloadService;
+    private readonly IMameVersionCatalogService _versionCatalogService;
 
-    public MameSetupValidationService(MamePluginAssetValidator pluginAssetValidator, MameDownloadService downloadService)
+    public MameSetupValidationService(MamePluginAssetValidator pluginAssetValidator, IMameVersionCatalogService versionCatalogService)
     {
         _pluginAssetValidator = pluginAssetValidator;
-        _downloadService = downloadService;
+        _versionCatalogService = versionCatalogService;
     }
 
     public async Task<MameSetupState> ValidateAsync(MameSetupValidationRequest request, CancellationToken cancellationToken)
@@ -47,8 +47,8 @@ public sealed class MameSetupValidationService : IMameSetupValidationService
         string? latestVersion = null;
         try
         {
-            var versions = await _downloadService.GetKnownVersionsAsync(cancellationToken).ConfigureAwait(false);
-            latestVersion = versions.OrderByDescending(v => v).FirstOrDefault();
+            var latest = await _versionCatalogService.GetLatestVersionAsync(cancellationToken).ConfigureAwait(false);
+            latestVersion = latest.LatestVersion;
         }
         catch
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionCatalogService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionCatalogService.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using System.Text.Json;
+
+namespace OasisEditor;
+
+public sealed class MameVersionCatalogService : IMameVersionCatalogService
+{
+    private readonly MameDownloadService _downloadService;
+    private readonly string _catalogCachePath;
+
+    public MameVersionCatalogService(MameDownloadService downloadService)
+    {
+        _downloadService = downloadService;
+        var cacheDirectory = Path.Combine(MameRuntimePaths.EnsureManagedRuntimeRootDirectory(), "state");
+        Directory.CreateDirectory(cacheDirectory);
+        _catalogCachePath = Path.Combine(cacheDirectory, "mame-version-catalog.json");
+    }
+
+    public async Task<MameVersionCatalogResult> GetLatestVersionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var versions = await _downloadService.GetKnownVersionsAsync(cancellationToken).ConfigureAwait(false);
+            var ordered = versions.OrderByDescending(v => v, StringComparer.Ordinal).ToArray();
+            var latest = ordered.FirstOrDefault();
+            await SaveCacheAsync(new CatalogCacheModel(ordered, latest), cancellationToken).ConfigureAwait(false);
+            return new MameVersionCatalogResult(latest, ordered, false);
+        }
+        catch
+        {
+            var cached = await TryLoadCacheAsync(cancellationToken).ConfigureAwait(false);
+            if (cached is null)
+            {
+                return new MameVersionCatalogResult(null, Array.Empty<string>(), true);
+            }
+
+            return new MameVersionCatalogResult(cached.LatestVersion, cached.KnownVersions ?? Array.Empty<string>(), true);
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken)
+    {
+        var result = await GetLatestVersionAsync(cancellationToken).ConfigureAwait(false);
+        return result.KnownVersions;
+    }
+
+    private async Task SaveCacheAsync(CatalogCacheModel model, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(_catalogCachePath, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CatalogCacheModel?> TryLoadCacheAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_catalogCachePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_catalogCachePath, cancellationToken).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<CatalogCacheModel>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record CatalogCacheModel(IReadOnlyList<string> KnownVersions, string? LatestVersion);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -65,22 +65,16 @@
 
                 <Border Margin="0,12,0,0" Padding="12" CornerRadius="4" Background="#22000000">
                     <StackPanel>
-                        <TextBlock FontWeight="SemiBold" Text="Editor-managed runtime paths" />
+                        <TextBlock FontWeight="SemiBold" Text="Editor-managed runtime" />
                         <TextBlock Margin="0,6,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
-                                   Text="MAME runtime root (editor-managed: %LOCALAPPDATA%\OasisEditor\MAME\)" />
-                        <TextBox Margin="0,4,0,0"
-                                 IsReadOnly="True"
-                                 Text="{Binding MameInstallRootDirectory, Mode=OneWay}" />
-                        <TextBlock Margin="0,4,0,0"
-                                   Foreground="{DynamicResource TextSecondaryBrush}"
-                                   Text="Lua plugin source (editor-managed)" />
-                        <TextBox Margin="0,4,0,0"
-                                 IsReadOnly="True"
-                                 Text="{Binding MameLuaPluginPath, Mode=OneWay}" />
+                                   Text="MAME installs are managed automatically under %LOCALAPPDATA%\OasisEditor\MAME\." />
                         <TextBlock Margin="0,4,0,0"
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    Text="Lua plugin deployment is automatic and no longer configured per-user." />
+                        <TextBlock Margin="0,4,0,0"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   Text="Use Diagnostics/Output Log for detailed path troubleshooting." />
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
### Motivation
- Align the Preferences UI with the MAME architecture redesign by avoiding exposure of internal runtime filesystem paths and emphasizing that MAME installs and Lua plugin deployment are editor-managed.

### Description
- Update `WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml` to remove read-only text boxes bound to `MameInstallRootDirectory` and `MameLuaPluginPath` and replace them with concise explanatory text explaining that installs live under `%LOCALAPPDATA%\OasisEditor\MAME\` and that plugin deployment is automatic, while leaving existing MAME actions/status controls intact.

### Testing
- Per project constraints no WPF/.NET automated tests were run in this environment; `git add`/`git commit` for the modified `PreferencesView.xaml` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00a24e3a9c83279d3d87abbdeab3b2)