### PR TITLE
Add initial Skia reel renderer with runtime offset tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -147,14 +147,6 @@ public sealed class Panel2DRendererTests
             PanelViewportTransform.Identity);
     }
 
-    [Fact]
-    public void SevenSegment_BuildSegments_ReturnsThreeHorizontalBands()
-    {
-        var segments = SevenSegmentElementRenderer.BuildSegments(new SKRect(0, 0, 20, 30), 2f, 3f);
-
-        Assert.Equal(3, segments.Count);
-        Assert.All(segments, segment => Assert.True(segment.Width > segment.Height));
-    }
     private sealed class FakeRenderer(PanelElementKind kind) : IPanelElementRenderer
     {
         public PanelElementKind Kind { get; } = kind;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -118,6 +118,43 @@ public sealed class Panel2DRendererTests
         Assert.Equal(expected, actual, 4);
     }
 
+
+    [Fact]
+    public void Render_WithSevenSegmentRenderer_DoesNotThrow()
+    {
+        var renderer = new Panel2DRenderer([new SevenSegmentElementRenderer()]);
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetSegmentCellMasksIfChanged("seg-1", [0x3F]);
+        runtimeState.SetSegmentCellBrightnessIfChanged("seg-1", [0.8d]);
+        using var surface = SKSurface.Create(new SKImageInfo(64, 64));
+
+        renderer.Render(
+            surface.Canvas,
+            [
+                new PanelElementModel
+                {
+                    Kind = PanelElementKind.SevenSegment,
+                    IsVisible = true,
+                    ObjectId = "seg-1",
+                    Name = "Seven",
+                    Width = 24,
+                    Height = 36,
+                    OnColorHex = "#FF4444",
+                    OffColorHex = "#220000"
+                }
+            ],
+            runtimeState,
+            PanelViewportTransform.Identity);
+    }
+
+    [Fact]
+    public void SevenSegment_BuildSegments_ReturnsThreeHorizontalBands()
+    {
+        var segments = SevenSegmentElementRenderer.BuildSegments(new SKRect(0, 0, 20, 30), 2f, 3f);
+
+        Assert.Equal(3, segments.Count);
+        Assert.All(segments, segment => Assert.True(segment.Width > segment.Height));
+    }
     private sealed class FakeRenderer(PanelElementKind kind) : IPanelElementRenderer
     {
         public PanelElementKind Kind { get; } = kind;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -80,6 +80,44 @@ public sealed class Panel2DRendererTests
             PanelViewportTransform.Identity);
     }
 
+    [Fact]
+    public void Render_WithReelRenderer_DoesNotThrow()
+    {
+        var renderer = new Panel2DRenderer([new ReelElementRenderer()]);
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetReelPositionIfChanged("reel-1", 31);
+        using var surface = SKSurface.Create(new SKImageInfo(64, 64));
+
+        renderer.Render(
+            surface.Canvas,
+            [
+                new PanelElementModel
+                {
+                    Kind = PanelElementKind.Reel,
+                    IsVisible = true,
+                    ObjectId = "reel-1",
+                    Name = "Reel",
+                    Width = 24,
+                    Height = 24,
+                    Stops = 16
+                }
+            ],
+            runtimeState,
+            PanelViewportTransform.Identity);
+    }
+
+    [Theory]
+    [InlineData(0, 12, 0d)]
+    [InlineData(96, 12, 0d)]
+    [InlineData(-1, 12, 95d / 96d)]
+    [InlineData(24, 12, 0.25d)]
+    public void ReelOffset_ComputesExpectedWrappedOffset(int position, int stops, double expected)
+    {
+        var actual = ReelElementRenderer.ComputeWrappedOffset(position, stops);
+
+        Assert.Equal(expected, actual, 4);
+    }
+
     private sealed class FakeRenderer(PanelElementKind kind) : IPanelElementRenderer
     {
         public PanelElementKind Kind { get; } = kind;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -32,7 +32,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             IsAntialias = true
         };
 
-        context.Canvas.DrawRoundRect(bounds, 4f, 4f, paint);
+        context.Canvas.DrawRect(bounds, paint);
 
         var displayText = element.DisplayText;
         if (string.IsNullOrWhiteSpace(displayText))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -1,0 +1,78 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class ReelElementRenderer : IPanelElementRenderer
