### PR TITLE
Drive reel visuals from MAME emulation output

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -9,25 +9,44 @@ public sealed class MameStdoutParserTests
     public void ProcessLine_WhenLampLine_AppliesLampState()
     {
         var lampAdapter = new RecordingLampAdapter();
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter);
+        var reelAdapter = new RecordingReelAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter);
 
         parser.ProcessLine("lamp7 1");
 
         var call = Assert.Single(lampAdapter.Calls);
         Assert.Equal(7, call.LampId);
         Assert.Equal(1, call.Value);
+        Assert.Empty(reelAdapter.Calls);
+    }
+
+    [Fact]
+    public void ProcessLine_WhenReelLine_AppliesReelState()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter);
+
+        parser.ProcessLine("reel3 = 94");
+
+        var call = Assert.Single(reelAdapter.Calls);
+        Assert.Equal(3, call.ReelId);
+        Assert.Equal(94, call.Value);
+        Assert.Empty(lampAdapter.Calls);
     }
 
     [Fact]
     public void ProcessLine_WhenUnknownLine_LogsDiagnostic()
     {
         var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
         string? diagnostic = null;
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, message => diagnostic = message);
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, message => diagnostic = message);
 
         parser.ProcessLine("unknown output");
 
         Assert.Empty(lampAdapter.Calls);
+        Assert.Empty(reelAdapter.Calls);
         Assert.NotNull(diagnostic);
         Assert.Contains("Unhandled line", diagnostic);
     }
@@ -35,10 +54,12 @@ public sealed class MameStdoutParserTests
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
     {
         public List<(int LampId, int Value)> Calls { get; } = [];
+        public void ApplyLampState(int lampId, int lampValue) => Calls.Add((lampId, lampValue));
+    }
 
-        public void ApplyLampState(int lampId, int lampValue)
-        {
-            Calls.Add((lampId, lampValue));
-        }
+    private sealed class RecordingReelAdapter : IMameReelRuntimeAdapter
+    {
+        public List<(int ReelId, int Value)> Calls { get; } = [];
+        public void ApplyReelState(int reelId, int reelValue) => Calls.Add((reelId, reelValue));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -198,6 +198,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                         dispatcher.Invoke(work);
                     }
                 }),
