### PR TITLE
Add configurable MAME ROM source preferences and archive extension support

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
@@ -12,7 +12,7 @@ public sealed class MameRomDownloadServiceTests
 
         var url = sut.BuildDownloadUrl("mpu4");
 
-        Assert.Equal("https://archive.org/download/mame-0.272-romset-complete-merged/arcade/mpu4.7z", url);
+        Assert.Equal("https://archive.org/download/MAME215RomsOnlyMerged/mpu4.zip", url);
     }
 
     [Fact]
@@ -29,12 +29,12 @@ public sealed class MameRomDownloadServiceTests
         var sut = new MameRomDownloadService
         {
             DownloadRootUrl = "https://example.com/roms",
-            ArchiveExtension = ".7z"
+            ArchiveExtension = ".zip"
         };
 
         var url = sut.BuildDownloadUrl("mpu4");
 
-        Assert.Equal("https://example.com/roms/mpu4.7z", url);
+        Assert.Equal("https://example.com/roms/mpu4.zip", url);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
@@ -12,7 +12,7 @@ public sealed class MameRomDownloadServiceTests
 
         var url = sut.BuildDownloadUrl("mpu4");
 
-        Assert.Equal("https://archive.org/download/CentralArquivistaArcade/mpu4.zip", url);
+        Assert.Equal("https://archive.org/download/mame-0.272-romset-complete-merged/arcade/mpu4.7z", url);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
@@ -22,4 +22,29 @@ public sealed class MameRomDownloadServiceTests
 
         Assert.Throws<ArgumentException>(new Action(() => sut.BuildRomArchiveFileName("   ")));
     }
+
+    [Fact]
+    public void BuildDownloadUrl_UsesConfiguredBaseUrlAnd7zExtension()
+    {
+        var sut = new MameRomDownloadService
+        {
+            DownloadRootUrl = "https://example.com/roms",
+            ArchiveExtension = ".7z"
+        };
+
+        var url = sut.BuildDownloadUrl("mpu4");
+
+        Assert.Equal("https://example.com/roms/mpu4.7z", url);
+    }
+
+    [Fact]
+    public void BuildRomArchiveFileName_RejectsUnsupportedExtension()
+    {
+        var sut = new MameRomDownloadService
+        {
+            ArchiveExtension = ".rar"
+        };
+
+        Assert.Throws<ArgumentException>(() => sut.BuildRomArchiveFileName("mpu4"));
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -16,8 +16,8 @@ public sealed class MamePreferences
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
     public string CommandLineOverrides { get; init; } = string.Empty;
     public bool KeepMameUpToDateAutomatically { get; init; } = true;
-    public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/mame-0.272-romset-complete-merged/arcade/";
-    public string RomArchiveExtension { get; init; } = ".7z";
+    public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/MAME215RomsOnlyMerged/";
+    public string RomArchiveExtension { get; init; } = ".zip";
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -16,8 +16,8 @@ public sealed class MamePreferences
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
     public string CommandLineOverrides { get; init; } = string.Empty;
     public bool KeepMameUpToDateAutomatically { get; init; } = true;
-    public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/CentralArquivistaArcade/";
-    public string RomArchiveExtension { get; init; } = ".zip";
+    public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/mame-0.272-romset-complete-merged/arcade/";
+    public string RomArchiveExtension { get; init; } = ".7z";
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -16,6 +16,8 @@ public sealed class MamePreferences
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
     public string CommandLineOverrides { get; init; } = string.Empty;
     public bool KeepMameUpToDateAutomatically { get; init; } = true;
+    public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/CentralArquivistaArcade/";
+    public string RomArchiveExtension { get; init; } = ".zip";
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -33,6 +33,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameReleaseSource = string.Empty;
     private string _mameLuaPluginPath = string.Empty;
     private string _mameCommandLineOverrides = string.Empty;
+    private string _mameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
+    private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private bool _keepMameUpToDateAutomatically = true;
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
@@ -98,6 +100,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ResyncMamePluginsCommand = new RelayCommand(ResyncMamePlugins);
         RemoveCachedMameVersionCommand = new RelayCommand(RemoveCachedMameVersion);
         DownloadMameRomCommand = new RelayCommand(DownloadMameRom, CanDownloadMameRom);
+        ResetMameRomSourceDefaultsCommand = new RelayCommand(ResetMameRomSourceDefaults);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
@@ -138,6 +141,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameReleaseSource = preferences.Mame.ReleaseSource;
         _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
         _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
+        _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
+        _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
+        _mameRomDownloadService.DownloadRootUrl = _mameRomDownloadBaseUrl;
+        _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
         _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
@@ -266,6 +273,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand RemoveCachedMameVersionCommand { get; }
     public ICommand DownloadMameRomCommand { get; }
     public ICommand CloseProjectSettingsCommand { get; }
+    public ICommand ResetMameRomSourceDefaultsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
     public ICommand ExitCommand { get; }
@@ -320,6 +328,31 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
+    public string MameRomDownloadBaseUrl
+    {
+        get => _mameRomDownloadBaseUrl;
+        set
+        {
+            if (SetProperty(ref _mameRomDownloadBaseUrl, value))
+            {
+                _mameRomDownloadService.DownloadRootUrl = value;
+                SavePreferences();
+            }
+        }
+    }
+
+    public string MameRomArchiveExtension
+    {
+        get => _mameRomArchiveExtension;
+        set
+        {
+            if (SetProperty(ref _mameRomArchiveExtension, value))
+            {
+                _mameRomDownloadService.ArchiveExtension = value;
+                SavePreferences();
+            }
+        }
+    }
     public bool KeepMameUpToDateAutomatically
     {
         get => _keepMameUpToDateAutomatically;
@@ -1302,7 +1335,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 ExecutablePath = MameExecutablePath,
                 ReleaseSource = MameReleaseSource,
                 CommandLineOverrides = MameCommandLineOverrides,
-                KeepMameUpToDateAutomatically = KeepMameUpToDateAutomatically
+                KeepMameUpToDateAutomatically = KeepMameUpToDateAutomatically,
+                RomDownloadBaseUrl = MameRomDownloadBaseUrl,
+                RomArchiveExtension = MameRomArchiveExtension
             }
         });
     }
