### PR TITLE
Parse MAME vfdduty stdout with platform-specific ranges

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -78,6 +78,25 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.Equal(0, masks[0]);
     }
 
+    [Fact]
+    public void ApplyVfdBrightness_AppliesPerDisplayBrightnessAcrossAllAlphaCells()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, 1, MameSegmentOutputType.Vfd);
+        adapter.ApplySegmentState(1, 2, MameSegmentOutputType.Vfd);
+        adapter.ApplyVfdBrightness(0, 0.25d);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var brightness = document.RuntimeState.GetSegmentCellBrightness("alpha-0", 16);
+        Assert.Equal(16, brightness.Length);
+        Assert.All(brightness, value => Assert.Equal(0.25d, value));
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -44,7 +44,7 @@ public sealed class MameStdoutParserTests
         var reelAdapter = new RecordingReelAdapter();
         var segmentAdapter = new RecordingSegmentAdapter();
         string? diagnostic = null;
-        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter, message => diagnostic = message);
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter, diagnosticLogger: message => diagnostic = message);
 
         parser.ProcessLine("unknown output");
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -99,6 +99,9 @@ public sealed class MameStdoutParserTests
         Assert.Empty(lampAdapter.Calls);
         Assert.Empty(reelAdapter.Calls);
         Assert.Empty(segmentAdapter.Calls);
+        var duty = Assert.Single(segmentAdapter.BrightnessCalls);
+        Assert.Equal(0, duty.CellId);
+        Assert.Equal(1d, duty.Brightness);
         Assert.Null(diagnostic);
     }
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
@@ -116,6 +119,8 @@ public sealed class MameStdoutParserTests
     private sealed class RecordingSegmentAdapter : IMameSegmentRuntimeAdapter
     {
         public List<(int CellId, int Mask, MameSegmentOutputType OutputType)> Calls { get; } = [];
+        public List<(int CellId, double Brightness)> BrightnessCalls { get; } = [];
         public void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType) => Calls.Add((cellId, segmentMask, outputType));
+        public void ApplyVfdBrightness(int cellId, double normalizedBrightness) => BrightnessCalls.Add((cellId, normalizedBrightness));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -84,6 +84,23 @@ public sealed class MameStdoutParserTests
         Assert.Equal(16, call.Mask);
     }
 
