### PR TITLE
Add persistent Output Log autoscroll toggle and default-enabled filters

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -5,6 +5,7 @@ public sealed class EditorPreferences
     public ThemePreference ThemePreference { get; init; } = ThemePreference.Dark;
 
     public MamePreferences Mame { get; init; } = new();
+    public OutputLogPreferences OutputLog { get; init; } = new();
 
     public Dictionary<string, ProjectWindowState> ProjectWindowStates { get; init; } = new();
 }
@@ -30,4 +31,12 @@ public sealed class ProjectWindowState
     public double Width { get; init; }
     public double Height { get; init; }
     public bool IsMaximized { get; init; }
+}
+
+public sealed class OutputLogPreferences
+{
+    public bool ShowInfoLogs { get; init; } = true;
+    public bool ShowWarningLogs { get; init; } = true;
+    public bool ShowErrorLogs { get; init; } = true;
+    public bool AutoScroll { get; init; } = true;
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -150,6 +150,7 @@ public partial class MainWindow : Window
         {
             ThemePreference = preferences.ThemePreference,
             Mame = preferences.Mame,
+            OutputLog = preferences.OutputLog,
             ProjectWindowStates = states
         });
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -158,6 +158,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _debugOutputLamps = preferences.Mame.DebugOutputLamps;
         _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
         _debugOutputStdOut = preferences.Mame.DebugOutputStdOut;
+        _outputLog.ShowInfoLogs = preferences.OutputLog.ShowInfoLogs;
+        _outputLog.ShowWarningLogs = preferences.OutputLog.ShowWarningLogs;
+        _outputLog.ShowErrorLogs = preferences.OutputLog.ShowErrorLogs;
+        _outputLog.AutoScroll = preferences.OutputLog.AutoScroll;
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
@@ -1442,6 +1446,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 DebugOutputStdOut = DebugOutputStdOut,
                 RomDownloadBaseUrl = MameRomDownloadBaseUrl,
                 RomArchiveExtension = MameRomArchiveExtension
+            },
+            OutputLog = new OutputLogPreferences
+            {
+                ShowInfoLogs = _outputLog.ShowInfoLogs,
+                ShowWarningLogs = _outputLog.ShowWarningLogs,
+                ShowErrorLogs = _outputLog.ShowErrorLogs,
+                AutoScroll = _outputLog.AutoScroll
             }
         });
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1440,6 +1440,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
     private void SavePreferences()
     {
+        var existingPreferences = _preferencesStore.Load();
         _preferencesStore.Save(new EditorPreferences
         {
             ThemePreference = SelectedThemePreference,
@@ -1462,7 +1463,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 ShowWarningLogs = _outputLog.ShowWarningLogs,
                 ShowErrorLogs = _outputLog.ShowErrorLogs,
                 AutoScroll = _outputLog.AutoScroll
-            }
+            },
+            ProjectWindowStates = existingPreferences.ProjectWindowStates
         });
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -62,6 +62,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly MamePluginDeploymentService _mamePluginDeploymentService = new();
     private readonly IMameSetupOrchestrator _mameSetupOrchestrator;
     private readonly IMameVersionCatalogService _mameVersionCatalogService;
+    private bool _isLoadingPreferences;
     private readonly IMameEmulationService _mameEmulationService;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
     private bool _isAutoProvisioningMame;
@@ -142,26 +143,34 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             UpdateDocumentPanelSelection,
             NotifyHierarchyCommands);
 
-        var preferences = _preferencesStore.Load();
-        _selectedThemePreference = preferences.ThemePreference;
-        _mameVersion = preferences.Mame.Version;
-        _mameExecutablePath = preferences.Mame.ExecutablePath;
-        _mameInstallRootDirectory = MameRuntimePaths.EnsureManagedRuntimeRootDirectory();
-        _mameReleaseSource = preferences.Mame.ReleaseSource;
-        _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
-        _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
-        _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
-        _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
-        _mameRomDownloadService.DownloadRootUrl = _mameRomDownloadBaseUrl;
-        _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
-        _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
-        _debugOutputLamps = preferences.Mame.DebugOutputLamps;
-        _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
-        _debugOutputStdOut = preferences.Mame.DebugOutputStdOut;
-        _outputLog.ShowInfoLogs = preferences.OutputLog.ShowInfoLogs;
-        _outputLog.ShowWarningLogs = preferences.OutputLog.ShowWarningLogs;
-        _outputLog.ShowErrorLogs = preferences.OutputLog.ShowErrorLogs;
-        _outputLog.AutoScroll = preferences.OutputLog.AutoScroll;
+        _isLoadingPreferences = true;
+        try
+        {
+            var preferences = _preferencesStore.Load();
+            _selectedThemePreference = preferences.ThemePreference;
+            _mameVersion = preferences.Mame.Version;
+            _mameExecutablePath = preferences.Mame.ExecutablePath;
+            _mameInstallRootDirectory = MameRuntimePaths.EnsureManagedRuntimeRootDirectory();
+            _mameReleaseSource = preferences.Mame.ReleaseSource;
+            _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
+            _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
+            _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
+            _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
+            _mameRomDownloadService.DownloadRootUrl = _mameRomDownloadBaseUrl;
+            _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
+            _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
+            _debugOutputLamps = preferences.Mame.DebugOutputLamps;
+            _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
+            _debugOutputStdOut = preferences.Mame.DebugOutputStdOut;
+            _outputLog.ShowInfoLogs = preferences.OutputLog.ShowInfoLogs;
+            _outputLog.ShowWarningLogs = preferences.OutputLog.ShowWarningLogs;
+            _outputLog.ShowErrorLogs = preferences.OutputLog.ShowErrorLogs;
+            _outputLog.AutoScroll = preferences.OutputLog.AutoScroll;
+        }
+        finally
+        {
+            _isLoadingPreferences = false;
+        }
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
@@ -2090,6 +2099,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnOutputLogPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        if (e.PropertyName is nameof(OutputLogViewModel.ShowInfoLogs)
+            or nameof(OutputLogViewModel.ShowWarningLogs)
+            or nameof(OutputLogViewModel.ShowErrorLogs)
+            or nameof(OutputLogViewModel.AutoScroll))
+        {
+            if (!_isLoadingPreferences)
+            {
+                SavePreferences();
+            }
+
+            return;
+        }
+
         if (e.PropertyName is not nameof(OutputLogViewModel.LastEntry))
         {
             return;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -18,6 +18,7 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     private bool _showInfoLogs = true;
     private bool _showWarningLogs = true;
     private bool _showErrorLogs = true;
+    private bool _autoScroll = true;
     private IReadOnlyList<OutputLogEntry> _selectedEntries = Array.Empty<OutputLogEntry>();
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -74,6 +75,21 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
             }
 
             _lastEntry = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool AutoScroll
