### PR TITLE
Remap MAME 16-seg bit order and handle reversed alpha panels in MameSegmentRuntimeAdapter

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -66,7 +66,7 @@ public sealed class MameSegmentRuntimeAdapterTests
         var masks = document.RuntimeState.GetSegmentCellMasks("alpha-rev", 16);
         Assert.Equal(0x59, masks[0]);
         Assert.Equal(0xDD, masks[1]);
-        Assert.Equal(0xA3, masks[15]);
+        Assert.Equal(0x33, masks[15]);
     }
 
     [Theory]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -21,8 +21,8 @@ public sealed class MameSegmentRuntimeAdapterTests
         second();
 
         var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
-        Assert.Equal(1, masks[0]);
-        Assert.Equal(2, masks[1]);
+        Assert.Equal(4, masks[0]);
+        Assert.Equal(8, masks[1]);
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public sealed class MameSegmentRuntimeAdapterTests
         dispatch();
 
         var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
-        Assert.Equal(3, masks[0]);
-        Assert.Equal(2, masks[1]);
+        Assert.Equal(12, masks[0]);
+        Assert.Equal(8, masks[1]);
     }
 
     [Fact]
@@ -64,9 +64,9 @@ public sealed class MameSegmentRuntimeAdapterTests
         dispatch();
 
         var masks = document.RuntimeState.GetSegmentCellMasks("alpha-rev", 16);
-        Assert.Equal(0xAA, masks[0]);
-        Assert.Equal(0xBB, masks[1]);
-        Assert.Equal(0xCC, masks[15]);
+        Assert.Equal(0x59, masks[0]);
+        Assert.Equal(0x5D, masks[1]);
+        Assert.Equal(0xA3, masks[15]);
     }
 
     [Theory]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -65,7 +65,7 @@ public sealed class MameSegmentRuntimeAdapterTests
 
         var masks = document.RuntimeState.GetSegmentCellMasks("alpha-rev", 16);
         Assert.Equal(0x59, masks[0]);
-        Assert.Equal(0x5D, masks[1]);
+        Assert.Equal(0xDD, masks[1]);
         Assert.Equal(0xA3, masks[15]);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -44,6 +44,54 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.Equal(2, masks[1]);
     }
 
+    [Fact]
+    public void ApplySegmentState_ForReversedAlpha_MapsDescendingCellIdsToAscendingVisualCells()
+    {
+        var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");
+        var document = new DocumentTabViewModel(panelDocument);
+        document.SetPanelElements([
+            new PanelElementModel { ObjectId = "alpha-rev", Kind = PanelElementKind.Alpha, DisplayNumber = 10, IsReversed = true }
+        ]);
+
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(25, 0xAA);
+        adapter.ApplySegmentState(24, 0xBB);
+        adapter.ApplySegmentState(10, 0xCC);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("alpha-rev", 16);
+        Assert.Equal(0xAA, masks[0]);
+        Assert.Equal(0xBB, masks[1]);
+        Assert.Equal(0xCC, masks[15]);
+    }
+
+    [Theory]
+    [InlineData(1 << 0, 1 << 2)]
+    [InlineData(1 << 1, 1 << 3)]
+    [InlineData(1 << 2, 1 << 1)]
+    [InlineData(1 << 3, 1 << 4)]
+    [InlineData(1 << 4, 1 << 7)]
+    [InlineData(1 << 5, 1 << 6)]
+    [InlineData(1 << 6, 1 << 5)]
+    [InlineData(1 << 7, 1 << 0)]
+    public void ApplySegmentState_RemapAlphaBitsToGeometryIndices(int sourceMask, int expectedMask)
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, sourceMask);
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
+        Assert.Equal(expectedMask, masks[0]);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -2,6 +2,29 @@ namespace OasisEditor;
 
 public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 {
+    // MAME's 16-seg VFD bit order does not match the geometry index order used by
+    // `oasis_16_segment_display_definition.json`, so remap incoming masks once here.
+    // sourceBit -> targetBit
+    private static readonly int[] AlphaSixteenSegmentBitToGeometryIndex =
+    [
+        2,  // top-left horizontal
+        3,  // top-right horizontal
+        1,  // upper-right vertical
+        4,  // lower-right vertical
+        7,  // bottom-right horizontal
+        6,  // bottom-left horizontal
+        5,  // lower-left vertical
+        0,  // upper-left vertical
+        11, // middle-left horizontal
+        12, // middle-right horizontal
+        14, // upper-left diagonal
+        13, // upper-right diagonal
+        10, // lower-right diagonal
+        9,  // lower-left diagonal
+        8,  // lower center vertical
+        15  // upper center vertical
+    ];
+
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
@@ -43,17 +66,21 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
             foreach (var (cellId, mask) in snapshot)
             {
-                _latestMasksByCell[cellId] = mask;
+                _latestMasksByCell[cellId] = RemapAlphaSegmentMask(mask);
             }
 
             foreach (var element in document.GetPanelElements().Where(e => e.Kind == PanelElementKind.Alpha && !string.IsNullOrWhiteSpace(e.ObjectId)))
             {
                 var objectId = element.ObjectId!;
                 var baseIndex = element.DisplayNumber.GetValueOrDefault(0);
+                var isReversed = element.IsReversed == true;
                 var cellMasks = new int[16];
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
-                    if (_latestMasksByCell.TryGetValue(baseIndex + i, out var mask))
+                    var mappedCellId = isReversed
+                        ? baseIndex + (cellMasks.Length - 1 - i)
+                        : baseIndex + i;
+                    if (_latestMasksByCell.TryGetValue(mappedCellId, out var mask))
                     {
                         cellMasks[i] = mask;
                     }
@@ -70,5 +97,21 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);
             }
         }
+    }
+
+    private static int RemapAlphaSegmentMask(int sourceMask)
+    {
+        var remapped = 0;
+        for (var sourceBit = 0; sourceBit < AlphaSixteenSegmentBitToGeometryIndex.Length; sourceBit++)
+        {
+            if ((sourceMask & (1 << sourceBit)) == 0)
+            {
+                continue;
+            }
+
+            remapped |= 1 << AlphaSixteenSegmentBitToGeometryIndex[sourceBit];
+        }
+
+        return remapped;
     }
 }


### PR DESCRIPTION
### Motivation
- MAME's 16-segment VFD bit order does not match the geometry index order used by the display definition, causing incorrect segment visuals. 
- Alpha panel elements that are marked `IsReversed` must map descending cell ids to ascending visual cells so the UI shows the correct order.

### Description
- Add `AlphaSixteenSegmentBitToGeometryIndex` table and `RemapAlphaSegmentMask` helper to remap incoming MAME segment masks to the editor's geometry indices. 
- Apply the remapped masks when updating `_latestMasksByCell` so stored masks match the display geometry. 
- Support `IsReversed` on `PanelElementModel` by mapping cell ids in reverse when composing `cellMasks` for visual update. 
- Add unit tests `ApplySegmentState_ForReversedAlpha_MapsDescendingCellIdsToAscendingVisualCells` and `ApplySegmentState_RemapAlphaBitsToGeometryIndices` to exercise reversed panels and bit remapping behavior.

### Testing
- Ran the test project with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests`. 
- All tests, including the new `MameSegmentRuntimeAdapterTests` cases, completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08a73595f88327873979289cd466bf)