### PR TITLE
feat: add MAME input command formatting service

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceCaseInsensitiveTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceCaseInsensitiveTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceCaseInsensitiveTests
+{
+    [Fact]
+    public void Analyze_ShortcutsDifferOnlyByCase_AreReportedAsDuplicates()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", KeyboardShortcut = "Space" },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "space" }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        var duplicate = diagnostics.Where(d => d.Code == "input.duplicate_shortcut").ToList();
+        Assert.Equal(2, duplicate.Count);
+        Assert.Contains(duplicate, d => d.InputDefinitionId == "a");
+        Assert.Contains(duplicate, d => d.InputDefinitionId == "b");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceCombinedWarningsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceCombinedWarningsTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceCombinedWarningsTests
+{
+    [Fact]
+    public void Analyze_MultipleWarningConditions_AggregatesAllExpectedDiagnostics()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var sharedVisualId = Guid.NewGuid();
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "ABC", KeyboardShortcut = "Space", LinkedVisualElementId = sharedVisualId },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "space", LinkedVisualElementId = sharedVisualId }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        Assert.Equal(5, diagnostics.Count);
+        Assert.Equal(1, diagnostics.Count(d => d.Code == "input.unresolved_target"));
+        Assert.Equal(2, diagnostics.Count(d => d.Code == "input.duplicate_shortcut"));
+        Assert.Equal(2, diagnostics.Count(d => d.Code == "input.duplicate_linked_visual"));
+        Assert.All(diagnostics, d => Assert.Equal(InputMapDiagnosticSeverity.Warning, d.Severity));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceInvalidEntryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceInvalidEntryTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceInvalidEntryTests
+{
+    [Fact]
+    public void Analyze_EntriesWithoutIds_AreIgnored()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var sharedVisualId = Guid.NewGuid();
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", KeyboardShortcut = "Space", LinkedVisualElementId = sharedVisualId },
+            new InputDefinitionModel { Id = "", Name = "Invalid", Kind = InputDefinitionKind.Button, ButtonNumber = "ABC", KeyboardShortcut = "Space", LinkedVisualElementId = sharedVisualId }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        Assert.Empty(diagnostics.Where(d => d.InputDefinitionId == string.Empty));
+        Assert.DoesNotContain(diagnostics, d => d.Code == "input.duplicate_shortcut");
+        Assert.DoesNotContain(diagnostics, d => d.Code == "input.duplicate_linked_visual");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceLinkedVisualNoWarningTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceLinkedVisualNoWarningTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceLinkedVisualNoWarningTests
+{
+    [Fact]
+    public void Analyze_UniqueLinkedVisuals_DoNotProduceDuplicateLinkedVisualWarnings()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", LinkedVisualElementId = Guid.NewGuid() },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", LinkedVisualElementId = Guid.NewGuid() }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        Assert.DoesNotContain(diagnostics, d => d.Code == "input.duplicate_linked_visual");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceLinkedVisualTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceLinkedVisualTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceLinkedVisualTests
+{
+    [Fact]
+    public void Analyze_DuplicateLinkedVisual_ProducesWarningForEachInput()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var visualId = Guid.NewGuid();
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", LinkedVisualElementId = visualId },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", LinkedVisualElementId = visualId }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        var duplicates = diagnostics.Where(d => d.Code == "input.duplicate_linked_visual").ToList();
+        Assert.Equal(2, duplicates.Count);
+        Assert.All(duplicates, d => Assert.Equal(InputMapDiagnosticSeverity.Warning, d.Severity));
+        Assert.Contains(duplicates, d => d.InputDefinitionId == "a");
+        Assert.Contains(duplicates, d => d.InputDefinitionId == "b");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceNoWarningTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceNoWarningTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceNoWarningTests
+{
+    [Fact]
+    public void Analyze_ValidDistinctMappedInputs_ProducesNoWarnings()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", KeyboardShortcut = "Space" },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Enter" },
+            new InputDefinitionModel { Id = "c", Name = "Coin", Kind = InputDefinitionKind.Coin, CoinInput = true, KeyboardShortcut = "C" }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        Assert.Empty(diagnostics);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDiagnosticsServiceTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDiagnosticsServiceTests
+{
+    [Fact]
+    public void Analyze_UnresolvableInput_ProducesUnresolvedTargetWarning()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "Bad", Kind = InputDefinitionKind.Button, ButtonNumber = "ABC" }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        var warning = Assert.Single(diagnostics);
+        Assert.Equal("input.unresolved_target", warning.Code);
+        Assert.Equal("a", warning.InputDefinitionId);
+        Assert.Equal(InputMapDiagnosticSeverity.Warning, warning.Severity);
+    }
+
+    [Fact]
+    public void Analyze_DuplicateShortcut_ProducesWarningForEachInput()
+    {
+        var service = new InputMapDiagnosticsService(new MameInputPortResolver());
+        var inputs = new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", KeyboardShortcut = "Space" },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Space" }
+        };
+
+        var diagnostics = service.Analyze(FruitMachinePlatformType.MPU4, inputs);
+
+        var duplicate = diagnostics.Where(d => d.Code == "input.duplicate_shortcut").ToList();
+        Assert.Equal(2, duplicate.Count);
+        Assert.Contains(duplicate, d => d.InputDefinitionId == "a");
+        Assert.Contains(duplicate, d => d.InputDefinitionId == "b");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
@@ -28,6 +28,7 @@ public sealed class MainWindowViewModelInputDiagnosticsTests
         SetPrivateField(vm, "_loadedProject", project);
         SetPrivateField(vm, "_selectedFruitMachinePlatform", FruitMachinePlatformType.MPU4);
         SetPrivateField(vm, "_inputMapDiagnosticsService", new InputMapDiagnosticsService(new MameInputPortResolver()));