+{
+    private const double LegacyReelPositionsPerRevolution = 96d;
+
+    public PanelElementKind Kind => PanelElementKind.Reel;
+
+    public void Render(in PanelElementRenderContext context, PanelElementModel element)
+    {
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        var stops = Math.Max(1, element.Stops.GetValueOrDefault(1));
+        var reelPosition = context.RuntimeState.GetReelPosition(element.ObjectId);
+        var wrappedOffset = ComputeWrappedOffset(reelPosition, stops);
+
+        using var borderPaint = new SKPaint { Color = new SKColor(45, 45, 45), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        using var clipPath = new SKPath();
+        clipPath.AddRect(bounds);
+
+        context.Canvas.Save();
+        context.Canvas.ClipPath(clipPath);
+
+        var cellHeight = bounds.Height;
+        DrawStrip(context.Canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight), bounds.Width, cellHeight, stops);
+        DrawStrip(context.Canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight) + cellHeight, bounds.Width, cellHeight, stops);
+
+        context.Canvas.Restore();
+        context.Canvas.DrawRect(bounds, borderPaint);
+    }
+
+    internal static double ComputeWrappedOffset(int position, int stops)
+    {
+        var safeStops = Math.Max(1, stops);
+        var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, safeStops);
+        var raw = ((position % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
+        return raw / positionsPerRevolution;
+    }
+
+    private static void DrawStrip(SKCanvas canvas, float left, float top, float width, float height, int stops)
+    {
+        var safeStops = Math.Max(1, stops);
+        var stopHeight = height / safeStops;
+
+        for (var index = 0; index < safeStops; index++)
+        {
+            var y = top + (index * stopHeight);
+            var t = safeStops == 1 ? 0d : index / (double)(safeStops - 1);
+            var baseColor = Lerp(new SKColor(36, 36, 36), new SKColor(180, 180, 180), t);
+
+            using var fill = new SKPaint { Color = baseColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+            using var label = new SKPaint { Color = SKColors.White, IsAntialias = true, TextSize = Math.Max(10f, stopHeight * 0.35f) };
+
+            var rect = SKRect.Create(left, y, width, stopHeight);
+            canvas.DrawRect(rect, fill);
+
+            var text = index.ToString();
+            var textBounds = new SKRect();
+            label.MeasureText(text, ref textBounds);
+            var textX = left + (width * 0.5f) - (textBounds.MidX);
+            var textY = y + (stopHeight * 0.5f) - textBounds.MidY;
+            canvas.DrawText(text, textX, textY, label);
+        }
+    }
+
+    private static SKColor Lerp(SKColor from, SKColor to, double t)
+    {
+        var clamped = Math.Clamp(t, 0d, 1d);
+        byte Blend(byte a, byte b) => (byte)Math.Clamp(Math.Round(a + ((b - a) * clamped)), 0d, 255d);
+        return new SKColor(Blend(from.Red, to.Red), Blend(from.Green, to.Green), Blend(from.Blue, to.Blue), 255);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -1,9 +1,13 @@
+using System.IO;
+using System.Text.Json;
 using SkiaSharp;
 
 namespace OasisEditor.Rendering;
 
 internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
 {
+    private static readonly Lazy<SevenSegmentSkiaDefinition?> Definition = new(LoadDefinition);
+
     public PanelElementKind Kind => PanelElementKind.SevenSegment;
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -14,48 +18,77 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
             return;
         }
 
-        using var background = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var border = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
-        context.Canvas.DrawRoundRect(bounds, 3f, 3f, background);
-        context.Canvas.DrawRoundRect(bounds, 3f, 3f, border);
+        var definition = Definition.Value;
+        if (definition is null)
+        {
+            return;
+        }
 
         var masks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 1);
         var brightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 1);
-        var isLit = masks.Length > 0 && masks[0] != 0;
+        var segmentMask = masks.Length > 0 ? masks[0] : 0;
         var litAmount = brightness.Length > 0 ? Math.Clamp(brightness[0], 0d, 1d) : 1d;
 
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
-        var segColor = isLit ? Lerp(offColor, onColor, litAmount) : offColor;
+        using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
 
-        var thickness = MathF.Max(2f, bounds.Height * 0.12f);
-        var pad = thickness * 0.8f;
-        using var segmentPaint = new SKPaint { Color = segColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+        var scale = Math.Min(bounds.Width / definition.Width, bounds.Height / definition.Height);
+        var offsetX = bounds.Left + ((bounds.Width - (definition.Width * scale)) * 0.5f);
+        var offsetY = bounds.Top + ((bounds.Height - (definition.Height * scale)) * 0.5f);
 
-        foreach (var segment in BuildSegments(bounds, pad, thickness))
+        context.Canvas.Save();
+        context.Canvas.Translate(offsetX, offsetY);
+        context.Canvas.Scale(scale, scale);
+
+        foreach (var segment in definition.Segments)
         {
-            context.Canvas.DrawRoundRect(segment, thickness * 0.4f, thickness * 0.4f, segmentPaint);
+            var lit = (segmentMask & (1 << segment.Index)) != 0;
+            paint.Color = lit ? Lerp(offColor, onColor, litAmount) : offColor;
+            context.Canvas.DrawPath(segment.Path, paint);
         }
+
+        if (definition.DecimalPoint is not null)
+        {
+            paint.Color = offColor;
+            context.Canvas.DrawPath(definition.DecimalPoint, paint);
+        }
+
+        context.Canvas.Restore();
     }
 
-    internal static IReadOnlyList<SKRect> BuildSegments(SKRect bounds, float padding, float thickness)
+    private static SevenSegmentSkiaDefinition? LoadDefinition()
     {
-        var left = bounds.Left + padding;
-        var right = bounds.Right - padding;
-        var top = bounds.Top + padding;
-        var bottom = bounds.Bottom - padding;
-        var mid = (top + bottom) * 0.5f;
-        var span = right - left;
-        var half = MathF.Max(1f, (span * 0.5f) - (thickness * 0.5f));
+        var path = Path.Combine(AppContext.BaseDirectory, "Assets", "SegmentDisplays", "oasis_7_segment_display_definition.json");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
 
-        var cx = (left + right) * 0.5f;
+        var json = File.ReadAllText(path);
+        var root = JsonSerializer.Deserialize<SevenSegmentDefinitionRoot>(json);
+        var cell = root?.Cell;
+        if (cell?.Size is null || cell.Segments is null || cell.Segments.Count != 7)
+        {
+            return null;
+        }
 
-        return
-        [
-            SKRect.Create(cx - half, top, half * 2f, thickness),
-            SKRect.Create(cx - half, mid - (thickness * 0.5f), half * 2f, thickness),
-            SKRect.Create(cx - half, bottom - thickness, half * 2f, thickness)
-        ];
+        var paths = new List<SevenSegmentSkiaPath>(cell.Segments.Count);
+        foreach (var segment in cell.Segments)
+        {
+            if (string.IsNullOrWhiteSpace(segment.PathData))
+            {
+                return null;
+            }
+
+            paths.Add(new SevenSegmentSkiaPath(segment.Index, SKPath.ParseSvgPathData(segment.PathData)));
+        }
+
+        var decimalPath = string.IsNullOrWhiteSpace(cell.DecimalPoint?.PathData)
+            ? null
+            : SKPath.ParseSvgPathData(cell.DecimalPoint.PathData);
+
+        return new SevenSegmentSkiaDefinition((float)cell.Size.Width, (float)cell.Size.Height, paths, decimalPath);
     }
 
     private static SKColor Lerp(SKColor from, SKColor to, double t)
@@ -63,5 +96,37 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
         var clamped = Math.Clamp(t, 0d, 1d);
         byte Blend(byte a, byte b) => (byte)Math.Clamp(Math.Round(a + ((b - a) * clamped)), 0d, 255d);
         return new SKColor(Blend(from.Red, to.Red), Blend(from.Green, to.Green), Blend(from.Blue, to.Blue), 255);
+    }
+
+    private sealed record SevenSegmentSkiaDefinition(float Width, float Height, IReadOnlyList<SevenSegmentSkiaPath> Segments, SKPath? DecimalPoint);
+    private sealed record SevenSegmentSkiaPath(int Index, SKPath Path);
+
+    private sealed class SevenSegmentDefinitionRoot
+    {
+        public SevenSegmentCell? Cell { get; set; }
+    }
+
+    private sealed class SevenSegmentCell
+    {
+        public SevenSegmentSize? Size { get; set; }
+        public List<SevenSegmentPath>? Segments { get; set; }
+        public SevenSegmentDecimalPoint? DecimalPoint { get; set; }
+    }
+
+    private sealed class SevenSegmentSize
+    {
+        public double Width { get; set; }
+        public double Height { get; set; }
+    }
+
+    private sealed class SevenSegmentPath
+    {
+        public int Index { get; set; }
+        public string? PathData { get; set; }
+    }
+
+    private sealed class SevenSegmentDecimalPoint
+    {
+        public string? PathData { get; set; }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -31,11 +31,25 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
 
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
+
+        using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
+
+        var marginX = bounds.Width * 0.1f;
+        var marginY = bounds.Height * 0.1f;
+        var contentBounds = SKRect.Create(
+            bounds.Left + marginX,
+            bounds.Top + marginY,
+            Math.Max(1f, bounds.Width - (marginX * 2f)),
+            Math.Max(1f, bounds.Height - (marginY * 2f)));
+
         using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
 
-        var scale = Math.Min(bounds.Width / definition.Width, bounds.Height / definition.Height);
-        var offsetX = bounds.Left + ((bounds.Width - (definition.Width * scale)) * 0.5f);
-        var offsetY = bounds.Top + ((bounds.Height - (definition.Height * scale)) * 0.5f);
+        var scale = Math.Min(contentBounds.Width / definition.Width, contentBounds.Height / definition.Height);
+        var offsetX = contentBounds.Left + ((contentBounds.Width - (definition.Width * scale)) * 0.5f);
+        var offsetY = contentBounds.Top + ((contentBounds.Height - (definition.Height * scale)) * 0.5f);
 
         context.Canvas.Save();
         context.Canvas.Translate(offsetX, offsetY);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -1,0 +1,67 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
+{
+    public PanelElementKind Kind => PanelElementKind.SevenSegment;
+
+    public void Render(in PanelElementRenderContext context, PanelElementModel element)
+    {
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        using var background = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var border = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        context.Canvas.DrawRoundRect(bounds, 3f, 3f, background);
+        context.Canvas.DrawRoundRect(bounds, 3f, 3f, border);
+
+        var masks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 1);
+        var brightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 1);
+        var isLit = masks.Length > 0 && masks[0] != 0;
+        var litAmount = brightness.Length > 0 ? Math.Clamp(brightness[0], 0d, 1d) : 1d;
+
+        var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
+        var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
+        var segColor = isLit ? Lerp(offColor, onColor, litAmount) : offColor;
+
+        var thickness = MathF.Max(2f, bounds.Height * 0.12f);
+        var pad = thickness * 0.8f;
+        using var segmentPaint = new SKPaint { Color = segColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+
+        foreach (var segment in BuildSegments(bounds, pad, thickness))
+        {
+            context.Canvas.DrawRoundRect(segment, thickness * 0.4f, thickness * 0.4f, segmentPaint);
+        }
+    }
+
+    internal static IReadOnlyList<SKRect> BuildSegments(SKRect bounds, float padding, float thickness)
+    {
+        var left = bounds.Left + padding;
+        var right = bounds.Right - padding;
+        var top = bounds.Top + padding;
+        var bottom = bounds.Bottom - padding;
+        var mid = (top + bottom) * 0.5f;
+        var span = right - left;
+        var half = MathF.Max(1f, (span * 0.5f) - (thickness * 0.5f));
+
+        var cx = (left + right) * 0.5f;
+
+        return
+        [
+            SKRect.Create(cx - half, top, half * 2f, thickness),
+            SKRect.Create(cx - half, mid - (thickness * 0.5f), half * 2f, thickness),
+            SKRect.Create(cx - half, bottom - thickness, half * 2f, thickness)
+        ];
+    }
+
+    private static SKColor Lerp(SKColor from, SKColor to, double t)
+    {
+        var clamped = Math.Clamp(t, 0d, 1d);
+        byte Blend(byte a, byte b) => (byte)Math.Clamp(Math.Round(a + ((b - a) * clamped)), 0d, 255d);
+        return new SKColor(Blend(from.Red, to.Red), Blend(from.Green, to.Green), Blend(from.Blue, to.Blue), 255);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -66,7 +66,10 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
         }
 
         var json = File.ReadAllText(path);
-        var root = JsonSerializer.Deserialize<SevenSegmentDefinitionRoot>(json);
+        var root = JsonSerializer.Deserialize<SevenSegmentDefinitionRoot>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
         var cell = root?.Cell;
         if (cell?.Size is null || cell.Segments is null || cell.Segments.Count != 7)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -105,8 +105,21 @@ public partial class PlayView : UserControl
         canvas.Restore();
     }
 