@@ -1701,6 +1736,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
 
     private bool CanDownloadMameRom() => LoadedProject is not null && !string.IsNullOrWhiteSpace(MameRomName) && !_isMameRomDownloadInProgress;
+
+    private void ResetMameRomSourceDefaults()
+    {
+        MameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
+        MameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
+        AddOutputEntry("Reset ROM source preferences to defaults.", OutputLogStatus.Info);
+    }
 
     private void DownloadMameRom()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
@@ -1,12 +1,16 @@
-using System.Net.Http;
 using System.IO;
+using System.Net.Http;
 
 namespace OasisEditor;
 
 public sealed class MameRomDownloadService
 {
-    private const string DownloadRootUrl = "https://archive.org/download/CentralArquivistaArcade/";
+    public const string DefaultDownloadRootUrl = "https://archive.org/download/CentralArquivistaArcade/";
+    public const string DefaultArchiveExtension = ".zip";
     private static readonly HttpClient HttpClient = new();
+
+    public string DownloadRootUrl { get; set; } = DefaultDownloadRootUrl;
+    public string ArchiveExtension { get; set; } = DefaultArchiveExtension;
 
     public static string GetRomDownloadDirectory()
     {
@@ -21,12 +25,14 @@ public sealed class MameRomDownloadService
             throw new ArgumentException("ROM name must be provided.", nameof(romName));
         }
 
-        return $"{romName.Trim()}.zip";
+        var extension = NormalizeArchiveExtension(ArchiveExtension);
+        return $"{romName.Trim()}{extension}";
     }
 
     public string BuildDownloadUrl(string romName)
     {
-        return $"{DownloadRootUrl}{BuildRomArchiveFileName(romName)}";
+        var rootUrl = NormalizeDownloadRootUrl(DownloadRootUrl);
+        return $"{rootUrl}{BuildRomArchiveFileName(romName)}";
     }
 
     public string GetRomArchivePath(string romName)
@@ -58,5 +64,35 @@ public sealed class MameRomDownloadService
         await using var targetStream = File.Create(archivePath);
         await sourceStream.CopyToAsync(targetStream, cancellationToken).ConfigureAwait(false);
         return archivePath;
