### PR TITLE
Enhance Output pane selection/copy and log file actions

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OutputLogEnhancementTests.cs
@@ -53,4 +53,48 @@ public sealed class OutputLogEnhancementTests
             Directory.Delete(root, true);
         }
     }
+
+    [Fact]
+    public void ViewModel_CopySelection_ExcludesHiddenFilteredRows()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"oasis-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var vm = new OutputLogViewModel(new OutputLogDiskWriter(root));
+            vm.AddOutputEntry("info", OutputLogStatus.Info);
+            vm.AddOutputEntry("warn", OutputLogStatus.Warning);
+            vm.AddOutputEntry("error", OutputLogStatus.Error);
+            vm.ShowWarningLogs = false;
+
+            vm.UpdateSelectedEntries(vm.OutputEntries);
+            var text = vm.BuildClipboardTextForSelection();
+
+            Assert.Contains("[Info] info", text);
+            Assert.Contains("[Error] error", text);
+            Assert.DoesNotContain("[Warning] warn", text);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ViewModel_CopySelectionHeader_UsesSingularForSingleItem()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"oasis-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var vm = new OutputLogViewModel(new OutputLogDiskWriter(root));
+            vm.AddOutputEntry("info", OutputLogStatus.Info);
+            vm.UpdateSelectedEntries(vm.OutputEntries.Take(1));
+            Assert.Equal("Copy Row", vm.CopySelectionHeader);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -305,6 +305,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
     public ObservableCollection<OutputLogEntry> OutputEntries { get; }
+    public OutputLogViewModel OutputLog => _outputLog;
     public IReadOnlyList<AssetDirectoryNodeViewModel> AssetDirectoryTree => _assetBrowser.AssetDirectoryTree;
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -1,5 +1,8 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -13,6 +16,7 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     private bool _showInfoLogs = true;
     private bool _showWarningLogs = true;
     private bool _showErrorLogs = true;
+    private IReadOnlyList<OutputLogEntry> _selectedEntries = Array.Empty<OutputLogEntry>();
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -34,6 +38,9 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     public ObservableCollection<OutputLogEntry> OutputEntries { get; }
     public ICollectionView FilteredEntries { get; }
     public ICommand ClearOutputCommand { get; }
+    public string CurrentLogPath => _diskWriter.CurrentLogPath;
+    public string LogDirectoryPath => Path.GetDirectoryName(CurrentLogPath) ?? string.Empty;
+    public string CopySelectionHeader => SelectedEntries.Count == 1 ? "Copy Row" : "Copy Rows";
 
     public bool ShowInfoLogs
     {
@@ -68,6 +75,17 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         }
     }
 
+    public IReadOnlyList<OutputLogEntry> SelectedEntries
+    {
+        get => _selectedEntries;
+        private set
+        {
+            _selectedEntries = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(CopySelectionHeader));
+        }
+    }
+
     public void AddOutputEntry(string message, OutputLogStatus status)
     {
         var entry = new OutputLogEntry(DateTime.Now, message, status);
@@ -93,6 +111,42 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         }
     }
 
+    public void UpdateSelectedEntries(IEnumerable<OutputLogEntry> selectedEntries)
+    {
+        SelectedEntries = selectedEntries
+            .Where(entry => ShouldShowEntry(entry))
+            .ToList();
+    }
+
+    public string BuildClipboardTextForSelection()
+    {
+        return string.Join(Environment.NewLine, SelectedEntries.Select(entry => entry.ToClipboardLine()));
+    }
+
+    public bool TryOpenCurrentLog(out string? failureReason)
+    {
+        failureReason = null;
+        if (!File.Exists(CurrentLogPath))
+        {
+            failureReason = $"Cannot open log; file does not exist: {CurrentLogPath}";
+            return false;
+        }
+
+        return TryLaunch(new ProcessStartInfo(CurrentLogPath) { UseShellExecute = true }, out failureReason);
+    }
+
+    public bool TryShowLogInExplorer(out string? failureReason)
+    {
+        failureReason = null;
+        if (!Directory.Exists(LogDirectoryPath))
+        {
+            failureReason = $"Cannot show log directory; directory does not exist: {LogDirectoryPath}";
+            return false;
+        }
+
+        return TryLaunch(new ProcessStartInfo("explorer.exe", $"\"{LogDirectoryPath}\"") { UseShellExecute = true }, out failureReason);
+    }
+
     private bool CanClearOutput()
     {
         return OutputEntries.Count > 0;
@@ -103,6 +157,21 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         OutputEntries.Clear();
         LastEntry = null;
         AddOutputEntry("Output log cleared.", OutputLogStatus.Info);
+    }
+
+    private static bool TryLaunch(ProcessStartInfo startInfo, out string? failureReason)
+    {
+        failureReason = null;
+        try
+        {
+            Process.Start(startInfo);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failureReason = ex.Message;
+            return false;
+        }
     }
 
     private bool ShouldShowEntry(object item)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -88,7 +88,7 @@
                                                  CanClose="False">
                             <Border Padding="10"
                                     Background="{DynamicResource ToolBarBackgroundBrush}">
-                                <views:OutputLogView />
+                                <views:OutputLogView DataContext="{Binding OutputLog}" />
                             </Border>
                         </layout:LayoutAnchorable>
                     </layout:LayoutAnchorablePane>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -14,6 +14,15 @@
 
         <DockPanel Grid.Row="0"
                    LastChildFill="False">