-    private void OnPlaySkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)
+    private async void OnPlaySkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
+        EnsurePlayViewFocused();
+
+        if (eventArgs.ChangedButton == MouseButton.Left)
+        {
+            if (ViewModel is not null && TryResolveSkiaVisualElementId(eventArgs.GetPosition(PlaySkiaSurface), out var visualElementId))
+            {
+                await ViewModel.TryHandlePlayViewPointerDownAsync(visualElementId, isFocused: true, CancellationToken.None);
+                eventArgs.Handled = true;
+            }
+
+            return;
+        }
+
         if (eventArgs.ChangedButton != MouseButton.Middle)
         {
             return;
@@ -121,19 +134,32 @@ public partial class PlayView : UserControl
 
     private void OnPlaySkiaSurfaceMouseMove(object sender, MouseEventArgs eventArgs)
     {
+        var current = eventArgs.GetPosition(PlaySkiaSurface);
+        var isClickable = TryResolveSkiaVisualElementId(current, out _);
+        PlaySkiaSurface.Cursor = isClickable ? Cursors.Hand : Cursors.Arrow;
+
         if (!_isSkiaPanning)
         {
             return;
         }
-
-        var current = eventArgs.GetPosition(PlaySkiaSurface);
         var delta = current - _skiaPanStart;
         _skiaPan = _skiaPanOrigin + (Vector)delta;
         PlaySkiaSurface.InvalidateVisual();
     }
 
-    private void OnPlaySkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
+    private async void OnPlaySkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
     {
+        if (eventArgs.ChangedButton == MouseButton.Left)
+        {
+            if (ViewModel is not null && TryResolveSkiaVisualElementId(eventArgs.GetPosition(PlaySkiaSurface), out var visualElementId))
+            {
+                await ViewModel.TryHandlePlayViewPointerUpAsync(visualElementId, isFocused: true, CancellationToken.None);
+                eventArgs.Handled = true;
+            }
+
+            return;
+        }
+
         if (eventArgs.ChangedButton != MouseButton.Middle)
         {
             return;
@@ -197,12 +223,12 @@ public partial class PlayView : UserControl
 
     private void OnPlayCanvasPreviewMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
-        EnsurePlayCanvasFocused();
+        EnsurePlayViewFocused();
     }
 
     private void OnRootPreviewMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
-        EnsurePlayCanvasFocused();
+        EnsurePlayViewFocused();
     }
 
     private async void OnPlayCanvasPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs eventArgs)
