### PR TITLE
Add MAME auto-update preference and UI binding

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class EditorPreferencesSerializationTests
+{
+    [Fact]
+    public void MamePreferences_Defaults_AutoUpdateToTrue()
+    {
+        var preferences = new EditorPreferences();
+
+        Assert.True(preferences.Mame.KeepMameUpToDateAutomatically);
+    }
+
+    [Fact]
+    public void DeserializingLegacyPreferences_UsesAutoUpdateDefaultTrue()
+    {
+        var json = """
+        {
+          "ThemePreference": 2,
+          "Mame": {
+            "Version": "0268",
+            "ExecutablePath": "C:\\\\Mame\\\\mame.exe",
+            "ReleaseSource": "https://github.com/mamedev/mame/releases",
+            "CommandLineOverrides": ""
+          },
+          "ProjectWindowStates": {}
+        }
+        """;
+
+        var preferences = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(preferences);
+        Assert.True(preferences!.Mame.KeepMameUpToDateAutomatically);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -34,4 +34,21 @@ public sealed class EditorPreferencesSerializationTests
         Assert.NotNull(preferences);
         Assert.True(preferences!.Mame.KeepMameUpToDateAutomatically);
     }
+    [Fact]
+    public void DeserializingPreferences_WithAutoUpdateFalse_PreservesFalse()
+    {
+        var json = """
+        {
+          "Mame": {
+            "KeepMameUpToDateAutomatically": false
+          }
+        }
+        """;
+
+        var preferences = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(preferences);
+        Assert.False(preferences!.Mame.KeepMameUpToDateAutomatically);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSetupValidationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSetupValidationServiceTests.cs
@@ -50,10 +50,10 @@ public sealed class MameSetupValidationServiceTests
 
     private sealed class StubMameVersionCatalogService(string latestVersion) : IMameVersionCatalogService
     {
-        public Task<MameVersionCatalog> GetCatalogAsync(string releaseSource, CancellationToken cancellationToken)
-            => Task.FromResult(new MameVersionCatalog([latestVersion], latestVersion, DateTimeOffset.UtcNow, false, releaseSource));
+        public Task<MameVersionCatalogResult> GetLatestVersionAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new MameVersionCatalogResult(latestVersion, [latestVersion], false));
 
-        public Task<MameVersionCatalog> GetLatestVersionAsync(CancellationToken cancellationToken)
-            => Task.FromResult(new MameVersionCatalog([latestVersion], latestVersion, DateTimeOffset.UtcNow, false, "stub"));
+        public Task<IReadOnlyList<string>> GetKnownVersionsAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<string>>([latestVersion]);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSetupValidationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSetupValidationServiceTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameSetupValidationServiceTests
+{
+    [Fact]
+    public async Task ValidateAsync_SelectedVersionMissingFromManagedInstall_ReportsIssue()
+    {
+        var installRoot = Path.Combine(Path.GetTempPath(), $"oasis-mame-test-{Guid.NewGuid():N}");
+        var pluginSource = Path.Combine(installRoot, "plugins");
+        Directory.CreateDirectory(pluginSource);
+        File.WriteAllText(Path.Combine(pluginSource, "init.lua"), "-- test");
+        File.WriteAllText(Path.Combine(pluginSource, "plugin.json"), "{}");
+
+        var executablePath = Path.Combine(installRoot, "mame0281", "mame.exe");
+        Directory.CreateDirectory(Path.GetDirectoryName(executablePath)!);
+        File.WriteAllText(executablePath, string.Empty);
+
+        var sut = new MameSetupValidationService(
+            new MamePluginAssetValidator(),
+            new StubMameVersionCatalogService("0287"));
+
+        try
+        {
+            var state = await sut.ValidateAsync(
+                new MameSetupValidationRequest(
+                    executablePath,
+                    installRoot,
+                    pluginSource,
+                    "0287",
+                    "https://github.com/mamedev/mame/releases"),
+                CancellationToken.None);
+
+            Assert.Equal(MameSetupPhase.NeedsAttention, state.Phase);
+            Assert.Contains(state.Issues, issue => issue.Contains("0287", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(installRoot))
+            {
+                Directory.Delete(installRoot, true);
+            }
+        }
+    }
+
+    private sealed class StubMameVersionCatalogService(string latestVersion) : IMameVersionCatalogService
+    {
+        public Task<MameVersionCatalog> GetCatalogAsync(string releaseSource, CancellationToken cancellationToken)
+            => Task.FromResult(new MameVersionCatalog([latestVersion], latestVersion, DateTimeOffset.UtcNow, false, releaseSource));
+
+        public Task<MameVersionCatalog> GetLatestVersionAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new MameVersionCatalog([latestVersion], latestVersion, DateTimeOffset.UtcNow, false, "stub"));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -15,6 +15,7 @@ public sealed class MamePreferences
     public string ExecutablePath { get; init; } = string.Empty;
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
     public string CommandLineOverrides { get; init; } = string.Empty;
+    public bool KeepMameUpToDateAutomatically { get; init; } = true;
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1052,6 +1052,25 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return normalizedVersions.FirstOrDefault();
     }
 
+    private bool IsLatestVersionInstallNeeded(string latestKnownVersion)
+    {
+        if (string.IsNullOrWhiteSpace(latestKnownVersion))
+        {
+            return false;
+        }
+
+        var latestInstalledVersion = TryGetLatestInstalledMameVersion();
+        if (string.IsNullOrWhiteSpace(latestInstalledVersion))
+        {
+            return true;
+        }
+
+        var ordered = MameVersionParsing.NormalizeSortAndDedupe([latestKnownVersion, latestInstalledVersion]);
+        var highestKnown = ordered.FirstOrDefault();
+        return string.Equals(highestKnown, latestKnownVersion, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(latestKnownVersion, latestInstalledVersion, StringComparison.OrdinalIgnoreCase);
+    }
+
     private async Task TryAutoProvisionMameAsync(MameSetupState state)
     {
         if (_isAutoProvisioningMame)
@@ -1065,21 +1084,27 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        var hasMissingExecutableIssue = state.Issues.Any(issue => issue.Contains("executable", StringComparison.OrdinalIgnoreCase));
-        if (!hasMissingExecutableIssue)
-        {
-            return;
-        }
-
         if (string.IsNullOrWhiteSpace(state.LatestKnownVersion))
         {
             AddOutputEntry("Auto-provision skipped: latest MAME version is unknown.", OutputLogStatus.Warning);
             return;
         }
 
+        var hasMissingExecutableIssue = state.Issues.Any(issue => issue.Contains("executable", StringComparison.OrdinalIgnoreCase));
+        var needsLatestVersionInstall = IsLatestVersionInstallNeeded(state.LatestKnownVersion);
+        if (!hasMissingExecutableIssue && !needsLatestVersionInstall)
+        {
+            return;
+        }
+
         try
         {
             _isAutoProvisioningMame = true;
+            if (needsLatestVersionInstall)
+            {
+                AddOutputEntry($"Auto-update enabled. Latest known version {state.LatestKnownVersion} is newer than installed/selected version {MameVersion}.", OutputLogStatus.Info);
+            }
+
             MameVersion = state.LatestKnownVersion;
             AddOutputEntry($"Auto-provisioning MAME {MameVersion} in background...", OutputLogStatus.Info);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -137,6 +137,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
 
+        if (_keepMameUpToDateAutomatically)
+        {
+            SyncMameVersionToLatestInstalled();
+        }
+
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
         _documentWorkspace = new DocumentWorkspaceViewModel(
@@ -308,7 +313,26 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
-    public bool KeepMameUpToDateAutomatically { get => _keepMameUpToDateAutomatically; set { if (SetProperty(ref _keepMameUpToDateAutomatically, value)) SavePreferences(); } }
+    public bool KeepMameUpToDateAutomatically
+    {
+        get => _keepMameUpToDateAutomatically;
+        set
+        {
+            if (!SetProperty(ref _keepMameUpToDateAutomatically, value))
+            {
+                return;
+            }
+
+            if (value)
+            {
+                SyncMameVersionToLatestInstalled();
+            }
+
+            OnPropertyChanged(nameof(IsMameVersionEditable));
+            SavePreferences();
+        }
+    }
+    public bool IsMameVersionEditable => !KeepMameUpToDateAutomatically;
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -988,6 +1012,46 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry($"Resolved installed MAME executable: {resolvedPath}", OutputLogStatus.Info);
     }
 
+    private void SyncMameVersionToLatestInstalled()
+    {
+        var latestInstalledVersion = TryGetLatestInstalledMameVersion();
+        if (string.IsNullOrWhiteSpace(latestInstalledVersion))
+        {
+            return;
+        }
+
+        if (!string.Equals(MameVersion, latestInstalledVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            MameVersion = latestInstalledVersion;
+            AddOutputEntry($"Auto-update enabled. Using latest installed MAME version: {MameVersion}.", OutputLogStatus.Info);
+        }
+    }
+
+    private string? TryGetLatestInstalledMameVersion()
+    {
+        if (string.IsNullOrWhiteSpace(MameInstallRootDirectory) || !Directory.Exists(MameInstallRootDirectory))
+        {
+            return null;
+        }
+
+        var discoveredVersions = new List<string>();
+        foreach (var installDirectory in Directory.EnumerateDirectories(MameInstallRootDirectory, "mame*"))
+        {
+            var directoryName = Path.GetFileName(installDirectory);
+            if (!string.IsNullOrWhiteSpace(directoryName) && directoryName.StartsWith("mame", StringComparison.OrdinalIgnoreCase))
+            {
+                var version = directoryName[4..];
+                if (!string.IsNullOrWhiteSpace(version))
+                {
+                    discoveredVersions.Add(version);
+                }
+            }
+        }
+
+        var normalizedVersions = MameVersionParsing.NormalizeSortAndDedupe(discoveredVersions);
+        return normalizedVersions.FirstOrDefault();
+    }
+
     private async Task TryAutoProvisionMameAsync(MameSetupState state)
     {
         if (_isAutoProvisioningMame)
@@ -1027,6 +1091,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 CancellationToken.None);
 
             MameExecutablePath = executablePath;
+            SyncMameVersionToLatestInstalled();
             AddOutputEntry($"Auto-provisioning completed. Executable: {executablePath}", OutputLogStatus.Info);
 
             ResyncMamePlugins();
@@ -1120,6 +1185,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry(removed
                 ? $"Removed cached MAME version {MameVersion}."
                 : $"No cached MAME version directory found for {MameVersion}.", removed ? OutputLogStatus.Info : OutputLogStatus.Warning);
+
+            if (KeepMameUpToDateAutomatically)
+            {
+                SyncMameVersionToLatestInstalled();
+            }
         }
         catch (Exception ex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -956,6 +956,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (state.Phase == MameSetupPhase.Ready)
         {
             AddOutputEntry($"MAME preferences validation passed. Latest known version: {MameSetupLatestKnownVersion}.", OutputLogStatus.Info);
+            await TryAutoProvisionMameAsync(state);
         }
         else
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1037,6 +1037,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var discoveredVersions = new List<string>();
         foreach (var installDirectory in Directory.EnumerateDirectories(MameInstallRootDirectory, "mame*"))
         {
+            var executableCandidates = new[]
+            {
+                Path.Combine(installDirectory, "mame.exe"),
+                Path.Combine(installDirectory, Path.GetFileName(installDirectory), "mame.exe")
+            };
+
+            if (!executableCandidates.Any(File.Exists))
+            {
+                continue;
+            }
+
             var directoryName = Path.GetFileName(installDirectory);
             if (!string.IsNullOrWhiteSpace(directoryName) && directoryName.StartsWith("mame", StringComparison.OrdinalIgnoreCase))
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -33,6 +33,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameReleaseSource = string.Empty;
     private string _mameLuaPluginPath = string.Empty;
     private string _mameCommandLineOverrides = string.Empty;
+    private bool _keepMameUpToDateAutomatically = true;
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
@@ -131,6 +132,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameReleaseSource = preferences.Mame.ReleaseSource;
         _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
+        _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
@@ -306,6 +308,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
+    public bool KeepMameUpToDateAutomatically { get => _keepMameUpToDateAutomatically; set { if (SetProperty(ref _keepMameUpToDateAutomatically, value)) SavePreferences(); } }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -992,6 +995,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (!KeepMameUpToDateAutomatically)
+        {
+            AddOutputEntry("Auto-provision skipped: Keep MAME up to date automatically is disabled.", OutputLogStatus.Info);
+            return;
+        }
+
         var hasMissingExecutableIssue = state.Issues.Any(issue => issue.Contains("executable", StringComparison.OrdinalIgnoreCase));
         if (!hasMissingExecutableIssue)
         {
@@ -1127,7 +1136,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 Version = MameVersion,
                 ExecutablePath = MameExecutablePath,
                 ReleaseSource = MameReleaseSource,
-                CommandLineOverrides = MameCommandLineOverrides
+                CommandLineOverrides = MameCommandLineOverrides,
+                KeepMameUpToDateAutomatically = KeepMameUpToDateAutomatically
             }
         });
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1070,16 +1070,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        var latestInstalledVersion = TryGetLatestInstalledMameVersion();
-        if (string.IsNullOrWhiteSpace(latestInstalledVersion))
+        var selectedOrInstalledVersion = string.IsNullOrWhiteSpace(MameVersion)
+            ? TryGetLatestInstalledMameVersion()
+            : MameVersion;
+
+        if (string.IsNullOrWhiteSpace(selectedOrInstalledVersion))
         {
             return true;
         }
 
-        var ordered = MameVersionParsing.NormalizeSortAndDedupe([latestKnownVersion, latestInstalledVersion]);
+        var ordered = MameVersionParsing.NormalizeSortAndDedupe([latestKnownVersion, selectedOrInstalledVersion]);
         var highestKnown = ordered.FirstOrDefault();
         return string.Equals(highestKnown, latestKnownVersion, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(latestKnownVersion, latestInstalledVersion, StringComparison.OrdinalIgnoreCase);
+            && !string.Equals(latestKnownVersion, MameVersionParsing.NormalizeVersion(selectedOrInstalledVersion), StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task TryAutoProvisionMameAsync(MameSetupState state)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSetupValidationService.cs
@@ -22,6 +22,22 @@ public sealed class MameSetupValidationService : IMameSetupValidationService
             issues.Add("MAME executable is missing.");
         }
 
+        if (!string.IsNullOrWhiteSpace(request.SelectedVersion) && !string.IsNullOrWhiteSpace(request.InstallRootDirectory))
+        {
+            var normalizedSelectedVersion = MameVersionParsing.NormalizeVersion(request.SelectedVersion);
+            var expectedInstallDirectory = Path.Combine(request.InstallRootDirectory, $"mame{normalizedSelectedVersion}");
+            var expectedExecutableCandidates = new[]
+            {
+                Path.Combine(expectedInstallDirectory, "mame.exe"),
+                Path.Combine(expectedInstallDirectory, $"mame{normalizedSelectedVersion}", "mame.exe")
+            };
+
+            if (!expectedExecutableCandidates.Any(File.Exists))
+            {
+                issues.Add($"Selected MAME version {normalizedSelectedVersion} is not installed.");
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(request.InstallRootDirectory))
         {
             issues.Add("Managed runtime root is unavailable.");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -51,7 +51,9 @@
                 </StackPanel.Style>
                 <TextBlock FontSize="18" FontWeight="SemiBold" Text="MAME" />
                 <TextBlock Margin="0,16,0,4" Text="MAME Version" Foreground="{DynamicResource TextSecondaryBrush}" />
-                <TextBox Text="{Binding MameVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <TextBox Text="{Binding MameVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         IsReadOnly="{Binding KeepMameUpToDateAutomatically}"
+                         ToolTip="When auto-update is enabled, this value tracks the latest installed MAME version." />
 
 
                 <CheckBox Margin="0,10,0,0"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -53,6 +53,11 @@
                 <TextBlock Margin="0,16,0,4" Text="MAME Version" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding MameVersion, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+
+                <CheckBox Margin="0,10,0,0"
+                          Content="Keep MAME up to date automatically"
+                          IsChecked="{Binding KeepMameUpToDateAutomatically, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
                 <TextBlock Margin="0,8,0,4" Text="MAME Executable" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <Grid>
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
### Motivation
- Provide an explicit persisted user preference for the MAME auto-update/provision policy so auto-update can be controlled while preserving the current default behavior.
- Make auto-provisioning behavior configurable and backward-compatible with existing preference payloads.

### Description
- Add a new `bool KeepMameUpToDateAutomatically { get; init; } = true` to `MamePreferences` in `EditorPreferences.cs` to default auto-update to enabled.
- Expose `KeepMameUpToDateAutomatically` on `MainWindowViewModel`, load it from `EditorPreferencesStore`, save it via `SavePreferences()`, and short-circuit background provisioning in `TryAutoProvisionMameAsync` when the flag is false.
- Add a checkbox to the MAME preferences UI (`OasisEditor/Views/PreferencesView.xaml`) bound to `KeepMameUpToDateAutomatically` so users can toggle the setting from Preferences.
- Add xUnit tests (`OasisEditor.Tests/EditorPreferencesSerializationTests.cs`) that assert the new preference defaults to `true` and that deserializing legacy preference JSON (without the new field) preserves the `true` default.

### Testing
- Added automated tests: `EditorPreferencesSerializationTests` with 2 tests covering default and legacy-deserialization behavior, but no tests were executed in this Codex environment per repository constraints.
- Please run the test suite locally with `dotnet test` in the `OasisEditor.Tests` project to verify the new tests pass (expected to pass given the default).
- Manual verification steps recorded in the PR metadata include toggling the checkbox and confirming background auto-provisioning is skipped or allowed according to the preference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00ce6dc2008327b0219497fa89b6c5)