+            <Button DockPanel.Dock="Right"
+                    Margin="8,0,0,0"
+                    Padding="10,4"
+                    Click="OnShowLogInExplorerClicked"
+                    Content="Show In Explorer" />
+            <Button DockPanel.Dock="Right"
+                    Padding="10,4"
+                    Click="OnOpenLogClicked"
+                    Content="Open Log" />
             <CheckBox Margin="0,0,8,0"
                       VerticalAlignment="Center"
                       IsChecked="{Binding ShowInfoLogs}"
@@ -32,11 +41,23 @@
                     Content="Clear" />
         </DockPanel>
 
-        <ListBox Grid.Row="1"
+        <ListBox x:Name="OutputList"
+                 Grid.Row="1"
                  Margin="0,8,0,0"
                  BorderThickness="0"
                  ItemsSource="{Binding FilteredEntries}"
-                 SelectionMode="Extended">
+                 SelectionMode="Extended"
+                 SelectionChanged="OnOutputSelectionChanged">
+            <ListBox.ContextMenu>
+                <ContextMenu Style="{StaticResource EditorContextMenuStyle}">
+                    <MenuItem Header="Clear Log"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Command="{Binding ClearOutputCommand}" />
+                    <MenuItem Header="{Binding CopySelectionHeader}"
+                              Style="{StaticResource EditorContextMenuItemStyle}"
+                              Click="OnCopySelectionClicked" />
+                </ContextMenu>
+            </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
@@ -1,4 +1,7 @@
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace OasisEditor.Views;
 
@@ -7,5 +10,71 @@ public partial class OutputLogView : UserControl
     public OutputLogView()
     {
         InitializeComponent();
+        CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, OnCopySelectionExecuted));
+        InputBindings.Add(new KeyBinding(ApplicationCommands.Copy, Key.C, ModifierKeys.Control));
+    }
+
+    private OutputLogViewModel? ViewModel => DataContext as OutputLogViewModel;
+
+    private void OnOutputSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        ViewModel.UpdateSelectedEntries(OutputList.SelectedItems.Cast<OutputLogEntry>());
+    }
+
+    private void OnCopySelectionExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        CopySelection();
+    }
+
+    private void OnCopySelectionClicked(object sender, RoutedEventArgs e)
+    {
+        CopySelection();
+    }
+
+    private void OnOpenLogClicked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        if (!ViewModel.TryOpenCurrentLog(out var failureReason) && !string.IsNullOrWhiteSpace(failureReason))
+        {
+            ViewModel.AddOutputEntry(failureReason, OutputLogStatus.Warning);
+        }
+    }
+
+    private void OnShowLogInExplorerClicked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        if (!ViewModel.TryShowLogInExplorer(out var failureReason) && !string.IsNullOrWhiteSpace(failureReason))
+        {
+            ViewModel.AddOutputEntry(failureReason, OutputLogStatus.Warning);
+        }
+    }
+
+    private void CopySelection()
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        var text = ViewModel.BuildClipboardTextForSelection();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        Clipboard.SetText(text);
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Output pane usable for runtime debugging by supporting Windows-style multi-selection, visible-only clipboard copy, and quick access to persistent run logs. 
- Keep disk I/O out of view logic and fail safely when OS actions (open file / show folder) cannot be performed. 

### Description
- Added selection tracking and clipboard helpers to `OutputLogViewModel` including `SelectedEntries`, `UpdateSelectedEntries`, and `BuildClipboardTextForSelection`, and exposed `CurrentLogPath`/`LogDirectoryPath` (file: `ViewModels/OutputLogViewModel.cs`).
- Added safe OS actions `TryOpenCurrentLog` and `TryShowLogInExplorer` with guarded `ProcessStartInfo` launching and non-fatal failure reporting (file: `ViewModels/OutputLogViewModel.cs`).
- Updated the Output pane view to add `Open Log` and `Show In Explorer` toolbar buttons, a named `ListBox` (`OutputList`) with `SelectionMode="Extended"`, a context menu with dynamic copy header, and wired selection/copy handlers including `Ctrl+C` support (files: `Views/OutputLogView.xaml` and `Views/OutputLogView.xaml.cs`).
- Added unit tests covering log rotation (existing) and new behaviors for filtered-copy exclusion and singular/plural copy labeling (file: `OasisEditor.Tests/OutputLogEnhancementTests.cs`).

### Testing
- Added automated tests: `DiskWriter_RotatesCurrentLogToPrevious`, `ViewModel_FiltersBySeverityWithoutRemovingSourceEntries`, `ViewModel_CopySelection_ExcludesHiddenFilteredRows`, and `ViewModel_CopySelectionHeader_UsesSingularForSingleItem` (file: `OasisEditor.Tests/OutputLogEnhancementTests.cs`).
- No test execution was performed in this environment per repository constraints; please run `dotnet test` locally to validate the new tests and behavior.
- Manual verification steps are included in the PR metadata and recommend checking `Ctrl+C` copy, filter exclusion of hidden rows, context-menu labels, `Open Log`, `Show In Explorer`, and that `Clear Log` does not truncate `Editor.log`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03991497388327a1dde740309f70d6)