### PR TITLE
Add output log severity filters and persistent disk logging

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+
+namespace OasisEditor.Tests;
+
+public sealed class OutputLogEnhancementTests
+{
+    [Fact]
+    public void DiskWriter_RotatesCurrentLogToPrevious()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"oasis-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var current = Path.Combine(root, "Editor.log");
+            File.WriteAllText(current, "old");
+
+            var writer = new OutputLogDiskWriter(root);
+            writer.Initialize();
+
+            Assert.True(File.Exists(writer.CurrentLogPath));
+            Assert.True(File.Exists(writer.PreviousLogPath));
+            Assert.Equal("old", File.ReadAllText(writer.PreviousLogPath));
+            Assert.Equal(string.Empty, File.ReadAllText(writer.CurrentLogPath));
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ViewModel_FiltersBySeverityWithoutRemovingSourceEntries()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"oasis-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var vm = new OutputLogViewModel(new OutputLogDiskWriter(root));
+            vm.AddOutputEntry("info", OutputLogStatus.Info);
+            vm.AddOutputEntry("warn", OutputLogStatus.Warning);
+            vm.AddOutputEntry("error", OutputLogStatus.Error);
+
+            vm.ShowInfoLogs = false;
+            var visible = vm.FilteredEntries.Cast<OutputLogEntry>().ToList();
+
+            Assert.Equal(3, vm.OutputEntries.Count);
+            Assert.Equal(2, visible.Count);
+            Assert.DoesNotContain(visible, e => e.Status == OutputLogStatus.Info);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Xunit;
 
 namespace OasisEditor.Tests;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimePaths.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimePaths.cs
@@ -28,4 +28,15 @@ public static class MameRuntimePaths
         Directory.CreateDirectory(romRoot);
         return romRoot;
     }
+
+    public static string EnsureManagedLogRootDirectory()
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OasisEditor",
+            "System",
+            "Logs");
+        Directory.CreateDirectory(root);
+        return root;
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogDiskWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogDiskWriter.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 
 namespace OasisEditor;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogDiskWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogDiskWriter.cs
