### PR TITLE
Auto-resolve managed MAME executable on startup

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -905,6 +905,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private async Task ValidateMamePreferencesAsync()
     {
+        AutoResolveManagedMameExecutablePath();
+
         _mameSetupState = new MameSetupState(MameSetupPhase.Validating, "Validating setup...", MameSetupLatestKnownVersion, true, []);
         OnPropertyChanged(nameof(MameSetupPhaseDisplay));
         OnPropertyChanged(nameof(IsMameSetupInProgress));
@@ -941,6 +943,46 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
             await TryAutoProvisionMameAsync(state);
         }
+    }
+
+    private void AutoResolveManagedMameExecutablePath()
+    {
+        if (!string.IsNullOrWhiteSpace(MameExecutablePath) && File.Exists(MameExecutablePath))
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory) || !Directory.Exists(MameInstallRootDirectory))
+        {
+            return;
+        }
+
+        var candidates = new List<string>();
+        if (!string.IsNullOrWhiteSpace(MameVersion))
+        {
+            var versionInstallDirectory = _mameDownloadService.GetInstallDirectory(MameInstallRootDirectory, MameVersion);
+            candidates.Add(Path.Combine(versionInstallDirectory, "mame.exe"));
+            candidates.Add(Path.Combine(versionInstallDirectory, $"mame{MameVersion}", "mame.exe"));
+        }
+
+        foreach (var installDirectory in Directory.EnumerateDirectories(MameInstallRootDirectory, "mame*"))
+        {
+            candidates.Add(Path.Combine(installDirectory, "mame.exe"));
+            candidates.Add(Path.Combine(installDirectory, Path.GetFileName(installDirectory), "mame.exe"));
+        }
+
+        var resolvedPath = candidates
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .FirstOrDefault(File.Exists);
+
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            return;
+        }
+
+        MameExecutablePath = resolvedPath;
+        AddOutputEntry($"Resolved installed MAME executable: {resolvedPath}", OutputLogStatus.Info);
     }
 
     private async Task TryAutoProvisionMameAsync(MameSetupState state)


### PR DESCRIPTION
### Motivation
- Prevent the editor from re-downloading/installing MAME on relaunch when a valid managed install already exists but the stored `MameExecutablePath` is missing or stale.
- Support varied extraction layouts under the managed runtime root so existing installs are detected reliably.

### Description
- Added a call to `AutoResolveManagedMameExecutablePath()` at the start of `ValidateMamePreferencesAsync()` to attempt discovery before reporting a missing executable. 
- Implemented `AutoResolveManagedMameExecutablePath()` in `MainWindowViewModel.cs` to probe the expected version directory and scan `mame*` directories under the managed runtime root, and to handle both direct (`.../mame####/mame.exe`) and nested (`.../mame####/mame####/mame.exe`) layouts. 
- When a valid `mame.exe` is found the code assigns `MameExecutablePath` (using the existing property setter to persist) and logs the resolved path.
- Changed file: `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`.

### Testing
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the build could not be executed in this environment because `dotnet` is not installed, so no automated build/test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00c54b1d108327a0193cfcd80e126d)