### PR TITLE
Wire MAME stdout lamp updates into Panel2D runtime visuals

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -17,6 +17,8 @@ public sealed class MamePreferences
     public string CommandLineOverrides { get; init; } = string.Empty;
     public bool KeepMameUpToDateAutomatically { get; init; } = true;
     public bool DebugOutputLamps { get; init; }
+    public bool DebugOutputStdIn { get; init; }
+    public bool DebugOutputStdOut { get; init; }
     public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/MAME215RomsOnlyMerged/";
     public string RomArchiveExtension { get; init; } = ".zip";
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -16,6 +16,7 @@ public sealed class MamePreferences
     public string ReleaseSource { get; init; } = "https://github.com/mamedev/mame/releases";
     public string CommandLineOverrides { get; init; } = string.Empty;
     public bool KeepMameUpToDateAutomatically { get; init; } = true;
+    public bool DebugOutputLamps { get; init; }
     public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/MAME215RomsOnlyMerged/";
     public string RomArchiveExtension { get; init; } = ".zip";
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -37,6 +37,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private bool _keepMameUpToDateAutomatically = true;
     private bool _debugOutputLamps;
+    private bool _debugOutputStdIn;
+    private bool _debugOutputStdOut;
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
@@ -154,6 +156,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
         _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
         _debugOutputLamps = preferences.Mame.DebugOutputLamps;
+        _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
+        _debugOutputStdOut = preferences.Mame.DebugOutputStdOut;
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
@@ -181,8 +185,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameProcessRunner(
                 stdoutLogger: line =>
                 {
-                    AddOutputEntry($"[MAME] {line}", OutputLogStatus.Info);
+                    if (DebugOutputStdOut)
+                    {
+                        AddOutputEntry($"[MAME-STDOUT] {line}", OutputLogStatus.Info);
+                    }
                     mameStdoutParser.ProcessLine(line);
+                },
+                stdinLogger: line =>
+                {
+                    if (DebugOutputStdIn)
+                    {
+                        AddOutputEntry($"[MAME-STDIN] {line}", OutputLogStatus.Info);
+                    }
                 },
                 stderrLogger: line => AddOutputEntry($"[MAME-ERR] {line}", OutputLogStatus.Warning)),
             BuildMameLaunchRequest);
@@ -429,6 +443,28 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         set
         {
             if (SetProperty(ref _debugOutputLamps, value))
+            {
+                SavePreferences();
+            }
+        }
+    }
+    public bool DebugOutputStdIn
+    {
+        get => _debugOutputStdIn;
+        set
+        {
+            if (SetProperty(ref _debugOutputStdIn, value))
+            {
+                SavePreferences();
+            }
+        }
+    }
+    public bool DebugOutputStdOut
+    {
+        get => _debugOutputStdOut;
+        set
+        {
+            if (SetProperty(ref _debugOutputStdOut, value))
             {
                 SavePreferences();
             }
@@ -1409,6 +1445,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 CommandLineOverrides = MameCommandLineOverrides,
                 KeepMameUpToDateAutomatically = KeepMameUpToDateAutomatically,
                 DebugOutputLamps = DebugOutputLamps,
+                DebugOutputStdIn = DebugOutputStdIn,
+                DebugOutputStdOut = DebugOutputStdOut,
                 RomDownloadBaseUrl = MameRomDownloadBaseUrl,
                 RomArchiveExtension = MameRomArchiveExtension
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -155,10 +155,31 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
+        var mameStdoutParser = new MameStdoutParser(
+            new MameLampStateParser(),
+            new MameLampRuntimeAdapter(
+                () => OpenDocuments,
+                work =>
+                {
+                    var dispatcher = Application.Current.Dispatcher;
+                    if (dispatcher.CheckAccess())
+                    {
+                        work();
+                    }
+                    else
+                    {
+                        dispatcher.Invoke(work);
+                    }
+                }),
+            diagnosticLogger: line => AddOutputEntry(line, OutputLogStatus.Info));
         _mameEmulationService = new MameEmulationService(
             new MameProcessStartInfoBuilder(),
             new MameProcessRunner(
-                stdoutLogger: line => AddOutputEntry($"[MAME] {line}", OutputLogStatus.Info),
+                stdoutLogger: line =>
+                {
+                    AddOutputEntry($"[MAME] {line}", OutputLogStatus.Info);
+                    mameStdoutParser.ProcessLine(line);
+                },
                 stderrLogger: line => AddOutputEntry($"[MAME-ERR] {line}", OutputLogStatus.Warning)),
             BuildMameLaunchRequest);
         _mameEmulationService.StateChanged += (_, state) =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -183,14 +183,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameEmulationService = new MameEmulationService(
             new MameProcessStartInfoBuilder(),
             new MameProcessRunner(
-                stdoutLogger: line =>
-                {
-                    if (DebugOutputStdOut)
-                    {
-                        AddOutputEntry($"[MAME-STDOUT] {line}", OutputLogStatus.Info);
-                    }
-                    mameStdoutParser.ProcessLine(line);
-                },
+                stdoutLogger: line => ProcessMameStdoutLine(line, mameStdoutParser),
                 stdinLogger: line =>
                 {
                     if (DebugOutputStdIn)
@@ -1451,6 +1444,33 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 RomArchiveExtension = MameRomArchiveExtension
             }
         });
+    }
+
+    private void ProcessMameStdoutLine(string line, IMameStdoutParser parser)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return;
+        }
+
+        var normalized = line.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Replace("\\n", "\n", StringComparison.Ordinal);
+        var segments = normalized.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var segment in segments)
+        {
+            if (DebugOutputStdOut)
+            {
+                AddOutputEntry($"[MAME-STDOUT] {segment}", OutputLogStatus.Info);
+            }
+
+            parser.ProcessLine(segment);
+        }
     }
 
     private void OpenProjectSettings()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -36,6 +36,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
     private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private bool _keepMameUpToDateAutomatically = true;
