### PR TITLE
Enable Play View pan and zoom interactions

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
@@ -26,6 +26,11 @@
                     PreviewKeyUp="OnPlayCanvasPreviewKeyUp"
                     PreviewMouseLeftButtonDown="OnPlayCanvasPreviewMouseLeftButtonDown"
                     PreviewMouseLeftButtonUp="OnPlayCanvasPreviewMouseLeftButtonUp"
+                    MouseDown="OnPlayCanvasMouseDown"
+                    MouseMove="OnPlayCanvasMouseMove"
+                    MouseUp="OnPlayCanvasMouseUp"
+                    MouseWheel="OnPlayCanvasMouseWheel"
+                    LostMouseCapture="OnPlayCanvasLostMouseCapture"
                     LostKeyboardFocus="OnPlayCanvasLostKeyboardFocus"
                     Unloaded="OnPlayCanvasUnloaded" />
         </Border>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -124,6 +124,32 @@ public partial class PlayView : UserControl
         await ViewModel.TryHandlePlayViewPointerUpAsync(visualElementId, isFocused: true, CancellationToken.None);
     }
 
+
+    private void OnPlayCanvasMouseDown(object sender, MouseButtonEventArgs eventArgs)
+    {
+        CanvasPanZoomBehavior.HandleMouseDown(PlayCanvas, eventArgs);
+    }
+
+    private void OnPlayCanvasMouseMove(object sender, MouseEventArgs eventArgs)
+    {
+        CanvasPanZoomBehavior.HandleMouseMove(PlayCanvas, eventArgs);
+    }
+
+    private void OnPlayCanvasMouseUp(object sender, MouseButtonEventArgs eventArgs)
+    {
+        CanvasPanZoomBehavior.HandleMouseUp(PlayCanvas, eventArgs);
+    }
+
+    private void OnPlayCanvasMouseWheel(object sender, MouseWheelEventArgs eventArgs)
+    {
+        CanvasPanZoomBehavior.HandleMouseWheel(PlayCanvas, eventArgs);
+    }
+
+    private void OnPlayCanvasLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    {
+        CanvasPanZoomBehavior.HandleLostMouseCapture(PlayCanvas);
+    }
+
     private async void OnPlayCanvasLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs eventArgs)
     {
         if (ViewModel is null)


### PR DESCRIPTION
### Motivation
- The Play View should support the same pan and zoom viewport controls as the Panel2D document view so users can navigate the panel in Play mode without enabling editing/selection features.
- Reuse the editor's existing `CanvasPanZoomBehavior` so Play View gestures behave consistently with the editor canvas.

### Description
- Hooked `MouseDown`, `MouseMove`, `MouseUp`, `MouseWheel`, and `LostMouseCapture` events on the `PlayCanvas` in `PlayView.xaml` and added matching handlers in `PlayView.xaml.cs` that delegate to `CanvasPanZoomBehavior` (`HandleMouseDown`, `HandleMouseMove`, `HandleMouseUp`, `HandleMouseWheel`, `HandleLostMouseCapture`).
- Preserved Play View's existing pointer/key preview handlers and click-to-route logic so no document-edit selection or mutation behavior was introduced.
- Files changed: `WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml` and `WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs`.

### Testing
- No automated tests were executed in this environment due to the Windows/.NET/WPF toolchain constraint described in `AGENT.md`.
- Recommend running the full unit test project with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` locally to validate there are no regressions.
- Recommend specifically ensuring the play-view input-related tests run and pass, for example `PlayViewPointerInputRouterTests`, `PlayViewPointerInputRouterFocusTests`, `PlayViewKeyboardInputRouterTests`, and `PlayViewInputRouterReleaseAllTests`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a09e064ea148327bc2a539146aed392)