### PR TITLE
MAME: live version parsing and resilient catalog fallback

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVersionParsingTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVersionParsingTests.cs
@@ -1,3 +1,5 @@
+using Xunit;
+
 namespace OasisEditor.Tests;
 
 public sealed class MameVersionParsingTests

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVersionParsingTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVersionParsingTests.cs
@@ -1,0 +1,43 @@
+namespace OasisEditor.Tests;
+
+public sealed class MameVersionParsingTests
+{
+    [Fact]
+    public void MamedevParser_Parses_OfficialBinaryPackagesPattern()
+    {
+        const string html = "<h1>MAME 0.287 Official Binary Packages</h1>";
+        var parsed = MameVersionParsing.TryParseLatestFromMamedevReleasePage(html);
+        Assert.Equal("0287", parsed);
+    }
+
+    [Fact]
+    public void MamedevParser_Parses_LatestReleasePattern()
+    {
+        const string html = "The latest official MAME release is version 0.286.";
+        var parsed = MameVersionParsing.TryParseLatestFromMamedevReleasePage(html);
+        Assert.Equal("0286", parsed);
+    }
+
+    [Fact]
+    public void GithubParser_ChoosesHighestAcrossPatterns()
+    {
+        const string html = "<span>MAME 0.286</span><a href='/tag/mame0287'>mame0287</a>";
+        var parsed = MameVersionParsing.TryParseLatestFromGitHubReleases(html);
+        Assert.Equal("0287", parsed);
+    }
+
+    [Fact]
+    public void NormalizeSortAndDedupe_NormalizesDedupesAndSortsNumerically()
+    {
+        var ordered = MameVersionParsing.NormalizeSortAndDedupe(["287", "0286", "mame0287", "0258"]);
+        Assert.Equal(["0287", "0286", "0258"], ordered);
+    }
+
+    [Fact]
+    public void MamedevParser_ReturnsNullForMalformedInput()
+    {
+        const string html = "<html>No release text here</html>";
+        var parsed = MameVersionParsing.TryParseLatestFromMamedevReleasePage(html);
+        Assert.Null(parsed);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameDownloadService.cs
@@ -11,20 +11,19 @@ public sealed class MameDownloadService
 
     public Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken)
     {
-        // Phase C seed list aligned with legacy default and current branch conventions.
-        IReadOnlyList<string> versions = ["0258", "0267", "0281"];
+        IReadOnlyList<string> versions = MameVersionParsing.GetSeedVersions();
         return Task.FromResult(versions);
     }
 
     public string GetArchiveUrl(string releaseSource, string version)
     {
-        var normalizedVersion = NormalizeVersion(version);
+        var normalizedVersion = MameVersionParsing.NormalizeVersion(version);
         var archiveName = BuildArchiveFileName(normalizedVersion);
         return $"{releaseSource.TrimEnd('/')}/download/mame{normalizedVersion}/{archiveName}";
     }
 
     public string GetInstallDirectory(string installRootDirectory, string version)
-        => Path.Combine(installRootDirectory, $"mame{NormalizeVersion(version)}");
+        => Path.Combine(installRootDirectory, $"mame{MameVersionParsing.NormalizeVersion(version)}");
 
     public async Task<string> DownloadAndExtractAsync(
         string releaseSource,
@@ -33,7 +32,7 @@ public sealed class MameDownloadService
         IProgress<string>? progress,
         CancellationToken cancellationToken)
     {
-        var normalizedVersion = NormalizeVersion(version);
+        var normalizedVersion = MameVersionParsing.NormalizeVersion(version);
         var installDirectory = GetInstallDirectory(installRootDirectory, normalizedVersion);
         var archiveName = BuildArchiveFileName(normalizedVersion);
         var archiveUrl = GetArchiveUrl(releaseSource, normalizedVersion);
@@ -101,15 +100,4 @@ public sealed class MameDownloadService
         }
     }
 
