### PR TITLE
Stop emulation synchronously during editor shutdown

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1557,10 +1557,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        if (CanStopEmulation())
-        {
-            StopEmulation();
-        }
+        StopEmulationForShutdown();
 
         ClosePreferences();
         CloseProjectSettings();
@@ -1589,10 +1586,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void ExitApplication()
     {
-        if (CanStopEmulation())
-        {
-            StopEmulation();
-        }
+        StopEmulationForShutdown();
 
         Application.Current.Shutdown();
     }
@@ -1625,7 +1619,30 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStop;
     }
 
+    private void StopEmulationForShutdown()
+    {
+        if (!CanStopEmulation())
+        {
+            return;
+        }
+
+        AddOutputEntry("Emulation stop requested.", OutputLogStatus.Info);
+        try
+        {
+            _mameEmulationService.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Emulation failed to stop cleanly: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
     private async void StopEmulation()
+    {
+        await StopEmulationAsync().ConfigureAwait(false);
+    }
+
+    private async Task StopEmulationAsync()
     {
         if (!CanStopEmulation())
         {


### PR DESCRIPTION
### Motivation

- Ensure the MAME process is stopped when the editor is closed so a running emulation is not left orphaned. 
- Make application exit behave equivalently to the user choosing `Emulation > Stop` by waiting for the emulation stop to complete before shutdown.

### Description

- Call a new `StopEmulationForShutdown()` helper from both `CloseProject()` and `ExitApplication()` in `MainWindowViewModel.cs` so shutdown always attempts to stop emulation first.
- Add `StopEmulationForShutdown()` which synchronously waits on `_mameEmulationService.StopAsync(CancellationToken.None)` via `.GetAwaiter().GetResult()` and preserves existing logging/error handling.
- Refactor the existing menu stop handler to call a new `StopEmulationAsync()` helper and make `StopEmulation()` delegate to that helper so normal UI stop remains asynchronous.
- All changes are in `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs` and preserve prior logging behavior when stopping fails.

### Testing

- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --filter "FullyQualifiedName~MameEmulation"` but the command could not run because `dotnet` is not installed in this environment.
- No automated tests were executed successfully in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a087f88e4ac8327a28ec871f3716255)