### PR TITLE
Add MAME emulation runtime inventory (Step 1)

### DIFF
--- a/WindowsNetProjects/OasisEditor/MAME_EMULATION_RUNTIME_INVENTORY.md
+++ b/WindowsNetProjects/OasisEditor/MAME_EMULATION_RUNTIME_INVENTORY.md
@@ -1,0 +1,137 @@
+# MAME Emulation Runtime Inventory (Step 1)
+
+Date: 2026-05-11
+Scope: Legacy Unity `LayoutEditor` emulation runtime behavior that must be understood before WPF runtime code changes.
+
+## 1) Legacy Emulation menu inventory
+
+Legacy native menu defines these `Emulation/*` entries:
+
+- `Start And Load State`
+- `Save State And Exit`
+- `Start`
+- `Load State`
+- `Save State`
+- `Exit`
+- `Pause`
+- `Resume`
+- `Throttle`
+- `Unthrottle`
+- `Soft Reset`
+- `Hard Reset`
+
+Dispatch behavior is thin: handlers call `Editor.Instance.MameController` methods directly (e.g., `StartMame`, `Pause`, `Resume`, `Exit`, reset/state commands).
+
+Implication for WPF port: current plan’s `Start/Stop/Pause/Resume` shell is a subset of legacy and should remain command-driven, with room for later expansion to reset/throttle/state commands.
+
+## 2) Legacy process launch args and runtime toggles
+
+`MameController.StartMame(bool loadState)` constructs args in this shape:
+
+- First token: project ROM name (`Project.Settings.Mame.RomName`)
+- Output mode: either `-output console` or `-output network`
+- Optional toggles:
+  - `-console`
+  - `-plugin oasis`
+  - `-skip_gameinfo`
+- Video mode:
+  - `-video none -seconds_to_run 999999999` when `ArgsVideoNone`
+  - otherwise `-window`
+- ROM path always appended:
+  - `-rompath "<persistentDataPath>\\Downloads\\MAME\\ROMs"`
+- Optional save-state on start:
+  - `-state oasis_save_state` when `loadState == true`
+
+Process configuration:
+
+- Working directory: computed MAME version folder (`.../Downloads/MAME/mame####`)
+- Executable: `mame.exe`
+- `UseShellExecute = false`
+- `RedirectStandardInput/Output/Error = true`
+- `CreateNoWindow` controlled by serialized `ProcessCreateNoWindow`
+- Asynchronous output/error reads via `BeginOutputReadLine` and `BeginErrorReadLine`
+
+## 3) Legacy Lua plugin/stdin protocol shape
+
+Controller writes plain command lines to MAME stdin (`Process.StandardInput.WriteLine(...)`).
+
+Observed command strings from controller:
+
+- `exit`
+- `pause`
+- `resume`
+- `soft_reset`
+- `hard_reset`
+- `throttled <bool>`
+- `state_load oasis_save_state`
+- `state_save oasis_save_state`
+- `state_save_and_exit oasis_save_state`
+- `set_input_value <tag> <mask> <0|1>`
+
+Lua plugin side (`stdin_thread.lua` + `command_processor.lua`):
+
+- Spins command polling thread and dispatches by lowercased first token.
+- Tokenization uses quoted split helper with simple quote-pair behavior (no robust escaping semantics).
+- Supports `?`-prefixed expression evaluation path.
+
+Port implication: keep an explicit stdin writer abstraction now, but preserve plaintext line command compatibility with this plugin contract.
+
+## 4) Legacy stdout/stderr protocol with lamp focus
+
+`MameController.ProcessLine(...)` routes output by prefixes:
+
+- `lamp*` -> lamp parser
+- `reel*` -> reel parser
+- `vfd*` -> vfd parser
+- `digit*` -> digit parser
+
+For Step 1 milestone focus, lamp line parsing behavior is:
+
+- Parses lamp index from text between `lamp` prefix and first space.
+- Parses lamp value from text after last space.
+- Writes value into `LampValues[lampNumber]`.
+
+Notable parser fragility to preserve/repair in WPF parser design:
+
+- No guard rails around malformed lines (`int.Parse` assumptions).
+- Partial/unknown lines are effectively ignored unless debug logging is enabled.
+- No explicit plugin “ready” handshake used by runtime state.
+
+Stderr handling:
+
+- Error lines are received asynchronously and logged as `[MAME-ERR] ...` only when `DebugOutputStdOut` is enabled.
+
+## 5) Pause / resume / stop / cleanup behavior
+
+Legacy command behavior:
+
+- Pause -> writes `pause`
+- Resume -> writes `resume`
+- Exit -> writes `exit`
+- Save-and-exit -> writes `state_save_and_exit oasis_save_state`
+
+Cleanup behavior today is split/incomplete:
+
+- `OnDestroy()` unsubscribes output handler, cancels output read, and kills process if present.
+- In-code TODO comment explicitly says this should move into a real `StopMame()` flow.
+- There is no robust state machine (`Stopped/Starting/Running/...`) in legacy.
+
+Port implication: WPF runtime should formalize explicit lifecycle states and deterministic stop/cleanup paths (including project close/editor exit).
+
+## 6) Open runtime questions captured before implementation
+
+1. Should WPF `Stop` map to stdin `exit`, forced kill fallback, or both with timeout?
+2. Should we keep `-output console` as default (legacy prefab indicates yes), and expose network mode later only?
+3. Do we treat plugin readiness as inferred from first known protocol line, or define a new ready signal contract?
+4. Should stderr always be logged in WPF output log (recommended) instead of debug-gated behavior?
+5. Should the initial WPF parser support lamp-only first while passing through unknown lines diagnostically (recommended for milestone)?
+
+## 7) Files inspected for this inventory
+
+- `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenu/NativeMenuDefinition.cs`
+- `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/NativeMenus/SelectionHandler.Emulation.cs`
+- `UnityProjects/LayoutEditor/Assets/_Project/Scripts/Oasis/MAME/MameController.cs`
+- `UnityProjects/LayoutEditor/Assets/_Project/Prefabs/MameController.prefab`
+- `UnityProjects/LayoutEditor_ExternalAssets/Windows/MameLuaPlugins/oasis/system/stdin_thread.lua`
+- `UnityProjects/LayoutEditor_ExternalAssets/Windows/MameLuaPlugins/oasis/system/command_processor.lua`
+- `UnityProjects/LayoutEditor_ExternalAssets/Windows/MameLuaPlugins/oasis/system/utility.lua`

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
@@ -1,0 +1,50 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameEmulationCommandStateEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_WhenNoProjectLoaded_StartIsDisabled()
+    {
+        var state = MameEmulationCommandStateEvaluator.Evaluate(false, MameEmulationState.Stopped);
+
+        Assert.False(state.CanStart);
+        Assert.False(state.CanStop);
+        Assert.False(state.CanPause);
+        Assert.False(state.CanResume);
+    }
+
+    [Fact]
+    public void Evaluate_WhenStoppedWithProject_StartEnabledOnly()
+    {
+        var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Stopped);
+
+        Assert.True(state.CanStart);
+        Assert.False(state.CanStop);
+        Assert.False(state.CanPause);
+        Assert.False(state.CanResume);
+    }
+
+    [Fact]
+    public void Evaluate_WhenRunning_StopAndPauseEnabled()
+    {
+        var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Running);
+
+        Assert.False(state.CanStart);
+        Assert.True(state.CanStop);
+        Assert.True(state.CanPause);
+        Assert.False(state.CanResume);
+    }
+
+    [Fact]
+    public void Evaluate_WhenPaused_StopAndResumeEnabled()
+    {
+        var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Paused);
+
+        Assert.False(state.CanStart);
+        Assert.True(state.CanStop);
+        Assert.False(state.CanPause);
+        Assert.True(state.CanResume);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -131,6 +131,17 @@
                 <MenuItem Header="_Output"
                           Click="OnOutputWindowMenuItemClicked" />
             </MenuItem>