+
+    [Fact]
+    public void ProcessLine_WhenVfdDutyLine_DoesNotLogUnhandledDiagnostic()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
+        string? diagnostic = null;
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter, () => FruitMachinePlatformType.MPU4, message => diagnostic = message);
+
+        parser.ProcessLine("vfdduty0 = 31");
+
+        Assert.Empty(lampAdapter.Calls);
+        Assert.Empty(reelAdapter.Calls);
+        Assert.Empty(segmentAdapter.Calls);
+        Assert.Null(diagnostic);
+    }
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
     {
         public List<(int LampId, int Value)> Calls { get; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDutyParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDutyParserTests.cs
@@ -1,0 +1,42 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameVfdDutyParserTests
+{
+    [Fact]
+    public void TryParseNormalized_Mpu4_UsesRangeZeroToThirtyOne()
+    {
+        var parser = new MameVfdDutyParser();
+
+        var parsed = parser.TryParseNormalized("vfdduty0 = 31", FruitMachinePlatformType.MPU4, out var cellId, out var brightness);
+
+        Assert.True(parsed);
+        Assert.Equal(0, cellId);
+        Assert.Equal(1d, brightness);
+    }
+
+    [Fact]
+    public void TryParseNormalized_Scorpion4_UsesRangeZeroToSeven()
+    {
+        var parser = new MameVfdDutyParser();
+
+        var parsed = parser.TryParseNormalized("vfdduty2 = 7", FruitMachinePlatformType.Scorpion4, out var cellId, out var brightness);
+
+        Assert.True(parsed);
+        Assert.Equal(2, cellId);
+        Assert.Equal(1d, brightness);
+    }
+
+    [Fact]
+    public void TryParseNormalized_UnknownPlatform_FallsBackToMpu4Range()
+    {
+        var parser = new MameVfdDutyParser();
+
+        var parsed = parser.TryParseNormalized("vfdduty5 = 31", FruitMachinePlatformType.MPU3, out _, out var brightness);
+
+        Assert.True(parsed);
+        Assert.Equal(1d, brightness);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -236,6 +236,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                         dispatcher.Invoke(work);
                     }
                 }),
+            platformProvider: () => SelectedFruitMachinePlatform,
             diagnosticLogger: line => AddOutputEntry(line, OutputLogStatus.Info));
         _mameProcessRunner = new MameProcessRunner(
             stdoutLogger: line => ProcessMameStdoutLine(line, mameStdoutParser),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -42,6 +42,7 @@ public interface IMameReelRuntimeAdapter
 public interface IMameSegmentRuntimeAdapter
 {
     void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType);
+    void ApplyVfdBrightness(int cellId, double normalizedBrightness);
 }
 
 public sealed record MameProcessLaunchRequest(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -7,10 +7,10 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> _pendingMasks = new();
-    private readonly Dictionary<int, double> _pendingVfdBrightnessByCell = new();
+    private readonly Dictionary<int, double> _pendingVfdBrightnessByDisplay = new();
     private readonly Dictionary<int, int> _latestVfdMasksByCell = new();
     private readonly Dictionary<int, int> _latestDigitMasksByCell = new();
-    private readonly Dictionary<int, double> _latestVfdBrightnessByCell = new();
+    private readonly Dictionary<int, double> _latestVfdBrightnessByDisplay = new();
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
@@ -35,7 +35,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     {
         lock (_pendingSync)
         {
-            _pendingVfdBrightnessByCell[cellId] = Math.Clamp(normalizedBrightness, 0d, 1d);
+            _pendingVfdBrightnessByDisplay[cellId] = Math.Clamp(normalizedBrightness, 0d, 1d);
             if (_uiUpdateScheduled) return;
             _uiUpdateScheduled = true;
         }
@@ -50,9 +50,9 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         lock (_pendingSync)
         {
             snapshot = new(_pendingMasks);
-            brightnessSnapshot = new(_pendingVfdBrightnessByCell);
+            brightnessSnapshot = new(_pendingVfdBrightnessByDisplay);
             _pendingMasks.Clear();
-            _pendingVfdBrightnessByCell.Clear();
+            _pendingVfdBrightnessByDisplay.Clear();
             _uiUpdateScheduled = false;
         }
 
@@ -74,7 +74,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
             foreach (var (cellId, brightness) in brightnessSnapshot)
             {
-                _latestVfdBrightnessByCell[cellId] = brightness;
+                _latestVfdBrightnessByDisplay[cellId] = brightness;
             }
 
             foreach (var element in document.GetPanelElements().Where(e => (e.Kind == PanelElementKind.Alpha || e.Kind == PanelElementKind.SevenSegment) && !string.IsNullOrWhiteSpace(e.ObjectId)))
@@ -94,7 +94,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                             : RemapMameMaskToWpfSegmentOrder(mask);
                     }
 
-                    if (element.Kind == PanelElementKind.Alpha && _latestVfdBrightnessByCell.TryGetValue(baseIndex + i, out var brightness))
+                    if (element.Kind == PanelElementKind.Alpha && _latestVfdBrightnessByDisplay.TryGetValue(baseIndex, out var brightness))
                     {
                         cellBrightness[i] = brightness;
                     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -7,8 +7,10 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> _pendingMasks = new();
+    private readonly Dictionary<int, double> _pendingVfdBrightnessByCell = new();
     private readonly Dictionary<int, int> _latestVfdMasksByCell = new();
     private readonly Dictionary<int, int> _latestDigitMasksByCell = new();
+    private readonly Dictionary<int, double> _latestVfdBrightnessByCell = new();
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
@@ -29,13 +31,28 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         _uiDispatch(ApplyPendingOnUiThread);
     }
 
+    public void ApplyVfdBrightness(int cellId, double normalizedBrightness)
+    {
+        lock (_pendingSync)
+        {
+            _pendingVfdBrightnessByCell[cellId] = Math.Clamp(normalizedBrightness, 0d, 1d);
+            if (_uiUpdateScheduled) return;
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
     private void ApplyPendingOnUiThread()
     {
         Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> snapshot;
+        Dictionary<int, double> brightnessSnapshot;
         lock (_pendingSync)
         {
             snapshot = new(_pendingMasks);
+            brightnessSnapshot = new(_pendingVfdBrightnessByCell);
             _pendingMasks.Clear();
+            _pendingVfdBrightnessByCell.Clear();
             _uiUpdateScheduled = false;
         }
 
@@ -55,12 +72,18 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 }
             }
 
+            foreach (var (cellId, brightness) in brightnessSnapshot)
+            {
+                _latestVfdBrightnessByCell[cellId] = brightness;
+            }
+
             foreach (var element in document.GetPanelElements().Where(e => (e.Kind == PanelElementKind.Alpha || e.Kind == PanelElementKind.SevenSegment) && !string.IsNullOrWhiteSpace(e.ObjectId)))
             {
                 var objectId = element.ObjectId!;
                 var baseIndex = element.DisplayNumber.GetValueOrDefault(0);
                 var cellCount = element.Kind == PanelElementKind.SevenSegment ? 1 : 16;
                 var cellMasks = new int[cellCount];
+                var cellBrightness = new double[cellCount];
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
                     var source = element.Kind == PanelElementKind.SevenSegment ? _latestDigitMasksByCell : _latestVfdMasksByCell;
@@ -70,9 +93,21 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                             ? mask
                             : RemapMameMaskToWpfSegmentOrder(mask);
                     }
+
+                    if (element.Kind == PanelElementKind.Alpha && _latestVfdBrightnessByCell.TryGetValue(baseIndex + i, out var brightness))
+                    {
+                        cellBrightness[i] = brightness;
+                    }
+                    else
+                    {
+                        cellBrightness[i] = 1d;
+                    }
                 }
 
-                if (document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks))
+                var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks);
+                var brightnessChanged = element.Kind == PanelElementKind.Alpha
+                    && document.RuntimeState.SetSegmentCellBrightnessIfChanged(objectId, cellBrightness);
+                if (maskChanged || brightnessChanged)
                 {
                     changedObjectIds.Add(objectId);
                 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -50,8 +50,9 @@ public sealed class MameStdoutParser : IMameStdoutParser
             return;
         }
 
