### PR TITLE
Fix output log pane refresh and selection copy ordering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 
@@ -91,9 +92,16 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     public void AddOutputEntry(string message, OutputLogStatus status)
     {
         var entry = new OutputLogEntry(DateTime.Now, message, status);
-        OutputEntries.Add(entry);
-        LastEntry = entry;
-        NotifyClearCommand();
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is not null && !dispatcher.CheckAccess())
+        {
+            dispatcher.Invoke(() => AddEntryOnUiThread(entry));
+        }
+        else
+        {
+            AddEntryOnUiThread(entry);
+        }
 
         try
         {
@@ -115,9 +123,22 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
 
     public void UpdateSelectedEntries(IEnumerable<OutputLogEntry> selectedEntries)
     {
-        SelectedEntries = selectedEntries
+        var selectedSet = selectedEntries
             .Where(entry => ShouldShowEntry(entry))
+            .ToHashSet();
+
+        if (selectedSet.Count == 0)
+        {
+            SelectedEntries = Array.Empty<OutputLogEntry>();
+            return;
+        }
+
+        var orderedSelection = FilteredEntries
+            .Cast<OutputLogEntry>()
+            .Where(selectedSet.Contains)
             .ToList();
+
+        SelectedEntries = orderedSelection;
     }
 
     public string BuildClipboardTextForSelection()
@@ -149,6 +170,13 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         return _shellLauncher.TryLaunch(new ProcessStartInfo("explorer.exe", $"\"{LogDirectoryPath}\"") { UseShellExecute = true }, out failureReason);
     }
 
+
+    private void AddEntryOnUiThread(OutputLogEntry entry)
+    {
+        OutputEntries.Add(entry);
+        LastEntry = entry;
+        NotifyClearCommand();
+    }
     private bool CanClearOutput()
     {
         return OutputEntries.Count > 0;


### PR DESCRIPTION
### Motivation

- New MAME output lines were sometimes not visible until toggling a filter and the app could raise cross-thread `CollectionView` exceptions when background threads mutated the `OutputEntries` collection. 
- Copying selected rows produced non-deterministic ordering because the raw `SelectedItems` enumeration did not preserve the current filtered view order.

### Description

- Marshal insertion of `OutputLogEntry` objects onto the UI thread by using `Application.Current.Dispatcher` in `AddOutputEntry` and delegating the actual collection mutation to a new `AddEntryOnUiThread` helper. 
- Preserve disk logging by still calling `_diskWriter.Append(entry)` after enqueueing the entry to the UI thread. 
- Make selection copy order deterministic by building a `HashSet` of selected entries and then enumerating `FilteredEntries` to produce `SelectedEntries` in the view order within `UpdateSelectedEntries`.
- Add `using System.Windows;` to access `Application.Current.Dispatcher` and keep all other public APIs unchanged.

### Testing

- Attempted `dotnet build OasisEditor.sln` in this environment but it failed because `dotnet` is not available (`/bin/bash: dotnet: command not found`), so a full build/test run could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a060a6f7a188327b006729569c7f684)