+        SetPrivateField(vm, "_outputLog", new OutputLogViewModel());
 
         InvokePrivateMethod(vm, "RefreshInputMapDiagnostics");
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
@@ -10,14 +10,14 @@ public sealed class MainWindowViewModelInputDiagnosticsTests
     {
         var vm = CreateUninitializedViewModel();
 
-        var project = new EditorProject(
-            "Test",
-            "C:/temp/test.oasisproj",
-            "C:/temp",
-            "C:/temp/Assets",
-            "C:/temp/Machines",
-            "C:/temp/Generated")
+        var project = new EditorProject
         {
+            Name = "Test",
+            ProjectFilePath = "C:/temp/test.oasisproj",
+            ProjectDirectory = "C:/temp",
+            AssetsDirectory = "C:/temp/Assets",
+            MachinesDirectory = "C:/temp/Machines",
+            GeneratedDirectory = "C:/temp/Generated",
             FruitMachinePlatform = FruitMachinePlatformType.MPU4
         }.WithInputDefinitions(new[]
         {
@@ -38,7 +38,7 @@ public sealed class MainWindowViewModelInputDiagnosticsTests
 
     private static MainWindowViewModel CreateUninitializedViewModel()
     {
-        return (MainWindowViewModel)System.Runtime.Serialization.FormatterServices
+        return (MainWindowViewModel)System.Runtime.CompilerServices.RuntimeHelpers
             .GetUninitializedObject(typeof(MainWindowViewModel));
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelInputDiagnosticsTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MainWindowViewModelInputDiagnosticsTests
+{
+    [Fact]
+    public void RefreshInputMapDiagnostics_WithDuplicateShortcuts_UpdatesWarningCount()
+    {
+        var vm = CreateUninitializedViewModel();
+
+        var project = new EditorProject(
+            "Test",
+            "C:/temp/test.oasisproj",
+            "C:/temp",
+            "C:/temp/Assets",
+            "C:/temp/Machines",
+            "C:/temp/Generated")
+        {
+            FruitMachinePlatform = FruitMachinePlatformType.MPU4
+        }.WithInputDefinitions(new[]
+        {
+            new InputDefinitionModel { Id = "a", Name = "A", Kind = InputDefinitionKind.Button, ButtonNumber = "1", KeyboardShortcut = "Space" },
+            new InputDefinitionModel { Id = "b", Name = "B", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Space" }
+        });
+
+        SetPrivateField(vm, "_loadedProject", project);
+        SetPrivateField(vm, "_selectedFruitMachinePlatform", FruitMachinePlatformType.MPU4);
+        SetPrivateField(vm, "_inputMapDiagnosticsService", new InputMapDiagnosticsService(new MameInputPortResolver()));
+
+        InvokePrivateMethod(vm, "RefreshInputMapDiagnostics");
+
+        Assert.True(vm.HasInputMapDiagnostics);
+        Assert.Equal(2, vm.InputMapWarningCount);
+        Assert.Equal(2, vm.InputMapDiagnostics.Count(d => d.Code == "input.duplicate_shortcut"));
+    }
+
+    private static MainWindowViewModel CreateUninitializedViewModel()
+    {
+        return (MainWindowViewModel)System.Runtime.Serialization.FormatterServices
+            .GetUninitializedObject(typeof(MainWindowViewModel));
+    }
+
+    private static void SetPrivateField<T>(MainWindowViewModel vm, string name, T value)
+    {
+        var field = typeof(MainWindowViewModel).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(vm, value);
+    }
+
+    private static void InvokePrivateMethod(MainWindowViewModel vm, string name)
+    {
+        var method = typeof(MainWindowViewModel).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(vm, null);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
@@ -12,7 +12,7 @@ public sealed class MameInputCommandServiceTests
         var service = new MameInputCommandService(resolver);
         var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2" };
 
-        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: true, CancellationToken.None);
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.MPU4, input, isPressed: true, CancellationToken.None);
 
         Assert.True(wrote);
         Assert.Single(processRunner.Commands);
@@ -27,7 +27,7 @@ public sealed class MameInputCommandServiceTests
         var service = new MameInputCommandService(resolver);
         var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Button, ButtonNumber = "ABC" };
 
-        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: true, CancellationToken.None);
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.MPU4, input, isPressed: true, CancellationToken.None);
 
         Assert.False(wrote);
         Assert.Empty(processRunner.Commands);
@@ -41,7 +41,7 @@ public sealed class MameInputCommandServiceTests
         var service = new MameInputCommandService(resolver);
         var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Coin, CoinInput = true };
 
-        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: false, CancellationToken.None);
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.MPU4, input, isPressed: false, CancellationToken.None);
 
         Assert.True(wrote);
         Assert.Single(processRunner.Commands);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