@@ -283,6 +309,51 @@ public partial class PlayView : UserControl
         return false;
     }
 
+
+    private bool TryResolveSkiaVisualElementId(Point screenPoint, out Guid visualElementId)
+    {
+        var selected = ViewModel?.SelectedDocument;
+        if (selected is null)
+        {
+            visualElementId = Guid.Empty;
+            return false;
+        }
+
+        var clickableObjectIds = new HashSet<Guid>(
+            (ViewModel?.InputDefinitions ?? [])
+                .Where(input => input.LinkedVisualElementId.HasValue)
+                .Select(input => input.LinkedVisualElementId!.Value));
+
+        if (clickableObjectIds.Count == 0)
+        {
+            visualElementId = Guid.Empty;
+            return false;
+        }
+
+        var viewport = new PanelViewportTransform(_skiaZoom, _skiaPan.X, _skiaPan.Y);
+        var documentPoint = viewport.ScreenToDocument(screenPoint);
+
+        foreach (var element in selected.GetPanelElements().Reverse())
+        {
+            if (!element.IsVisible || !Guid.TryParse(element.ObjectId, out var elementId) || !clickableObjectIds.Contains(elementId))
+            {
+                continue;
+            }
+
+            if (documentPoint.X >= element.X
+                && documentPoint.X <= element.X + element.Width
+                && documentPoint.Y >= element.Y
+                && documentPoint.Y <= element.Y + element.Height)
+            {
+                visualElementId = elementId;
+                return true;
+            }
+        }
+
+        visualElementId = Guid.Empty;
+        return false;
+    }
+
     private void UpdateSelectedDocumentSubscription(DocumentTabViewModel? selected)
     {
         if (ReferenceEquals(_subscribedDocument, selected))
@@ -325,30 +396,11 @@ public partial class PlayView : UserControl
         }
     }
 
