### PR TITLE
Batch and coalesce MAME lamp runtime updates

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
@@ -27,6 +27,52 @@ public sealed class MameLampRuntimeAdapterTests
         Assert.Equal(1d, document.RuntimeState.GetLampIntensity("lamp-8"));
     }
 
+    [Fact]
+    public void ApplyLampState_WhenNoMatchingLamp_DoesNotPublishVisualPreviewEvent()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameLampRuntimeAdapter(
+            () => [document],
+            () => false,
+            _ => { },
+            action => dispatches.Add(action));
+
+        var previewEventCount = 0;
+        document.PanelVisualStateChanged += _ => previewEventCount++;
+
+        adapter.ApplyLampState(999, 255);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        Assert.Equal(0, previewEventCount);
+        Assert.Equal(0d, document.RuntimeState.GetLampIntensity("lamp-7"));
+        Assert.Equal(0d, document.RuntimeState.GetLampIntensity("lamp-8"));
+    }
+
+    [Fact]
+    public void ApplyLampState_WhenDebugEnabled_LogsAppliedLampState()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var logs = new List<string>();
+        var adapter = new MameLampRuntimeAdapter(
+            () => [document],
+            () => true,
+            logs.Add,
+            action => dispatches.Add(action));
+
+        adapter.ApplyLampState(7, 255);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var log = Assert.Single(logs);
+        Assert.Contains("lamp7", log);
+        Assert.Contains("intensity=1", log);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile(

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
@@ -1,0 +1,45 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameLampRuntimeAdapterTests
+{
+    [Fact]
+    public void ApplyLampState_CoalescesPendingUpdatesIntoSingleUiDispatch()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameLampRuntimeAdapter(
+            () => [document],
+            () => false,
+            _ => { },
+            action => dispatches.Add(action));
+
+        adapter.ApplyLampState(7, 255);
+        adapter.ApplyLampState(7, 0);
+        adapter.ApplyLampState(8, 255);
+
+        Assert.Single(dispatches);
+        dispatches[0]();
+
+        Assert.Equal(0d, document.RuntimeState.GetLampIntensity("lamp-7"));
+        Assert.Equal(1d, document.RuntimeState.GetLampIntensity("lamp-8"));
+    }
+
+    private static DocumentTabViewModel CreateDocument()
+    {
+        var panelDocument = new EditorDocument(
+            EditorDocumentType.Panel2D,
+            "panel",
+            "panel.panel2d",
+            "panel");
+        var tab = new DocumentTabViewModel(panelDocument);
+        tab.SetPanelElements(
+        [
+            new PanelElementModel { ObjectId = "lamp-7", Kind = PanelElementKind.Lamp, DisplayNumber = 7 },
+            new PanelElementModel { ObjectId = "lamp-8", Kind = PanelElementKind.Lamp, DisplayNumber = 8 }
+        ]);
+        return tab;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameLampRuntimeAdapterTests.cs
@@ -29,10 +29,9 @@ public sealed class MameLampRuntimeAdapterTests
 
     private static DocumentTabViewModel CreateDocument()
     {
-        var panelDocument = new EditorDocument(
-            EditorDocumentType.Panel2D,
-            "panel",
+        var panelDocument = EditorDocument.CreateFromFile(
             "panel.panel2d",
+            "panel",
             "panel");
         var tab = new DocumentTabViewModel(panelDocument);
         tab.SetPanelElements(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -62,6 +62,7 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
             var matchingObjectIdsByLamp = GetOrBuildLampMapping(document);
 
             var hasAnyApplied = false;
+            var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
             foreach (var (pendingLampId, pendingLampValue) in snapshot)
             {
                 if (!matchingObjectIdsByLamp.TryGetValue(pendingLampId, out var matchingObjectIds)
@@ -85,12 +86,13 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
                 {
                     document.RuntimeState.SetLampIntensity(objectId, normalizedIntensity);
                     hasAnyApplied = true;
+                    changedObjectIds.Add(objectId);
                 }
             }
 
             if (hasAnyApplied)
             {
-                document.NotifyPanelVisualPreviewChanged();
+                document.NotifyPanelVisualPreviewChanged(changedObjectIds);
             }
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -2,10 +2,13 @@ namespace OasisEditor;
 
 public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
 {
+    private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Func<bool> _debugOutputEnabledProvider;
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
+    private readonly Dictionary<int, int> _pendingLampValues = new();
+    private bool _uiUpdateScheduled;
 
     public MameLampRuntimeAdapter(
         Func<IEnumerable<DocumentTabViewModel>> documentProvider,
@@ -21,44 +24,80 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
 
     public void ApplyLampState(int lampId, int lampValue)
     {
-        _uiDispatch(() => ApplyOnUiThread(lampId, lampValue));
+        lock (_pendingSync)
+        {
+            _pendingLampValues[lampId] = lampValue;
+            if (_uiUpdateScheduled)
+            {
+                return;
+            }
+
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
     }
 
-    private void ApplyOnUiThread(int lampId, int lampValue)
+    private void ApplyPendingOnUiThread()
     {
-        var normalizedIntensity = lampValue switch
+        Dictionary<int, int> snapshot;
+        lock (_pendingSync)
         {
-            <= 0 => 0d,
-            <= 1 => 1d,
-            _ => Math.Clamp(lampValue / 255d, 0d, 1d)
-        };
-        if (_debugOutputEnabledProvider())
+            snapshot = new Dictionary<int, int>(_pendingLampValues);
+            _pendingLampValues.Clear();
+            _uiUpdateScheduled = false;
+        }
+
+        if (snapshot.Count == 0)
         {
-            _infoLogger($"[MAME-LAMP] lamp{lampId} value={lampValue} intensity={normalizedIntensity:0.###}");
+            return;
         }
 
         foreach (var document in _documentProvider())
         {
-            var matchingObjectIds = document
+            var matchingObjectIdsByLamp = document
                 .GetPanelElements()
                 .Where(element => element.Kind == PanelElementKind.Lamp
-                    && element.DisplayNumber.GetValueOrDefault() == lampId
-                    && !string.IsNullOrWhiteSpace(element.ObjectId))
-                .Select(element => element.ObjectId)
-                .Distinct(StringComparer.Ordinal)
-                .ToArray();
+                    && !string.IsNullOrWhiteSpace(element.ObjectId)
+                    && element.DisplayNumber.HasValue)
+                .GroupBy(element => element.DisplayNumber.GetValueOrDefault())
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(element => element.ObjectId)
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray());
 
-            if (matchingObjectIds.Length == 0)
+            var hasAnyApplied = false;
+            foreach (var (pendingLampId, pendingLampValue) in snapshot)
             {
-                continue;
+                if (!matchingObjectIdsByLamp.TryGetValue(pendingLampId, out var matchingObjectIds)
+                    || matchingObjectIds.Length == 0)
+                {
+                    continue;
+                }
+
+                var normalizedIntensity = pendingLampValue switch
+                {
+                    <= 0 => 0d,
+                    <= 1 => 1d,
+                    _ => Math.Clamp(pendingLampValue / 255d, 0d, 1d)
+                };
+                if (_debugOutputEnabledProvider())
+                {
+                    _infoLogger($"[MAME-LAMP] lamp{pendingLampId} value={pendingLampValue} intensity={normalizedIntensity:0.###}");
+                }
+
+                foreach (var objectId in matchingObjectIds)
+                {
+                    document.RuntimeState.SetLampIntensity(objectId, normalizedIntensity);
+                    hasAnyApplied = true;
+                }
             }
 
-            foreach (var objectId in matchingObjectIds)
+            if (hasAnyApplied)
             {
-                document.RuntimeState.SetLampIntensity(objectId, normalizedIntensity);
+                document.NotifyPanelVisualPreviewChanged();
             }
-
-            document.NotifyPanelVisualPreviewChanged();
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -84,9 +84,11 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
 
                 foreach (var objectId in matchingObjectIds)
                 {
-                    document.RuntimeState.SetLampIntensity(objectId, normalizedIntensity);
-                    hasAnyApplied = true;
-                    changedObjectIds.Add(objectId);
+                    if (document.RuntimeState.SetLampIntensityIfChanged(objectId, normalizedIntensity))
+                    {
+                        hasAnyApplied = true;
+                        changedObjectIds.Add(objectId);
+                    }
                 }
             }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
@@ -8,6 +8,7 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, int> _pendingLampValues = new();
+    private readonly Dictionary<Guid, LampDocumentMappingCacheEntry> _lampMappingsByDocumentId = new();
     private bool _uiUpdateScheduled;
 
     public MameLampRuntimeAdapter(
@@ -53,19 +54,12 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
             return;
         }
 
-        foreach (var document in _documentProvider())
+        var documents = _documentProvider().ToArray();
+        PruneDocumentCaches(documents);
+
+        foreach (var document in documents)
         {
-            var matchingObjectIdsByLamp = document
-                .GetPanelElements()
-                .Where(element => element.Kind == PanelElementKind.Lamp
-                    && !string.IsNullOrWhiteSpace(element.ObjectId)
-                    && element.DisplayNumber.HasValue)
-                .GroupBy(element => element.DisplayNumber.GetValueOrDefault())
-                .ToDictionary(
-                    group => group.Key,
-                    group => group.Select(element => element.ObjectId)
-                        .Distinct(StringComparer.Ordinal)
-                        .ToArray());
+            var matchingObjectIdsByLamp = GetOrBuildLampMapping(document);
 
             var hasAnyApplied = false;
             foreach (var (pendingLampId, pendingLampValue) in snapshot)
@@ -98,6 +92,83 @@ public sealed class MameLampRuntimeAdapter : IMameLampRuntimeAdapter
             {
                 document.NotifyPanelVisualPreviewChanged();
             }
+        }
+    }
+
+    private void PruneDocumentCaches(IReadOnlyCollection<DocumentTabViewModel> documents)
+    {
+        var activeIds = documents.Select(document => document.DocumentId).ToHashSet();
+        var staleDocumentIds = _lampMappingsByDocumentId.Keys
+            .Where(documentId => !activeIds.Contains(documentId))
+            .ToArray();
+        foreach (var staleDocumentId in staleDocumentIds)
+        {
+            if (_lampMappingsByDocumentId.Remove(staleDocumentId, out var staleEntry))
+            {
+                staleEntry.Detach();
+            }
+        }
+    }
+
+    private IReadOnlyDictionary<int, string[]> GetOrBuildLampMapping(DocumentTabViewModel document)
+    {
+        if (_lampMappingsByDocumentId.TryGetValue(document.DocumentId, out var cacheEntry)
+            && !cacheEntry.IsDirty)
+        {
+            return cacheEntry.MappingByLampId;
+        }
+
+        var mapping = document
+            .GetPanelElements()
+            .Where(element => element.Kind == PanelElementKind.Lamp
+                && !string.IsNullOrWhiteSpace(element.ObjectId)
+                && element.DisplayNumber.HasValue)
+            .GroupBy(element => element.DisplayNumber.GetValueOrDefault())
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(element => element.ObjectId)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray());
+
+        if (cacheEntry is null)
+        {
+            cacheEntry = new LampDocumentMappingCacheEntry(document, mapping);
+            _lampMappingsByDocumentId[document.DocumentId] = cacheEntry;
+            return cacheEntry.MappingByLampId;
+        }
+
+        cacheEntry.Replace(mapping);
+        return cacheEntry.MappingByLampId;
+    }
+
+    private sealed class LampDocumentMappingCacheEntry
+    {
+        private readonly DocumentTabViewModel _document;
+
+        public LampDocumentMappingCacheEntry(DocumentTabViewModel document, IReadOnlyDictionary<int, string[]> mappingByLampId)
+        {
+            _document = document;
+            MappingByLampId = mappingByLampId;
+            _document.PanelChanged += OnPanelChanged;
+        }
+
+        public IReadOnlyDictionary<int, string[]> MappingByLampId { get; private set; }
+        public bool IsDirty { get; private set; }
+
+        public void Replace(IReadOnlyDictionary<int, string[]> mappingByLampId)
+        {
+            MappingByLampId = mappingByLampId;
+            IsDirty = false;
+        }
+
+        public void OnPanelChanged(PanelChangeEvent _)
+        {
+            IsDirty = true;
+        }
+
+        public void Detach()
+        {
+            _document.PanelChanged -= OnPanelChanged;
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -26,6 +26,18 @@ public static class PanelLayoutMapper
             typeof(PanelRuntimeVisualRegistry),
             typeof(PanelLayoutMapper),
             new PropertyMetadata(null));
+    private static readonly DependencyProperty CachedLampOnBrushProperty =
+        DependencyProperty.RegisterAttached(
+            "CachedLampOnBrush",
+            typeof(Brush),
+            typeof(PanelLayoutMapper),
+            new PropertyMetadata(null));
+    private static readonly DependencyProperty CachedLampOffBrushProperty =
+        DependencyProperty.RegisterAttached(
+            "CachedLampOffBrush",
+            typeof(Brush),
+            typeof(PanelLayoutMapper),
+            new PropertyMetadata(null));
 
     public static bool IsApplyingLayout(Canvas canvas)
     {
@@ -190,8 +202,11 @@ public static class PanelLayoutMapper
                 return;
             }
 
-            var backgroundHex = isOn ? onColorHex : offColorHex ?? onColorHex;
-            border.Background = PanelElementFactory.TryCreateBrushForRuntime(backgroundHex, Brushes.Transparent);
+            var cachedBrush = isOn
+                ? GetOrCreateCachedLampOnBrush(border, onColorHex)
+                : GetOrCreateCachedLampOffBrush(border, offColorHex ?? onColorHex);
+            border.Background = cachedBrush;
+            border.Opacity = Math.Max(0.1d, normalizedIntensity);
         }
         else if (visual is Image image)
         {
@@ -223,5 +238,29 @@ public static class PanelLayoutMapper
         }
 
         return registry;
+    }
+
+    private static Brush GetOrCreateCachedLampOnBrush(Border border, string? onColorHex)
+    {
+        if (border.GetValue(CachedLampOnBrushProperty) is Brush brush)
+        {
+            return brush;
+        }
+
+        brush = PanelElementFactory.TryCreateBrushForRuntime(onColorHex, Brushes.Transparent);
+        border.SetValue(CachedLampOnBrushProperty, brush);
+        return brush;
+    }
+
+    private static Brush GetOrCreateCachedLampOffBrush(Border border, string? offColorHex)
+    {
+        if (border.GetValue(CachedLampOffBrushProperty) is Brush brush)
+        {
+            return brush;
+        }
+
+        brush = PanelElementFactory.TryCreateBrushForRuntime(offColorHex, Brushes.Transparent);
+        border.SetValue(CachedLampOffBrushProperty, brush);
+        return brush;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -133,14 +133,9 @@ public static class PanelLayoutMapper
             return;
         }
 
-        var elementsByObjectId = tab.GetPanelElements()
-            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId))
-            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
-
         foreach (var objectId in visualStateChange.ValuesByObjectId.Keys)
         {
-            if (!elementsByObjectId.TryGetValue(objectId, out var sourceModel)
-                || sourceModel.Kind != PanelElementKind.Lamp)
+            if (!tab.TryGetLampElement(objectId, out var sourceModel))
             {
                 continue;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -21,17 +20,10 @@ public static class PanelLayoutMapper
             typeof(PanelLayoutMapper),
             new PropertyMetadata(false));
 
-    private static readonly DependencyProperty ObjectVisualMapProperty =
+    private static readonly DependencyProperty RuntimeVisualRegistryProperty =
         DependencyProperty.RegisterAttached(
-            "ObjectVisualMap",
-            typeof(Dictionary<string, FrameworkElement>),
-            typeof(PanelLayoutMapper),
-            new PropertyMetadata(null));
-
-    private static readonly DependencyProperty MissingVisualLogSetProperty =
-        DependencyProperty.RegisterAttached(
-            "MissingVisualLogSet",
-            typeof(HashSet<string>),
+            "RuntimeVisualRegistry",
+            typeof(PanelRuntimeVisualRegistry),
             typeof(PanelLayoutMapper),
             new PropertyMetadata(null));
 
@@ -174,15 +166,10 @@ public static class PanelLayoutMapper
             return;
         }
 
-        var objectVisualMap = GetOrCreateObjectVisualMap(canvas);
-        if (!objectVisualMap.TryGetValue(objectId, out var visual))
+        var registry = GetOrCreateRuntimeVisualRegistry(canvas);
+        if (!registry.TryGetVisual(objectId, out var visual))
         {
-            var missingIds = GetOrCreateMissingVisualLogSet(canvas);
-            if (missingIds.Add(objectId))
-            {
-                Debug.WriteLine($"[PanelLayoutMapper] UpdateLampVisual skipped; visual not found for objectId '{objectId}'.");
-            }
-
+            registry.LogMissingObjectIdOnce(objectId);
             return;
         }
 
@@ -224,36 +211,17 @@ public static class PanelLayoutMapper
 
     private static void RebuildObjectVisualMap(Canvas canvas)
     {
-        var map = GetOrCreateObjectVisualMap(canvas);
-        map.Clear();
-        foreach (var element in canvas.Children.OfType<FrameworkElement>().Where(GetIsPersistedElement))
-        {
-            if (!string.IsNullOrWhiteSpace(element.Uid))
-            {
-                map[element.Uid.Trim()] = element;
-            }
-        }
+        GetOrCreateRuntimeVisualRegistry(canvas).Rebuild(canvas, GetIsPersistedElement);
     }
 
-    private static Dictionary<string, FrameworkElement> GetOrCreateObjectVisualMap(Canvas canvas)
+    private static PanelRuntimeVisualRegistry GetOrCreateRuntimeVisualRegistry(Canvas canvas)
     {
-        if (canvas.GetValue(ObjectVisualMapProperty) is not Dictionary<string, FrameworkElement> map)
+        if (canvas.GetValue(RuntimeVisualRegistryProperty) is not PanelRuntimeVisualRegistry registry)
         {
-            map = new Dictionary<string, FrameworkElement>(StringComparer.Ordinal);
-            canvas.SetValue(ObjectVisualMapProperty, map);
+            registry = new PanelRuntimeVisualRegistry();
+            canvas.SetValue(RuntimeVisualRegistryProperty, registry);
         }
 
-        return map;
-    }
-
-    private static HashSet<string> GetOrCreateMissingVisualLogSet(Canvas canvas)
-    {
-        if (canvas.GetValue(MissingVisualLogSetProperty) is not HashSet<string> missingIds)
-        {
-            missingIds = new HashSet<string>(StringComparer.Ordinal);
-            canvas.SetValue(MissingVisualLogSetProperty, missingIds);
-        }
-
-        return missingIds;
+        return registry;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -155,7 +155,6 @@ public static class PanelLayoutMapper
                 sourceModel.OnColorHex,
                 sourceModel.OffColorHex,
                 sourceModel.AssetPath);
-            runtimeState.SetLampIntensity(objectId, runtimeState.GetLampIntensity(objectId));
         }
     }
 
