### PR TITLE
Add project-level MAME ROM settings and Project Settings bindings

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -9,4 +9,6 @@ public sealed class EditorProject
     public required string MachinesDirectory { get; init; }
     public required string GeneratedDirectory { get; init; }
     public FruitMachinePlatformType FruitMachinePlatform { get; set; } = FruitMachinePlatformType.None;
+    public string MameRomName { get; set; } = string.Empty;
+    public bool AutomaticallyDownloadMissingRoms { get; set; } = true;
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -37,6 +37,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
+    private string _mameRomName = string.Empty;
+    private bool _automaticallyDownloadMissingRoms = true;
     private readonly AssetBrowserViewModel _assetBrowser;
     private readonly OutputLogViewModel _outputLog;
     private readonly InspectorViewModel _inspector;
@@ -333,6 +335,44 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
     public bool IsMameVersionEditable => !KeepMameUpToDateAutomatically;
+    public string MameRomName
+    {
+        get => _mameRomName;
+        set
+        {
+            if (!SetProperty(ref _mameRomName, value))
+            {
+                return;
+            }
+
+            if (LoadedProject is null)
+            {
+                return;
+            }
+
+            LoadedProject.MameRomName = value;
+            SaveLoadedProjectMetadata();
+        }
+    }
+    public bool AutomaticallyDownloadMissingRoms
+    {
+        get => _automaticallyDownloadMissingRoms;
+        set
+        {
+            if (!SetProperty(ref _automaticallyDownloadMissingRoms, value))
+            {
+                return;
+            }
+
+            if (LoadedProject is null)
+            {
+                return;
+            }
+
+            LoadedProject.AutomaticallyDownloadMissingRoms = value;
+            SaveLoadedProjectMetadata();
+        }
+    }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -1315,6 +1355,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var project = LoadProjectFromFile(startupProjectFilePath);
         LoadedProject = project;
         SelectedFruitMachinePlatform = project.FruitMachinePlatform;
+        MameRomName = project.MameRomName;
+        AutomaticallyDownloadMissingRoms = project.AutomaticallyDownloadMissingRoms;
         PanelElementFactory.ProjectDirectoryPath = project.ProjectDirectory;
         ProjectFilePath = project.ProjectFilePath;
         UpdateRecentProjects(project.ProjectFilePath);
@@ -1360,6 +1402,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var machinesDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "machines");
         var generatedDirectory = ResolveProjectDirectory(projectDirectory, layoutElement, "generated");
         var fruitMachinePlatform = ResolveFruitMachinePlatform(projectDocument.RootElement);
+        var mameRomName = ResolveMameRomName(projectDocument.RootElement);
+        var automaticallyDownloadMissingRoms = ResolveAutomaticallyDownloadMissingRoms(projectDocument.RootElement);
 
         return new EditorProject
         {
@@ -1369,7 +1413,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AssetsDirectory = assetsDirectory,
             MachinesDirectory = machinesDirectory,
             GeneratedDirectory = generatedDirectory,
-            FruitMachinePlatform = fruitMachinePlatform
+            FruitMachinePlatform = fruitMachinePlatform,
+            MameRomName = mameRomName,
+            AutomaticallyDownloadMissingRoms = automaticallyDownloadMissingRoms
         };
     }
 
@@ -1513,7 +1559,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     {
                         wroteProjectSettings = true;
                         writer.WritePropertyName("project_settings");
-                        WriteProjectSettings(writer, property.Value, LoadedProject.FruitMachinePlatform);
+                        WriteProjectSettings(writer, property.Value, LoadedProject.FruitMachinePlatform, LoadedProject.MameRomName, LoadedProject.AutomaticallyDownloadMissingRoms);
                         continue;
                     }
 
@@ -1525,6 +1571,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     writer.WritePropertyName("project_settings");
                     writer.WriteStartObject();
                     writer.WriteString("FruitMachine_Platform", LoadedProject.FruitMachinePlatform.ToString());
+                    writer.WriteString("MameRomName", LoadedProject.MameRomName);
+                    writer.WriteBoolean("AutomaticallyDownloadMissingRoms", LoadedProject.AutomaticallyDownloadMissingRoms);
                     writer.WriteEndObject();
                 }
 
@@ -1539,10 +1587,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private static void WriteProjectSettings(Utf8JsonWriter writer, JsonElement existingProjectSettings, FruitMachinePlatformType platform)
+    private static void WriteProjectSettings(Utf8JsonWriter writer, JsonElement existingProjectSettings, FruitMachinePlatformType platform, string mameRomName, bool automaticallyDownloadMissingRoms)
     {
         writer.WriteStartObject();
         var wrotePlatform = false;
+        var wroteMameRomName = false;
+        var wroteAutomaticallyDownloadMissingRoms = false;
 
         foreach (var settingProperty in existingProjectSettings.EnumerateObject())
         {
@@ -1552,6 +1602,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 wrotePlatform = true;
                 continue;
             }
+            if (settingProperty.NameEquals("MameRomName"))
+            {
+                writer.WriteString("MameRomName", mameRomName);
+                wroteMameRomName = true;
+                continue;
+            }
+            if (settingProperty.NameEquals("AutomaticallyDownloadMissingRoms"))
+            {
+                writer.WriteBoolean("AutomaticallyDownloadMissingRoms", automaticallyDownloadMissingRoms);
+                wroteAutomaticallyDownloadMissingRoms = true;
+                continue;
+            }
 
             settingProperty.WriteTo(writer);
         }