+    private bool _debugOutputLamps;
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
@@ -152,6 +153,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameRomDownloadService.DownloadRootUrl = _mameRomDownloadBaseUrl;
         _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
         _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
+        _debugOutputLamps = preferences.Mame.DebugOutputLamps;
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
@@ -159,6 +161,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameLampStateParser(),
             new MameLampRuntimeAdapter(
                 () => OpenDocuments,
+                () => DebugOutputLamps,
+                message => AddOutputEntry(message, OutputLogStatus.Info),
                 work =>
                 {
                     var dispatcher = Application.Current.Dispatcher;
@@ -419,6 +423,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
     public bool IsMameVersionEditable => !KeepMameUpToDateAutomatically;
+    public bool DebugOutputLamps
+    {
+        get => _debugOutputLamps;
+        set
+        {
+            if (SetProperty(ref _debugOutputLamps, value))
+            {
+                SavePreferences();
+            }
+        }
+    }
     public string MameRomName
     {
         get => _mameRomName;
@@ -1393,6 +1408,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 ReleaseSource = MameReleaseSource,
                 CommandLineOverrides = MameCommandLineOverrides,
                 KeepMameUpToDateAutomatically = KeepMameUpToDateAutomatically,
+                DebugOutputLamps = DebugOutputLamps,
                 RomDownloadBaseUrl = MameRomDownloadBaseUrl,
                 RomArchiveExtension = MameRomArchiveExtension
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -26,7 +26,12 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
 
     private void ApplyOnUiThread(int lampId, int lampValue)
     {
-        var normalizedIntensity = Math.Clamp(lampValue / 255d, 0d, 1d);
+        var normalizedIntensity = lampValue switch
+        {
+            <= 0 => 0d,
+            <= 1 => 1d,
+            _ => Math.Clamp(lampValue / 255d, 0d, 1d)
+        };
         if (_debugOutputEnabledProvider())
         {
             _infoLogger($"[MAME-LAMP] lamp{lampId} value={lampValue} intensity={normalizedIntensity:0.###}");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -3,11 +3,19 @@ namespace OasisEditor;
 public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
 {
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Func<bool> _debugOutputEnabledProvider;
+    private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
 
-    public MameLampRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    public MameLampRuntimeAdapter(
+        Func<IEnumerable<DocumentTabViewModel>> documentProvider,
+        Func<bool> debugOutputEnabledProvider,
+        Action<string> infoLogger,
+        Action<Action> uiDispatch)
     {
         _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _debugOutputEnabledProvider = debugOutputEnabledProvider ?? throw new ArgumentNullException(nameof(debugOutputEnabledProvider));
+        _infoLogger = infoLogger ?? throw new ArgumentNullException(nameof(infoLogger));
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
     }
 
@@ -19,6 +27,11 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
     private void ApplyOnUiThread(int lampId, int lampValue)
     {
         var normalizedIntensity = Math.Clamp(lampValue / 255d, 0d, 1d);
+        if (_debugOutputEnabledProvider())
+        {
+            _infoLogger($"[MAME-LAMP] lamp{lampId} value={lampValue} intensity={normalizedIntensity:0.###}");
+        }
+
         foreach (var document in _documentProvider())
         {
             var matchingObjectIds = document

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -1,0 +1,46 @@
+namespace OasisEditor;
+
+public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
+{
+    private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Action<Action> _uiDispatch;
+
+    public MameLampRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    {
+        _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
+    }
+
+    public void ApplyLampState(int lampId, int lampValue)
+    {
+        _uiDispatch(() => ApplyOnUiThread(lampId, lampValue));
+    }
+
+    private void ApplyOnUiThread(int lampId, int lampValue)
+    {
+        var normalizedIntensity = Math.Clamp(lampValue / 255d, 0d, 1d);
+        foreach (var document in _documentProvider())
+        {
+            var matchingObjectIds = document
+                .GetPanelElements()
+                .Where(element => element.Kind == PanelElementKind.Lamp
+                    && element.DisplayNumber.GetValueOrDefault() == lampId
+                    && !string.IsNullOrWhiteSpace(element.ObjectId))
+                .Select(element => element.ObjectId)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (matchingObjectIds.Length == 0)
+            {
+                continue;
+            }
+
+            foreach (var objectId in matchingObjectIds)
+            {
+                document.RuntimeState.SetLampIntensity(objectId, normalizedIntensity);
+            }
+
+            document.NotifyPanelVisualPreviewChanged();
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampStateParser.cs
@@ -1,4 +1,5 @@
 namespace OasisEditor;
+using System.Text.RegularExpressions;
 
 public interface IMameLampStateParser
 {
@@ -7,6 +8,10 @@ public interface IMameLampStateParser
 
 public sealed class MameLampStateParser : IMameLampStateParser
 {
+    private static readonly Regex LampLineRegex = new(
+        @"lamp\s*(\d+)\s*=\s*(-?\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     public bool TryParse(string line, out int lampId, out int lampValue)
     {
         lampId = 0;
@@ -18,6 +23,14 @@ public sealed class MameLampStateParser : IMameLampStateParser
         }
 
         var trimmed = line.Trim();
+        var regexMatch = LampLineRegex.Match(trimmed);
+        if (regexMatch.Success
+            && int.TryParse(regexMatch.Groups[1].Value, out lampId)
+            && int.TryParse(regexMatch.Groups[2].Value, out lampValue))
+        {
+            return true;
+        }
+
         var tokens = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (tokens.Length < 2)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
@@ -8,20 +8,22 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 {
     private readonly Func<Process> _processFactory;
     private readonly Action<string>? _stdoutLogger;
+    private readonly Action<string>? _stdinLogger;
     private readonly Action<string>? _stderrLogger;
     private Process? _process;
     private Task? _stdoutPumpTask;
     private Task? _stderrPumpTask;
 
-    public MameProcessRunner(Action<string>? stdoutLogger = null, Action<string>? stderrLogger = null)
-        : this(() => new Process(), stdoutLogger, stderrLogger)
+    public MameProcessRunner(Action<string>? stdoutLogger = null, Action<string>? stdinLogger = null, Action<string>? stderrLogger = null)
+        : this(() => new Process(), stdoutLogger, stdinLogger, stderrLogger)
     {
     }
 
-    internal MameProcessRunner(Func<Process> processFactory, Action<string>? stdoutLogger = null, Action<string>? stderrLogger = null)
+    internal MameProcessRunner(Func<Process> processFactory, Action<string>? stdoutLogger = null, Action<string>? stdinLogger = null, Action<string>? stderrLogger = null)
     {
         _processFactory = processFactory ?? throw new ArgumentNullException(nameof(processFactory));
         _stdoutLogger = stdoutLogger;
+        _stdinLogger = stdinLogger;
         _stderrLogger = stderrLogger;
     }
 
@@ -94,6 +96,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             throw new InvalidOperationException("Cannot write input because MAME process is not running.");
         }
 
+        _stdinLogger?.Invoke(command);
         await process.StandardInput.WriteLineAsync(new StringBuilder(command), cancellationToken).ConfigureAwait(false);
         await process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -141,16 +141,18 @@ public static class PanelLayoutMapper
                 continue;
             }
 
+            var lampVisualState = visualStateChange.ValuesByObjectId[objectId] switch
+            {
+                LampVisualState state => state,
+                true => new LampVisualState(true, runtimeState.GetLampIntensity(objectId)),
+                _ => new LampVisualState(false, runtimeState.GetLampIntensity(objectId))
+            };
+
             UpdateLampVisual(
                 canvas,
                 objectId,
-                runtimeState.GetLampIntensity(objectId),
-                visualStateChange.ValuesByObjectId[objectId] switch
-                {
-                    LampVisualState state => state.IsLampTestOn,
-                    true => true,
-                    _ => false
-                },
+                lampVisualState.Intensity,
+                lampVisualState.IsLampTestOn || lampVisualState.Intensity > 0d,
                 sourceModel.OnColorHex,
                 sourceModel.OffColorHex,
                 sourceModel.AssetPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -145,7 +145,12 @@ public static class PanelLayoutMapper
                 canvas,
                 objectId,
                 runtimeState.GetLampIntensity(objectId),
-                visualStateChange.ValuesByObjectId[objectId] is true,
+                visualStateChange.ValuesByObjectId[objectId] switch
+                {
+                    LampVisualState state => state.IsLampTestOn,
+                    true => true,
+                    _ => false
+                },
                 sourceModel.OnColorHex,
                 sourceModel.OffColorHex,
                 sourceModel.AssetPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -27,7 +27,7 @@ public sealed class PanelRuntimeState
             return 0d;
         }
 
-        return _lampIntensityByObjectId.GetValueOrDefault(objectId.Trim(), 1d);
+        return _lampIntensityByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
     }
 
     public void ClearLampIntensity(string objectId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -140,9 +140,11 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 && element.Kind == PanelElementKind.Lamp)
             .ToDictionary(
                 element => element.ObjectId,
-                element => (object)(_runtimeState.IsLampTestActive
+                element => (object)new LampVisualState(
+                    _runtimeState.IsLampTestActive
                     && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
-                    && string.Equals(element.ObjectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal)));
+                    && string.Equals(element.ObjectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal),
+                    _runtimeState.GetLampIntensity(element.ObjectId)));
 
         var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
         foreach (var kvp in visualStateByObjectId)
@@ -242,6 +244,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         return PanelSelectionContract.IsMatch(storageElement, selection);
     }
 }
+
+internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
 
 public sealed record PanelVisualStateChangedEvent(
     Guid DocumentId,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -64,6 +64,14 @@
                           Foreground="{DynamicResource TextPrimaryBrush}"
                           Content="Debug Output Lamps"
                           IsChecked="{Binding DebugOutputLamps, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox Margin="0,8,0,0"
+                          Foreground="{DynamicResource TextPrimaryBrush}"
+                          Content="Debug Output Std Out"
+                          IsChecked="{Binding DebugOutputStdOut, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox Margin="0,8,0,0"
+                          Foreground="{DynamicResource TextPrimaryBrush}"
+                          Content="Debug Output Std In"
+                          IsChecked="{Binding DebugOutputStdIn, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
 
                 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -60,6 +60,10 @@
                           Foreground="{DynamicResource TextPrimaryBrush}"
                           Content="Keep MAME up to date automatically"
                           IsChecked="{Binding KeepMameUpToDateAutomatically, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <CheckBox Margin="0,8,0,0"
+                          Foreground="{DynamicResource TextPrimaryBrush}"
+                          Content="Debug Output Lamps"
+                          IsChecked="{Binding DebugOutputLamps, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
 
                 


### PR DESCRIPTION
### Motivation
- MAME launches and audio were working but panel lamp art did not reflect MAME-emitted lamp changes because parsed stdout lines were not wired into the panel runtime state and visual delta tracking ignored intensity-only changes. 
- The change bridges parsed lamp protocol lines into the existing panel runtime/update pipeline so live emulation drives the UI visuals.

### Description
- Added `MameLampRuntimeAdapter` implementing `IMameLampRuntimeAdapter` that maps `DisplayNumber` to Panel2D `ObjectId`, normalizes lamp intensity from `0..255` to `0..1`, updates `DocumentTabViewModel.RuntimeState`, and triggers `NotifyPanelVisualPreviewChanged()` on the UI thread. 
- Created a `MameStdoutParser` instance in `MainWindowViewModel` and invoked `ProcessLine` from the MAME stdout logger while preserving existing `[MAME]` log output. 
- Updated `DocumentTabViewModel.NotifyPanelVisualPreviewChanged()` to produce a composite `LampVisualState` (lamp-test boolean + intensity) so intensity-only changes produce delta events. 
- Updated `PanelLayoutMapper.ApplyVisualState()` to accept the new composite payload while remaining compatible with legacy boolean payloads.

### Testing
- No automated tests were executed in this environment because the Codex session does not have the Windows/.NET/WPF toolchain required to build or run the editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04e6673af48327a32f3005bd202e3d)