### PR TITLE
Preserve MAME ROM preferences when saving window placement

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -149,6 +149,7 @@ public partial class MainWindow : Window
         _preferencesStore.Save(new EditorPreferences
         {
             ThemePreference = preferences.ThemePreference,
+            Mame = preferences.Mame,
             ProjectWindowStates = states
         });
     }


### PR DESCRIPTION
### Motivation
- Prevent the `Mame` preferences (including `ROM Download Base URL` and `ROM Archive Extension`) from being dropped when `SaveWindowPlacement()` wrote a new `EditorPreferences` payload during shutdown, which caused those fields to reset to defaults on relaunch.

### Description
- Restore preservation of MAME settings by adding `Mame = preferences.Mame` to the `SaveWindowPlacement()` call in `WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs` so the existing `Mame` object is carried into the saved `EditorPreferences`.

### Testing
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` but `dotnet` is not available in this environment, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04d0082074832786d8d48abc977077)