### PR TITLE
Add local ROM directory fallback before remote MAME ROM download

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -51,4 +51,21 @@ public sealed class EditorPreferencesSerializationTests
         Assert.False(preferences!.Mame.KeepMameUpToDateAutomatically);
     }
 
+    [Fact]
+    public void DeserializingLegacyPreferences_UsesLocalRomDefaults()
+    {
+        var json = """
+        {
+          "Mame": {
+            "RomDownloadBaseUrl": "https://example.com/roms/"
+          }
+        }
+        """;
+
+        var preferences = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(preferences);
+        Assert.Equal(string.Empty, preferences!.Mame.LocalRomSourceDirectory);
+        Assert.Equal(".zip", preferences.Mame.LocalRomArchiveExtension);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Xunit;
 using OasisEditor;
 
@@ -46,5 +47,19 @@ public sealed class MameRomDownloadServiceTests
         };
 
         Assert.Throws<ArgumentException>(() => sut.BuildRomArchiveFileName("mpu4"));
+    }
+
+    [Fact]
+    public void GetLocalRomArchivePath_UsesConfiguredDirectoryAndExtension()
+    {
+        var sut = new MameRomDownloadService
+        {
+            LocalRomSourceDirectory = "C:/MAME_ROMS_0261/",
+            LocalRomArchiveExtension = ".7z"
+        };
+
+        var path = sut.GetLocalRomArchivePath("mpu4");
+
+        Assert.Equal(Path.Combine("C:/MAME_ROMS_0261/", "mpu4.7z"), path);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -22,6 +22,8 @@ public sealed class MamePreferences
     public bool DebugOutputStdOut { get; init; }
     public string RomDownloadBaseUrl { get; init; } = "https://archive.org/download/MAME215RomsOnlyMerged/";
     public string RomArchiveExtension { get; init; } = ".zip";
+    public string LocalRomSourceDirectory { get; init; } = string.Empty;
+    public string LocalRomArchiveExtension { get; init; } = ".zip";
 }
 
 public sealed class ProjectWindowState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -35,6 +35,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameCommandLineOverrides = string.Empty;
     private string _mameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
     private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
+    private string _mameLocalRomSourceDirectory = string.Empty;
+    private string _mameLocalRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private bool _keepMameUpToDateAutomatically = true;
     private bool _debugOutputLamps;
     private bool _debugOutputStdIn;
@@ -156,8 +158,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
             _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
             _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
+            _mameLocalRomSourceDirectory = preferences.Mame.LocalRomSourceDirectory;
+            _mameLocalRomArchiveExtension = preferences.Mame.LocalRomArchiveExtension;
             _mameRomDownloadService.DownloadRootUrl = _mameRomDownloadBaseUrl;
             _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
+            _mameRomDownloadService.LocalRomSourceDirectory = _mameLocalRomSourceDirectory;
+            _mameRomDownloadService.LocalRomArchiveExtension = _mameLocalRomArchiveExtension;
             _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
             _debugOutputLamps = preferences.Mame.DebugOutputLamps;
             _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
@@ -419,6 +425,32 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _mameRomArchiveExtension, value))
             {
                 _mameRomDownloadService.ArchiveExtension = value;
+                SavePreferences();
+            }
+        }
+    }
+
+    public string MameLocalRomSourceDirectory
+    {
+        get => _mameLocalRomSourceDirectory;
+        set
+        {
+            if (SetProperty(ref _mameLocalRomSourceDirectory, value))
+            {
+                _mameRomDownloadService.LocalRomSourceDirectory = value;
+                SavePreferences();
+            }
+        }
+    }
+
+    public string MameLocalRomArchiveExtension
+    {
+        get => _mameLocalRomArchiveExtension;
+        set
+        {
+            if (SetProperty(ref _mameLocalRomArchiveExtension, value))
+            {
+                _mameRomDownloadService.LocalRomArchiveExtension = value;
                 SavePreferences();
             }
         }
@@ -1455,7 +1487,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 DebugOutputStdIn = DebugOutputStdIn,
                 DebugOutputStdOut = DebugOutputStdOut,
                 RomDownloadBaseUrl = MameRomDownloadBaseUrl,
-                RomArchiveExtension = MameRomArchiveExtension
+                RomArchiveExtension = MameRomArchiveExtension,
+                LocalRomSourceDirectory = MameLocalRomSourceDirectory,
+                LocalRomArchiveExtension = MameLocalRomArchiveExtension
             },
             OutputLog = new OutputLogPreferences
             {
@@ -1997,6 +2031,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         MameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
         MameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
+        MameLocalRomSourceDirectory = string.Empty;
+        MameLocalRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
         AddOutputEntry("Reset ROM source preferences to defaults.", OutputLogStatus.Info);
     }
 