+            new MameReelStateParser(),
+            new MameReelRuntimeAdapter(
+                () => OpenDocuments,
+                work =>
+                {
+                    var dispatcher = Application.Current.Dispatcher;
+                    if (dispatcher.CheckAccess())
+                    {
+                        work();
+                    }
+                    else
+                    {
+                        dispatcher.Invoke(work);
+                    }
+                }),
             diagnosticLogger: line => AddOutputEntry(line, OutputLogStatus.Info));
         _mameEmulationService = new MameEmulationService(
             new MameProcessStartInfoBuilder(),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -1,0 +1,131 @@
+namespace OasisEditor;
+
+public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
+{
+    private readonly object _pendingSync = new();
+    private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Action<Action> _uiDispatch;
+    private readonly Dictionary<int, int> _pendingReelValues = new();
+    private readonly Dictionary<Guid, ReelDocumentMappingCacheEntry> _reelMappingsByDocumentId = new();
+    private bool _uiUpdateScheduled;
+
+    public MameReelRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    {
+        _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
+    }
+
+    public void ApplyReelState(int reelId, int reelValue)
+    {
+        lock (_pendingSync)
+        {
+            _pendingReelValues[reelId] = reelValue;
+            if (_uiUpdateScheduled)
+            {
+                return;
+            }
+
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
+    private void ApplyPendingOnUiThread()
+    {
+        Dictionary<int, int> snapshot;
+        lock (_pendingSync)
+        {
+            snapshot = new Dictionary<int, int>(_pendingReelValues);
+            _pendingReelValues.Clear();
+            _uiUpdateScheduled = false;
+        }
+
+        if (snapshot.Count == 0)
+        {
+            return;
+        }
+
+        var documents = _documentProvider().ToArray();
+        PruneDocumentCaches(documents);
+
+        foreach (var document in documents)
+        {
+            var objectIdsByReel = GetOrBuildReelMapping(document);
+            var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var (reelId, reelValue) in snapshot)
+            {
+                if (!objectIdsByReel.TryGetValue(reelId, out var objectIds) || objectIds.Length == 0)
+                {
+                    continue;
+                }
+
+                foreach (var objectId in objectIds)
+                {
+                    if (document.RuntimeState.SetReelPositionIfChanged(objectId, reelValue))
+                    {
+                        changedObjectIds.Add(objectId);
+                    }
+                }
+            }
+
+            if (changedObjectIds.Count > 0)
+            {
+                document.NotifyPanelVisualPreviewChanged(changedObjectIds);
+            }
+        }
+    }
+
+    private void PruneDocumentCaches(IReadOnlyCollection<DocumentTabViewModel> documents)
+    {
+        var activeIds = documents.Select(document => document.DocumentId).ToHashSet();
+        foreach (var staleDocumentId in _reelMappingsByDocumentId.Keys.Where(id => !activeIds.Contains(id)).ToArray())
+        {
+            if (_reelMappingsByDocumentId.Remove(staleDocumentId, out var staleEntry))
+            {
+                staleEntry.Detach();
+            }
+        }
+    }
+
+    private IReadOnlyDictionary<int, string[]> GetOrBuildReelMapping(DocumentTabViewModel document)
+    {
+        if (_reelMappingsByDocumentId.TryGetValue(document.DocumentId, out var cacheEntry) && !cacheEntry.IsDirty)
+        {
+            return cacheEntry.MappingByReelId;
+        }
+
+        var mapping = document.GetPanelElements()
+            .Where(element => element.Kind == PanelElementKind.Reel && !string.IsNullOrWhiteSpace(element.ObjectId) && element.DisplayNumber.HasValue)
+            .GroupBy(element => element.DisplayNumber!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.ObjectId).Distinct(StringComparer.Ordinal).ToArray());
+
+        if (cacheEntry is null)
+        {
+            cacheEntry = new ReelDocumentMappingCacheEntry(document, mapping);
+            _reelMappingsByDocumentId[document.DocumentId] = cacheEntry;
+            return cacheEntry.MappingByReelId;
+        }
+
+        cacheEntry.Replace(mapping);
+        return cacheEntry.MappingByReelId;
+    }
+
+    private sealed class ReelDocumentMappingCacheEntry
+    {
+        private readonly DocumentTabViewModel _document;
+        public ReelDocumentMappingCacheEntry(DocumentTabViewModel document, IReadOnlyDictionary<int, string[]> mappingByReelId)
+        {
+            _document = document;
+            MappingByReelId = mappingByReelId;
+            _document.PanelChanged += OnPanelChanged;
+        }
+
+        public IReadOnlyDictionary<int, string[]> MappingByReelId { get; private set; }
+        public bool IsDirty { get; private set; }
+        public void Replace(IReadOnlyDictionary<int, string[]> mappingByReelId) { MappingByReelId = mappingByReelId; IsDirty = false; }
+        public void OnPanelChanged(PanelChangeEvent _) => IsDirty = true;
+        public void Detach() => _document.PanelChanged -= OnPanelChanged;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
@@ -1,0 +1,60 @@
+using System.Text.RegularExpressions;
+
+namespace OasisEditor;
+
+public interface IMameReelStateParser
+{
+    bool TryParse(string line, out int reelId, out int reelValue);
+}
+
+public sealed partial class MameReelStateParser : IMameReelStateParser
+{
+    [GeneratedRegex(@"reel\s*(\d+)\s*=\s*(-?\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex ReelEqualsPattern();
+
+    public bool TryParse(string line, out int reelId, out int reelValue)
+    {
+        reelId = 0;
+        reelValue = 0;
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var trimmed = line.Trim();
+        var regexMatch = ReelEqualsPattern().Match(trimmed);
+        if (regexMatch.Success
+            && int.TryParse(regexMatch.Groups[1].Value, out reelId)
+            && int.TryParse(regexMatch.Groups[2].Value, out reelValue))
+        {
+            return true;
+        }
+
+        var tokens = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length < 2)
+        {
+            return false;
+        }
+
+        var tokenWithPrefix = tokens[0];
+        if (!tokenWithPrefix.StartsWith("reel", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var reelToken = tokenWithPrefix["reel".Length..];
+        if (reelToken.Length == 0)
+        {
+            return false;
+        }
+
+        var valueToken = tokens[^1];
+        if (!int.TryParse(reelToken, out reelId) || !int.TryParse(valueToken, out reelValue))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -34,6 +34,11 @@ public interface IMameLampRuntimeAdapter
     void ApplyLampState(int lampId, int lampValue);
 }
 
+public interface IMameReelRuntimeAdapter
+{
+    void ApplyReelState(int reelId, int reelValue);
+}
+
 public sealed record MameProcessLaunchRequest(
     string MameExecutablePath,
     string MameRomName,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -4,12 +4,16 @@ public sealed class MameStdoutParser : IMameStdoutParser
 {
     private readonly IMameLampStateParser _lampStateParser;
     private readonly IMameLampRuntimeAdapter _lampRuntimeAdapter;
+    private readonly IMameReelStateParser _reelStateParser;
+    private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
     private readonly Action<string>? _diagnosticLogger;
 
-    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, Action<string>? diagnosticLogger = null)
+    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, Action<string>? diagnosticLogger = null)
     {
         _lampStateParser = lampStateParser ?? throw new ArgumentNullException(nameof(lampStateParser));
         _lampRuntimeAdapter = lampRuntimeAdapter ?? throw new ArgumentNullException(nameof(lampRuntimeAdapter));
+        _reelStateParser = reelStateParser ?? throw new ArgumentNullException(nameof(reelStateParser));
+        _reelRuntimeAdapter = reelRuntimeAdapter ?? throw new ArgumentNullException(nameof(reelRuntimeAdapter));
         _diagnosticLogger = diagnosticLogger;
     }
 
@@ -23,6 +27,12 @@ public sealed class MameStdoutParser : IMameStdoutParser
         if (_lampStateParser.TryParse(line, out var lampId, out var lampValue))
         {
             _lampRuntimeAdapter.ApplyLampState(lampId, lampValue);
+            return;
+        }
+
+        if (_reelStateParser.TryParse(line, out var reelId, out var reelValue))
+        {
+            _reelRuntimeAdapter.ApplyReelState(reelId, reelValue);
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -254,12 +254,32 @@ internal static class PanelElementFactory
                 HorizontalAlignment = HorizontalAlignment.Stretch
             };
 
+            var wrappedReelImage = new Image
+            {
+                Stretch = Stretch.Fill,
+                Source = source,
+                Width = reelImage.Width,
+                Height = reelImage.Height,
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+
+            var reelCanvas = new Canvas
+            {
+                Width = width,
+                Height = reelImage.Height
+            };
+            Canvas.SetTop(reelImage, 0d);
+            Canvas.SetTop(wrappedReelImage, reelImage.Height);
+            reelCanvas.Children.Add(reelImage);
+            reelCanvas.Children.Add(wrappedReelImage);
+
             surface.Child = new Grid
             {
                 ClipToBounds = true,
                 Children =
                 {
-                    reelImage
+                    reelCanvas
                 }
             };
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -6,6 +6,7 @@ namespace OasisEditor;
 
 public static class PanelLayoutMapper
 {
+    private const double LegacyReelPositionsPerRevolution = 96d;
     private static readonly DependencyProperty IsApplyingLayoutProperty =
         DependencyProperty.RegisterAttached(
             "IsApplyingLayout",
@@ -254,15 +255,17 @@ public static class PanelLayoutMapper
         }
 
         var safeStops = Math.Max(1, stops);
-        var normalizedPosition = ((position % safeStops) + safeStops) % safeStops;
         var bandHeight = primaryImage.Height;
         if (bandHeight <= 0d)
         {
             return;
         }
 
+        var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, safeStops);
         var stopHeight = bandHeight / safeStops;
-        var rawOffset = normalizedPosition * stopHeight;
+        var subStepHeight = stopHeight / (positionsPerRevolution / safeStops);
+        var rawPosition = ((position % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
+        var rawOffset = rawPosition * subStepHeight;
         var wrappedOffset = ((rawOffset % bandHeight) + bandHeight) % bandHeight;
         var top = -wrappedOffset;
 
@@ -330,4 +333,3 @@ public static class PanelLayoutMapper
         element.Opacity = opacity;
     }
 }
-

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -135,26 +135,37 @@ public static class PanelLayoutMapper
 
         foreach (var objectId in visualStateChange.ValuesByObjectId.Keys)
         {
-            if (!tab.TryGetLampElement(objectId, out var sourceModel))
+            if (tab.TryGetLampElement(objectId, out var sourceModel))
             {
+                var lampVisualState = visualStateChange.ValuesByObjectId[objectId] switch
+                {
+                    LampVisualState state => state,
+                    true => new LampVisualState(true, runtimeState.GetLampIntensity(objectId)),
+                    _ => new LampVisualState(false, runtimeState.GetLampIntensity(objectId))
+                };
+
+                UpdateLampVisual(
+                    canvas,
+                    objectId,
+                    lampVisualState.Intensity,
+                    lampVisualState.IsLampTestOn || lampVisualState.Intensity > 0d,
+                    sourceModel.OnColorHex,
+                    sourceModel.OffColorHex,
+                    sourceModel.AssetPath);
                 continue;
             }
 
-            var lampVisualState = visualStateChange.ValuesByObjectId[objectId] switch
+            if (tab.TryGetReelElement(objectId, out var reelModel))
             {
-                LampVisualState state => state,
-                true => new LampVisualState(true, runtimeState.GetLampIntensity(objectId)),
-                _ => new LampVisualState(false, runtimeState.GetLampIntensity(objectId))
-            };
+                var reelVisualState = visualStateChange.ValuesByObjectId[objectId] switch
+                {
+                    ReelVisualState state => state,
+                    int value => new ReelVisualState(value),
+                    _ => new ReelVisualState(runtimeState.GetReelPosition(objectId))
+                };
 
-            UpdateLampVisual(
-                canvas,
-                objectId,
-                lampVisualState.Intensity,
-                lampVisualState.IsLampTestOn || lampVisualState.Intensity > 0d,
-                sourceModel.OnColorHex,
-                sourceModel.OffColorHex,
-                sourceModel.AssetPath);
+                UpdateReelVisual(canvas, objectId, reelVisualState.Position, reelModel.Stops.GetValueOrDefault(1));
+            }
         }
     }
 
@@ -221,6 +232,26 @@ public static class PanelLayoutMapper
         }
     }
 
+
+    public static void UpdateReelVisual(Canvas canvas, string objectId, int position, int stops)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return;
+        }
+
+        var registry = GetOrCreateRuntimeVisualRegistry(canvas);
+        if (!registry.TryGetVisual(objectId, out var visual) || visual is not Border border || border.Child is not Grid grid || grid.Children.Count == 0 || grid.Children[0] is not Image image)
+        {
+            return;
+        }
+
+        var safeStops = Math.Max(1, stops);
+        var normalizedPosition = ((position % safeStops) + safeStops) % safeStops;
+        var stopHeight = border.Height / safeStops;
+        image.RenderTransform = new TranslateTransform(0d, -(normalizedPosition * stopHeight));
+    }
+
     private static bool GetIsPersistedElement(FrameworkElement element)
     {
         return (bool)element.GetValue(IsPersistedElementProperty);
@@ -281,3 +312,5 @@ public static class PanelLayoutMapper
         element.Opacity = opacity;
     }
 }
+
+

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -241,15 +241,33 @@ public static class PanelLayoutMapper
         }
 
         var registry = GetOrCreateRuntimeVisualRegistry(canvas);
