### PR TITLE
Import and render MFME Label components in Panel2D

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -13,6 +13,7 @@ public sealed class HierarchyPanelCommandServiceTests
     [InlineData((int)PanelElementKind.Reel, "reel", "Reel 3")]
     [InlineData((int)PanelElementKind.SevenSegment, "sevenSegment", "7 Segment 4")]
     [InlineData((int)PanelElementKind.Alpha, "alpha", "Alpha")]
+    [InlineData((int)PanelElementKind.Label, "label", "Label")]
     public void SmokeLikeFlow_HierarchyCommandsUndoRedoAndSaveReopen_PreservesPanelElements(
         int kindValue,
         string kindToken,
@@ -64,6 +65,7 @@ public sealed class HierarchyPanelCommandServiceTests
     [InlineData((int)PanelElementKind.Reel, "group:reel", "reel")]
     [InlineData((int)PanelElementKind.SevenSegment, "group:sevenSegment", "sevenSegment")]
     [InlineData((int)PanelElementKind.Alpha, "group:alpha", "alpha")]
+    [InlineData((int)PanelElementKind.Label, "group:label", "label")]
     public void HierarchyProvider_NativeGroups_ExposeNativeSelectionTokens(
         int kindValue,
         string expectedGroupKey,

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -50,7 +50,15 @@ public sealed class MfmeToOasisComponentMapperTests
                     "ExtractComponentMatrixAlpha",
                     new MfmeLegacyPoint(1, 2),
                     new MfmeLegacyPoint(3, 4),
-                    Reversed: false)
+                    Reversed: false),
+                new MfmeLegacyLabelComponent(
+                    new MfmeLegacyPoint(50, 60),
+                    new MfmeLegacyPoint(120, 24),
+                    "COLLECT",
+                    "Tahoma",
+                    "Bold",
+                    "10",
+                    new MfmeLegacyColor(1f, 1f, 0f, 1f))
             ]
         };
 
@@ -60,7 +68,7 @@ public sealed class MfmeToOasisComponentMapperTests
 
         Assert.Empty(result.Warnings);
         Assert.Empty(result.SkippedLegacyComponentTypes);
-        Assert.Equal(5, result.Elements.Count);
+        Assert.Equal(6, result.Elements.Count);
 
         var background = result.Elements[0];
         Assert.Equal(PanelElementKind.Background, background.Kind);
@@ -106,6 +114,15 @@ public sealed class MfmeToOasisComponentMapperTests
         Assert.Equal(PanelElementKind.Alpha, alpha.Kind);
         Assert.Equal("Alpha", alpha.Name);
         Assert.False(alpha.IsReversed);
+
+        var label = result.Elements[5];
+        Assert.Equal(PanelElementKind.Label, label.Kind);
+        Assert.Equal("Label", label.Name);
+        Assert.Equal("COLLECT", label.DisplayText);
+        Assert.Equal("Tahoma", label.TextBoxFontName);
+        Assert.Equal("Bold", label.TextBoxFontStyle);
+        Assert.Equal("10", label.TextBoxFontSize);
+        Assert.Equal("#FFFFFF00", label.TextColorHex);
 
         Assert.All(result.Elements, element => Assert.NotEqual(PanelElementKind.Unknown, element.Kind));
         Assert.All(result.Elements, element => Assert.False(string.IsNullOrWhiteSpace(element.ObjectId)));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -234,6 +234,17 @@ internal static class MfmeExtractManifestParser
                     ReadBool(component, "Reversed"));
                 return true;
 
+            case "extractcomponentlabel":
+                parsedComponent = new MfmeLegacyLabelComponent(
+                    position,
+                    size,
+                    ReadString(component, "TextBoxText"),
+                    ReadString(component, "TextBoxFontName"),
+                    ReadString(component, "TextBoxFontStyle"),
+                    ReadString(component, "TextBoxFontSize"),
+                    ReadColor(component, "TextColor"));
+                return true;
+
             default:
                 parsedComponent = null!;
                 return false;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -101,3 +101,20 @@ internal sealed record MfmeLegacyAlphaComponent(
         null,
         null,
         null);
+
+internal sealed record MfmeLegacyLabelComponent(
+    MfmeLegacyPoint Position,
+    MfmeLegacyPoint Size,
+    string? TextBoxText,
+    string? TextBoxFontName,
+    string? TextBoxFontStyle,
+    string? TextBoxFontSize,
+    MfmeLegacyColor? TextColor)
+    : MfmeLegacyComponentBase(
+        "Label",
+        Position,
+        Size,
+        TextBoxText,
+        TextBoxFontName,
+        TextBoxFontStyle,
+        TextBoxFontSize);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -33,6 +33,9 @@ internal sealed class MfmeToOasisComponentMapper
                 case MfmeLegacyAlphaComponent alpha:
                     elements.Add(MapAlpha(alpha));
                     break;