@@ -1,0 +1,65 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameInputCommandServiceTests
+{
+    [Fact]
+    public async Task TrySendInputStateAsync_WithResolvableInput_WritesFormattedCommand()
+    {
+        var resolver = new MameInputPortResolver();
+        var processRunner = new FakeMameProcessRunner();
+        var service = new MameInputCommandService(resolver);
+        var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2" };
+
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: true, CancellationToken.None);
+
+        Assert.True(wrote);
+        Assert.Single(processRunner.Commands);
+        Assert.Equal("set_input_value IN0 0x02 1", processRunner.Commands[0]);
+    }
+
+    [Fact]
+    public async Task TrySendInputStateAsync_WithUnresolvableInput_DoesNotWriteCommand()
+    {
+        var resolver = new MameInputPortResolver();
+        var processRunner = new FakeMameProcessRunner();
+        var service = new MameInputCommandService(resolver);
+        var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Button, ButtonNumber = "ABC" };
+
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: true, CancellationToken.None);
+
+        Assert.False(wrote);
+        Assert.Empty(processRunner.Commands);
+    }
+
+    [Fact]
+    public async Task TrySendInputStateAsync_WithReleaseState_WritesZeroState()
+    {
+        var resolver = new MameInputPortResolver();
+        var processRunner = new FakeMameProcessRunner();
+        var service = new MameInputCommandService(resolver);
+        var input = new InputDefinitionModel { Id = "input-1", Kind = InputDefinitionKind.Coin, CoinInput = true };
+
+        var wrote = await service.TrySendInputStateAsync(processRunner, FruitMachinePlatformType.Mpu4, input, isPressed: false, CancellationToken.None);
+
+        Assert.True(wrote);
+        Assert.Single(processRunner.Commands);
+        Assert.Equal("set_input_value COINS 1 0", processRunner.Commands[0]);
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs
@@ -16,7 +16,7 @@ public sealed class MameInputCommandServiceTests
 
         Assert.True(wrote);
         Assert.Single(processRunner.Commands);
-        Assert.Equal("set_input_value IN0 0x02 1", processRunner.Commands[0]);
+        Assert.Equal("set_input_value ORANGE1 4 1", processRunner.Commands[0]);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterReleaseAllTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterReleaseAllTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewInputRouterReleaseAllTests
+{
+    [Fact]
+    public async Task ReleaseAllAsync_RemovesMissingDefinitionFromActiveSet()
+    {
+        var runner = new FakeMameProcessRunner();
+        var router = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2" };
+
+        var pressed = await router.TryPressAsync(FruitMachinePlatformType.MPU4, input, CancellationToken.None);
+        Assert.True(pressed);
+        Assert.Single(runner.Commands);
+
+        var released = await router.ReleaseAllAsync(FruitMachinePlatformType.MPU4, new Dictionary<string, InputDefinitionModel>(), CancellationToken.None);
+        Assert.Equal(0, released);
+
+        var pressedAgain = await router.TryPressAsync(FruitMachinePlatformType.MPU4, input, CancellationToken.None);
+        Assert.True(pressedAgain);
+        Assert.Equal(2, runner.Commands.Count);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[1]);
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -1,0 +1,54 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewInputRouterTests
+{
+    [Fact]
+    public async Task TryPressAsync_DuplicatePress_DoesNotSendSecondDown()
+    {
+        var processRunner = new FakeMameProcessRunner();
+        var router = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), processRunner);
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2" };
+
+        var first = await router.TryPressAsync(FruitMachinePlatformType.MPU4, input, CancellationToken.None);
+        var second = await router.TryPressAsync(FruitMachinePlatformType.MPU4, input, CancellationToken.None);
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Single(processRunner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", processRunner.Commands[0]);
+    }
+
+    [Fact]
+    public async Task ReleaseAllAsync_ReleasesPressedInputs()
+    {
+        var processRunner = new FakeMameProcessRunner();
+        var router = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), processRunner);
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2" };
+
+        await router.TryPressAsync(FruitMachinePlatformType.MPU4, input, CancellationToken.None);
+
+        var released = await router.ReleaseAllAsync(
+            FruitMachinePlatformType.MPU4,
+            new Dictionary<string, InputDefinitionModel> { [input.Id] = input },
+            CancellationToken.None);
+
+        Assert.Equal(1, released);
+        Assert.Equal(2, processRunner.Commands.Count);
+        Assert.Equal("set_input_value ORANGE1 4 0", processRunner.Commands[1]);
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterFocusTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterFocusTests.cs
@@ -1,0 +1,56 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewKeyboardInputRouterFocusTests
+{
+    [Fact]
+    public async Task TryHandleKeyDownAsync_WhenNotFocused_DoesNotSendCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var router = CreateRouter(runner);
+
+        var sent = await router.TryHandleKeyDownAsync(
+            FruitMachinePlatformType.MPU4,
+            "Space",
+            isFocused: false,
+            isRepeat: false,
+            CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandleKeyUpAsync_WhenNotFocused_DoesNotSendRelease()
+    {
+        var runner = new FakeMameProcessRunner();
+        var router = CreateRouter(runner);
+
+        await router.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, isRepeat: false, CancellationToken.None);
+        var sent = await router.TryHandleKeyUpAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: false, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Single(runner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[0]);
+    }
+
+    private static PlayViewKeyboardInputRouter CreateRouter(FakeMameProcessRunner runner)
+    {
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Space" };
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewKeyboardInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterTests.cs
@@ -1,0 +1,69 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewKeyboardInputRouterTests
+{
+    [Fact]
+    public async Task TryHandleKeyDownAsync_RepeatKey_DoesNotSendDuplicateCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var keyboardRouter = CreateRouter(runner, out _);
+
+        var first = await keyboardRouter.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, isRepeat: false, CancellationToken.None);
+        var repeat = await keyboardRouter.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, isRepeat: true, CancellationToken.None);
+
+        Assert.True(first);
+        Assert.False(repeat);
+        Assert.Single(runner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[0]);
+    }
+
+    [Fact]
+    public async Task TryHandleKeyUpAsync_FocusedKey_ReleasesInput()
+    {
+        var runner = new FakeMameProcessRunner();
+        var keyboardRouter = CreateRouter(runner, out _);
+
+        await keyboardRouter.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, isRepeat: false, CancellationToken.None);
+        var released = await keyboardRouter.TryHandleKeyUpAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, CancellationToken.None);
+
+        Assert.True(released);
+        Assert.Equal(2, runner.Commands.Count);
+        Assert.Equal("set_input_value ORANGE1 4 0", runner.Commands[1]);
+    }
+
+    [Fact]
+    public async Task ReleaseAllActiveAsync_ReleasesWhenFocusLost()
+    {
+        var runner = new FakeMameProcessRunner();
+        var keyboardRouter = CreateRouter(runner, out _);
+
+        await keyboardRouter.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "Space", isFocused: true, isRepeat: false, CancellationToken.None);
+        var count = await keyboardRouter.ReleaseAllActiveAsync(FruitMachinePlatformType.MPU4, CancellationToken.None);
+
+        Assert.Equal(1, count);
+        Assert.Equal(2, runner.Commands.Count);
+        Assert.Equal("set_input_value ORANGE1 4 0", runner.Commands[1]);
+    }
+
+    private static PlayViewKeyboardInputRouter CreateRouter(FakeMameProcessRunner runner, out InputDefinitionModel input)
+    {
+        var commandService = new MameInputCommandService(new MameInputPortResolver());
+        var inputRouter = new PlayViewInputRouter(commandService, runner);
+        input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Space" };
+        return new PlayViewKeyboardInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterUnknownShortcutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterUnknownShortcutTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewKeyboardInputRouterUnknownShortcutTests
+{
+    [Fact]
+    public async Task TryHandleKeyDownAsync_UnknownShortcut_DoesNotSendCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var router = CreateRouter(runner);
+
+        var sent = await router.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "F12", isFocused: true, isRepeat: false, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandleKeyUpAsync_UnknownShortcut_DoesNotSendRelease()
+    {
+        var runner = new FakeMameProcessRunner();
+        var router = CreateRouter(runner);
+
+        var sent = await router.TryHandleKeyUpAsync(FruitMachinePlatformType.MPU4, "F12", isFocused: true, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    private static PlayViewKeyboardInputRouter CreateRouter(FakeMameProcessRunner runner)
+    {
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2", KeyboardShortcut = "Space" };
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewKeyboardInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterFocusTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterFocusTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewPointerInputRouterFocusTests
+{
+    [Fact]
+    public async Task TryHandlePointerDownAsync_WhenNotFocused_DoesNotSendCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var router = CreateRouter(runner, visualId);
+
+        var sent = await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: false, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandlePointerUpAsync_WhenNotFocused_DoesNotSendRelease()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var router = CreateRouter(runner, visualId);
+
+        await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: true, CancellationToken.None);
+        var sent = await router.TryHandlePointerUpAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: false, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Single(runner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[0]);
+    }
+
+    private static PlayViewPointerInputRouter CreateRouter(FakeMameProcessRunner runner, Guid visualId)
+    {
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2", LinkedVisualElementId = visualId };
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewPointerInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterTests.cs
@@ -1,0 +1,75 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewPointerInputRouterTests
+{
+    [Fact]
+    public async Task TryHandlePointerDownAsync_LinkedVisual_SendsDownCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var router = CreateRouter(runner, visualId);
+
+        var sent = await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: true, CancellationToken.None);
+
+        Assert.True(sent);
+        Assert.Single(runner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[0]);
+    }
+
+    [Fact]
+    public async Task TryHandlePointerUpAsync_NotFocused_DoesNotSendRelease()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var router = CreateRouter(runner, visualId);
+
+        await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: true, CancellationToken.None);
+        var sent = await router.TryHandlePointerUpAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: false, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Single(runner.Commands);
+    }
+
+    [Fact]
+    public async Task ReleaseAllActiveAsync_ReleasesPressedPointerInputs()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var router = CreateRouter(runner, visualId);
+
+        await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, visualId, isFocused: true, CancellationToken.None);
+        var released = await router.ReleaseAllActiveAsync(FruitMachinePlatformType.MPU4, CancellationToken.None);
+
+        Assert.Equal(1, released);
+        Assert.Equal(2, runner.Commands.Count);
+        Assert.Equal("set_input_value ORANGE1 4 0", runner.Commands[1]);
+    }
+
+    private static PlayViewPointerInputRouter CreateRouter(FakeMameProcessRunner runner, Guid visualId)
+    {
+        var input = new InputDefinitionModel
+        {
+            Id = "btn-1",
+            Kind = InputDefinitionKind.Button,
+            ButtonNumber = "2",
+            LinkedVisualElementId = visualId
+        };
+
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewPointerInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterUnlinkedTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewPointerInputRouterUnlinkedTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewPointerInputRouterUnlinkedTests
+{
+    [Fact]
+    public async Task TryHandlePointerDownAsync_UnlinkedVisual_DoesNotSendCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var linkedVisualId = Guid.NewGuid();
+        var unlinkedVisualId = Guid.NewGuid();
+        var router = CreateRouter(runner, linkedVisualId);
+
+        var sent = await router.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, unlinkedVisualId, isFocused: true, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandlePointerUpAsync_UnlinkedVisual_DoesNotSendCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var linkedVisualId = Guid.NewGuid();
+        var unlinkedVisualId = Guid.NewGuid();
+        var router = CreateRouter(runner, linkedVisualId);
+
+        var sent = await router.TryHandlePointerUpAsync(FruitMachinePlatformType.MPU4, unlinkedVisualId, isFocused: true, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Empty(runner.Commands);
+    }
+
+    private static PlayViewPointerInputRouter CreateRouter(FakeMameProcessRunner runner, Guid linkedVisualId)
+    {
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "2", LinkedVisualElementId = linkedVisualId };
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewPointerInputRouter(inputRouter, new[] { input });
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDiagnostics.cs
@@ -33,6 +33,7 @@ public sealed class InputMapDiagnosticsService : IInputMapDiagnosticsService
 
         var diagnostics = new List<InputMapDiagnostic>();
         var keyToInputs = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        var linkedVisualToInputs = new Dictionary<Guid, List<string>>();
 
         foreach (var input in inputs)
         {
@@ -60,6 +61,17 @@ public sealed class InputMapDiagnosticsService : IInputMapDiagnosticsService
 
                 ids.Add(input.Id);
             }
+
+            if (input.LinkedVisualElementId is Guid linkedVisualId)
+            {
+                if (!linkedVisualToInputs.TryGetValue(linkedVisualId, out var linkedInputIds))
+                {
+                    linkedInputIds = [];
+                    linkedVisualToInputs[linkedVisualId] = linkedInputIds;
+                }
+
+                linkedInputIds.Add(input.Id);
+            }
         }
 
         foreach (var pair in keyToInputs)
@@ -74,6 +86,23 @@ public sealed class InputMapDiagnosticsService : IInputMapDiagnosticsService
                 diagnostics.Add(new InputMapDiagnostic(
                     "input.duplicate_shortcut",
                     $"Keyboard shortcut '{pair.Key}' is used by multiple input definitions.",
+                    inputId,
+                    InputMapDiagnosticSeverity.Warning));
+            }
+        }
+
+        foreach (var pair in linkedVisualToInputs)
+        {
+            if (pair.Value.Count <= 1)
+            {
+                continue;
+            }
+
+            foreach (var inputId in pair.Value)
+            {
+                diagnostics.Add(new InputMapDiagnostic(
+                    "input.duplicate_linked_visual",
+                    $"Linked visual '{pair.Key}' is referenced by multiple input definitions.",
                     inputId,
                     InputMapDiagnosticSeverity.Warning));
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDiagnostics.cs
@@ -1,0 +1,84 @@
+namespace OasisEditor;
+
+public sealed record InputMapDiagnostic(
+    string Code,
+    string Message,
+    string InputDefinitionId,
+    InputMapDiagnosticSeverity Severity);
+
+public enum InputMapDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+public interface IInputMapDiagnosticsService
+{
+    IReadOnlyList<InputMapDiagnostic> Analyze(FruitMachinePlatformType platform, IReadOnlyList<InputDefinitionModel> inputs);
+}
+
+public sealed class InputMapDiagnosticsService : IInputMapDiagnosticsService
+{
+    private readonly IMameInputPortResolver _resolver;
+
+    public InputMapDiagnosticsService(IMameInputPortResolver resolver)
+    {
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+    }
+
+    public IReadOnlyList<InputMapDiagnostic> Analyze(FruitMachinePlatformType platform, IReadOnlyList<InputDefinitionModel> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var diagnostics = new List<InputMapDiagnostic>();
+        var keyToInputs = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var input in inputs)
+        {
+            if (input is null || string.IsNullOrWhiteSpace(input.Id))
+            {
+                continue;
+            }
+
+            if (!_resolver.TryResolve(platform, input, out _))
+            {
+                diagnostics.Add(new InputMapDiagnostic(
+                    "input.unresolved_target",
+                    $"Input '{input.Name}' cannot resolve MAME tag/mask for platform {platform}.",
+                    input.Id,
+                    InputMapDiagnosticSeverity.Warning));
+            }
+
+            if (!string.IsNullOrWhiteSpace(input.KeyboardShortcut))
+            {
+                if (!keyToInputs.TryGetValue(input.KeyboardShortcut, out var ids))
+                {
+                    ids = [];
+                    keyToInputs[input.KeyboardShortcut] = ids;
+                }
+
+                ids.Add(input.Id);
+            }
+        }
+
+        foreach (var pair in keyToInputs)
+        {
+            if (pair.Value.Count <= 1)
+            {
+                continue;
+            }
+
+            foreach (var inputId in pair.Value)
+            {
+                diagnostics.Add(new InputMapDiagnostic(
+                    "input.duplicate_shortcut",
+                    $"Keyboard shortcut '{pair.Key}' is used by multiple input definitions.",
+                    inputId,
+                    InputMapDiagnosticSeverity.Warning));
+            }
+        }
+
+        return diagnostics;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -404,6 +404,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         private set => SetProperty(ref _inputMapDiagnostics, value);
     }
 
+    public int InputMapWarningCount => InputMapDiagnostics.Count(d => d.Severity == InputMapDiagnosticSeverity.Warning);
+    public bool HasInputMapDiagnostics => InputMapDiagnostics.Count > 0;
+
 
     public FruitMachinePlatformType SelectedFruitMachinePlatform
     {
@@ -1791,11 +1794,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (LoadedProject is null)
         {
             InputMapDiagnostics = [];
+            OnPropertyChanged(nameof(InputMapWarningCount));
+            OnPropertyChanged(nameof(HasInputMapDiagnostics));
             return;
         }
 
         InputMapDiagnostics = _inputMapDiagnosticsService.Analyze(SelectedFruitMachinePlatform, LoadedProject.InputDefinitions);
-        var warningCount = InputMapDiagnostics.Count(d => d.Severity == InputMapDiagnosticSeverity.Warning);
+        OnPropertyChanged(nameof(InputMapWarningCount));
+        OnPropertyChanged(nameof(HasInputMapDiagnostics));
+        var warningCount = InputMapWarningCount;
         if (warningCount > 0)
         {
             AddOutputEntry($"Input Map diagnostics reported {warningCount} warning(s).", OutputLogStatus.Warning);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -69,6 +69,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
     private bool _isAutoProvisioningMame;
     private MameEmulationState _mameEmulationState = MameEmulationState.Stopped;
+    private readonly IInputMapDiagnosticsService _inputMapDiagnosticsService = new InputMapDiagnosticsService(new MameInputPortResolver());
+    private IReadOnlyList<InputMapDiagnostic> _inputMapDiagnostics = [];
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -396,6 +398,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
     public IReadOnlyList<InputDefinitionModel> InputDefinitions => LoadedProject?.InputDefinitions ?? [];
+    public IReadOnlyList<InputMapDiagnostic> InputMapDiagnostics
+    {
+        get => _inputMapDiagnostics;
+        private set => SetProperty(ref _inputMapDiagnostics, value);
+    }
 
 
     public FruitMachinePlatformType SelectedFruitMachinePlatform
@@ -412,6 +419,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             {
                 LoadedProject.FruitMachinePlatform = value;
                 SaveLoadedProjectMetadata();
+                RefreshInputMapDiagnostics();
             }
         }
     }
@@ -996,6 +1004,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
             SaveLoadedProjectMetadata();
             OnPropertyChanged(nameof(InputDefinitions));
+            RefreshInputMapDiagnostics();
             AddOutputEntry($"MFME import created {result.InputDefinitions.Count} input definitions.", OutputLogStatus.Info);
         }
 
@@ -1774,6 +1783,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _assetBrowser.RefreshAssetBrowser();
         StatusMessage = $"Project opened: {project.Name} ({project.ProjectFilePath})";
         AddOutputEntry($"Loaded startup project '{project.Name}' from {project.ProjectFilePath}", OutputLogStatus.Info);
+        RefreshInputMapDiagnostics();
+    }
+
+    private void RefreshInputMapDiagnostics()
+    {
+        if (LoadedProject is null)
+        {
+            InputMapDiagnostics = [];
+            return;
+        }
+
+        InputMapDiagnostics = _inputMapDiagnosticsService.Analyze(SelectedFruitMachinePlatform, LoadedProject.InputDefinitions);
+        var warningCount = InputMapDiagnostics.Count(d => d.Severity == InputMapDiagnosticSeverity.Warning);
+        if (warningCount > 0)
+        {
+            AddOutputEntry($"Input Map diagnostics reported {warningCount} warning(s).", OutputLogStatus.Warning);
+        }
     }
 
     private EditorProject LoadProjectFromFile(string projectFilePath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameInputCommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameInputCommandService.cs
@@ -1,0 +1,32 @@
+namespace OasisEditor;
+
+public interface IMameInputCommandService
+{
+    Task<bool> TrySendInputStateAsync(IMameProcessRunner processRunner, FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
+}
+
+public sealed class MameInputCommandService : IMameInputCommandService
+{
+    private readonly IMameInputPortResolver _inputPortResolver;
+
+    public MameInputCommandService(IMameInputPortResolver inputPortResolver)
+    {
+        _inputPortResolver = inputPortResolver ?? throw new ArgumentNullException(nameof(inputPortResolver));
+    }
+
+    public async Task<bool> TrySendInputStateAsync(IMameProcessRunner processRunner, FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(processRunner);
+        ArgumentNullException.ThrowIfNull(inputDefinition);
+
+        if (!_inputPortResolver.TryResolve(platform, inputDefinition, out var target))
+        {
+            return false;
+        }
+
+        var state = isPressed ? "1" : "0";
+        var command = $"set_input_value {target.Tag} {target.Mask} {state}";
+        await processRunner.WriteStandardInputAsync(command, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -1,0 +1,77 @@
+namespace OasisEditor;
+
+public sealed class PlayViewInputRouter
+{
+    private readonly IMameInputCommandService _commandService;
+    private readonly IMameProcessRunner _processRunner;
+    private readonly HashSet<string> _activeInputIds = [];
+
+    public PlayViewInputRouter(IMameInputCommandService commandService, IMameProcessRunner processRunner)
+    {
+        _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
+        _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+    }
+
+    public async Task<bool> TryPressAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(inputDefinition);
+
+        if (string.IsNullOrWhiteSpace(inputDefinition.Id))
+        {
+            return false;
+        }
+
+        if (!_activeInputIds.Add(inputDefinition.Id))
+        {
+            return false;
+        }
+
+        var wrote = await _commandService.TrySendInputStateAsync(_processRunner, platform, inputDefinition, isPressed: true, cancellationToken).ConfigureAwait(false);
+        if (!wrote)
+        {
+            _activeInputIds.Remove(inputDefinition.Id);
+        }
+
+        return wrote;
+    }
+
+    public async Task<bool> TryReleaseAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(inputDefinition);
+
+        if (string.IsNullOrWhiteSpace(inputDefinition.Id) || !_activeInputIds.Remove(inputDefinition.Id))
+        {
+            return false;
+        }
+
+        return await _commandService.TrySendInputStateAsync(_processRunner, platform, inputDefinition, isPressed: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> ReleaseAllAsync(FruitMachinePlatformType platform, IReadOnlyDictionary<string, InputDefinitionModel> inputDefinitionsById, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(inputDefinitionsById);
+
+        if (_activeInputIds.Count == 0)
+        {
+            return 0;
+        }
+
+        var released = 0;
+        foreach (var inputId in _activeInputIds.ToArray())
+        {
+            if (!inputDefinitionsById.TryGetValue(inputId, out var definition))
+            {
+                continue;
+            }
+
+            _activeInputIds.Remove(inputId);
+            var wrote = await _commandService.TrySendInputStateAsync(_processRunner, platform, definition, isPressed: false, cancellationToken).ConfigureAwait(false);
+            if (wrote)
+            {
+                released++;
+            }
+        }
+
+        return released;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -61,6 +61,7 @@ public sealed class PlayViewInputRouter
         {
             if (!inputDefinitionsById.TryGetValue(inputId, out var definition))
             {
+                _activeInputIds.Remove(inputId);
                 continue;
             }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
@@ -1,0 +1,67 @@
+namespace OasisEditor;
+
+public sealed class PlayViewKeyboardInputRouter
+{
+    private readonly PlayViewInputRouter _inputRouter;
+    private readonly Dictionary<string, string> _shortcutToInputId;
+    private readonly Dictionary<string, InputDefinitionModel> _inputById;
+
+    public PlayViewKeyboardInputRouter(PlayViewInputRouter inputRouter, IEnumerable<InputDefinitionModel> inputDefinitions)
+    {
+        _inputRouter = inputRouter ?? throw new ArgumentNullException(nameof(inputRouter));
+        ArgumentNullException.ThrowIfNull(inputDefinitions);
+
+        _shortcutToInputId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        _inputById = new Dictionary<string, InputDefinitionModel>(StringComparer.Ordinal);
+
+        foreach (var input in inputDefinitions)
+        {
+            if (input is null || string.IsNullOrWhiteSpace(input.Id))
+            {
+                continue;
+            }
+
+            _inputById[input.Id] = input;
+
+            if (!string.IsNullOrWhiteSpace(input.KeyboardShortcut) && !_shortcutToInputId.ContainsKey(input.KeyboardShortcut))
+            {
+                _shortcutToInputId[input.KeyboardShortcut] = input.Id;
+            }
+        }
+    }
+
+    public Task<bool> TryHandleKeyDownAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, bool isRepeat, CancellationToken cancellationToken)
+    {
+        if (!isFocused || isRepeat || string.IsNullOrWhiteSpace(keyboardShortcut))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!_shortcutToInputId.TryGetValue(keyboardShortcut, out var inputId) || !_inputById.TryGetValue(inputId, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+    }
+
+    public Task<bool> TryHandleKeyUpAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
+    {
+        if (!isFocused || string.IsNullOrWhiteSpace(keyboardShortcut))
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!_shortcutToInputId.TryGetValue(keyboardShortcut, out var inputId) || !_inputById.TryGetValue(inputId, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+    }
+
+    public Task<int> ReleaseAllActiveAsync(FruitMachinePlatformType platform, CancellationToken cancellationToken)
+    {
+        return _inputRouter.ReleaseAllAsync(platform, _inputById, cancellationToken);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewPointerInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewPointerInputRouter.cs
@@ -1,0 +1,57 @@
+namespace OasisEditor;
+
+public sealed class PlayViewPointerInputRouter
+{
+    private readonly PlayViewInputRouter _inputRouter;
+    private readonly Dictionary<Guid, InputDefinitionModel> _inputsByVisualId;
+
+    public PlayViewPointerInputRouter(PlayViewInputRouter inputRouter, IEnumerable<InputDefinitionModel> inputDefinitions)
+    {
+        _inputRouter = inputRouter ?? throw new ArgumentNullException(nameof(inputRouter));
+        ArgumentNullException.ThrowIfNull(inputDefinitions);
+
+        _inputsByVisualId = new Dictionary<Guid, InputDefinitionModel>();
+        foreach (var input in inputDefinitions)
+        {
+            if (input?.LinkedVisualElementId is null)
+            {
+                continue;
+            }
+
+            if (!_inputsByVisualId.ContainsKey(input.LinkedVisualElementId.Value))
+            {
+                _inputsByVisualId[input.LinkedVisualElementId.Value] = input;
+            }
+        }
+    }
+
+    public Task<bool> TryHandlePointerDownAsync(FruitMachinePlatformType platform, Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
+    {
+        if (!isFocused || !_inputsByVisualId.TryGetValue(visualElementId, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+    }
+
+    public Task<bool> TryHandlePointerUpAsync(FruitMachinePlatformType platform, Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
+    {
+        if (!isFocused || !_inputsByVisualId.TryGetValue(visualElementId, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+    }
+
+    public Task<int> ReleaseAllActiveAsync(FruitMachinePlatformType platform, CancellationToken cancellationToken)
+    {
+        var byInputId = _inputsByVisualId.Values
+            .Where(v => !string.IsNullOrWhiteSpace(v.Id))
+            .GroupBy(v => v.Id, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        return _inputRouter.ReleaseAllAsync(platform, byInputId, cancellationToken);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
@@ -7,7 +7,13 @@
              d:DesignHeight="320"
              d:DesignWidth="700">
     <Grid>
-        <DataGrid ItemsSource="{Binding InputDefinitions}"
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <DataGrid Grid.Row="0"
+                  ItemsSource="{Binding InputDefinitions}"
                   AutoGenerateColumns="False"
                   IsReadOnly="True"
                   CanUserAddRows="False"
@@ -31,5 +37,30 @@
                 <DataGridTextColumn Header="Notes" Binding="{Binding Notes}" Width="1.3*" />
             </DataGrid.Columns>
         </DataGrid>
+
+        <Border Grid.Row="1"
+                Margin="0,8,0,0"
+                Padding="8"
+                BorderBrush="{DynamicResource DividerBrush}"
+                BorderThickness="1"
+                Background="{DynamicResource SurfaceRaisedBrush}">
+            <StackPanel>
+                <TextBlock FontWeight="SemiBold"
+                           Text="Input Map Diagnostics" />
+                <ItemsControl Margin="0,6,0,0"
+                              ItemsSource="{Binding InputMapDiagnostics}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock TextWrapping="Wrap">
+                                <Run Text="[" />
+                                <Run Text="{Binding Severity}" />
+                                <Run Text="] " />
+                                <Run Text="{Binding Message}" />
+                            </TextBlock>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
@@ -45,8 +45,13 @@
                 BorderThickness="1"
                 Background="{DynamicResource SurfaceRaisedBrush}">
             <StackPanel>
-                <TextBlock FontWeight="SemiBold"
-                           Text="Input Map Diagnostics" />
+                <DockPanel>
+                    <TextBlock FontWeight="SemiBold"
+                               Text="Input Map Diagnostics" />
+                    <TextBlock HorizontalAlignment="Right"
+                               Foreground="{DynamicResource SecondaryTextBrush}"
+                               Text="{Binding InputMapWarningCount, StringFormat=Warnings: {0}}" />
+                </DockPanel>
                 <ItemsControl Margin="0,6,0,0"
                               ItemsSource="{Binding InputMapDiagnostics}">
                     <ItemsControl.ItemTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
@@ -65,6 +65,20 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+                <TextBlock Margin="0,6,0,0"
+                           Foreground="{DynamicResource SecondaryTextBrush}"
+                           Text="No input map diagnostics.">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasInputMapDiagnostics}" Value="False">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
             </StackPanel>
         </Border>
     </Grid>


### PR DESCRIPTION
### Motivation
- Centralize MAME stdin command formatting and guarded dispatch for the Input Map / Play View workstream so runtime input wiring is testable and does not send invalid commands.

### Description
- Add `IMameInputCommandService` and `MameInputCommandService` which use `IMameInputPortResolver` to resolve `Tag`/`Mask` and write `set_input_value <tag> <mask> <0|1>` to `IMameProcessRunner.WriteStandardInputAsync`, implemented in `WindowsNetProjects/OasisEditor/OasisEditor/MameInputCommandService.cs` and exercised by tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputCommandServiceTests.cs`.

### Testing
- No automated tests were executed in this Codex environment due to the environment/toolchain constraints documented in `AGENT.md`; unit tests `MameInputCommandServiceTests` were added covering resolvable button formatting, unresolved-input skip behavior, and coin release formatting, and should be run locally with `dotnet test` and are expected to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a09bb2fe8d883279b729aaf5de65f89)