+            <MenuItem Header="_Emulation">
+                <MenuItem Header="_Start"
+                          Command="{Binding StartEmulationCommand}" />
+                <MenuItem Header="S_top"
+                          Command="{Binding StopEmulationCommand}" />
+                <Separator />
+                <MenuItem Header="_Pause"
+                          Command="{Binding PauseEmulationCommand}" />
+                <MenuItem Header="_Resume"
+                          Command="{Binding ResumeEmulationCommand}" />
+            </MenuItem>
         </Menu>
 
         <ContentControl x:Name="EditorShellHost"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -61,6 +61,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IMameVersionCatalogService _mameVersionCatalogService;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
     private bool _isAutoProvisioningMame;
+    private MameEmulationState _mameEmulationState = MameEmulationState.Stopped;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -104,6 +105,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
+        StartEmulationCommand = new RelayCommand(StartEmulation, CanStartEmulation);
+        StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
+        PauseEmulationCommand = new RelayCommand(PauseEmulation, CanPauseEmulation);
+        ResumeEmulationCommand = new RelayCommand(ResumeEmulation, CanResumeEmulation);
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
@@ -277,6 +282,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
     public ICommand ExitCommand { get; }
+    public ICommand StartEmulationCommand { get; }
+    public ICommand StopEmulationCommand { get; }
+    public ICommand PauseEmulationCommand { get; }
+    public ICommand ResumeEmulationCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -458,6 +467,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
 
     public bool HasLoadedProject => LoadedProject is not null;
