### PR TITLE
Skia PlayView: improve lamp text sizing, baseline alignment and deterministic bounds

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
@@ -55,4 +55,28 @@ public sealed class LampElementRendererTests
             line => Assert.Equal("BIFF THE", line.Text),
             line => Assert.Equal("BOUNCER", line.Text));
     }
+
+    [Fact]
+    public void GetEffectiveWrapWidth_AllowsSingleLineWhenItFitsLampBounds()
+    {
+        using var paint = new SKPaint { TextSize = 16f, Typeface = SKTypeface.FromFamilyName("Tahoma") ?? SKTypeface.Default };
+        var text = "TO ACTIVATE PICKS";
+        var measured = paint.MeasureText(text);
+
+        var wrapWidth = LampElementRenderer.GetEffectiveWrapWidth(text, insetWidth: measured - 2d, lampWidth: measured, paint);
+
+        Assert.True(wrapWidth >= measured);
+    }
+
+    [Fact]
+    public void GetEffectiveWrapWidth_UsesInsetWidthWhenSingleLineDoesNotFit()
+    {
+        using var paint = new SKPaint { TextSize = 16f, Typeface = SKTypeface.FromFamilyName("Tahoma") ?? SKTypeface.Default };
+        var text = "TO ACTIVATE PICKS";
+        var measured = paint.MeasureText(text);
+
+        var wrapWidth = LampElementRenderer.GetEffectiveWrapWidth(text, insetWidth: measured - 20d, lampWidth: measured - 20d, paint);
+
+        Assert.True(wrapWidth < measured);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
@@ -37,4 +37,22 @@ public sealed class LampElementRendererTests
         Assert.True(textBounds.Width >= 1f);
         Assert.True(textBounds.Height >= 1f);
     }
+
+    [Fact]
+    public void WrapTextToPixelWidth_KeepsMfmeLikeWordWrapping()
+    {
+        using var paint = new SKPaint
+        {
+            TextSize = 16f,
+            Typeface = SKTypeface.FromFamilyName("Tahoma") ?? SKTypeface.Default,
+            IsAntialias = true
+        };
+
+        var targetWidth = paint.MeasureText("BIFF THE") + 0.5f;
+        var lines = LampElementRenderer.WrapTextToPixelWidth("BIFF THE BOUNCER", targetWidth, paint);
+
+        Assert.Collection(lines,
+            line => Assert.Equal("BIFF THE", line.Text),
+            line => Assert.Equal("BOUNCER", line.Text));
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
@@ -1,0 +1,40 @@
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class LampElementRendererTests
+{
+    [Fact]
+    public void ParseFontSize_ValidAndFallbackValues_AreDeterministic()
+    {
+        Assert.Equal(16d, LampElementRenderer.ParseFontSize("12"), 3);
+        Assert.Equal(10.66666664d, LampElementRenderer.ParseFontSize(null), 6);
+        Assert.Equal(10.66666664d, LampElementRenderer.ParseFontSize("bad"), 6);
+    }
+
+    [Fact]
+    public void GetTextBounds_AppliesInsetAndClampsSize()
+    {
+        var bounds = SKRect.Create(10f, 20f, 100f, 50f);
+
+        var textBounds = LampElementRenderer.GetTextBounds(bounds);
+
+        Assert.Equal(18f, textBounds.Left, 3);
+        Assert.Equal(25f, textBounds.Top, 3);
+        Assert.Equal(84f, textBounds.Width, 3);
+        Assert.Equal(40f, textBounds.Height, 3);
+    }
+
+    [Fact]
+    public void GetTextBounds_WithTinyLamp_DoesNotReturnNonPositiveDimensions()
+    {
+        var bounds = SKRect.Create(0f, 0f, 0.2f, 0.2f);
+
+        var textBounds = LampElementRenderer.GetTextBounds(bounds);
+
+        Assert.True(textBounds.Width >= 1f);
+        Assert.True(textBounds.Height >= 1f);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -41,6 +41,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         }
 
         var fontSize = ParseFontSize(element.TextBoxFontSize);
+        var textBounds = GetTextBounds(bounds);
         using var textPaint = new SKPaint
         {
             Color = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White),
@@ -49,11 +50,14 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             Typeface = ResolveTypeface(element.TextBoxFontName, element.TextBoxFontStyle)
         };
 
-        var charWidth = Math.Max(1d, fontSize * 0.55d);
-        var lineHeight = Math.Max(1d, fontSize * 1.2d);
+        var fontMetrics = textPaint.FontMetrics;
+        var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
+        var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
+        var measuredCharWidth = textPaint.MeasureText("0");
+        var charWidth = Math.Max(1d, measuredCharWidth > 0f ? measuredCharWidth : fontSize * 0.55d);
         var layout = RuntimeTextLayout.Layout(
             displayText,
-            bounds.Width,
+            textBounds.Width,
             charWidth,
             lineHeight,
             RuntimeTextHorizontalAlignment.Center);
@@ -64,7 +68,10 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         }
 
         var totalTextHeight = layout.Lines.Count * lineHeight;