@@ -1559,6 +1621,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (!wrotePlatform)
         {
             writer.WriteString("FruitMachine_Platform", platform.ToString());
+        }
+        if (!wroteMameRomName)
+        {
+            writer.WriteString("MameRomName", mameRomName);
+        }
+        if (!wroteAutomaticallyDownloadMissingRoms)
+        {
+            writer.WriteBoolean("AutomaticallyDownloadMissingRoms", automaticallyDownloadMissingRoms);
         }
 
         writer.WriteEndObject();
@@ -1585,6 +1655,33 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         AddOutputEntry($"Unknown FruitMachine_Platform '{rawPlatform}' in project settings; defaulting to None.", OutputLogStatus.Warning);
         return FruitMachinePlatformType.None;
+    }
+
+    private static string ResolveMameRomName(JsonElement root)
+    {
+        if (!root.TryGetProperty("project_settings", out var projectSettingsElement)
+            || !projectSettingsElement.TryGetProperty("MameRomName", out var romNameElement))
+        {
+            return string.Empty;
+        }
+
+        return romNameElement.GetString() ?? string.Empty;
+    }
+
+    private static bool ResolveAutomaticallyDownloadMissingRoms(JsonElement root)
+    {
+        if (!root.TryGetProperty("project_settings", out var projectSettingsElement)
+            || !projectSettingsElement.TryGetProperty("AutomaticallyDownloadMissingRoms", out var autoDownloadElement))
+        {
+            return true;
+        }
+
+        return autoDownloadElement.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => true
+        };
     }
 
     private static string ResolveProjectDirectory(string projectDirectory, JsonElement layoutElement, string propertyName)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -34,11 +35,24 @@
 
         <TextBlock Grid.Row="5" Margin="0,12,0,4" Text="Assets folder" Foreground="{DynamicResource TextSecondaryBrush}" />
         <TextBlock Grid.Row="6" TextWrapping="Wrap" Text="{Binding LoadedProject.AssetsDirectory, TargetNullValue=Open or create a project first.}" />
-            <TextBlock Grid.Row="7" Margin="0,12,0,4" Text="Fruit machine platform" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <TextBlock Grid.Row="7" Margin="0,12,0,4" Text="Fruit machine platform" Foreground="{DynamicResource TextSecondaryBrush}" />
         <ComboBox Grid.Row="8"
                   MinWidth="220"
                   HorizontalAlignment="Left"
                   ItemsSource="{Binding FruitMachinePlatformTypes}"
                   SelectedItem="{Binding SelectedFruitMachinePlatform}" />
+
+        <TextBlock Grid.Row="9" Margin="0,12,0,4" Text="MAME ROM" Foreground="{DynamicResource TextSecondaryBrush}" />
+        <StackPanel Grid.Row="10" Orientation="Vertical">
+            <TextBox Width="220"
+                     HorizontalAlignment="Left"
+                     Text="{Binding MameRomName, UpdateSourceTrigger=LostFocus}" />
+            <TextBlock Margin="0,8,0,0"
+                       Text="Status: Unknown"
+                       Foreground="{DynamicResource TextSecondaryBrush}" />
+            <CheckBox Margin="0,8,0,0"
+                      Content="Automatically download missing ROMs"
+                      IsChecked="{Binding AutomaticallyDownloadMissingRoms}" />
+        </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Introduce project-level storage for a configured MAME ROM name to support automated validation and provisioning workflows. 
- Allow per-project control over whether missing ROMs should be auto-downloaded to support differing project policies. 
- Provide a UI surface in Project Settings so users can view/edit ROM name and toggle auto-download before adding provisioning services.

### Description
- Added `MameRomName` and `AutomaticallyDownloadMissingRoms` fields to the `EditorProject` model with defaults of `""` and `true` respectively. 
- Exposed `MameRomName` and `AutomaticallyDownloadMissingRoms` as bindable properties on `MainWindowViewModel` and wired them to persist into the `.oasisproj` under `project_settings` during save. 
- Implemented project-load parsing for `MameRomName` and `AutomaticallyDownloadMissingRoms` with backward-compatible defaults (empty string and `true`) when settings are absent or invalid. 
- Updated `ProjectSettingsView.xaml` to add a ROM name `TextBox` (commits on `LostFocus`), a status placeholder, and an `Automatically download missing ROMs` `CheckBox` bound to the new properties.

### Testing
- No automated tests were executed in this Codex environment due to repository environment constraints (no local build/test per agent policy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0215cbb2a08327ad24e05c7f68fd12)