-    private static string NormalizeVersion(string version)
-    {
-        var numericOnly = new string(version.Where(char.IsDigit).ToArray());
-        if (string.IsNullOrWhiteSpace(numericOnly))
-        {
-            throw new InvalidOperationException("MAME version must contain digits.");
-        }
-
-        var numericVersion = int.Parse(numericOnly);
-        return numericVersion.ToString("0000");
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionCatalogService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionCatalogService.cs
@@ -1,10 +1,12 @@
 using System.IO;
+using System.Net.Http;
 using System.Text.Json;
 
 namespace OasisEditor;
 
 public sealed class MameVersionCatalogService : IMameVersionCatalogService
 {
+    private static readonly HttpClient HttpClient = new();
     private readonly MameDownloadService _downloadService;
     private readonly string _catalogCachePath;
 
@@ -18,24 +20,31 @@ public sealed class MameVersionCatalogService : IMameVersionCatalogService
 
     public async Task<MameVersionCatalogResult> GetLatestVersionAsync(CancellationToken cancellationToken)
     {
-        try
-        {
-            var versions = await _downloadService.GetKnownVersionsAsync(cancellationToken).ConfigureAwait(false);
-            var ordered = versions.OrderByDescending(v => v, StringComparer.Ordinal).ToArray();
-            var latest = ordered.FirstOrDefault();
-            await SaveCacheAsync(new CatalogCacheModel(ordered, latest), cancellationToken).ConfigureAwait(false);
-            return new MameVersionCatalogResult(latest, ordered, false);
-        }
-        catch
-        {
-            var cached = await TryLoadCacheAsync(cancellationToken).ConfigureAwait(false);
-            if (cached is null)
-            {
-                return new MameVersionCatalogResult(null, Array.Empty<string>(), true);
-            }
+        var seed = MameVersionParsing.GetSeedVersions();
+        var cached = await TryLoadCacheAsync(cancellationToken).ConfigureAwait(false);
 
-            return new MameVersionCatalogResult(cached.LatestVersion, cached.KnownVersions ?? Array.Empty<string>(), true);
+        var discovered = await TryFetchLiveVersionAsync(cancellationToken).ConfigureAwait(false);
+        if (discovered is not null)
+        {
+            var merged = MameVersionParsing.NormalizeSortAndDedupe([
+                discovered.LatestVersion,
+                .. discovered.KnownVersions,
+                .. (cached?.KnownVersions ?? []),
+                .. seed]);
+
+            var latest = merged.FirstOrDefault();
+            _ = TrySaveCacheAsync(new CatalogCacheModel(merged, latest, DateTime.UtcNow, discovered.Source), cancellationToken);
+            return new MameVersionCatalogResult(latest, merged, false);
         }
+
+        if (cached is not null)
+        {
+            var mergedCached = MameVersionParsing.NormalizeSortAndDedupe([.. (cached.KnownVersions ?? []), .. seed]);
+            return new MameVersionCatalogResult(cached.LatestVersion ?? mergedCached.FirstOrDefault(), mergedCached, true);
+        }
+
+        var fallback = MameVersionParsing.NormalizeSortAndDedupe(seed);
+        return new MameVersionCatalogResult(fallback.FirstOrDefault(), fallback, true);
     }
 
     public async Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken)
@@ -44,10 +53,48 @@ public sealed class MameVersionCatalogService : IMameVersionCatalogService
         return result.KnownVersions;
     }
 
-    private async Task SaveCacheAsync(CatalogCacheModel model, CancellationToken cancellationToken)
+    private async Task<LiveDiscoveryResult?> TryFetchLiveVersionAsync(CancellationToken cancellationToken)
     {
-        var json = JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(_catalogCachePath, json, cancellationToken).ConfigureAwait(false);
+        var mamedevHtml = await TryGetStringAsync("https://www.mamedev.org/release.html", cancellationToken).ConfigureAwait(false);
+        var mamedevVersion = mamedevHtml is null ? null : MameVersionParsing.TryParseLatestFromMamedevReleasePage(mamedevHtml);
+        if (!string.IsNullOrWhiteSpace(mamedevVersion))
+        {
+            return new LiveDiscoveryResult(mamedevVersion, [mamedevVersion], "MamedevReleasePage");
+        }
+
+        var githubHtml = await TryGetStringAsync("https://github.com/mamedev/mame/releases", cancellationToken).ConfigureAwait(false);
+        var githubVersion = githubHtml is null ? null : MameVersionParsing.TryParseLatestFromGitHubReleases(githubHtml);
+        if (!string.IsNullOrWhiteSpace(githubVersion))
+        {
+            return new LiveDiscoveryResult(githubVersion, [githubVersion], "GitHubReleases");
+        }
+
+        return null;
+    }
+
+    private static async Task<string?> TryGetStringAsync(string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await HttpClient.GetStringAsync(url, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task TrySaveCacheAsync(CatalogCacheModel model, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(model, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(_catalogCachePath, json, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Ignore cache write failures; live result remains valid.
+        }
     }
 
     private async Task<CatalogCacheModel?> TryLoadCacheAsync(CancellationToken cancellationToken)
@@ -68,5 +115,11 @@ public sealed class MameVersionCatalogService : IMameVersionCatalogService
         }
     }
 
-    private sealed record CatalogCacheModel(IReadOnlyList<string> KnownVersions, string? LatestVersion);
+    private sealed record LiveDiscoveryResult(string LatestVersion, IReadOnlyList<string> KnownVersions, string Source);
+
+    private sealed record CatalogCacheModel(
+        IReadOnlyList<string> KnownVersions,
+        string? LatestVersion,
+        DateTime? LastSuccessfulRefreshUtc = null,
+        string? Source = null);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionParsing.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVersionParsing.cs
@@ -1,0 +1,86 @@
+using System.Text.RegularExpressions;
+
+namespace OasisEditor;
+
+internal static partial class MameVersionParsing
+{
+    private static readonly string[] SeedVersions = ["0281", "0267", "0258"];
+
+    public static IReadOnlyList<string> GetSeedVersions() => SeedVersions;
+
+    public static string? TryParseLatestFromMamedevReleasePage(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return null;
+        }
+
+        var matches = MamedevReleaseRegexMatches(html);
+        return SelectHighestNormalized(matches.Select(m => NormalizeVersion(m.Groups[1].Value)));
+    }
+
+    public static string? TryParseLatestFromGitHubReleases(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return null;
+        }
+
+        var fromReleaseTitle = GitHubReleaseTitleRegex().Matches(html)
+            .Select(m => NormalizeVersion(m.Groups[1].Value));
+        var fromTag = GitHubTagRegex().Matches(html)
+            .Select(m => NormalizeVersion(m.Groups[1].Value));
+
+        return SelectHighestNormalized(fromReleaseTitle.Concat(fromTag));
+    }
+
+    public static string NormalizeVersion(string version)
+    {
+        var numericOnly = new string(version.Where(char.IsDigit).ToArray());
+        if (string.IsNullOrWhiteSpace(numericOnly))
+        {
+            throw new InvalidOperationException("MAME version must contain digits.");
+        }
+
+        var numericVersion = int.Parse(numericOnly);
+        return numericVersion.ToString("0000");
+    }
+
+    public static IReadOnlyList<string> NormalizeSortAndDedupe(IEnumerable<string> versions)
+    {
+        var ordered = versions
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(NormalizeVersion)
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(v => int.Parse(v))
+            .ToArray();
+
+        return ordered;
+    }
+
+    private static string? SelectHighestNormalized(IEnumerable<string> versions)
+    {
+        return versions
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(v => int.Parse(v))
+            .FirstOrDefault();
+    }
+
+    [GeneratedRegex("MAME\\s+0\\.(\\d{3})\\s+Official Binary Packages", RegexOptions.IgnoreCase)]
+    private static partial Regex MamedevReleaseRegex();
+
+    [GeneratedRegex("latest official MAME release is version\\s+0\\.(\\d{3})", RegexOptions.IgnoreCase)]
+    private static partial Regex MamedevLatestRegex();
+
+    [GeneratedRegex("MAME\\s+0\\.(\\d{3})", RegexOptions.IgnoreCase)]
+    private static partial Regex GitHubReleaseTitleRegex();
+
+    [GeneratedRegex("mame(\\d{4})", RegexOptions.IgnoreCase)]
+    private static partial Regex GitHubTagRegex();
+
+    private static IEnumerable<Match> MamedevReleaseRegexMatches(string html)
+        => MamedevReleaseRegex().Matches(html).Cast<Match>()
+            .Concat(MamedevLatestRegex().Matches(html).Cast<Match>());
+}
+