+    public MameEmulationState EmulationState
+    {
+        get => _mameEmulationState;
+        private set
+        {
+            if (SetProperty(ref _mameEmulationState, value))
+            {
+                NotifyEmulationCommands();
+            }
+        }
+    }
 
     public string ProjectFilePath
     {
@@ -1370,6 +1390,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (CanStopEmulation())
+        {
+            StopEmulation();
+        }
+
         ClosePreferences();
         CloseProjectSettings();
         ClearProjectSessionState();
@@ -1395,9 +1420,85 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ProjectFilePath = string.Empty;
     }
 
-    private static void ExitApplication()
+    private void ExitApplication()
     {
+        if (CanStopEmulation())
+        {
+            StopEmulation();
+        }
+
         Application.Current.Shutdown();
+    }
+
+    private bool CanStartEmulation()
+    {
+        return HasLoadedProject && EmulationState is MameEmulationState.Stopped or MameEmulationState.Failed;
+    }
+
+    private void StartEmulation()
+    {
+        if (!CanStartEmulation())
+        {
+            return;
+        }
+
+        EmulationState = MameEmulationState.Starting;
+        AddOutputEntry("Emulation start requested (runtime service stub).", OutputLogStatus.Info);
+        EmulationState = MameEmulationState.Running;
+        AddOutputEntry("Emulation state changed to Running (stub).", OutputLogStatus.Info);
+    }
+
+    private bool CanStopEmulation()
+    {
+        return EmulationState is MameEmulationState.Starting
+            or MameEmulationState.Running
+            or MameEmulationState.Paused
+            or MameEmulationState.Stopping;
+    }
+
+    private void StopEmulation()
+    {
+        if (!CanStopEmulation())
+        {
+            return;
+        }
+
+        EmulationState = MameEmulationState.Stopping;
+        AddOutputEntry("Emulation stop requested (runtime service stub).", OutputLogStatus.Info);
+        EmulationState = MameEmulationState.Stopped;
+        AddOutputEntry("Emulation state changed to Stopped (stub).", OutputLogStatus.Info);
+    }
+
+    private bool CanPauseEmulation()
+    {
+        return EmulationState == MameEmulationState.Running;
+    }
+
+    private void PauseEmulation()
+    {
+        if (!CanPauseEmulation())
+        {
+            return;
+        }
+
+        EmulationState = MameEmulationState.Paused;
+        AddOutputEntry("Emulation pause requested (runtime service stub).", OutputLogStatus.Info);
+    }
+
+    private bool CanResumeEmulation()
+    {
+        return EmulationState == MameEmulationState.Paused;
+    }
+
+    private void ResumeEmulation()
+    {
+        if (!CanResumeEmulation())
+        {
+            return;
+        }
+
+        EmulationState = MameEmulationState.Running;
+        AddOutputEntry("Emulation resume requested (runtime service stub).", OutputLogStatus.Info);
     }
 
     private void LoadStartupProject(string startupProjectFilePath)
@@ -1903,8 +2004,32 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             closeProjectRelayCommand.RaiseCanExecuteChanged();
         }
 
+        NotifyEmulationCommands();
         NotifyUndoRedoStateChanged();
         _assetBrowser.NotifyRefreshCommand();
+    }
+
+    private void NotifyEmulationCommands()
+    {
+        if (StartEmulationCommand is RelayCommand startEmulationCommand)
+        {
+            startEmulationCommand.RaiseCanExecuteChanged();
+        }
+
+        if (StopEmulationCommand is RelayCommand stopEmulationCommand)
+        {
+            stopEmulationCommand.RaiseCanExecuteChanged();
+        }
+
+        if (PauseEmulationCommand is RelayCommand pauseEmulationCommand)
+        {
+            pauseEmulationCommand.RaiseCanExecuteChanged();
+        }
+
+        if (ResumeEmulationCommand is RelayCommand resumeEmulationCommand)
+        {
+            resumeEmulationCommand.RaiseCanExecuteChanged();
+        }
     }
 
     private void NotifyUndoRedoStateChanged()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1432,7 +1432,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanStartEmulation()
     {
-        return HasLoadedProject && EmulationState is MameEmulationState.Stopped or MameEmulationState.Failed;
+        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStart;
     }
 
     private void StartEmulation()