@@ -192,20 +191,27 @@ public static class PanelLayoutMapper
                     image.Source = PanelElementFactory.TryCreateImageSourceForRuntime(assetPath);
                 }
 
-                image.Opacity = effectiveOpacity;
-                border.Background = Brushes.Transparent;
+                SetOpacityIfChanged(image, effectiveOpacity);
+                if (!ReferenceEquals(border.Background, Brushes.Transparent))
+                {
+                    border.Background = Brushes.Transparent;
+                }
                 return;
             }
 
             var cachedBrush = isOn
                 ? GetOrCreateCachedLampOnBrush(border, onColorHex)
                 : GetOrCreateCachedLampOffBrush(border, offColorHex ?? onColorHex);
-            border.Background = cachedBrush;
-            border.Opacity = Math.Max(0.1d, normalizedIntensity);
+            if (!ReferenceEquals(border.Background, cachedBrush))
+            {
+                border.Background = cachedBrush;
+            }
+
+            SetOpacityIfChanged(border, Math.Max(0.1d, normalizedIntensity));
         }
         else if (visual is Image image)
         {
-            image.Opacity = effectiveOpacity;
+            SetOpacityIfChanged(image, effectiveOpacity);
         }
     }
 
@@ -257,5 +263,15 @@ public static class PanelLayoutMapper
         brush = PanelElementFactory.TryCreateBrushForRuntime(offColorHex, Brushes.Transparent);
         border.SetValue(CachedLampOffBrushProperty, brush);
         return brush;