### PR DESCRIPTION
### Motivation

- Replace the hardcoded/seed-only MAME catalog with live discovery plus layered fallbacks so the editor can find new upstream MAME releases without manual updates. 
- Centralize parsing/normalization logic to make discovery testable and robust against varied upstream HTML patterns.
- Preserve offline/startup resilience by merging live results with cached and seed lists and never allowing discovery failures to crash startup.

### Description

- Added a new parsing helper `MameVersionParsing` to normalize versions, parse mamedev.org and GitHub release HTML, provide seed versions, and perform numeric dedupe/sort.
- Reworked `MameVersionCatalogService` to attempt live discovery in order: mamedev release page, GitHub releases, cached catalog, then seed fallback; discovered results are merged with cache/seed lists and written to disk with metadata, while cache failures are ignored safely.
- Updated `MameDownloadService` to reuse `MameVersionParsing` for normalization and to source seed versions from the parsing helper instead of duplicating logic.
- Added unit tests `MameVersionParsingTests` in `OasisEditor.Tests` covering mamedev patterns, GitHub patterns, normalization, ordering, deduplication, and malformed input handling.

### Testing

- No automated tests were executed in this environment per project constraints; unit tests were added under `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVersionParsingTests.cs` but not run here. 
- Local automated test command to run: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` (should be run on a Windows dev machine with the .NET SDK). 
- The code uses safe fallbacks and ignores cache-write/read/network failures so discovery errors will not cause startup crashes during local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00ca0d4c088327b17d4788f0c800bd)