-        if (_vfdDutyParser.TryParseNormalized(line, _platformProvider(), out _, out _))
+        if (_vfdDutyParser.TryParseNormalized(line, _platformProvider(), out var dutyCellId, out var normalizedBrightness))
         {
+            _segmentRuntimeAdapter.ApplyVfdBrightness(dutyCellId, normalizedBrightness);
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -8,9 +8,11 @@ public sealed class MameStdoutParser : IMameStdoutParser
     private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
     private readonly IMameSegmentStateParser _segmentStateParser;
     private readonly IMameSegmentRuntimeAdapter _segmentRuntimeAdapter;
+    private readonly MameVfdDutyParser _vfdDutyParser;
+    private readonly Func<FruitMachinePlatformType> _platformProvider;
     private readonly Action<string>? _diagnosticLogger;
 
-    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Action<string>? diagnosticLogger = null)
+    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Func<FruitMachinePlatformType>? platformProvider = null, Action<string>? diagnosticLogger = null)
     {
         _lampStateParser = lampStateParser ?? throw new ArgumentNullException(nameof(lampStateParser));
         _lampRuntimeAdapter = lampRuntimeAdapter ?? throw new ArgumentNullException(nameof(lampRuntimeAdapter));
@@ -18,6 +20,8 @@ public sealed class MameStdoutParser : IMameStdoutParser
         _reelRuntimeAdapter = reelRuntimeAdapter ?? throw new ArgumentNullException(nameof(reelRuntimeAdapter));
         _segmentStateParser = segmentStateParser ?? throw new ArgumentNullException(nameof(segmentStateParser));
         _segmentRuntimeAdapter = segmentRuntimeAdapter ?? throw new ArgumentNullException(nameof(segmentRuntimeAdapter));
+        _vfdDutyParser = new MameVfdDutyParser();
+        _platformProvider = platformProvider ?? (() => FruitMachinePlatformType.MPU4);
         _diagnosticLogger = diagnosticLogger;
     }
 
@@ -43,6 +47,11 @@ public sealed class MameStdoutParser : IMameStdoutParser
         if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask, out var outputType))
         {
             _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask, outputType);
