### PR TITLE
Add MAME VFD segment parsing and alpha display runtime updates

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -1,0 +1,56 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameSegmentRuntimeAdapterTests
+{
+    [Fact]
+    public void ApplySegmentState_PreservesPreviouslyReceivedCells()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, 1);
+        var first = Assert.Single(dispatches);
+        first();
+
+        adapter.ApplySegmentState(1, 2);
+        var second = Assert.Single(dispatches.Skip(1));
+        second();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
+        Assert.Equal(1, masks[0]);
+        Assert.Equal(2, masks[1]);
+    }
+
+    [Fact]
+    public void ApplySegmentState_CoalescesPendingUpdatesIntoSingleUiDispatch()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, 1);
+        adapter.ApplySegmentState(0, 3);
+        adapter.ApplySegmentState(1, 2);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
+        Assert.Equal(3, masks[0]);
+        Assert.Equal(2, masks[1]);
+    }
+
+    private static DocumentTabViewModel CreateDocument()
+    {
+        var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");
+        var tab = new DocumentTabViewModel(panelDocument);
+        tab.SetPanelElements([
+            new PanelElementModel { ObjectId = "alpha-0", Kind = PanelElementKind.Alpha, DisplayNumber = 0 }
+        ]);
+        return tab;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
@@ -1,0 +1,17 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameSegmentStateParserTests
+{
+    [Fact]
+    public void TryParse_VfdLine_ParsesCellAndMask()
+    {
+        var parser = new MameSegmentStateParser();
+        var ok = parser.TryParse("vfd12 = 769", out var cellId, out var mask);
+        Assert.True(ok);
+        Assert.Equal(12, cellId);
+        Assert.Equal(769, mask);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -10,7 +10,8 @@ public sealed class MameStdoutParserTests
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter);
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
 
         parser.ProcessLine("lamp7 1");
 
@@ -25,7 +26,8 @@ public sealed class MameStdoutParserTests
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter);
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
 
         parser.ProcessLine("reel3 = 94");
 
@@ -40,8 +42,9 @@ public sealed class MameStdoutParserTests
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
         string? diagnostic = null;
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, message => diagnostic = message);
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter, message => diagnostic = message);
 
         parser.ProcessLine("unknown output");
 
@@ -49,6 +52,21 @@ public sealed class MameStdoutParserTests
         Assert.Empty(reelAdapter.Calls);
         Assert.NotNull(diagnostic);
         Assert.Contains("Unhandled line", diagnostic);
+    }
+
+    [Fact]
+    public void ProcessLine_WhenSegmentLine_AppliesSegmentState()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
+
+        parser.ProcessLine("vfd12 = 769");
+
+        var call = Assert.Single(segmentAdapter.Calls);
+        Assert.Equal(12, call.CellId);
+        Assert.Equal(769, call.Mask);
     }
 
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
@@ -61,5 +79,11 @@ public sealed class MameStdoutParserTests
     {
         public List<(int ReelId, int Value)> Calls { get; } = [];
         public void ApplyReelState(int reelId, int reelValue) => Calls.Add((reelId, reelValue));
+    }
+
+    private sealed class RecordingSegmentAdapter : IMameSegmentRuntimeAdapter
+    {
+        public List<(int CellId, int Mask)> Calls { get; } = [];
+        public void ApplySegmentState(int cellId, int segmentMask) => Calls.Add((cellId, segmentMask));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -213,6 +213,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                         dispatcher.Invoke(work);
                     }
                 }),
+            new MameSegmentStateParser(),
+            new MameSegmentRuntimeAdapter(
+                () => OpenDocuments,
+                work =>
+                {
+                    var dispatcher = Application.Current.Dispatcher;
+                    if (dispatcher.CheckAccess())
+                    {
+                        work();
+                    }
+                    else
+                    {
+                        dispatcher.Invoke(work);
+                    }
+                }),
             diagnosticLogger: line => AddOutputEntry(line, OutputLogStatus.Info));
         _mameEmulationService = new MameEmulationService(
             new MameProcessStartInfoBuilder(),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -39,6 +39,11 @@ public interface IMameReelRuntimeAdapter
     void ApplyReelState(int reelId, int reelValue);
 }
 