+                case MfmeLegacyLabelComponent label:
+                    elements.Add(MapLabel(label));
+                    break;
                 default:
                     skipped.Add(component.SourceType);
                     warnings.Add(new MfmeImportWarning(
@@ -185,6 +188,26 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             IsReversed = component.Reversed,
+            ImportSource = CreateImportSource(component.SourceType)
+        };
+    }
+
+    private static PanelElementModel MapLabel(MfmeLegacyLabelComponent component)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = Guid.NewGuid().ToString("N"),
+            Name = "Label",
+            Kind = PanelElementKind.Label,
+            X = component.Position.X,
+            Y = component.Position.Y,
+            Width = component.Size.X,
+            Height = component.Size.Y,
+            DisplayText = NormalizeOptional(component.TextBoxText),
+            TextBoxFontName = NormalizeOptional(component.TextBoxFontName),
+            TextBoxFontStyle = NormalizeOptional(component.TextBoxFontStyle),
+            TextBoxFontSize = NormalizeOptional(component.TextBoxFontSize),
+            TextColorHex = ToHex(component.TextColor),
             ImportSource = CreateImportSource(component.SourceType)
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -54,6 +54,10 @@ internal static class Panel2DDocumentStorage
         {
             return PanelElementKind.Alpha;
         }
+        if (string.Equals(kind, "label", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.Label;
+        }
 
         return PanelElementKind.Unknown;
     }
@@ -71,6 +75,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "reel",
             PanelElementKind.SevenSegment => "sevenSegment",
             PanelElementKind.Alpha => "alpha",
+            PanelElementKind.Label => "label",
             _ => string.Empty
         };
     }
@@ -248,7 +253,7 @@ internal static class Panel2DDocumentStorage
         foreach (var element in elements)
         {
             var kind = ParseElementKind(element.Kind);
-            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
+            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.Label)
             {
                 return CurrentSchemaVersion;
             }
@@ -524,6 +529,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "Reel",
             PanelElementKind.SevenSegment => "7 Segment",
             PanelElementKind.Alpha => "Alpha",
+            PanelElementKind.Label => "Label",
             _ => "Rectangle"
         };
 
@@ -689,7 +695,8 @@ internal enum PanelElementKind
     Lamp,
     Reel,
     SevenSegment,
-    Alpha
+    Alpha,
+    Label
 }
 
 internal sealed record Panel2DDocumentFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -89,6 +89,7 @@ internal static class PanelElementFactory
             PanelElementKind.Reel => CreateReelVisual(element),
             PanelElementKind.SevenSegment => CreateSevenSegmentVisual(element),
             PanelElementKind.Alpha => CreateAlphaVisual(element),
+            PanelElementKind.Label => CreateLabelVisual(element),
             _ => null
         };
 
@@ -329,6 +330,18 @@ internal static class PanelElementFactory
                 ShowDecimalPoint = true
             }
         };
+    }
+
+    private static Border CreateLabelVisual(PanelElementFile element)
+    {
+        var text = string.IsNullOrWhiteSpace(element.DisplayText) ? "Label" : element.DisplayText;
+        return CreatePlaceholderComponentVisual(
+            element,
+            text,
+            null,
+            null,
+            element.TextColorHex,
+            CreateFontSettings(element.TextBoxFontName, element.TextBoxFontStyle, element.TextBoxFontSize));
     }
 
     private static Border CreatePlaceholderComponentVisual(PanelElementFile element, string label)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -23,6 +23,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
             BuildGroup("Reels", elements, PanelElementKind.Reel, "Reel"),
             BuildGroup("Seven Segments", elements, PanelElementKind.SevenSegment, "7 Segment"),
             BuildGroup("Alphas", elements, PanelElementKind.Alpha, "Alpha"),
+            BuildGroup("Labels", elements, PanelElementKind.Label, "Label"),
             BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
             BuildGroup("Rectangles", elements, PanelElementKind.Rectangle, "Rectangle"),
             BuildGroup("Anchors", elements, PanelElementKind.Anchor, "Anchor"),


### PR DESCRIPTION
### Motivation
- MFME extracts included Label components but these were not created or rendered when importing into Panel2D documents.
- Labels need to round-trip through the importer, persist in .panel2d files, be selectable in the hierarchy, and render on the canvas with correct text and font settings.
- Keep changes minimal and consistent with existing Lamp/Alpha/SevenSegment handling so labels behave like other native MFME component types.

### Description
- Added `MfmeLegacyLabelComponent` DTO and manifest parsing for `ExtractComponentLabel` in `MfmeLegacyExtractComponentDtos.cs` and `MfmeExtractManifestParser.cs` so label components are recognized during read.
- Implemented `MapLabel` in `MfmeToOasisComponentMapper.cs` to produce `PanelElementModel` entries carrying `DisplayText`, `TextBoxFontName`, `TextBoxFontStyle`, `TextBoxFontSize`, `TextColorHex`, and `ImportSource`.
- Introduced `PanelElementKind.Label` and wired parsing/serialization, schema-detection, and default naming in `Panel2DDocumentStorage.cs` so labels persist and are detected as current-schema elements.
- Implemented label visuals in `PanelElementFactory.cs` (`CreateLabelVisual`) reusing existing placeholder rendering and MFME font-resolution logic so imported labels are visible on the canvas.
- Added a Labels group to the panel hierarchy in `Panel2DHierarchyProvider.cs` and updated tests to cover mapping and hierarchy tokens for the new label kind.

### Testing
- No automated tests were executed in this environment because the Codex session lacks the required Windows/.NET/WPF toolchain per project `AGENT.md` (do not run tests here).
- Unit tests were updated to cover label import and hierarchy behavior: `MfmeToOasisComponentMapperTests` and `HierarchyPanelCommandServiceTests` contain new assertions for label mapping and grouping; these should be executed locally.
- Please run `dotnet test OasisEditor.sln` locally to validate (expected: updated tests pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a088a53262c8327ad61a4655088515c)