-        if (!registry.TryGetVisual(objectId, out var visual) || visual is not Border border || border.Child is not Grid grid || grid.Children.Count == 0 || grid.Children[0] is not Image image)
+        if (!registry.TryGetVisual(objectId, out var visual)
+            || visual is not Border border
+            || border.Child is not Grid grid
+            || grid.Children.Count == 0
+            || grid.Children[0] is not Canvas reelCanvas
+            || reelCanvas.Children.Count < 2
+            || reelCanvas.Children[0] is not Image primaryImage
+            || reelCanvas.Children[1] is not Image wrappedImage)
         {
             return;
         }
 
         var safeStops = Math.Max(1, stops);
         var normalizedPosition = ((position % safeStops) + safeStops) % safeStops;
-        var stopHeight = border.Height / safeStops;
-        image.RenderTransform = new TranslateTransform(0d, -(normalizedPosition * stopHeight));
+        var bandHeight = primaryImage.Height;
+        if (bandHeight <= 0d)
+        {
+            return;
+        }
+
+        var stopHeight = bandHeight / safeStops;
+        var rawOffset = normalizedPosition * stopHeight;
+        var wrappedOffset = ((rawOffset % bandHeight) + bandHeight) % bandHeight;
+        var top = -wrappedOffset;
+
+        Canvas.SetTop(primaryImage, top);
+        Canvas.SetTop(wrappedImage, top + bandHeight);
     }
 
     private static bool GetIsPersistedElement(FrameworkElement element)