+public interface IMameSegmentRuntimeAdapter
+{
+    void ApplySegmentState(int cellId, int segmentMask);
+}
+
 public sealed record MameProcessLaunchRequest(
     string MameExecutablePath,
     string MameRomName,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -1,0 +1,69 @@
+namespace OasisEditor;
+
+public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
+{
+    private readonly object _pendingSync = new();
+    private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Action<Action> _uiDispatch;
+    private readonly Dictionary<int, int> _pendingMasks = new();
+    private bool _uiUpdateScheduled;
+
+    public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    {
+        _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
+    }
+
+    public void ApplySegmentState(int cellId, int segmentMask)
+    {
+        lock (_pendingSync)
+        {
+            _pendingMasks[cellId] = segmentMask;
+            if (_uiUpdateScheduled) return;
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
+    private void ApplyPendingOnUiThread()
+    {
+        Dictionary<int, int> snapshot;
+        lock (_pendingSync)
+        {
+            snapshot = new(_pendingMasks);
+            _pendingMasks.Clear();
+            _uiUpdateScheduled = false;
+        }
+
+        foreach (var document in _documentProvider())
+        {
+            var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var element in document.GetPanelElements().Where(e => e.Kind == PanelElementKind.Alpha && !string.IsNullOrWhiteSpace(e.ObjectId)))
+            {
+                var objectId = element.ObjectId!;
+                var baseIndex = element.DisplayNumber.GetValueOrDefault(0);
+                var cellMasks = new int[16];
+                var hasAny = false;
+                for (var i = 0; i < cellMasks.Length; i++)
+                {
+                    if (snapshot.TryGetValue(baseIndex + i, out var mask))
+                    {
+                        cellMasks[i] = mask;
+                        hasAny = true;
+                    }
+                }
+
+                if (hasAny && document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks))
+                {
+                    changedObjectIds.Add(objectId);
+                }
+            }
+
+            if (changedObjectIds.Count > 0)
+            {
+                document.NotifyPanelVisualPreviewChanged(changedObjectIds);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -6,6 +6,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, int> _pendingMasks = new();
+    private readonly Dictionary<int, int> _latestMasksByCell = new();
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
@@ -39,22 +40,26 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         foreach (var document in _documentProvider())
         {
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var (cellId, mask) in snapshot)
+            {
+                _latestMasksByCell[cellId] = mask;
+            }
+
             foreach (var element in document.GetPanelElements().Where(e => e.Kind == PanelElementKind.Alpha && !string.IsNullOrWhiteSpace(e.ObjectId)))
             {
                 var objectId = element.ObjectId!;
                 var baseIndex = element.DisplayNumber.GetValueOrDefault(0);
                 var cellMasks = new int[16];
-                var hasAny = false;
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
-                    if (snapshot.TryGetValue(baseIndex + i, out var mask))
+                    if (_latestMasksByCell.TryGetValue(baseIndex + i, out var mask))
                     {
                         cellMasks[i] = mask;
-                        hasAny = true;
                     }
                 }
 
-                if (hasAny && document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks))
+                if (document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks))
                 {
                     changedObjectIds.Add(objectId);
                 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
@@ -1,0 +1,26 @@
+namespace OasisEditor;
+using System.Text.RegularExpressions;
+
+public interface IMameSegmentStateParser
+{
+    bool TryParse(string line, out int cellId, out int segmentMask);
+}
+
+public sealed class MameSegmentStateParser : IMameSegmentStateParser
+{
+    private static readonly Regex SegmentLineRegex = new(
+        @"vfd\s*(\d+)\s*=\s*(-?\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public bool TryParse(string line, out int cellId, out int segmentMask)
+    {
+        cellId = 0;
+        segmentMask = 0;
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        var match = SegmentLineRegex.Match(line.Trim());
+        return match.Success
+            && int.TryParse(match.Groups[1].Value, out cellId)
+            && int.TryParse(match.Groups[2].Value, out segmentMask);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -6,14 +6,18 @@ public sealed class MameStdoutParser : IMameStdoutParser
     private readonly IMameLampRuntimeAdapter _lampRuntimeAdapter;
     private readonly IMameReelStateParser _reelStateParser;
     private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
+    private readonly IMameSegmentStateParser _segmentStateParser;
+    private readonly IMameSegmentRuntimeAdapter _segmentRuntimeAdapter;
     private readonly Action<string>? _diagnosticLogger;
 
-    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, Action<string>? diagnosticLogger = null)
+    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Action<string>? diagnosticLogger = null)
     {
         _lampStateParser = lampStateParser ?? throw new ArgumentNullException(nameof(lampStateParser));
         _lampRuntimeAdapter = lampRuntimeAdapter ?? throw new ArgumentNullException(nameof(lampRuntimeAdapter));
         _reelStateParser = reelStateParser ?? throw new ArgumentNullException(nameof(reelStateParser));
         _reelRuntimeAdapter = reelRuntimeAdapter ?? throw new ArgumentNullException(nameof(reelRuntimeAdapter));
+        _segmentStateParser = segmentStateParser ?? throw new ArgumentNullException(nameof(segmentStateParser));
+        _segmentRuntimeAdapter = segmentRuntimeAdapter ?? throw new ArgumentNullException(nameof(segmentRuntimeAdapter));
         _diagnosticLogger = diagnosticLogger;
     }
 
@@ -33,6 +37,12 @@ public sealed class MameStdoutParser : IMameStdoutParser
         if (_reelStateParser.TryParse(line, out var reelId, out var reelValue))
         {
             _reelRuntimeAdapter.ApplyReelState(reelId, reelValue);
+            return;
+        }
+
+        if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask))
+        {
+            _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask);
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -171,9 +171,10 @@ public static class PanelLayoutMapper
 
             if (tab.TryGetAlphaElement(objectId, out _))
             {
-                var segmentState = visualStateChange.ValuesByObjectId[objectId] as SegmentVisualState?
-                    ?? new SegmentVisualState(runtimeState.GetSegmentCellMasks(objectId, 16));
-                UpdateSegmentVisual(canvas, objectId, segmentState.Value.CellMasks);
+                var segmentState = visualStateChange.ValuesByObjectId[objectId] is SegmentVisualState state
+                    ? state
+                    : new SegmentVisualState(runtimeState.GetSegmentCellMasks(objectId, 16));
+                UpdateSegmentVisual(canvas, objectId, segmentState.CellMasks);
             }
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -166,8 +166,35 @@ public static class PanelLayoutMapper
                 };
 
                 UpdateReelVisual(canvas, objectId, reelVisualState.Position, reelModel.Stops.GetValueOrDefault(1));
+                continue;
+            }
+
+            if (tab.TryGetAlphaElement(objectId, out _))
+            {
+                var segmentState = visualStateChange.ValuesByObjectId[objectId] as SegmentVisualState?
+                    ?? new SegmentVisualState(runtimeState.GetSegmentCellMasks(objectId, 16));
+                UpdateSegmentVisual(canvas, objectId, segmentState.Value.CellMasks);
             }
         }