-        var startY = bounds.Top + ((bounds.Height - totalTextHeight) / 2d) + fontSize;
+        var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f
+            ? Math.Abs(fontMetrics.Ascent)
+            : fontSize;
+        var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
         foreach (var line in layout.Lines)
         {
             if (string.IsNullOrEmpty(line.Text))
@@ -72,13 +79,22 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
                 continue;
             }
 
-            var x = bounds.Left + line.X;
+            var x = textBounds.Left + line.X;
             var y = startY + line.Y;
             context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
         }
     }
 
-    private static double ParseFontSize(string? value)
+    internal static SKRect GetTextBounds(in SKRect lampBounds)
+    {
+        var horizontalInset = Math.Min(lampBounds.Width * 0.1f, 8f);
+        var verticalInset = Math.Min(lampBounds.Height * 0.1f, 6f);
+        var width = Math.Max(1f, lampBounds.Width - (horizontalInset * 2f));
+        var height = Math.Max(1f, lampBounds.Height - (verticalInset * 2f));
+        return SKRect.Create(lampBounds.Left + horizontalInset, lampBounds.Top + verticalInset, width, height);
+    }
+
+    internal static double ParseFontSize(string? value)
     {
         if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) && parsed > 0d)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -53,7 +53,8 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         var fontMetrics = textPaint.FontMetrics;
         var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
         var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
-        var lines = WrapTextToPixelWidth(displayText, textBounds.Width, textPaint);
+        var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
+        var lines = WrapTextToPixelWidth(displayText, wrapWidth, textPaint);
         if (lines.Count == 0)
         {
             return;
@@ -101,6 +102,20 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         }
 
         return lines;
+    }
+
+    internal static double GetEffectiveWrapWidth(string text, double insetWidth, double lampWidth, SKPaint paint)
+    {
+        var epsilon = 1.5d;
+        var fullWidth = Math.Max(insetWidth, lampWidth);
+        var singleLineWidth = paint.MeasureText(text ?? string.Empty);
+
+        if (singleLineWidth <= fullWidth + epsilon)
+        {
+            return fullWidth + epsilon;
+        }
+
+        return insetWidth + epsilon;
     }
 
     private static List<PixelTextLine> WrapParagraphToPixelWidth(string paragraph, double maxWidth, SKPaint paint)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -53,36 +53,95 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         var fontMetrics = textPaint.FontMetrics;
         var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
         var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
-        var measuredCharWidth = textPaint.MeasureText("0");
-        var charWidth = Math.Max(1d, measuredCharWidth > 0f ? measuredCharWidth : fontSize * 0.55d);
-        var layout = RuntimeTextLayout.Layout(
-            displayText,
-            textBounds.Width,
-            charWidth,
-            lineHeight,
-            RuntimeTextHorizontalAlignment.Center);
-
-        if (layout.Lines.Count == 0)
+        var lines = WrapTextToPixelWidth(displayText, textBounds.Width, textPaint);
+        if (lines.Count == 0)
         {
             return;
         }
 
-        var totalTextHeight = layout.Lines.Count * lineHeight;
+        var totalTextHeight = lines.Count * lineHeight;
         var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f
             ? Math.Abs(fontMetrics.Ascent)
             : fontSize;
         var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
-        foreach (var line in layout.Lines)
+        for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
         {
+            var line = lines[lineIndex];
             if (string.IsNullOrEmpty(line.Text))
             {
                 continue;
             }
 
-            var x = textBounds.Left + line.X;
-            var y = startY + line.Y;
+            var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
+            var y = startY + (lineIndex * lineHeight);
             context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
         }