@@ -312,5 +330,4 @@ public static class PanelLayoutMapper
         element.Opacity = opacity;
     }
 }
-
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -3,12 +3,14 @@ namespace OasisEditor;
 public sealed class PanelRuntimeState
 {
     private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _reelPositionByObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
 
     public bool IsLampTestActive => !string.IsNullOrWhiteSpace(LampTestObjectId);
 
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
+    public IReadOnlyDictionary<string, int> ReelPositionByObjectId => _reelPositionByObjectId;
 
     public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
@@ -29,6 +31,23 @@ public sealed class PanelRuntimeState
         return true;
     }
 
+    public bool SetReelPositionIfChanged(string objectId, int position)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        if (_reelPositionByObjectId.TryGetValue(normalizedObjectId, out var previous) && previous == position)
+        {
+            return false;
+        }
+
+        _reelPositionByObjectId[normalizedObjectId] = position;
+        return true;
+    }
+
     public void SetLampIntensity(string objectId, double intensity)
     {
         SetLampIntensityIfChanged(objectId, intensity);
@@ -44,6 +63,16 @@ public sealed class PanelRuntimeState
         return _lampIntensityByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
     }
 
+    public int GetReelPosition(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return 0;
+        }
+
+        return _reelPositionByObjectId.GetValueOrDefault(objectId.Trim(), 0);
+    }
+
     public void ClearLampIntensity(string objectId)
     {
         if (!string.IsNullOrWhiteSpace(objectId))
@@ -56,5 +85,6 @@ public sealed class PanelRuntimeState
     {
         LampTestObjectId = null;
         _lampIntensityByObjectId.Clear();
+        _reelPositionByObjectId.Clear();
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -11,7 +11,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private string? _panelLayoutJson;
     private Panel2DDocumentModel _panelDocumentModel;
     private Dictionary<string, PanelElementModel> _lampElementsByObjectId = new(StringComparer.Ordinal);
-    private HashSet<string> _lampObjectIds = new(StringComparer.Ordinal);
+    private Dictionary<string, PanelElementModel> _reelElementsByObjectId = new(StringComparer.Ordinal);
+    private HashSet<string> _visualStateObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
     private double _panelPanX;
@@ -142,7 +143,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     {
         var changedObjectIds = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && element.Kind == PanelElementKind.Lamp)
+                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel))
             .Select(element => element.ObjectId)
             .ToArray();
         NotifyPanelVisualPreviewChanged(changedObjectIds);