-    private void ApplyClickableCursorHints(DocumentTabViewModel selectedDocument)
+    private void EnsurePlayViewFocused()
     {
-        var clickableObjectIds = new HashSet<Guid>(
-            (ViewModel?.InputDefinitions ?? [])
-                .Where(input => input.LinkedVisualElementId.HasValue)
-                .Select(input => input.LinkedVisualElementId!.Value));
-
-        foreach (var visual in PlayCanvas.Children.OfType<FrameworkElement>())
+        if (!IsKeyboardFocusWithin)
         {
-            var uid = visual.Uid?.Trim();
-            var isClickable = !string.IsNullOrWhiteSpace(uid)
-                && Guid.TryParse(uid, out var visualId)
-                && clickableObjectIds.Contains(visualId);
-            visual.Cursor = isClickable
-                ? Cursors.Hand
-                : Cursors.Arrow;
-        }
-    }
-
-    private void EnsurePlayCanvasFocused()
-    {
-        if (!PlayCanvas.IsKeyboardFocusWithin)
-        {
-            Keyboard.Focus(PlayCanvas);
+            Keyboard.Focus(this);
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -23,7 +23,7 @@ public partial class PlayView : UserControl
     private bool _isSkiaPanning;
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer()]);
+    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer()]);
 
     public PlayView()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -23,7 +23,7 @@ public partial class PlayView : UserControl
     private bool _isSkiaPanning;
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer()]);
+    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer()]);
 
     public PlayView()
     {


### PR DESCRIPTION
### Motivation
- Progress the Skia runtime renderer Step 4/5 by adding basic reel rendering so Play View can draw reels with the shared Skia renderer instead of per-WPF visuals.
- Provide a deterministic, testable mapping from runtime reel position to normalized strip offset to support future asset-parity improvements and to reduce WPF update overhead. 

### Description
- Add `ReelElementRenderer` implementing `IPanelElementRenderer` that computes a wrapped normalized offset from runtime reel position and renders a placeholder reel strip (gradient cells + labels) using Skia drawing primitives【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs†L5-L78】.
- Wire the new reel renderer into the Play View renderer dispatch so the `Panel2DRenderer` now includes Background, Lamp, and Reel renderers in the Skia dispatch list【F:WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs†L26-L27】.
- Extend unit tests in `Panel2DRendererTests` with a no-throw reel-render dispatch test and a `ComputeWrappedOffset` theory asserting normalized offset behavior for several edge cases【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs†L83-L119】.
- Keep the change focused and incremental (placeholder reel parity only); no edit-view migration or input-routing changes were introduced. 

### Testing
- ✅ Ran repository status inspection locally with `git -C /workspace/Oasis status --short --branch` to confirm staged/committed changes and branch `skia-reel-slice` was created and committed. 
- ⚠️ Did not run `dotnet test` in this environment due to the toolchain restriction; run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` locally to execute the new `Panel2DRendererTests` (added tests include `Render_WithReelRenderer_DoesNotThrow` and `ReelOffset_ComputesExpectedWrappedOffset`).
- ⚠️ Per project AGENT constraints, no WPF build/test was executed here; please run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.csproj` and then `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` on a Windows machine with the proper toolchain to validate the changes (see agent constraint note)【F:WindowsNetProjects/OasisEditor/AGENT.md†L14-L18】.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b67885830832781dd3e1fa46d5be5)