+    {
+        get => _autoScroll;
+        set
+        {
+            if (_autoScroll == value)
+            {
+                return;
+            }
+
+            _autoScroll = value;
             OnPropertyChanged();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -35,6 +35,10 @@
                       VerticalAlignment="Center"
                       IsChecked="{Binding ShowErrorLogs}"
                       Content="Error" />
+            <CheckBox Margin="0,0,8,0"
+                      VerticalAlignment="Center"
+                      IsChecked="{Binding AutoScroll}"
+                      Content="Autoscroll" />
             <Button DockPanel.Dock="Right"
                     Padding="10,4"
                     Command="{Binding ClearOutputCommand}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -7,11 +8,14 @@ namespace OasisEditor.Views;
 
 public partial class OutputLogView : UserControl
 {
+    private INotifyCollectionChanged? _observedOutputEntries;
+
     public OutputLogView()
     {
         InitializeComponent();
         CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, OnCopySelectionExecuted));
         InputBindings.Add(new KeyBinding(ApplicationCommands.Copy, Key.C, ModifierKeys.Control));
+        DataContextChanged += OnDataContextChanged;
     }
 
     private OutputLogViewModel? ViewModel => DataContext as OutputLogViewModel;
@@ -24,6 +28,39 @@ public partial class OutputLogView : UserControl
         }
 
         ViewModel.UpdateSelectedEntries(OutputList.SelectedItems.Cast<OutputLogEntry>());
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (_observedOutputEntries is not null)
+        {
+            _observedOutputEntries.CollectionChanged -= OnOutputEntriesCollectionChanged;
+            _observedOutputEntries = null;
+        }
+
+        if (ViewModel?.OutputEntries is INotifyCollectionChanged entries)
+        {
+            _observedOutputEntries = entries;
+            _observedOutputEntries.CollectionChanged += OnOutputEntriesCollectionChanged;
+        }
+    }
+
+    private void OnOutputEntriesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add || e.NewItems is null || e.NewItems.Count == 0)
+        {
+            return;
+        }
+
+        if (ViewModel?.AutoScroll != true)
+        {
+            return;
+        }
+
+        if (e.NewItems[e.NewItems.Count - 1] is OutputLogEntry entry)
+        {
+            OutputList.ScrollIntoView(entry);
+        }
     }
 
 


### PR DESCRIPTION
### Motivation
- The Output log view did not auto-scroll to new rows and filter checkbox states were not persisted, so users could lose expected behavior between sessions.
- Provide an editor-persistent, install-time default `Autoscroll` toggle alongside the existing Info/Warning/Error filter checkboxes so users can opt out of auto-scrolling if desired.

### Description
- Added a new `OutputLogPreferences` model to `EditorPreferences` with `ShowInfoLogs`, `ShowWarningLogs`, `ShowErrorLogs`, and `AutoScroll` all defaulting to `true` so first-install defaults are enabled (`EditorPreferences.cs`).
- Added an `AutoScroll` property to `OutputLogViewModel` and kept the `Show*` filter properties, with default `true` for `AutoScroll` (`ViewModels/OutputLogViewModel.cs`).
- Exposed an `Autoscroll` `CheckBox` in the `OutputLogView` XAML and bound it to `AutoScroll` so the UI can toggle the behavior (`Views/OutputLogView.xaml`).
- Implemented auto-scroll behavior by subscribing to the `OutputEntries` collection change notifications in `OutputLogView.xaml.cs` and calling `OutputList.ScrollIntoView(entry)` when new rows are added and `AutoScroll` is enabled.
- Wired loading and saving of the new `OutputLog` preferences via `MainWindowViewModel` so the four checkboxes persist across sessions (`MainWindowViewModel.cs`).

### Testing
- Attempted to run `dotnet build OasisEditor/OasisEditor.csproj` to validate compilation, but the `dotnet` CLI is not installed in this environment so the build could not be executed.
- No other automated tests were run in this environment; runtime verification should be performed locally (start the app, observe default enabled checkboxes and that new output rows scroll into view when `Autoscroll` is checked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a060d8342b08327bbc646b97a058d39)