+    }
+
+    public static void UpdateSegmentVisual(Canvas canvas, string objectId, int[] cellMasks)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || cellMasks is null)
+        {
+            return;
+        }
+
+        var registry = GetOrCreateRuntimeVisualRegistry(canvas);
+        if (!registry.TryGetVisual(objectId, out var visual)
+            || visual is not Border border
+            || border.Child is not SegmentDisplayVisualBase segmentVisual)
+        {
+            return;
+        }
+
+        segmentVisual.CellSegmentMasks = cellMasks.ToArray();
+        segmentVisual.InvalidateVisual();
     }
 
     public static void UpdateLampVisual(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -4,6 +4,7 @@ public sealed class PanelRuntimeState
 {
     private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _reelPositionByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
 
@@ -11,6 +12,7 @@ public sealed class PanelRuntimeState
 
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
     public IReadOnlyDictionary<string, int> ReelPositionByObjectId => _reelPositionByObjectId;
+    public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
 
     public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
@@ -86,5 +88,36 @@ public sealed class PanelRuntimeState
         LampTestObjectId = null;
         _lampIntensityByObjectId.Clear();
         _reelPositionByObjectId.Clear();
+        _segmentMasksByObjectId.Clear();
+    }
+
+    public bool SetSegmentCellMasksIfChanged(string objectId, int[] masks)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || masks is null)
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        if (_segmentMasksByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && previous.SequenceEqual(masks))
+        {
+            return false;
+        }
+
+        _segmentMasksByObjectId[normalizedObjectId] = masks.ToArray();
+        return true;
+    }
+
+    public int[] GetSegmentCellMasks(string objectId, int cellCount)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || cellCount <= 0)
+        {
+            return Array.Empty<int>();
+        }
+
+        return _segmentMasksByObjectId.TryGetValue(objectId.Trim(), out var value)
+            ? value.ToArray()
+            : new int[cellCount];
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -19,6 +19,7 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
     public Brush LitBrush { get; set; } = Brushes.OrangeRed;
     public Brush UnlitBrush { get; set; } = new SolidColorBrush(Color.FromArgb(120, 255, 69, 0));
     public string? DisplayText { get; set; }
+    public int[]? CellSegmentMasks { get; set; }
     public bool ShowDecimalPoint { get; set; }
 
     protected override void OnRender(DrawingContext drawingContext)