+    }
+
+    private static void SetOpacityIfChanged(UIElement element, double opacity)
+    {
+        if (Math.Abs(element.Opacity - opacity) < 0.0001d)
+        {
+            return;
+        }
+
+        element.Opacity = opacity;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -10,14 +10,28 @@ public sealed class PanelRuntimeState
 
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
 
-    public void SetLampIntensity(string objectId, double intensity)
+    public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
         if (string.IsNullOrWhiteSpace(objectId))
         {
-            return;
+            return false;
         }
 
-        _lampIntensityByObjectId[objectId.Trim()] = Math.Clamp(intensity, 0d, 1d);
+        var normalizedObjectId = objectId.Trim();
+        var normalizedIntensity = Math.Clamp(intensity, 0d, 1d);
+        if (_lampIntensityByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && Math.Abs(previous - normalizedIntensity) < 0.0001d)
+        {
+            return false;
+        }
+
+        _lampIntensityByObjectId[normalizedObjectId] = normalizedIntensity;
+        return true;
+    }
+
+    public void SetLampIntensity(string objectId, double intensity)
+    {
+        SetLampIntensityIfChanged(objectId, intensity);
     }
 
     public double GetLampIntensity(string objectId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeVisualRegistry.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeVisualRegistry.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace OasisEditor;
+
+internal sealed class PanelRuntimeVisualRegistry
+{
+    private readonly Dictionary<string, FrameworkElement> _visualsByObjectId = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _missingObjectIds = new(StringComparer.Ordinal);
+
+    public void Rebuild(Canvas canvas, Func<FrameworkElement, bool> persistedFilter)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(persistedFilter);
+
+        _visualsByObjectId.Clear();
+        foreach (var element in canvas.Children.OfType<FrameworkElement>().Where(persistedFilter))
+        {
+            if (!string.IsNullOrWhiteSpace(element.Uid))
+            {
+                _visualsByObjectId[element.Uid.Trim()] = element;
+            }
+        }
+    }
+
+    public bool TryGetVisual(string objectId, out FrameworkElement visual)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            visual = null!;
+            return false;
+        }
+
+        return _visualsByObjectId.TryGetValue(objectId, out visual!);
+    }
+
+    public void LogMissingObjectIdOnce(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return;
+        }
+
+        if (_missingObjectIds.Add(objectId))
+        {
+            Debug.WriteLine($"[PanelRuntimeVisualRegistry] Runtime visual not found for objectId '{objectId}'.");
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -10,6 +10,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private EditorDocument _document;
     private string? _panelLayoutJson;
     private Panel2DDocumentModel _panelDocumentModel;
+    private Dictionary<string, PanelElementModel> _lampElementsByObjectId = new(StringComparer.Ordinal);
+    private HashSet<string> _lampObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
     private double _panelPanX;
@@ -39,6 +41,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 .Select(Panel2DDocumentStorage.ToModel)
                 .ToArray()
         };