@@ -2030,9 +2066,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var downloadUrl = _mameRomDownloadService.BuildDownloadUrl(romName);
         try
         {
+            var localSourcePath = _mameRomDownloadService.GetLocalRomArchivePath(romName);
             var archivePath = await _mameRomDownloadService.DownloadRomAsync(romName, CancellationToken.None);
             MameRomStatus = "Installed";
-            AddOutputEntry($"MAME ROM downloaded to '{archivePath}'.", OutputLogStatus.Info);
+            if (!string.IsNullOrWhiteSpace(localSourcePath) && File.Exists(localSourcePath))
+            {
+                AddOutputEntry($"MAME ROM copied from local source '{localSourcePath}' to '{archivePath}'.", OutputLogStatus.Info);
+            }
+            else
+            {
+                AddOutputEntry($"MAME ROM downloaded to '{archivePath}'.", OutputLogStatus.Info);
+            }
         }
         catch (Exception ex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRomDownloadService.cs
@@ -11,6 +11,8 @@ public sealed class MameRomDownloadService
 
     public string DownloadRootUrl { get; set; } = DefaultDownloadRootUrl;
     public string ArchiveExtension { get; set; } = DefaultArchiveExtension;
+    public string LocalRomSourceDirectory { get; set; } = string.Empty;
+    public string LocalRomArchiveExtension { get; set; } = DefaultArchiveExtension;
 
     public static string GetRomDownloadDirectory()
     {
@@ -59,11 +61,31 @@ public sealed class MameRomDownloadService
         }
 
         Directory.CreateDirectory(GetRomDownloadDirectory());
+        var localSourcePath = GetLocalRomArchivePath(romName);
+        if (!string.IsNullOrWhiteSpace(localSourcePath) && File.Exists(localSourcePath))
+        {
+            File.Copy(localSourcePath, archivePath, overwrite: true);
+            return archivePath;
+        }
+
         var downloadUrl = BuildDownloadUrl(romName);
         await using var sourceStream = await HttpClient.GetStreamAsync(downloadUrl, cancellationToken).ConfigureAwait(false);
         await using var targetStream = File.Create(archivePath);
         await sourceStream.CopyToAsync(targetStream, cancellationToken).ConfigureAwait(false);
         return archivePath;
+    }
+
+    public string GetLocalRomArchivePath(string romName)
+    {
+        if (string.IsNullOrWhiteSpace(LocalRomSourceDirectory))
+        {
+            return string.Empty;
+        }
+
+        var directory = LocalRomSourceDirectory.Trim();
+        var extension = NormalizeArchiveExtension(LocalRomArchiveExtension);
+        var fileName = $"{romName.Trim()}{extension}";
+        return Path.Combine(directory, fileName);
     }
 
     private static string NormalizeDownloadRootUrl(string rootUrl)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -82,6 +82,13 @@
                     <ComboBoxItem Content=".7z" />
                     <ComboBoxItem Content=".zip" />
                 </ComboBox>
+                <TextBlock Margin="0,10,0,4" Text="Local ROM Source Directory" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBox Text="{Binding MameLocalRomSourceDirectory, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <TextBlock Margin="0,10,0,4" Text="Local ROM Archive Extension" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <ComboBox Width="120" HorizontalAlignment="Left" SelectedValuePath="Content" SelectedValue="{Binding MameLocalRomArchiveExtension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <ComboBoxItem Content=".7z" />
+                    <ComboBoxItem Content=".zip" />
+                </ComboBox>
                 <Button Margin="0,10,0,0" Padding="10,4" Content="Reset ROM Source Defaults" Command="{Binding ResetMameRomSourceDefaultsCommand}" />
 
                 <StackPanel Margin="0,12,0,0" Orientation="Horizontal">


### PR DESCRIPTION
## Summary
- added new MAME preference fields for a local ROM source directory and local ROM archive extension
- exposed those fields in the Preferences pane alongside existing ROM download settings
- updated `MameRomDownloadService` to check the configured local ROM source first and copy a matching archive into OasisEditor’s managed ROM directory
- preserved existing remote download behavior as a fallback when local source is not configured or ROM is not found locally
- updated reset-to-default behavior to include local ROM source settings
- added/updated unit tests for local ROM path composition and preference default deserialization behavior

## Behavior change
When the Project Settings **Download** button is used for a ROM:
1. If `Local ROM Source Directory` is populated, Oasis checks `<local dir>/<rom name><local extension>` first.
2. If found, it copies that file into the local Oasis ROM cache.
3. If not found, it downloads from `ROM Download Base URL` using `ROM Archive Extension`.

## Notes
- no runtime/build/test execution was performed in this environment per repository guidance (static code update only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08627acea88327890bb911d81b7bed)