### PR TITLE
Handle digiti MAME segment output with polarity inversion

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -12,11 +12,11 @@ public sealed class MameSegmentRuntimeAdapterTests
         var dispatches = new List<Action>();
         var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
 
-        adapter.ApplySegmentState(0, 1);
+        adapter.ApplySegmentState(0, 1, MameSegmentOutputType.Vfd);
         var first = Assert.Single(dispatches);
         first();
 
-        adapter.ApplySegmentState(1, 2);
+        adapter.ApplySegmentState(1, 2, MameSegmentOutputType.Vfd);
         var second = Assert.Single(dispatches.Skip(1));
         second();
 
@@ -32,9 +32,9 @@ public sealed class MameSegmentRuntimeAdapterTests
         var dispatches = new List<Action>();
         var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
 
-        adapter.ApplySegmentState(0, 1);
-        adapter.ApplySegmentState(0, 3);
-        adapter.ApplySegmentState(1, 2);
+        adapter.ApplySegmentState(0, 1, MameSegmentOutputType.Vfd);
+        adapter.ApplySegmentState(0, 3, MameSegmentOutputType.Vfd);
+        adapter.ApplySegmentState(1, 2, MameSegmentOutputType.Vfd);
 
         var dispatch = Assert.Single(dispatches);
         dispatch();
@@ -51,7 +51,7 @@ public sealed class MameSegmentRuntimeAdapterTests
         var dispatches = new List<Action>();
         var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
 
-        adapter.ApplySegmentState(3, 16);
+        adapter.ApplySegmentState(3, 16, MameSegmentOutputType.Digit);
 
         var dispatch = Assert.Single(dispatches);
         dispatch();
@@ -59,6 +59,23 @@ public sealed class MameSegmentRuntimeAdapterTests
         var masks = document.RuntimeState.GetSegmentCellMasks("seven-3", 1);
         Assert.Single(masks);
         Assert.Equal(16, masks[0]);
+    }
+
+    [Fact]
+    public void ApplySegmentState_DoesNotApplyVfdMasksToSevenSegment()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(3, 255, MameSegmentOutputType.Vfd);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("seven-3", 1);
+        Assert.Single(masks);
+        Assert.Equal(0, masks[0]);
     }
 
     private static DocumentTabViewModel CreateDocument()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
@@ -24,4 +24,32 @@ public sealed class MameSegmentStateParserTests
         Assert.Equal(3, cellId);
         Assert.Equal(16, mask);
     }