@@ -1,0 +1,38 @@
+using System.Text;
+
+namespace OasisEditor;
+
+public sealed class OutputLogDiskWriter
+{
+    private readonly string _logDirectory;
+
+    public OutputLogDiskWriter(string logDirectory)
+    {
+        _logDirectory = logDirectory;
+    }
+
+    public string CurrentLogPath => Path.Combine(_logDirectory, "Editor.log");
+    public string PreviousLogPath => Path.Combine(_logDirectory, "Editor-prev.log");
+
+    public void Initialize()
+    {
+        Directory.CreateDirectory(_logDirectory);
+        if (File.Exists(PreviousLogPath))
+        {
+            File.Delete(PreviousLogPath);
+        }
+
+        if (File.Exists(CurrentLogPath))
+        {
+            File.Move(CurrentLogPath, PreviousLogPath);
+        }
+
+        File.WriteAllText(CurrentLogPath, string.Empty);
+    }
+
+    public void Append(OutputLogEntry entry)
+    {
+        var line = entry.ToClipboardLine() + Environment.NewLine;
+        File.AppendAllText(CurrentLogPath, line, Encoding.UTF8);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogEntry.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OutputLogEntry.cs
@@ -15,7 +15,14 @@ public sealed record OutputLogEntry(DateTime Timestamp, string Message, OutputLo
     private static readonly Brush WarningBrush = Brushes.Gold;
     private static readonly Brush ErrorBrush = Brushes.IndianRed;
 
-    public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss");
+    public string FormattedTimestamp => Timestamp.ToString("HH:mm:ss.fff");
+
+    public string SeverityLabel => Status.ToString();
+
+    public string ToClipboardLine()
+    {
+        return $"[{FormattedTimestamp}] [{SeverityLabel}] {Message}";
+    }
 
     public string IconGlyph => Status switch
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -1,24 +1,57 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace OasisEditor;
 
 public sealed class OutputLogViewModel : INotifyPropertyChanged
 {
+    private readonly OutputLogDiskWriter _diskWriter;
     private OutputLogEntry? _lastEntry;
+    private bool _showInfoLogs = true;
+    private bool _showWarningLogs = true;
+    private bool _showErrorLogs = true;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public OutputLogViewModel()
+        : this(new OutputLogDiskWriter(MameRuntimePaths.EnsureManagedLogRootDirectory()))
     {
+    }
+
+    public OutputLogViewModel(OutputLogDiskWriter diskWriter)
+    {
+        _diskWriter = diskWriter;
         OutputEntries = new ObservableCollection<OutputLogEntry>();
+        FilteredEntries = CollectionViewSource.GetDefaultView(OutputEntries);
+        FilteredEntries.Filter = ShouldShowEntry;
         ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
+        _diskWriter.Initialize();
     }
 
     public ObservableCollection<OutputLogEntry> OutputEntries { get; }
+    public ICollectionView FilteredEntries { get; }
     public ICommand ClearOutputCommand { get; }
+
+    public bool ShowInfoLogs
+    {
+        get => _showInfoLogs;
+        set => SetFilter(ref _showInfoLogs, value);
+    }
+
+    public bool ShowWarningLogs
+    {
+        get => _showWarningLogs;
+        set => SetFilter(ref _showWarningLogs, value);
+    }
+
+    public bool ShowErrorLogs
+    {
+        get => _showErrorLogs;
+        set => SetFilter(ref _showErrorLogs, value);
+    }
 
     public OutputLogEntry? LastEntry
     {
@@ -41,6 +74,23 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         OutputEntries.Add(entry);
         LastEntry = entry;
         NotifyClearCommand();
+
+        try
+        {
+            _diskWriter.Append(entry);
+        }
+        catch
+        {
+            // Keep logging failures non-fatal.
+        }
+    }
+
+    public void NotifyClearCommand()
+    {
+        if (ClearOutputCommand is RelayCommand clearRelayCommand)
+        {
+            clearRelayCommand.RaiseCanExecuteChanged();
+        }
     }
 
     private bool CanClearOutput()
@@ -55,12 +105,32 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         AddOutputEntry("Output log cleared.", OutputLogStatus.Info);
     }
 
-    public void NotifyClearCommand()
+    private bool ShouldShowEntry(object item)
     {
-        if (ClearOutputCommand is RelayCommand clearRelayCommand)
+        if (item is not OutputLogEntry entry)
         {
-            clearRelayCommand.RaiseCanExecuteChanged();
+            return false;
         }
+
+        return entry.Status switch
+        {
+            OutputLogStatus.Info => ShowInfoLogs,
+            OutputLogStatus.Warning => ShowWarningLogs,
+            OutputLogStatus.Error => ShowErrorLogs,
+            _ => true
+        };
+    }
+
+    private void SetFilter(ref bool field, bool value, [CallerMemberName] string? propertyName = null)
+    {
+        if (field == value)
+        {
+            return;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        FilteredEntries.Refresh();
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -14,6 +14,18 @@
 
         <DockPanel Grid.Row="0"
                    LastChildFill="False">
+            <CheckBox Margin="0,0,8,0"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding ShowInfoLogs}"
+                      Content="Info" />
+            <CheckBox Margin="0,0,8,0"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding ShowWarningLogs}"
+                      Content="Warning" />
+            <CheckBox Margin="0,0,8,0"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding ShowErrorLogs}"
+                      Content="Error" />
             <Button DockPanel.Dock="Right"
                     Padding="10,4"
                     Command="{Binding ClearOutputCommand}"
@@ -23,7 +35,8 @@
         <ListBox Grid.Row="1"
                  Margin="0,8,0,0"
                  BorderThickness="0"
-                 ItemsSource="{Binding OutputEntries}">
+                 ItemsSource="{Binding FilteredEntries}"
+                 SelectionMode="Extended">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
### Motivation
- Improve the Output pane so it can be used for runtime debugging by adding severity filtering and durable run logs as described in the Output Log Enhancement Plan.
- Provide a copy-friendly, timestamped line format and prepare the view for Windows-style multi-selection and clipboard copy features without mutating the source log collection.

### Description
- Add `OutputLogDiskWriter` to handle log directory creation and startup rotation semantics for `Editor.log` and `Editor-prev.log` and append formatted lines to disk asynchronously-suitable (file: `OutputLogDiskWriter.cs`).
- Extend `MameRuntimePaths` with `EnsureManagedLogRootDirectory()` to provide `%LOCALAPPDATA%\OasisEditor\System\Logs` as the log location.
- Update `OutputLogEntry` to include milliseconds and a `ToClipboardLine()` method producing the standardized format `[{HH:mm:ss.fff}] [Severity] Message` (file: `OutputLogEntry.cs`).
- Update `OutputLogViewModel` to use a `CollectionView` filter and expose `ShowInfoLogs`, `ShowWarningLogs`, and `ShowErrorLogs` properties so filtering hides rows in the view only while preserving `OutputEntries`, and wire disk appends via the disk writer with non-fatal error handling (file: `ViewModels/OutputLogViewModel.cs`).
- Update `OutputLogView.xaml` to add Info/Warning/Error checkboxes bound to the filter properties, switch the list to bind `FilteredEntries`, and enable `SelectionMode="Extended"` to prepare for multi-selection copy and context-menu work.
- Add focused unit tests (`OutputLogEnhancementTests.cs`) covering log rotation and view-model filtering behavior without removing source entries.

### Testing
- Added two automated unit tests: `DiskWriter_RotatesCurrentLogToPrevious` and `ViewModel_FiltersBySeverityWithoutRemovingSourceEntries` in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs` (tests were added but not executed here).
- No automated tests were run in this execution environment due to the project environment constraints; please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` locally to validate the new tests.
- Manual/local verification should include checking `Editor.log`/`Editor-prev.log` rotation, that `Show*Logs` toggles hide/show entries only in the UI and do not remove items from `OutputEntries`, and that appended disk lines match the `[{HH:mm:ss.fff}] [Severity] Message` format.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a039578a6148327b0174f0d04f257f6)