### PR TITLE
Remap MAME VFD 16-segment bits to WPF segment order

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -2,25 +2,7 @@ namespace OasisEditor;
 
 public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 {
-    private static readonly int[] LegacyMameBitToWpfSegmentIndexMap =
-    [
-        2,  // 0: top-left bar
-        3,  // 1: top-right bar
-        1,  // 2: right-top bar
-        4,  // 3: right-bottom bar
-        7,  // 4: bottom-right bar
-        6,  // 5: bottom-left bar
-        5,  // 6: left-bottom bar
-        0,  // 7: left-top bar
-        11, // 8: horizontal-middle-left bar
-        12, // 9: horizontal-middle-right bar
-        15, // 10: vertical-middle-top bar
-        8,  // 11: vertical-middle-bottom bar
-        9,  // 12: diagonal-left-bottom bar
-        14, // 13: diagonal-left-top bar
-        13, // 14: diagonal-right-top bar
-        10  // 15: diagonal-right-bottom bar
-    ];
+    private static readonly int[] Led16SegBitToWpfSegmentIndexMap = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
@@ -94,18 +76,58 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private static int RemapMameMaskToWpfSegmentOrder(int rawMask)
     {
         var normalizedMask = rawMask & 0xFFFF;
+
+        if ((normalizedMask & 0xC000) == 0)
+        {
+            return ExpandLed14SegIntoSixteenSegmentMask(normalizedMask);
+        }
+
         var remappedMask = 0;
 
-        for (var bit = 0; bit < LegacyMameBitToWpfSegmentIndexMap.Length; bit++)
+        for (var bit = 0; bit < Led16SegBitToWpfSegmentIndexMap.Length; bit++)
         {
             if ((normalizedMask & (1 << bit)) == 0)
             {
                 continue;
             }
 
-            remappedMask |= 1 << LegacyMameBitToWpfSegmentIndexMap[bit];
+            remappedMask |= 1 << Led16SegBitToWpfSegmentIndexMap[bit];
         }
 
         return remappedMask;
+    }
+
+    private static int ExpandLed14SegIntoSixteenSegmentMask(int led14Mask)
+    {
+        var expandedMask = 0;
+
+        // led14seg/led14segsc ordering from legacy Unity renderer:
+        // 0 -> both top split segments
+        // 3 -> both bottom split segments
+        if ((led14Mask & (1 << 0)) != 0)
+        {
+            expandedMask |= (1 << 0) | (1 << 1);
+        }
+
+        if ((led14Mask & (1 << 1)) != 0) expandedMask |= 1 << 2;
+        if ((led14Mask & (1 << 2)) != 0) expandedMask |= 1 << 3;
+
+        if ((led14Mask & (1 << 3)) != 0)
+        {
+            expandedMask |= (1 << 4) | (1 << 5);
+        }
+
+        if ((led14Mask & (1 << 4)) != 0) expandedMask |= 1 << 6;
+        if ((led14Mask & (1 << 5)) != 0) expandedMask |= 1 << 7;
+        if ((led14Mask & (1 << 6)) != 0) expandedMask |= 1 << 8;
+        if ((led14Mask & (1 << 7)) != 0) expandedMask |= 1 << 9;
+        if ((led14Mask & (1 << 8)) != 0) expandedMask |= 1 << 10;
+        if ((led14Mask & (1 << 9)) != 0) expandedMask |= 1 << 11;
+        if ((led14Mask & (1 << 10)) != 0) expandedMask |= 1 << 12;
+        if ((led14Mask & (1 << 11)) != 0) expandedMask |= 1 << 13;
+        if ((led14Mask & (1 << 12)) != 0) expandedMask |= 1 << 14;
+        if ((led14Mask & (1 << 13)) != 0) expandedMask |= 1 << 15;
+
+        return expandedMask;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -2,6 +2,25 @@ namespace OasisEditor;
 
 public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 {
+    private static readonly int[] LegacyMameBitToWpfSegmentIndexMap =
+    [
+        2,  // 0: top-left bar
+        3,  // 1: top-right bar
+        1,  // 2: right-top bar
+        4,  // 3: right-bottom bar
+        7,  // 4: bottom-right bar
+        6,  // 5: bottom-left bar
+        5,  // 6: left-bottom bar
+        0,  // 7: left-top bar
+        11, // 8: horizontal-middle-left bar
+        12, // 9: horizontal-middle-right bar
+        15, // 10: vertical-middle-top bar
+        8,  // 11: vertical-middle-bottom bar
+        9,  // 12: diagonal-left-bottom bar
+        14, // 13: diagonal-left-top bar
+        13, // 14: diagonal-right-top bar
+        10  // 15: diagonal-right-bottom bar
+    ];
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
@@ -55,7 +74,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 {
                     if (_latestMasksByCell.TryGetValue(baseIndex + i, out var mask))
                     {
-                        cellMasks[i] = mask;
+                        cellMasks[i] = RemapMameMaskToWpfSegmentOrder(mask);
                     }
                 }
 
@@ -70,5 +89,23 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);
             }
         }
+    }
+
+    private static int RemapMameMaskToWpfSegmentOrder(int rawMask)
+    {
+        var normalizedMask = rawMask & 0xFFFF;
+        var remappedMask = 0;
+
+        for (var bit = 0; bit < LegacyMameBitToWpfSegmentIndexMap.Length; bit++)
+        {
+            if ((normalizedMask & (1 << bit)) == 0)
+            {
+                continue;
+            }
+
+            remappedMask |= 1 << LegacyMameBitToWpfSegmentIndexMap[bit];
+        }
+
+        return remappedMask;
     }
 }


### PR DESCRIPTION
### Motivation
- MAME VFD output bit order for 16-segment alpha displays does not match the WPF geometry ordering used by the editor, causing segments to light in the wrong positions. 
- The change restores the intended visual mapping by translating legacy MAME bit masks into the editor's segment index order.

### Description
- Add a static lookup table `LegacyMameBitToWpfSegmentIndexMap` in `MameSegmentRuntimeAdapter.cs` that maps legacy MAME bit indices to WPF segment indices. 
- Apply the remapping when projecting per-cell VFD masks into the editor runtime by calling `RemapMameMaskToWpfSegmentOrder(...)` while building `cellMasks`. 
- Implement `RemapMameMaskToWpfSegmentOrder(int rawMask)` which normalizes the incoming mask to 16 bits and reconstructs a remapped mask using the lookup table, preserving existing incremental update and UI dispatch behavior.
- Modified file: `OasisEditor/MameSegmentRuntimeAdapter.cs`.

### Testing
- Attempted to run a full solution build with `dotnet build OasisEditor.sln`, but `dotnet` is not available in the execution environment so the build could not be performed here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08ae43026083278a77d0f0f5ca2f6f)