+
+    [Fact]
+    public void TryParse_DigitLine_NormalizesToActiveHighByte()
+    {
+        var parser = new MameSegmentStateParser();
+        var ok = parser.TryParse("digit4 = 255", out var cellId, out var mask);
+        Assert.True(ok);
+        Assert.Equal(4, cellId);
+        Assert.Equal(255, mask);
+    }
+
+    [Fact]
+    public void TryParse_DigitiLine_InvertsToActiveHighByte()
+    {
+        var parser = new MameSegmentStateParser();
+        var ok = parser.TryParse("digiti4 = 255", out var cellId, out var mask);
+        Assert.True(ok);
+        Assert.Equal(4, cellId);
+        Assert.Equal(0, mask);
+    }
+
+    [Fact]
+    public void TryParse_DigitiLine_UsesExactOutputName()
+    {
+        var parser = new MameSegmentStateParser();
+        var ok = parser.TryParse("digitid4 = 0", out _, out _);
+        Assert.False(ok);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentStateParserTests.cs
@@ -9,47 +9,51 @@ public sealed class MameSegmentStateParserTests
     public void TryParse_VfdLine_ParsesCellAndMask()
     {
         var parser = new MameSegmentStateParser();
-        var ok = parser.TryParse("vfd12 = 769", out var cellId, out var mask);
+        var ok = parser.TryParse("vfd12 = 769", out var cellId, out var mask, out var outputType);
         Assert.True(ok);
         Assert.Equal(12, cellId);
         Assert.Equal(769, mask);
+        Assert.Equal(MameSegmentOutputType.Vfd, outputType);
     }
 
     [Fact]
     public void TryParse_DigitLine_ParsesCellAndMask()
     {
         var parser = new MameSegmentStateParser();
-        var ok = parser.TryParse("digit3 = 16", out var cellId, out var mask);
+        var ok = parser.TryParse("digit3 = 16", out var cellId, out var mask, out var outputType);
         Assert.True(ok);
         Assert.Equal(3, cellId);
         Assert.Equal(16, mask);
+        Assert.Equal(MameSegmentOutputType.Digit, outputType);
     }
 
     [Fact]
     public void TryParse_DigitLine_NormalizesToActiveHighByte()
     {
         var parser = new MameSegmentStateParser();
-        var ok = parser.TryParse("digit4 = 255", out var cellId, out var mask);
+        var ok = parser.TryParse("digit4 = 255", out var cellId, out var mask, out var outputType);
         Assert.True(ok);
         Assert.Equal(4, cellId);
         Assert.Equal(255, mask);
+        Assert.Equal(MameSegmentOutputType.Digit, outputType);
     }
 
     [Fact]
     public void TryParse_DigitiLine_InvertsToActiveHighByte()
     {
         var parser = new MameSegmentStateParser();
-        var ok = parser.TryParse("digiti4 = 255", out var cellId, out var mask);
+        var ok = parser.TryParse("digiti4 = 255", out var cellId, out var mask, out var outputType);
         Assert.True(ok);
         Assert.Equal(4, cellId);
         Assert.Equal(0, mask);
+        Assert.Equal(MameSegmentOutputType.Digiti, outputType);
     }
 
     [Fact]
     public void TryParse_DigitiLine_UsesExactOutputName()
     {
         var parser = new MameSegmentStateParser();
-        var ok = parser.TryParse("digitid4 = 0", out _, out _);
+        var ok = parser.TryParse("digitid4 = 0", out _, out _, out _);
         Assert.False(ok);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -98,7 +98,7 @@ public sealed class MameStdoutParserTests
 
     private sealed class RecordingSegmentAdapter : IMameSegmentRuntimeAdapter
     {
-        public List<(int CellId, int Mask)> Calls { get; } = [];
-        public void ApplySegmentState(int cellId, int segmentMask) => Calls.Add((cellId, segmentMask));
+        public List<(int CellId, int Mask, MameSegmentOutputType OutputType)> Calls { get; } = [];
+        public void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType) => Calls.Add((cellId, segmentMask, outputType));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -41,7 +41,7 @@ public interface IMameReelRuntimeAdapter
 
 public interface IMameSegmentRuntimeAdapter
 {
-    void ApplySegmentState(int cellId, int segmentMask);
+    void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType);
 }
 
 public sealed record MameProcessLaunchRequest(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -6,8 +6,9 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
-    private readonly Dictionary<int, int> _pendingMasks = new();
-    private readonly Dictionary<int, int> _latestMasksByCell = new();
+    private readonly Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> _pendingMasks = new();
+    private readonly Dictionary<int, int> _latestVfdMasksByCell = new();
+    private readonly Dictionary<int, int> _latestDigitMasksByCell = new();
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
@@ -16,11 +17,11 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
     }
 
-    public void ApplySegmentState(int cellId, int segmentMask)
+    public void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType)
     {
         lock (_pendingSync)
         {
-            _pendingMasks[cellId] = segmentMask;
+            _pendingMasks[cellId] = (segmentMask, outputType);
             if (_uiUpdateScheduled) return;
             _uiUpdateScheduled = true;
         }
@@ -30,7 +31,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
     private void ApplyPendingOnUiThread()
     {
-        Dictionary<int, int> snapshot;
+        Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> snapshot;
         lock (_pendingSync)
         {
             snapshot = new(_pendingMasks);
@@ -42,9 +43,16 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         {
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
 
-            foreach (var (cellId, mask) in snapshot)
+            foreach (var (cellId, state) in snapshot)
             {
-                _latestMasksByCell[cellId] = mask;
+                if (state.OutputType == MameSegmentOutputType.Vfd)
+                {
+                    _latestVfdMasksByCell[cellId] = state.Mask;
+                }
+                else
+                {
+                    _latestDigitMasksByCell[cellId] = state.Mask;
+                }
             }
 
             foreach (var element in document.GetPanelElements().Where(e => (e.Kind == PanelElementKind.Alpha || e.Kind == PanelElementKind.SevenSegment) && !string.IsNullOrWhiteSpace(e.ObjectId)))
@@ -55,7 +63,8 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var cellMasks = new int[cellCount];
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
-                    if (_latestMasksByCell.TryGetValue(baseIndex + i, out var mask))
+                    var source = element.Kind == PanelElementKind.SevenSegment ? _latestDigitMasksByCell : _latestVfdMasksByCell;
+                    if (source.TryGetValue(baseIndex + i, out var mask))
                     {
                         cellMasks[i] = element.Kind == PanelElementKind.SevenSegment
                             ? mask

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
@@ -3,7 +3,14 @@ using System.Text.RegularExpressions;
 
 public interface IMameSegmentStateParser
 {
-    bool TryParse(string line, out int cellId, out int segmentMask);
+    bool TryParse(string line, out int cellId, out int segmentMask, out MameSegmentOutputType outputType);
+}
+
+public enum MameSegmentOutputType
+{
+    Digit,
+    Digiti,
+    Vfd
 }
 
 public sealed class MameSegmentStateParser : IMameSegmentStateParser
@@ -12,10 +19,11 @@ public sealed class MameSegmentStateParser : IMameSegmentStateParser
         @"^(vfd|digiti|digit)\s*(\d+)\s*=\s*(-?\d+)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    public bool TryParse(string line, out int cellId, out int segmentMask)
+    public bool TryParse(string line, out int cellId, out int segmentMask, out MameSegmentOutputType outputType)
     {
         cellId = 0;
         segmentMask = 0;
+        outputType = MameSegmentOutputType.Digit;
         if (string.IsNullOrWhiteSpace(line)) return false;
 
         var match = SegmentLineRegex.Match(line.Trim());
@@ -26,19 +34,22 @@ public sealed class MameSegmentStateParser : IMameSegmentStateParser
             return false;
         }
 
-        var outputType = match.Groups[1].Value;
-        if (outputType.Equals("digiti", StringComparison.OrdinalIgnoreCase))
+        var outputName = match.Groups[1].Value;
+        if (outputName.Equals("digiti", StringComparison.OrdinalIgnoreCase))
         {
+            outputType = MameSegmentOutputType.Digiti;
             segmentMask = (~rawMask) & 0xff;
             return true;
         }
 
-        if (outputType.Equals("digit", StringComparison.OrdinalIgnoreCase))
+        if (outputName.Equals("digit", StringComparison.OrdinalIgnoreCase))
         {
+            outputType = MameSegmentOutputType.Digit;
             segmentMask = rawMask & 0xff;
             return true;
         }
 
+        outputType = MameSegmentOutputType.Vfd;
         segmentMask = rawMask;
         return true;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
@@ -9,7 +9,7 @@ public interface IMameSegmentStateParser
 public sealed class MameSegmentStateParser : IMameSegmentStateParser
 {
     private static readonly Regex SegmentLineRegex = new(
-        @"(?:vfd|digit)\s*(\d+)\s*=\s*(-?\d+)",
+        @"^(vfd|digiti|digit)\s*(\d+)\s*=\s*(-?\d+)\s*$",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public bool TryParse(string line, out int cellId, out int segmentMask)
@@ -19,8 +19,27 @@ public sealed class MameSegmentStateParser : IMameSegmentStateParser
         if (string.IsNullOrWhiteSpace(line)) return false;
 
         var match = SegmentLineRegex.Match(line.Trim());
-        return match.Success
-            && int.TryParse(match.Groups[1].Value, out cellId)
-            && int.TryParse(match.Groups[2].Value, out segmentMask);
+        if (!match.Success
+            || !int.TryParse(match.Groups[2].Value, out cellId)
+            || !int.TryParse(match.Groups[3].Value, out var rawMask))
+        {
+            return false;
+        }
+
+        var outputType = match.Groups[1].Value;
+        if (outputType.Equals("digiti", StringComparison.OrdinalIgnoreCase))
+        {
+            segmentMask = (~rawMask) & 0xff;
+            return true;
+        }
+
+        if (outputType.Equals("digit", StringComparison.OrdinalIgnoreCase))
+        {
+            segmentMask = rawMask & 0xff;
+            return true;
+        }
+
+        segmentMask = rawMask;
+        return true;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -40,9 +40,9 @@ public sealed class MameStdoutParser : IMameStdoutParser
             return;
         }
 
-        if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask))
+        if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask, out var outputType))
         {
-            _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask);
+            _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask, outputType);
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Some MAME stdout lines use `digitiN` (inverted polarity) alongside `digitN`, and the parser previously ignored `digitiN`, causing junk segments to appear when MAME intended blanks. 
- The MAME MPU4 code writes `m_digitsi[index] = data ^ 0xff` and documents `digiti` as inverted polarity, so `digitiN = 255` must become a blank after inversion.

### Description
- Anchor and refine the segment-line regex to explicitly match `vfd`, `digiti`, or `digit` as whole names using `^(vfd|digiti|digit)\s*(\d+)\s*=\s*(-?\d+)\s*$`, preventing accidental partial matches. 
- Decode the capture groups so `group[2]` is the cell index `N` and `group[3]` is the numeric raw mask, and route both forms to the same cell index `N`.
- Normalize polarity per output name: for `digitN` use `segmentMask = raw & 0xff`, and for `digitiN` use `segmentMask = (~raw) & 0xff` (converting active-low to active-high); `vfd` behavior is preserved and passed through. 
- Preserve existing 8-bit segment bit ordering and mask semantics and keep negative-number acceptance in the regex unchanged to avoid surprising behavior for existing `vfd` lines.

### Testing
- Added unit tests `TryParse_DigitLine_NormalizesToActiveHighByte`, `TryParse_DigitiLine_InvertsToActiveHighByte`, and `TryParse_DigitiLine_UsesExactOutputName` alongside existing parser tests to validate `digit`/`digiti` behavior.
- Attempted to run the new tests with `dotnet test --filter MameSegmentStateParserTests` in this environment but the run failed because `dotnet` is not installed here (test run unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a09a7b3d8508327959ac6f899610324)