+        RebuildLampCaches();
     }
 
     public EditorDocument Document => _document;
@@ -88,6 +91,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                     .Select(Panel2DDocumentStorage.ToModel)
                     .ToArray()
             };
+            RebuildLampCaches();
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
         }
     }
@@ -123,6 +127,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             Summary = _panelDocumentModel.Summary,
             Elements = elements.ToArray()
         };
+        RebuildLampCaches();
 
         _panelLayoutJson = GetPanelLayoutProjectionJson();
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
@@ -151,16 +156,10 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
 
         _lastVisualStateByObjectId ??= new Dictionary<string, object>(StringComparer.Ordinal);
-        var lampObjectIds = _panelDocumentModel.Elements
-            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && element.Kind == PanelElementKind.Lamp)
-            .Select(element => element.ObjectId)
-            .ToHashSet(StringComparer.Ordinal);
-
         var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
         foreach (var objectId in changedObjectIds)
         {
-            if (string.IsNullOrWhiteSpace(objectId) || !lampObjectIds.Contains(objectId))
+            if (string.IsNullOrWhiteSpace(objectId) || !_lampObjectIds.Contains(objectId))
             {
                 continue;
             }
@@ -184,6 +183,17 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
 
         PanelVisualStateChanged?.Invoke(new PanelVisualStateChangedEvent(DocumentId, deltaByObjectId));
+    }
+
+    internal bool TryGetLampElement(string objectId, out PanelElementModel element)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            element = new PanelElementModel();
+            return false;
+        }
+
+        return _lampElementsByObjectId.TryGetValue(objectId, out element!);
     }
 
     internal string GetPanelLayoutProjectionJson()
