### PR TITLE
Prioritize managed/shared MAME ROM path when launching MAME

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
@@ -22,12 +22,30 @@ public sealed class MameProcessStartInfoBuilderTests
         Assert.Contains("myrom", startInfo.Arguments);
         Assert.Contains("-rompath", startInfo.Arguments);
         Assert.Contains(@"C:\Users\john\AppData\Local\OasisEditor\MAME\roms", startInfo.Arguments);
+        Assert.Contains(@"C:\Users\john\AppData\Local\OasisEditor\MAME\roms;C:\Mame\roms", startInfo.Arguments);
         Assert.Contains("-output console", startInfo.Arguments);
         Assert.Contains("-plugin oasis", startInfo.Arguments);
         Assert.Contains("-skip_gameinfo", startInfo.Arguments);
         Assert.Contains("-video none", startInfo.Arguments);
         Assert.Contains("-seconds_to_run 999999999", startInfo.Arguments);
         Assert.DoesNotContain("-plugins_path", startInfo.Arguments);
+    }
+
+    [Fact]
+    public void Build_PlacesRomPathBeforeRomName()
+    {
+        var builder = new MameProcessStartInfoBuilder();
+        var request = new MameProcessLaunchRequest(
+            @"C:\Mame\mame.exe",
+            "myrom",
+            @"C:\Shared\roms",
+            @"C:\plugins",
+            string.Empty);
+
+        var startInfo = builder.Build(request);
+        var expectedPrefix = "-rompath C:\\Shared\\roms;C:\\Mame\\roms myrom";
+
+        Assert.StartsWith(expectedPrefix, startInfo.Arguments);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
@@ -22,7 +22,6 @@ public sealed class MameProcessStartInfoBuilderTests
         Assert.Contains("myrom", startInfo.Arguments);
         Assert.Contains("-rompath", startInfo.Arguments);
         Assert.Contains(@"C:\Users\john\AppData\Local\OasisEditor\MAME\roms", startInfo.Arguments);
-        Assert.Contains(@"C:\Users\john\AppData\Local\OasisEditor\MAME\roms;C:\Mame\roms", startInfo.Arguments);
         Assert.Contains("-output console", startInfo.Arguments);
         Assert.Contains("-plugin oasis", startInfo.Arguments);
         Assert.Contains("-skip_gameinfo", startInfo.Arguments);
@@ -32,7 +31,7 @@ public sealed class MameProcessStartInfoBuilderTests
     }
 
     [Fact]
-    public void Build_PlacesRomPathBeforeRomName()
+    public void Build_PlacesRomNameBeforeOptionArguments()
     {
         var builder = new MameProcessStartInfoBuilder();
         var request = new MameProcessLaunchRequest(
@@ -43,7 +42,7 @@ public sealed class MameProcessStartInfoBuilderTests
             string.Empty);
 
         var startInfo = builder.Build(request);
-        var expectedPrefix = "-rompath C:\\Shared\\roms;C:\\Mame\\roms myrom";
+        var expectedPrefix = "myrom -rompath C:\\Shared\\roms";
 
         Assert.StartsWith(expectedPrefix, startInfo.Arguments);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
@@ -12,12 +12,9 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(request.MameRomName);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.MameRomRootPath);
         var arguments = new StringBuilder();
-        var effectiveRomPath = BuildRomPathArgument(request.MameExecutablePath, request.MameRomRootPath);
-
-        arguments.Append("-rompath ");
-        arguments.Append(EscapeArgument(effectiveRomPath));
-        arguments.Append(' ');
         arguments.Append(EscapeArgument(request.MameRomName));
+        arguments.Append(" -rompath ");
+        arguments.Append(EscapeArgument(request.MameRomRootPath));
         arguments.Append(" -output console");
         arguments.Append(" -plugin oasis");
         arguments.Append(" -skip_gameinfo");
@@ -56,18 +53,4 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
             : value;
     }
 
-    private static string BuildRomPathArgument(string executablePath, string managedRomRootPath)
-    {
-        var executableDirectory = Path.GetDirectoryName(executablePath) ?? string.Empty;
-        var localRomDirectory = string.IsNullOrWhiteSpace(executableDirectory)
-            ? string.Empty
-            : Path.Combine(executableDirectory, "roms");
-
-        if (string.IsNullOrWhiteSpace(localRomDirectory))
-        {
-            return managedRomRootPath;
-        }
-
-        return string.Join(';', new[] { managedRomRootPath, localRomDirectory });
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
@@ -12,9 +12,12 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(request.MameRomName);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.MameRomRootPath);
         var arguments = new StringBuilder();
+        var effectiveRomPath = BuildRomPathArgument(request.MameExecutablePath, request.MameRomRootPath);
+
+        arguments.Append("-rompath ");
+        arguments.Append(EscapeArgument(effectiveRomPath));
+        arguments.Append(' ');
         arguments.Append(EscapeArgument(request.MameRomName));
-        arguments.Append(" -rompath ");
-        arguments.Append(EscapeArgument(request.MameRomRootPath));
         arguments.Append(" -output console");
         arguments.Append(" -plugin oasis");
         arguments.Append(" -skip_gameinfo");
@@ -51,5 +54,20 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         return value.Contains(' ') || value.Contains('"')
             ? $"\"{value.Replace("\"", "\\\"")}\""
             : value;
+    }
+
+    private static string BuildRomPathArgument(string executablePath, string managedRomRootPath)
+    {
+        var executableDirectory = Path.GetDirectoryName(executablePath) ?? string.Empty;
+        var localRomDirectory = string.IsNullOrWhiteSpace(executableDirectory)
+            ? string.Empty
+            : Path.Combine(executableDirectory, "roms");
+
+        if (string.IsNullOrWhiteSpace(localRomDirectory))
+        {
+            return managedRomRootPath;
+        }
+
+        return string.Join(';', new[] { managedRomRootPath, localRomDirectory });
     }
 }


### PR DESCRIPTION
### Motivation
- Launching MAME was relying on the exe-local `roms` directory so downloaded ROMs in the centralized managed folder were not always found, causing missing file errors at startup.
- The runtime should explicitly expose the managed ROM folder first while preserving the legacy local `roms` directory as a fallback.

### Description
- Updated `MameProcessStartInfoBuilder.Build` to compute an `effectiveRomPath` and pass `-rompath` before the ROM name so MAME resolves the shared path first.
- Added a new `BuildRomPathArgument` helper that returns a semicolon-separated path combining the managed ROM root and the `<mame.exe dir>\roms` fallback.
- Kept existing headless arguments unchanged (`-output console`, `-plugin oasis`, `-skip_gameinfo`, `-video none`, etc.).
- Extended `MameProcessStartInfoBuilderTests` to assert the combined managed+local rompath and to add a `Build_PlacesRomPathBeforeRomName` test that verifies argument ordering.

### Testing
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --filter MameProcessStartInfoBuilderTests` but the environment lacks the `dotnet` SDK so the test run failed with `dotnet: command not found`.
- Added automated unit tests `Build_PlacesRomPathBeforeRomName` and updated `Build_IncludesRuntimeArgumentsForHeadlessOasisMode`, which should pass when run in a dev/CI environment with `dotnet` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04d6fa0d008327ad86481d07902ace)