@@ -159,16 +160,18 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         var deltaByObjectId = new Dictionary<string, object>(StringComparer.Ordinal);
         foreach (var objectId in changedObjectIds)
         {
-            if (string.IsNullOrWhiteSpace(objectId) || !_lampObjectIds.Contains(objectId))
+            if (string.IsNullOrWhiteSpace(objectId) || !_visualStateObjectIds.Contains(objectId))
             {
                 continue;
             }
 
-            var nextState = (object)new LampVisualState(
+            var nextState = _lampElementsByObjectId.ContainsKey(objectId)
+                ? (object)new LampVisualState(
                 _runtimeState.IsLampTestActive
                 && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
                 && string.Equals(objectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal),
-                _runtimeState.GetLampIntensity(objectId));
+                _runtimeState.GetLampIntensity(objectId))
+                : new ReelVisualState(_runtimeState.GetReelPosition(objectId));
             if (!_lastVisualStateByObjectId.TryGetValue(objectId, out var previous)
                 || !Equals(previous, nextState))
             {
@@ -194,6 +197,19 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
 
         return _lampElementsByObjectId.TryGetValue(objectId, out element!);
+    }
+
+
+
+    internal bool TryGetReelElement(string objectId, out PanelElementModel element)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            element = new PanelElementModel();
+            return false;
+        }
+
+        return _reelElementsByObjectId.TryGetValue(objectId, out element!);
     }
 
     internal string GetPanelLayoutProjectionJson()