@@ -262,6 +272,15 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
         var storageElement = Panel2DDocumentStorage.ToStorageElement(element);
         return PanelSelectionContract.IsMatch(storageElement, selection);
+    }
+
+    private void RebuildLampCaches()
+    {
+        _lampElementsByObjectId = _panelDocumentModel.Elements
+            .Where(element => element.Kind == PanelElementKind.Lamp
+                && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+        _lampObjectIds = _lampElementsByObjectId.Keys.ToHashSet(StringComparer.Ordinal);
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -135,29 +135,49 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal void NotifyPanelVisualPreviewChanged()
     {
-        var visualStateByObjectId = _panelDocumentModel.Elements
+        var changedObjectIds = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
                 && element.Kind == PanelElementKind.Lamp)
-            .ToDictionary(
-                element => element.ObjectId,
-                element => (object)new LampVisualState(
-                    _runtimeState.IsLampTestActive
-                    && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
-                    && string.Equals(element.ObjectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal),
-                    _runtimeState.GetLampIntensity(element.ObjectId)));
+            .Select(element => element.ObjectId)
+            .ToArray();
+        NotifyPanelVisualPreviewChanged(changedObjectIds);
+    }
+
+    internal void NotifyPanelVisualPreviewChanged(IReadOnlyCollection<string> changedObjectIds)
+    {
+        if (changedObjectIds.Count == 0)
+        {
+            return;
+        }
+
+        _lastVisualStateByObjectId ??= new Dictionary<string, object>(StringComparer.Ordinal);
+        var lampObjectIds = _panelDocumentModel.Elements
+            .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
+                && element.Kind == PanelElementKind.Lamp)
+            .Select(element => element.ObjectId)
+            .ToHashSet(StringComparer.Ordinal);
 
         var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
-        foreach (var kvp in visualStateByObjectId)
+        foreach (var objectId in changedObjectIds)
         {
-            if (_lastVisualStateByObjectId is null
-                || !_lastVisualStateByObjectId.TryGetValue(kvp.Key, out var previous)
-                || !Equals(previous, kvp.Value))
+            if (string.IsNullOrWhiteSpace(objectId) || !lampObjectIds.Contains(objectId))
             {
-                deltaByObjectId[kvp.Key] = kvp.Value;
+                continue;
+            }
+
+            var nextState = (object)new LampVisualState(
+                _runtimeState.IsLampTestActive
+                && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
+                && string.Equals(objectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal),
+                _runtimeState.GetLampIntensity(objectId));
+            if (!_lastVisualStateByObjectId.TryGetValue(objectId, out var previous)
+                || !Equals(previous, nextState))
+            {
+                _lastVisualStateByObjectId[objectId] = nextState;
+                deltaByObjectId[objectId] = nextState;
             }
         }
 
-        _lastVisualStateByObjectId = visualStateByObjectId;
         if (deltaByObjectId.Count == 0)
         {
             return;


### PR DESCRIPTION
### Motivation

- Reduce high-frequency UI-thread churn caused by one-dispatch-per-MAME-stdout-line so lamp flashing does not overwhelm the editor thread.  
- Preserve last-write-wins semantics for lamp values when multiple updates arrive before a UI update is performed.  

### Description

- Add a pending buffer and scheduling in `MameLampRuntimeAdapter` (`_pendingLampValues`, `_uiUpdateScheduled`) so `ApplyLampState` only queues the latest value per lamp and schedules a single UI dispatch.  
- Implement `ApplyPendingOnUiThread` to snapshot pending values, map lamp IDs to document `ObjectId`s, compute normalized intensities, and apply them to each document `RuntimeState` in one pass.  
- Only invoke `DocumentTabViewModel.NotifyPanelVisualPreviewChanged()` for a document when at least one lamp intensity was applied for that document.  
- Add unit test `OasisEditor.Tests/MameLampRuntimeAdapterTests.cs` that validates coalescing behavior and last-write-wins semantics.  

### Testing

- No automated tests were executed in this environment because the .NET SDK/WPF toolchain is not available here and `dotnet test` was not run.  
- A unit test was added at `OasisEditor.Tests/MameLampRuntimeAdapterTests.cs` and should be executed locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` (expected to validate coalescing and final intensity application).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06246404a88327b0e6973490c76705)