@@ -44,8 +45,11 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
 
         for (var i = 0; i < CellCount; i++)
         {
-            var charIndex = i < (DisplayText?.Length ?? 0) ? i : -1;
-            var segmentMask = charIndex >= 0 ? GetSegmentMaskForChar(DisplayText![charIndex]) : 0;
+            var segmentMask = CellSegmentMasks is not null && i < CellSegmentMasks.Length
+                ? CellSegmentMasks[i]
+                : i < (DisplayText?.Length ?? 0)
+                    ? GetSegmentMaskForChar(DisplayText![i])
+                    : 0;
             var cellTransform = new MatrixTransform(scale, 0, 0, scale, offsetX + (i * pitch * scale), offsetY);
 
             foreach (var segment in _definition.Cell.Segments)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -12,6 +12,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private Panel2DDocumentModel _panelDocumentModel;
     private Dictionary<string, PanelElementModel> _lampElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _reelElementsByObjectId = new(StringComparer.Ordinal);
+    private Dictionary<string, PanelElementModel> _alphaElementsByObjectId = new(StringComparer.Ordinal);
     private HashSet<string> _visualStateObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
@@ -143,7 +144,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     {
         var changedObjectIds = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel))
+                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel || element.Kind == PanelElementKind.Alpha))
             .Select(element => element.ObjectId)
             .ToArray();
         NotifyPanelVisualPreviewChanged(changedObjectIds);
@@ -171,7 +172,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 && !string.IsNullOrWhiteSpace(_runtimeState.LampTestObjectId)
                 && string.Equals(objectId, _runtimeState.LampTestObjectId, StringComparison.Ordinal),
                 _runtimeState.GetLampIntensity(objectId))
-                : new ReelVisualState(_runtimeState.GetReelPosition(objectId));
+                : _reelElementsByObjectId.ContainsKey(objectId)
+                    ? new ReelVisualState(_runtimeState.GetReelPosition(objectId))
+                    : new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 16));
             if (!_lastVisualStateByObjectId.TryGetValue(objectId, out var previous)
                 || !Equals(previous, nextState))
             {
@@ -210,6 +213,17 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
 
         return _reelElementsByObjectId.TryGetValue(objectId, out element!);
+    }
+
+    internal bool TryGetAlphaElement(string objectId, out PanelElementModel element)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            element = new PanelElementModel();
+            return false;
+        }
+
+        return _alphaElementsByObjectId.TryGetValue(objectId, out element!);
     }
 
     internal string GetPanelLayoutProjectionJson()
@@ -300,14 +314,19 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             .Where(element => element.Kind == PanelElementKind.Reel
                 && !string.IsNullOrWhiteSpace(element.ObjectId))
             .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+        _alphaElementsByObjectId = _panelDocumentModel.Elements
+            .Where(element => element.Kind == PanelElementKind.Alpha && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
         _visualStateObjectIds = _lampElementsByObjectId.Keys
             .Concat(_reelElementsByObjectId.Keys)
+            .Concat(_alphaElementsByObjectId.Keys)
             .ToHashSet(StringComparer.Ordinal);
     }
 }
 
 internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
 internal readonly record struct ReelVisualState(int Position);
+internal readonly record struct SegmentVisualState(int[] CellMasks);
 
 public sealed record PanelVisualStateChangedEvent(
     Guid DocumentId,


### PR DESCRIPTION
### Motivation
- MAME emits `vfdN = value` lines for VFD/segment displays which were previously unhandled and should drive Oasis Alpha/segment visuals. 
- The editor must map MAME cell indices to per-cell segment bitmasks so Alpha components render real-time segment state instead of only static characters.

### Description
- Added `IMameSegmentRuntimeAdapter`, `MameSegmentStateParser`, and `MameSegmentRuntimeAdapter` to parse `vfd` stdout lines and batch/apply cell segment masks to documents at UI time. 
- Extended `MameStdoutParser` to detect `vfd` lines and route them to the new segment runtime adapter. 
- Extended runtime state with segment storage and APIs: `PanelRuntimeState` now tracks `SegmentMasksByObjectId` and exposes `SetSegmentCellMasksIfChanged` and `GetSegmentCellMasks`. 
- Extended document visual pipeline: `DocumentTabViewModel` now tracks Alpha elements and emits `SegmentVisualState` deltas; `PanelLayoutMapper` adds `UpdateSegmentVisual` to apply masks to running visuals. 
- Updated rendering base: `SegmentDisplayVisualBase` supports `CellSegmentMasks` and will use provided masks to illuminate segments per cell (falling back to character-to-mask mapping if masks are not provided). 
- Wired new parser/adapter into `MainWindowViewModel` emulation bootstrap and added unit tests (`MameSegmentStateParserTests` plus updates to `MameStdoutParserTests`).
- Implementation assumes Alpha elements are represented as 16-cell displays and uses `DisplayNumber` as the base VFD index for mapping cells to element cells.

### Testing
- Added unit tests for `MameSegmentStateParser` and extended `MameStdoutParserTests` to assert `vfd` routing, but no full test run was possible in this environment. 
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --filter "MameStdoutParserTests|MameSegmentStateParserTests"`, which failed because `dotnet` is not available in the execution environment (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08a096c3a083278c515e83426c1162)