+            return;
+        }
+
+        if (_vfdDutyParser.TryParseNormalized(line, _platformProvider(), out _, out _))
+        {
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDutyParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDutyParser.cs
@@ -1,0 +1,48 @@
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace OasisEditor;
+
+public sealed class MameVfdDutyParser
+{
+    private static readonly Regex VfdDutyRegex = new(@"^vfdduty(?<cellId>\d+)\s*=\s*(?<duty>\d+)$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly IReadOnlyDictionary<FruitMachinePlatformType, int> MaxVfdDutyByPlatform =
+        new ReadOnlyDictionary<FruitMachinePlatformType, int>(new Dictionary<FruitMachinePlatformType, int>
+        {
+            [FruitMachinePlatformType.MPU4] = 31,
+            [FruitMachinePlatformType.Scorpion4] = 7
+        });
+
+    public bool TryParseNormalized(string line, FruitMachinePlatformType platform, out int cellId, out double normalizedBrightness)
+    {
+        cellId = 0;
+        normalizedBrightness = 0d;
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var match = VfdDutyRegex.Match(line);
+        if (!match.Success
+            || !int.TryParse(match.Groups["cellId"].Value, out cellId)
+            || !int.TryParse(match.Groups["duty"].Value, out var duty))
+        {
+            return false;
+        }
+
+        var maxDuty = ResolveMaxDuty(platform);
+        normalizedBrightness = maxDuty <= 0
+            ? 0d
+            : Math.Clamp((double)duty / maxDuty, 0d, 1d);
+        return true;
+    }
+
+    public static int ResolveMaxDuty(FruitMachinePlatformType platform)
+    {
+        return MaxVfdDutyByPlatform.TryGetValue(platform, out var maxDuty)
+            ? maxDuty
+            : 31;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelLayoutMapper.cs
@@ -174,12 +174,13 @@ public static class PanelLayoutMapper
                 var segmentState = visualStateChange.ValuesByObjectId[objectId] is SegmentVisualState state
                     ? state
                     : new SegmentVisualState(runtimeState.GetSegmentCellMasks(objectId, 16));
-                UpdateSegmentVisual(canvas, objectId, segmentState.CellMasks);
+                var cellCount = tab.TryGetSevenSegmentElement(objectId, out _) ? 1 : 16;
+                UpdateSegmentVisual(canvas, objectId, segmentState.CellMasks, runtimeState.GetSegmentCellBrightness(objectId, cellCount));
             }
         }
     }
 
-    public static void UpdateSegmentVisual(Canvas canvas, string objectId, int[] cellMasks)
+    public static void UpdateSegmentVisual(Canvas canvas, string objectId, int[] cellMasks, double[]? cellBrightness = null)
     {
         if (string.IsNullOrWhiteSpace(objectId) || cellMasks is null)
         {
@@ -195,6 +196,7 @@ public static class PanelLayoutMapper
         }
 
         segmentVisual.CellSegmentMasks = cellMasks.ToArray();
+        segmentVisual.CellBrightness = cellBrightness?.ToArray();
         segmentVisual.InvalidateVisual();
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -5,6 +5,7 @@ public sealed class PanelRuntimeState
     private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int> _reelPositionByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, double[]> _segmentBrightnessByObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
 
@@ -13,6 +14,7 @@ public sealed class PanelRuntimeState
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
     public IReadOnlyDictionary<string, int> ReelPositionByObjectId => _reelPositionByObjectId;
     public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
+    public IReadOnlyDictionary<string, double[]> SegmentBrightnessByObjectId => _segmentBrightnessByObjectId;
 
     public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
@@ -89,6 +91,7 @@ public sealed class PanelRuntimeState
         _lampIntensityByObjectId.Clear();
         _reelPositionByObjectId.Clear();
         _segmentMasksByObjectId.Clear();
+        _segmentBrightnessByObjectId.Clear();
     }
 
     public bool SetSegmentCellMasksIfChanged(string objectId, int[] masks)
@@ -107,6 +110,38 @@ public sealed class PanelRuntimeState
 
         _segmentMasksByObjectId[normalizedObjectId] = masks.ToArray();
         return true;
+    }
+
+
+    public bool SetSegmentCellBrightnessIfChanged(string objectId, double[] brightnessByCell)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || brightnessByCell is null)
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        if (_segmentBrightnessByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && previous.Length == brightnessByCell.Length
+            && previous.Zip(brightnessByCell, (left, right) => Math.Abs(left - right) < 0.0001d).All(equal => equal))
+        {
+            return false;
+        }
+
+        _segmentBrightnessByObjectId[normalizedObjectId] = brightnessByCell.Select(value => Math.Clamp(value, 0d, 1d)).ToArray();
+        return true;
+    }
+
+    public double[] GetSegmentCellBrightness(string objectId, int cellCount)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || cellCount <= 0)
+        {
+            return Array.Empty<double>();
+        }
+
+        return _segmentBrightnessByObjectId.TryGetValue(objectId.Trim(), out var value)
+            ? value.ToArray()
+            : Enumerable.Repeat(1d, cellCount).ToArray();
     }
 
     public int[] GetSegmentCellMasks(string objectId, int cellCount)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -63,18 +63,8 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
 
                 var lit = (segmentMask & (1 << segment.Index)) != 0;
                 drawingContext.PushTransform(cellTransform);
