### PR TITLE
Fix MFME Alpha component import aliases

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -298,6 +298,51 @@ public sealed class MfmeExtractReaderTests
         return path;
     }
 
+
+    [Fact]
+    public void Read_WithMfmeExtractAlphaType_ParsesAsAlphaComponent()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "layout.json");
+        File.WriteAllText(manifestPath, """
+        {
+          "ASName": "AlphaAlias",
+          "Components": [
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.MfmeExtractAlpha, MfmeTools",
+              "Position": { "X": 13, "Y": 14 },
+              "Size": { "X": 15, "Y": 16 },
+              "Reversed": true
+            }
+          ]
+        }
+        """);
+
+        try
+        {
+            var reader = new FileSystemMfmeExtractReader();
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = true
+            };
+
+            var result = reader.Read(context);
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            Assert.Empty(result.Warnings);
+            var alpha = Assert.IsType<MfmeLegacyAlphaComponent>(Assert.Single(result.Extract!.Components));
+            Assert.Equal("MfmeExtractAlpha", alpha.SourceType);
+            Assert.True(alpha.Reversed);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
     private static string CreateSupportedComponentsManifestJson()
     {
         return """

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -227,6 +227,9 @@ internal static class MfmeExtractManifestParser
             case "extractcomponentalpha":
             case "extractcomponentalphanew":
             case "extractcomponentmatrixalpha":
+            case "mfmeextractalpha":
+            case "mfmeextractalphanew":
+            case "mfmeextractmatrixalpha":
                 parsedComponent = new MfmeLegacyAlphaComponent(
                     sourceType,
                     position,


### PR DESCRIPTION
### Motivation
- MFME extracts sometimes encode alpha components using `MfmeExtract*` type names which were not recognized by the manifest parser, causing Alpha elements to be skipped during import.
- The goal is to ensure any MFME alpha variant (including the `MfmeExtract*` aliases) is parsed as an `MfmeLegacyAlphaComponent` so it maps to an Oasis `Alpha` panel element.

### Description
- Extended `MfmeExtractManifestParser` to accept additional alpha type aliases: `mfmeextractalpha`, `mfmeextractalphanew`, and `mfmeextractmatrixalpha` alongside existing `extractcomponent*` names so they parse into `MfmeLegacyAlphaComponent` (file: `OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs`).
- Added a regression test `Read_WithMfmeExtractAlphaType_ParsesAsAlphaComponent` to `OasisEditor.Tests/MfmeExtractReaderTests.cs` that writes a manifest with a `MfmeExtractAlpha` entry and asserts it is parsed as `MfmeLegacyAlphaComponent` and that `Reversed` is preserved.
- Updated project with the changes committed to ensure non-matrix and matrix alpha components behave consistently when imported.

### Testing
- Added unit test `Read_WithMfmeExtractAlphaType_ParsesAsAlphaComponent` under `OasisEditor.Tests` to cover the new alias parsing behavior (not executed here but included in the PR).
- Attempted to run targeted tests with `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --filter "MfmeExtractReaderTests|MfmeToOasisComponentMapperTests"` but the environment lacks the `dotnet` runtime, causing the test run to fail with `/bin/bash: dotnet: command not found`.
- No automated tests were run successfully in this environment; CI should validate the new test and the parser change after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a088cd4040c8327943c3df5828867ca)