+    }
+
+    internal static List<PixelTextLine> WrapTextToPixelWidth(string text, double maxWidth, SKPaint paint)
+    {
+        if (maxWidth <= 0d)
+        {
+            return [];
+        }
+
+        var normalized = text.Replace("\r\n", "\n");
+        var paragraphs = normalized.Split('\n');
+        var lines = new List<PixelTextLine>();
+        foreach (var paragraph in paragraphs)
+        {
+            var wrapped = WrapParagraphToPixelWidth(paragraph, maxWidth, paint);
+            if (wrapped.Count == 0)
+            {
+                lines.Add(new PixelTextLine(string.Empty, 0f));
+                continue;
+            }
+
+            lines.AddRange(wrapped);
+        }
+
+        return lines;
+    }
+
+    private static List<PixelTextLine> WrapParagraphToPixelWidth(string paragraph, double maxWidth, SKPaint paint)
+    {
+        if (string.IsNullOrEmpty(paragraph))
+        {
+            return [];
+        }
+
+        var words = paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+        {
+            return [];
+        }
+
+        var lines = new List<PixelTextLine>();
+        var current = string.Empty;
+        var currentWidth = 0f;
+
+        foreach (var word in words)
+        {
+            var candidate = string.IsNullOrEmpty(current) ? word : $"{current} {word}";
+            var candidateWidth = paint.MeasureText(candidate);
+            if (candidateWidth <= maxWidth || string.IsNullOrEmpty(current))
+            {
+                current = candidate;
+                currentWidth = candidateWidth;
+                continue;
+            }
+
+            lines.Add(new PixelTextLine(current, currentWidth));
+            current = word;
+            currentWidth = paint.MeasureText(word);
+        }
+
+        if (!string.IsNullOrEmpty(current))
+        {
+            lines.Add(new PixelTextLine(current, currentWidth));
+        }
+
+        return lines;
     }
 
     internal static SKRect GetTextBounds(in SKRect lampBounds)
@@ -103,6 +162,8 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
 
         return 10.66666664d;
     }
+
+    internal readonly record struct PixelTextLine(string Text, float Width);
 
     private static SKTypeface ResolveTypeface(string? fontName, string? fontStyle)
     {


### PR DESCRIPTION
### Motivation
- Improve visual parity of text-based lamps in the Skia Play View by using real font metrics and measured glyph widths instead of only fixed heuristics, while preserving deterministic fallbacks when OS/MFME font assets are missing. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L43-L75】【F:WindowsNetProjects/OasisEditor/AGENT.md†L1-L20】
- Ensure text remains stable under pan/zoom and runtime brightness changes and avoid any changes to reel behavior or input routing in this slice. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L28-L36】

### Description
- Measure font metrics and character width in `LampElementRenderer` and compute `lineHeight` and `charWidth` from `SKPaint.FontMetrics` / `MeasureText` where available to drive `RuntimeTextLayout`. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L51-L58】
- Add baseline-aware vertical centering and render text inside an inset inner rect returned by `GetTextBounds` so lamp text aligns and fits more like legacy layouts. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L70-L75】【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L88-L95】
- Expose deterministic helpers as `internal` (`ParseFontSize`, `GetTextBounds`) and add unit tests exercising font-size parsing and text-bounds inset/clamping edge cases. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L97-L105】【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs†L7-L40】

### Testing
- ✅ Repository inspection and context commands executed: `pwd && rg --files -g 'AGENTS.md' -g 'AGENT.md'` and combined `sed` reads of priority/plan/inventory/agent docs to collect direction and constraints. 【F:WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md†L1-L40】【F:WindowsNetProjects/OasisEditor/SKIA_RUNTIME_RENDERER_PLAN.md†L1-L40】【F:WindowsNetProjects/OasisEditor/SKIA_RUNTIME_RENDERER_INVENTORY.md†L1-L40】【F:WindowsNetProjects/OasisEditor/AGENT.md†L1-L20】
- ✅ Local repository operations performed in this environment (branch creation, staged changes and commit): `git checkout -b skia-lamp-text-parity-step5` and commit of the change; unit tests were added but not executed here. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L1-L20】【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs†L1-L20】
- ⚠️ Automated test execution was NOT run in this environment per project constraints; run locally with: `dotnet test` or to run only the new tests use `dotnet test --filter LampElementRendererTests`. 【F:WindowsNetProjects/OasisEditor/AGENT.md†L12-L18】

Manual verification checklist for John (visual/runtime checks)
- Verify Play View text-lamp sizing/centering across small/medium/large lamp rects and compare to legacy/WPF visuals. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L43-L75】
- Pan/zoom and exercise runtime brightness changes to confirm text stability (no drift/jitter) and deterministic fallback when `MfmeFonts` are absent. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs†L125-L141】【F:WindowsNetProjects/OasisEditor/AGENT.md†L12-L18]
- Confirm reel behavior and input routing remain unchanged in Play View after this change. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs†L1-L10】

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b800c21bc8327a54ab779dac1196c)