+    }
+
+    private static string NormalizeDownloadRootUrl(string rootUrl)
+    {
+        if (string.IsNullOrWhiteSpace(rootUrl)
+            || !Uri.TryCreate(rootUrl, UriKind.Absolute, out var parsed)
+            || (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("ROM download base URL must be an absolute HTTP/HTTPS URL.", nameof(rootUrl));
+        }
+
+        return rootUrl.EndsWith("/", StringComparison.Ordinal) ? rootUrl : rootUrl + "/";
+    }
+
+    private static string NormalizeArchiveExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            throw new ArgumentException("ROM archive extension must be provided.", nameof(extension));
+        }
+
+        var normalized = extension.Trim().ToLowerInvariant();
+        if (!normalized.StartsWith(".", StringComparison.Ordinal))
+        {
+            normalized = "." + normalized;
+        }
+
+        return normalized is ".zip" or ".7z"
+            ? normalized
+            : throw new ArgumentException("ROM archive extension must be .zip or .7z.", nameof(extension));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
@@ -5,8 +5,8 @@ namespace OasisEditor;
 
 public sealed class MameRomDownloadService
 {
-    public const string DefaultDownloadRootUrl = "https://archive.org/download/CentralArquivistaArcade/";
-    public const string DefaultArchiveExtension = ".zip";
+    public const string DefaultDownloadRootUrl = "https://archive.org/download/mame-0.272-romset-complete-merged/arcade/";
+    public const string DefaultArchiveExtension = ".7z";
     private static readonly HttpClient HttpClient = new();
 
     public string DownloadRootUrl { get; set; } = DefaultDownloadRootUrl;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
@@ -5,8 +5,8 @@ namespace OasisEditor;
 
 public sealed class MameRomDownloadService
 {
-    public const string DefaultDownloadRootUrl = "https://archive.org/download/mame-0.272-romset-complete-merged/arcade/";
-    public const string DefaultArchiveExtension = ".7z";
+    public const string DefaultDownloadRootUrl = "https://archive.org/download/MAME215RomsOnlyMerged/";
+    public const string DefaultArchiveExtension = ".zip";
     private static readonly HttpClient HttpClient = new();
 
     public string DownloadRootUrl { get; set; } = DefaultDownloadRootUrl;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -66,7 +66,10 @@
                 <TextBlock Margin="0,16,0,4" Text="ROM Download Base URL" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding MameRomDownloadBaseUrl, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                 <TextBlock Margin="0,10,0,4" Text="ROM Archive Extension" Foreground="{DynamicResource TextSecondaryBrush}" />
-                <TextBox Width="120" HorizontalAlignment="Left" Text="{Binding MameRomArchiveExtension, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <ComboBox Width="120" HorizontalAlignment="Left" SelectedValuePath="Content" SelectedValue="{Binding MameRomArchiveExtension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <ComboBoxItem Content=".7z" />
+                    <ComboBoxItem Content=".zip" />
+                </ComboBox>
                 <Button Margin="0,10,0,0" Padding="10,4" Content="Reset ROM Source Defaults" Command="{Binding ResetMameRomSourceDefaultsCommand}" />
 
                 <StackPanel Margin="0,12,0,0" Orientation="Horizontal">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -62,6 +62,13 @@
                           IsChecked="{Binding KeepMameUpToDateAutomatically, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
 
+                
+                <TextBlock Margin="0,16,0,4" Text="ROM Download Base URL" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBox Text="{Binding MameRomDownloadBaseUrl, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <TextBlock Margin="0,10,0,4" Text="ROM Archive Extension" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBox Width="120" HorizontalAlignment="Left" Text="{Binding MameRomArchiveExtension, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <Button Margin="0,10,0,0" Padding="10,4" Content="Reset ROM Source Defaults" Command="{Binding ResetMameRomSourceDefaultsCommand}" />
+
                 <StackPanel Margin="0,12,0,0" Orientation="Horizontal">
                     <Button Padding="10,4" Content="Validate Setup" Command="{Binding ValidateMamePreferencesCommand}" />
                     <TextBlock Margin="12,4,0,0" Text="{Binding MameValidationSummary}" TextWrapping="Wrap" />


### PR DESCRIPTION
### Motivation
- Provide configurable ROM download source and archive extension so ROM provisioning can target different hosts and formats (archive.org by default) rather than a hardcoded URL/`.zip` suffix.
- Support both `.zip` and `.7z` ROM archive formats and offer a simple reset-to-default UX so maintainers can revert to the known-good example values.

### Description
- Added persisted MAME preference fields `RomDownloadBaseUrl` and `RomArchiveExtension` with defaults in `WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs`.
- Reworked `MameRomDownloadService` to construct URLs from a configurable `DownloadRootUrl` + sanitized ROM name + normalized `ArchiveExtension`, and added validation helpers `NormalizeDownloadRootUrl` and `NormalizeArchiveExtension` to enforce HTTP/HTTPS and allowed extensions (`.zip` or `.7z`). (see `WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs`).
- Wired the new preferences through `MainWindowViewModel` including properties `MameRomDownloadBaseUrl` and `MameRomArchiveExtension`, Save/Load persistence, and a `ResetMameRomSourceDefaultsCommand` to restore defaults (see `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).
- Exposed UI controls in the MAME Preferences pane for editing the ROM base URL, archive extension, and a reset button (`WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml`).
- Extended unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs` with cases for configured base URL + `.7z` composition and rejection of unsupported extensions.

### Testing
- Added/updated automated unit tests: `MameRomDownloadServiceTests` now includes facts for default archive.org URL behavior, configured base URL + `.7z` URL composition, whitespace rejection, and unsupported-extension rejection (see `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs`).
- No test execution was performed in this environment because the .NET SDK/CLI is not available here; please run the test suite locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` to validate compilation and test outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0220c67fb88327bfd6123e515f2fd9)