@@ -280,11 +296,18 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             .Where(element => element.Kind == PanelElementKind.Lamp
                 && !string.IsNullOrWhiteSpace(element.ObjectId))
             .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
-        _lampObjectIds = _lampElementsByObjectId.Keys.ToHashSet(StringComparer.Ordinal);
+        _reelElementsByObjectId = _panelDocumentModel.Elements
+            .Where(element => element.Kind == PanelElementKind.Reel
+                && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+        _visualStateObjectIds = _lampElementsByObjectId.Keys
+            .Concat(_reelElementsByObjectId.Keys)
+            .ToHashSet(StringComparer.Ordinal);
     }
 }
 
 internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
+internal readonly record struct ReelVisualState(int Position);
 
 public sealed record PanelVisualStateChangedEvent(
     Guid DocumentId,


### PR DESCRIPTION
### Motivation
- Reels should be driven by the MAME emulation stream the same way lamps are, so panel visuals in the editor reflect live emulation state. 
- Reuse the existing lamp-routing architecture (parser → runtime adapter → document runtime state → incremental visual updates) to keep updates efficient and document-scoped.

### Description
- Added a `IMameReelRuntimeAdapter` abstraction and implemented `MameReelRuntimeAdapter` to batch `reelN` values, map them to open documents by `DisplayNumber`, and apply changes to per-document runtime state. (`MameReelRuntimeAdapter.cs`, `MameRuntimeAbstractions.cs`)
- Implemented `MameReelStateParser` to parse `reelN = value` stdout lines and extended `MameStdoutParser` to route reel lines to the reel runtime adapter in addition to lamps. (`MameReelStateParser.cs`, `MameStdoutParser.cs`)
- Extended `PanelRuntimeState` to store per-object reel positions and added `SetReelPositionIfChanged` / `GetReelPosition`. (`PanelRuntimeState.cs`)
- Extended `DocumentTabViewModel` to recognize reel elements in visual-state notifications, added reel caches and a `ReelVisualState` record, and included reels in `NotifyPanelVisualPreviewChanged` deltas. (`ViewModels/DocumentTabViewModel.cs`)
- Added `UpdateReelVisual` to `PanelLayoutMapper` which translates the reel image vertically inside its clipped viewport according to runtime position and the element `Stops` value. (`PanelLayoutMapper.cs`)
- Wired the new reel parser/adapter into the MAME stdout composition point in `MainWindowViewModel` so live stdout drives both lamps and reels. (`MainWindowViewModel.cs`)
- Updated unit tests for stdout parsing to cover reel routing and unknown-line diagnostics. (`OasisEditor.Tests/MameStdoutParserTests.cs`)

### Testing
- Added/updated unit test `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs` to validate lamp routing, reel routing, and unhandled-line diagnostic behavior (test sources included in the change). 
- No automated test run was executed in this environment due to the project environment constraint (no Windows/.NET/WPF toolchain available here), so CI or a local Windows build should run `dotnet test` to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a089232efbc8327a794e60bf45ef668)