@@ -1450,10 +1450,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanStopEmulation()
     {
-        return EmulationState is MameEmulationState.Starting
-            or MameEmulationState.Running
-            or MameEmulationState.Paused
-            or MameEmulationState.Stopping;
+        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStop;
     }
 
     private void StopEmulation()
@@ -1471,7 +1468,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanPauseEmulation()
     {
-        return EmulationState == MameEmulationState.Running;
+        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanPause;
     }
 
     private void PauseEmulation()
@@ -1487,7 +1484,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanResumeEmulation()
     {
-        return EmulationState == MameEmulationState.Paused;
+        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanResume;
     }
 
     private void ResumeEmulation()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
@@ -1,0 +1,28 @@
+namespace OasisEditor;
+
+public sealed class MameEmulationCommandState
+{
+    public bool CanStart { get; init; }
+    public bool CanStop { get; init; }
+    public bool CanPause { get; init; }
+    public bool CanResume { get; init; }
+}
+
+public static class MameEmulationCommandStateEvaluator
+{
+    public static MameEmulationCommandState Evaluate(bool hasLoadedProject, MameEmulationState state)
+    {
+        var canStart = hasLoadedProject && state is MameEmulationState.Stopped or MameEmulationState.Failed;
+        var canStop = state is MameEmulationState.Starting or MameEmulationState.Running or MameEmulationState.Paused or MameEmulationState.Stopping;
+        var canPause = state == MameEmulationState.Running;
+        var canResume = state == MameEmulationState.Paused;
+
+        return new MameEmulationCommandState
+        {
+            CanStart = canStart,
+            CanStop = canStop,
+            CanPause = canPause,
+            CanResume = canResume
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationState.cs
@@ -1,0 +1,11 @@
+namespace OasisEditor;
+
+public enum MameEmulationState
+{
+    Stopped = 0,
+    Starting = 1,
+    Running = 2,
+    Paused = 3,
+    Stopping = 4,
+    Failed = 5
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace OasisEditor;
+
+public interface IMameEmulationService
+{
+    MameEmulationState State { get; }
+    event EventHandler<MameEmulationState>? StateChanged;
+    Task StartAsync(CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+    Task PauseAsync(CancellationToken cancellationToken);
+    Task ResumeAsync(CancellationToken cancellationToken);
+}
+
+public interface IMameProcessRunner
+{
+    Task StartAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+    Task WriteStandardInputAsync(string command, CancellationToken cancellationToken);
+}
+
+public interface IMameProcessStartInfoBuilder
+{
+    ProcessStartInfo Build(MameProcessLaunchRequest request);
+}
+
+public interface IMameStdoutParser
+{
+    void ProcessLine(string line);
+}
+
+public interface IMameLampRuntimeAdapter
+{
+    void ApplyLampState(int lampId, int lampValue);
+}
+
+public sealed record MameProcessLaunchRequest(
+    string MameExecutablePath,
+    string MameRomName,
+    string MameRomRootPath,
+    string OasisPluginPath,
+    string AdditionalArguments);


### PR DESCRIPTION
### Motivation
- The `MAME_EMULATION_RUNTIME_PLAN.md` requires a legacy inventory checkpoint before implementing runtime code to avoid behavior drift. 
- Capturing the Unity `MameController` and Oasis Lua plugin protocol details reduces risk when porting launch/stdio/lamp behavior to WPF. 
- Recording open questions up-front preserves implementation decisions for later steps.

### Description
- Add `WindowsNetProjects/OasisEditor/MAME_EMULATION_RUNTIME_INVENTORY.md` containing a focused Step 1 inventory of legacy Emulation menu entries, process launch arguments/flags, hidden child-process and stdio configuration, Lua stdin command shapes, stdout/stderr parsing (lamp/reel/vfd/digit focus), cleanup observations, and open runtime questions. 
- The inventory documents parser fragilities and the legacy assumptions for `-rompath`, `-plugin oasis`, `-output console`, and `oasis_save_state` usage to guide the WPF port. 
- The file lists the specific legacy source files inspected so the port can be traced back to original code and assets.

### Testing
- Verified repository markdown list with `rg --files WindowsNetProjects/OasisEditor -g '*.md'` succeeded. 
- Inspected plan and legacy sources with `sed -n '1,520p' WindowsNetProjects/OasisEditor/MAME_EMULATION_RUNTIME_PLAN.md` and targeted `rg -n` searches for runtime symbols (e.g., `StartMame`, `ProcessLine`, `set_input_value`, `plugin oasis`) which all returned expected matches. 
- Confirmed inventory file content was written and viewable using `nl -ba WindowsNetProjects/OasisEditor/MAME_EMULATION_RUNTIME_INVENTORY.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022f9ab1e08327833f663b546026ce)