-                if (lit)
-                {
-                    drawingContext.PushOpacity(brightness);
-                }
-
-                drawingContext.DrawGeometry(lit ? LitBrush : UnlitBrush, SegmentPen, segment.Geometry);
-
-                if (lit)
-                {
-                    drawingContext.Pop();
-                }
-
+                var brush = lit ? ResolveLitBrush(brightness) : UnlitBrush;
+                drawingContext.DrawGeometry(brush, SegmentPen, segment.Geometry);
                 drawingContext.Pop();
             }
 
@@ -85,6 +75,41 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
                 drawingContext.Pop();
             }
         }
+    }
+
+
+    private Brush ResolveLitBrush(double brightness)
+    {
+        if (brightness >= 0.9999d)
+        {
+            return LitBrush;
+        }
+
+        if (brightness <= 0.0001d)
+        {
+            return UnlitBrush;
+        }
+
+        if (LitBrush is SolidColorBrush litSolid && UnlitBrush is SolidColorBrush unlitSolid)
+        {
+            var color = InterpolateColor(unlitSolid.Color, litSolid.Color, brightness);
+            var interpolated = new SolidColorBrush(color);
+            interpolated.Freeze();
+            return interpolated;
+        }
+
+        return LitBrush;
+    }
+
+    private static Color InterpolateColor(Color from, Color to, double t)
+    {
+        byte lerp(byte a, byte b) => (byte)Math.Clamp(Math.Round(a + ((b - a) * t)), 0d, 255d);
+
+        return Color.FromArgb(
+            lerp(from.A, to.A),
+            lerp(from.R, to.R),
+            lerp(from.G, to.G),
+            lerp(from.B, to.B));
     }
 
     protected abstract int GetSegmentMaskForChar(char c);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -21,6 +21,7 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
     public string? DisplayText { get; set; }
     public int[]? CellSegmentMasks { get; set; }
     public bool ShowDecimalPoint { get; set; }
+    public double[]? CellBrightness { get; set; }
 
     protected override void OnRender(DrawingContext drawingContext)
     {
@@ -51,6 +52,7 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
                     ? GetSegmentMaskForChar(DisplayText![i])
                     : 0;
             var cellTransform = new MatrixTransform(scale, 0, 0, scale, offsetX + (i * pitch * scale), offsetY);
+            var brightness = CellBrightness is not null && i < CellBrightness.Length ? Math.Clamp(CellBrightness[i], 0d, 1d) : 1d;
 
             foreach (var segment in _definition.Cell.Segments)
             {
@@ -61,7 +63,18 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
 
                 var lit = (segmentMask & (1 << segment.Index)) != 0;
                 drawingContext.PushTransform(cellTransform);
+                if (lit)
+                {
+                    drawingContext.PushOpacity(brightness);
+                }
+
                 drawingContext.DrawGeometry(lit ? LitBrush : UnlitBrush, SegmentPen, segment.Geometry);
+
+                if (lit)
+                {
+                    drawingContext.Pop();
+                }
+
                 drawingContext.Pop();
             }
 


### PR DESCRIPTION
### Motivation
- MAME emits `vfddutyN = XX` lines to set alpha (VFD) brightness which were being logged as unhandled output.  
- Different fruit machine platforms use different duty ranges, so normalization must be platform-aware and extensible for future platforms.

### Description
- Add `MameVfdDutyParser` which parses `vfddutyN = XX` using a regex and normalizes brightness using a per-platform `MaxVfdDutyByPlatform` map.  
- Initialize the map with `MPU4 => 31` and `Scorpion4 => 7` and fall back to `31` for unknown platforms to preserve safe behavior.  
- Update `MameStdoutParser` to hold a `MameVfdDutyParser` and a `Func<FruitMachinePlatformType>` `platformProvider`, and consume `vfdduty` lines (so they are no longer treated as unhandled).  
- Wire the `platformProvider` from `MainWindowViewModel` to use `SelectedFruitMachinePlatform`, and add unit tests: `MameVfdDutyParserTests` and a `MameStdoutParserTests` case ensuring `vfdduty` lines do not produce an unhandled diagnostic.

### Testing
- Added unit tests `MameVfdDutyParserTests` (MPU4, Scorpion4, fallback case) and a `MameStdoutParserTests` update to assert `vfdduty` is consumed.  
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --filter "MameStdoutParserTests|MameVfdDutyParserTests"` but the command failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a0fbb5a248327896297e071d49eb8)