### PR TITLE
Fix graphical lamp opacity during lamp test

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -180,7 +180,11 @@ public static class PanelLayoutMapper
         }
 
         var normalizedIntensity = Math.Clamp(intensity, 0d, 1d);
-        var effectiveOpacity = isOn ? Math.Max(0.1d, normalizedIntensity) : 0d;
+        var effectiveOpacity = !isOn
+            ? 0d
+            : normalizedIntensity > 0d
+                ? Math.Max(0.1d, normalizedIntensity)
+                : 1d;
 
         if (visual is Border border)
         {


### PR DESCRIPTION
### Motivation
- Graphical lamps in panel2d were visually blending into the background during lamp tests when they were logically "on" but reported zero intensity, producing a very faint appearance instead of a visible lamp.
- The issue appears related to the same opacity handling that previously affected text-based lamps, so the runtime opacity calculation needed refinement for image-based lamps.

### Description
- Changed opacity calculation in `UpdateLampVisual` in `WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs` so `effectiveOpacity` is computed as: off => `0d`, on with `intensity > 0` => `Math.Max(0.1d, normalizedIntensity)`, and on with `intensity == 0` => `1d` to ensure full visibility during lamp tests.
- Preserved existing behavior for text-style lamps by continuing to force `Border`-based lamps to full opacity so their on/off state remains represented by brush color.
- Image-based lamp visuals now use the updated `effectiveOpacity`, while text lamps remain unchanged to avoid regressions.

### Testing
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj -v minimal`, but the command failed in this environment because `dotnet` is not installed, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08882b5c748327b865e33dedef40f0)