### PR TITLE
Add Skia renderer diagnostics with throttled Output Log reporting

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -19,6 +19,7 @@ namespace OasisEditor;
 
 public sealed class MainWindowViewModel : INotifyPropertyChanged
 {
+    private const bool EnableSkiaRendererDiagnostics = true;
     private readonly RecentProjectsStore _recentProjectsStore = new();
     private readonly IApplicationThemeService _applicationThemeService;
     private readonly EditorPreferencesStore _preferencesStore;
@@ -128,8 +129,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
-        SkiaRenderDiagnostics.IsEnabled = true;
-        SkiaRenderDiagnostics.ReportReady += message => AddOutputEntry(message, OutputLogStatus.Info);
+        SkiaRenderDiagnostics.IsEnabled = EnableSkiaRendererDiagnostics;
+        if (EnableSkiaRendererDiagnostics)
+        {
+            SkiaRenderDiagnostics.ReportReady += message => AddOutputEntry(message, OutputLogStatus.Info);
+        }
         _activeDocumentContext = new ActiveDocumentContextService();
         _panelRuntimeStates = new PanelRuntimeStateStore();
         _assetBrowser = new AssetBrowserViewModel(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ using Microsoft.Win32;
 using OasisEditor.Features.MfmeImport;
 using EditorCommands = OasisEditor.Commands;
 using OasisEditor.Views;
+using OasisEditor.Rendering;
 
 namespace OasisEditor;
 
@@ -127,6 +128,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
+        SkiaRenderDiagnostics.IsEnabled = true;
+        SkiaRenderDiagnostics.ReportReady += message => AddOutputEntry(message, OutputLogStatus.Info);
         _activeDocumentContext = new ActiveDocumentContextService();
         _panelRuntimeStates = new PanelRuntimeStateStore();
         _assetBrowser = new AssetBrowserViewModel(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -44,17 +44,44 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
 
+        using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
+
+        var marginX = bounds.Width * 0.05f;
+        var marginY = bounds.Height * 0.1f;
+        var contentBounds = SKRect.Create(
+            bounds.Left + marginX,
+            bounds.Top + marginY,
+            Math.Max(1f, bounds.Width - (marginX * 2f)),
+            Math.Max(1f, bounds.Height - (marginY * 2f)));
+
         var cellCount = Math.Max(1, Math.Max(cellMasks.Length, cellBrightness.Length));
-        var width = Math.Max(1, (int)Math.Round(bounds.Width));
-        var height = Math.Max(1, (int)Math.Round(bounds.Height));
-        var masksHash = ComputeHash(cellMasks, cellCount);
-        var brightnessHash = ComputeBrightnessHash(cellBrightness, cellCount);
-        var key = new AlphaVisualCacheKey(width, height, cellCount, masksHash, brightnessHash, onColor, offColor);
-        var visual = GetOrCreateVisual(key, definition, cellMasks, cellBrightness);
-        context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
+        var pitch = definition.RecommendedPitch > 0f ? definition.RecommendedPitch : definition.Width;
+        var totalWidth = (pitch * cellCount) - Math.Max(0f, pitch - definition.Width);
+        var scale = Math.Min(contentBounds.Height / definition.Height, contentBounds.Width / Math.Max(1f, totalWidth));
+        var scaledPitch = pitch * scale;
+        var scaledCellWidth = definition.Width * scale;
+        var scaledCellHeight = definition.Height * scale;
+        var originX = contentBounds.Left + ((contentBounds.Width - ((scaledPitch * cellCount) - Math.Max(0f, scaledPitch - scaledCellWidth))) * 0.5f);
+        var originY = contentBounds.Top + ((contentBounds.Height - scaledCellHeight) * 0.5f);
+        var cellPixelWidth = Math.Max(1, (int)Math.Round(scaledCellWidth));
+        var cellPixelHeight = Math.Max(1, (int)Math.Round(scaledCellHeight));
+
+        for (var cellIndex = 0; cellIndex < cellCount; cellIndex++)
+        {
+            var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
+            var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
+            var brightnessBucket = (int)Math.Round(litAmount * 4d);
+            var key = new AlphaVisualCacheKey(cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor);
+            var visual = GetOrCreateVisual(key, definition);
+            var cellRect = SKRect.Create(originX + (cellIndex * scaledPitch), originY, scaledCellWidth, scaledCellHeight);
+            context.Canvas.DrawImage(visual, cellRect);
+        }
     }
 
-    private static SKImage GetOrCreateVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition, int[] cellMasks, double[] cellBrightness)
+    private static SKImage GetOrCreateVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
     {
         lock (VisualCacheGate)
         {
@@ -65,7 +92,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             }
 
             _diagnosticsCacheMisses++;
-            var created = BuildVisual(key, definition, cellMasks, cellBrightness);
+            var created = BuildVisual(key, definition);
             if (VisualCache.Count > MaxVisualCacheEntries)
             {
                 VisualCache.Clear();
@@ -76,74 +103,33 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         }
     }
 
-    private static SKImage BuildVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition, int[] cellMasks, double[] cellBrightness)
+    private static SKImage BuildVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
     {
         using var surface = SKSurface.Create(new SKImageInfo(key.Width, key.Height));
         var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
         var bounds = SKRect.Create(0f, 0f, key.Width, key.Height);
-        using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
-        canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
-        var marginX = bounds.Width * 0.05f;
-        var marginY = bounds.Height * 0.1f;
-        var contentBounds = SKRect.Create(bounds.Left + marginX, bounds.Top + marginY, Math.Max(1f, bounds.Width - (marginX * 2f)), Math.Max(1f, bounds.Height - (marginY * 2f)));
-        var pitch = definition.RecommendedPitch > 0f ? definition.RecommendedPitch : definition.Width;
-        var totalWidth = (pitch * key.CellCount) - Math.Max(0f, pitch - definition.Width);
-        var scale = Math.Min(contentBounds.Height / definition.Height, contentBounds.Width / Math.Max(1f, totalWidth));
-        var scaledPitch = pitch * scale;
-        var scaledCellWidth = definition.Width * scale;
-        var scaledCellHeight = definition.Height * scale;
-        var originX = contentBounds.Left + ((contentBounds.Width - ((scaledPitch * key.CellCount) - Math.Max(0f, scaledPitch - scaledCellWidth))) * 0.5f);
-        var originY = contentBounds.Top + ((contentBounds.Height - scaledCellHeight) * 0.5f);
         using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        var scale = Math.Min(bounds.Width / definition.Width, bounds.Height / definition.Height);
+        var offsetX = (bounds.Width - (definition.Width * scale)) * 0.5f;
+        var offsetY = (bounds.Height - (definition.Height * scale)) * 0.5f;
         canvas.Save();
-        for (var cellIndex = 0; cellIndex < key.CellCount; cellIndex++)
+        canvas.Translate(offsetX, offsetY);
+        canvas.Scale(scale, scale);
+        var litAmount = key.BrightnessBucket / 4d;
+        foreach (var segment in definition.Segments)
         {
-            var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
-            var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
-            canvas.Save();
-            canvas.Translate(originX + (cellIndex * scaledPitch), originY);
-            canvas.Scale(scale, scale);
-            foreach (var segment in definition.Segments)
-            {
-                var lit = (mask & (1 << segment.Index)) != 0;
-                paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
-                canvas.DrawPath(segment.Path, paint);
-            }
-            if (definition.DecimalPoint is not null)
-            {
-                paint.Color = key.OffColor;
-                canvas.DrawPath(definition.DecimalPoint, paint);
-            }
-            canvas.Restore();
+            var lit = (key.Mask & (1 << segment.Index)) != 0;
+            paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
+            canvas.DrawPath(segment.Path, paint);
         }
+        if (definition.DecimalPoint is not null)
+        {
+            paint.Color = key.OffColor;
+            canvas.DrawPath(definition.DecimalPoint, paint);
+        }
+        canvas.Restore();
         return surface.Snapshot();
-    }
-
-    private static int ComputeHash(int[] values, int cellCount)
-    {
-        var hash = new HashCode();
-        hash.Add(cellCount);
-        for (var i = 0; i < cellCount; i++)
-        {
-            hash.Add(i < values.Length ? values[i] : 0);
-        }
-
-        return hash.ToHashCode();
-    }
-
-    private static int ComputeBrightnessHash(double[] values, int cellCount)
-    {
-        var hash = new HashCode();
-        hash.Add(cellCount);
-        for (var i = 0; i < cellCount; i++)
-        {
-            var brightness = i < values.Length ? Math.Clamp(values[i], 0d, 1d) : 1d;
-            hash.Add((int)Math.Round(brightness * 4d));
-        }
-
-        return hash.ToHashCode();
     }
 
     private static AlphaSkiaDefinition? LoadDefinition()
@@ -191,7 +177,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
     }
 
     private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint);
-    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int CellCount, int MasksHash, int BrightnessHash, SKColor OnColor, SKColor OffColor);
+    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
 
     private sealed class AlphaDefinitionRoot

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -6,9 +6,23 @@ namespace OasisEditor.Rendering;
 
 internal sealed class AlphaElementRenderer : IPanelElementRenderer
 {
+    private const int MaxVisualCacheEntries = 4096;
     private static readonly Lazy<AlphaSkiaDefinition?> Definition = new(LoadDefinition);
+    private static readonly Dictionary<AlphaVisualCacheKey, SKImage> VisualCache = new();
+    private static readonly object VisualCacheGate = new();
+    [ThreadStatic]
+    private static int _diagnosticsCacheHits;
+    [ThreadStatic]
+    private static int _diagnosticsCacheMisses;
 
     public PanelElementKind Kind => PanelElementKind.Alpha;
+    internal static int DiagnosticsCacheHits => _diagnosticsCacheHits;
+    internal static int DiagnosticsCacheMisses => _diagnosticsCacheMisses;
+    internal static void ResetDiagnosticsCounters()
+    {
+        _diagnosticsCacheHits = 0;
+        _diagnosticsCacheMisses = 0;
+    }
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
     {
@@ -30,54 +44,80 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
 
-        using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
-
-        var marginX = bounds.Width * 0.05f;
-        var marginY = bounds.Height * 0.1f;
-        var contentBounds = SKRect.Create(
-            bounds.Left + marginX,
-            bounds.Top + marginY,
-            Math.Max(1f, bounds.Width - (marginX * 2f)),
-            Math.Max(1f, bounds.Height - (marginY * 2f)));
-
         var cellCount = Math.Max(1, Math.Max(cellMasks.Length, cellBrightness.Length));
-        var pitch = definition.RecommendedPitch > 0f ? definition.RecommendedPitch : definition.Width;
-        var totalWidth = (pitch * cellCount) - Math.Max(0f, pitch - definition.Width);
-        var scale = Math.Min(contentBounds.Height / definition.Height, contentBounds.Width / Math.Max(1f, totalWidth));
-        var scaledPitch = pitch * scale;
-        var scaledCellWidth = definition.Width * scale;
-        var scaledCellHeight = definition.Height * scale;
-        var originX = contentBounds.Left + ((contentBounds.Width - ((scaledPitch * cellCount) - Math.Max(0f, scaledPitch - scaledCellWidth))) * 0.5f);
-        var originY = contentBounds.Top + ((contentBounds.Height - scaledCellHeight) * 0.5f);
-
-        using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        var width = Math.Max(1, (int)Math.Round(bounds.Width));
+        var height = Math.Max(1, (int)Math.Round(bounds.Height));
         for (var cellIndex = 0; cellIndex < cellCount; cellIndex++)
         {
             var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
             var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
-
-            context.Canvas.Save();
-            context.Canvas.Translate(originX + (cellIndex * scaledPitch), originY);
-            context.Canvas.Scale(scale, scale);
-
-            foreach (var segment in definition.Segments)
-            {
-                var lit = (mask & (1 << segment.Index)) != 0;
-                paint.Color = lit ? Lerp(offColor, onColor, litAmount) : offColor;
-                context.Canvas.DrawPath(segment.Path, paint);
-            }
-
-            if (definition.DecimalPoint is not null)
-            {
-                paint.Color = offColor;
-                context.Canvas.DrawPath(definition.DecimalPoint, paint);
-            }
-
-            context.Canvas.Restore();
+            var brightnessBucket = (int)Math.Round(litAmount * 4d);
+            var key = new AlphaVisualCacheKey(width, height, cellCount, cellIndex, mask, brightnessBucket, onColor, offColor);
+            var visual = GetOrCreateVisual(key, definition);
+            context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
         }
+    }
+
+    private static SKImage GetOrCreateVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
+    {
+        lock (VisualCacheGate)
+        {
+            if (VisualCache.TryGetValue(key, out var cached))
+            {
+                _diagnosticsCacheHits++;
+                return cached;
+            }
+
+            _diagnosticsCacheMisses++;
+            var created = BuildVisual(key, definition);
+            if (VisualCache.Count > MaxVisualCacheEntries)
+            {
+                VisualCache.Clear();
+            }
+
+            VisualCache[key] = created;
+            return created;
+        }
+    }
+
+    private static SKImage BuildVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(key.Width, key.Height));
+        var canvas = surface.Canvas;
+        var bounds = SKRect.Create(0f, 0f, key.Width, key.Height);
+        using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
+        var marginX = bounds.Width * 0.05f;
+        var marginY = bounds.Height * 0.1f;
+        var contentBounds = SKRect.Create(bounds.Left + marginX, bounds.Top + marginY, Math.Max(1f, bounds.Width - (marginX * 2f)), Math.Max(1f, bounds.Height - (marginY * 2f)));
+        var pitch = definition.RecommendedPitch > 0f ? definition.RecommendedPitch : definition.Width;
+        var totalWidth = (pitch * key.CellCount) - Math.Max(0f, pitch - definition.Width);
+        var scale = Math.Min(contentBounds.Height / definition.Height, contentBounds.Width / Math.Max(1f, totalWidth));
+        var scaledPitch = pitch * scale;
+        var scaledCellWidth = definition.Width * scale;
+        var scaledCellHeight = definition.Height * scale;
+        var originX = contentBounds.Left + ((contentBounds.Width - ((scaledPitch * key.CellCount) - Math.Max(0f, scaledPitch - scaledCellWidth))) * 0.5f);
+        var originY = contentBounds.Top + ((contentBounds.Height - scaledCellHeight) * 0.5f);
+        using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        canvas.Save();
+        canvas.Translate(originX + (key.CellIndex * scaledPitch), originY);
+        canvas.Scale(scale, scale);
+        var litAmount = key.BrightnessBucket / 4d;
+        foreach (var segment in definition.Segments)
+        {
+            var lit = (key.Mask & (1 << segment.Index)) != 0;
+            paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
+            canvas.DrawPath(segment.Path, paint);
+        }
+        if (definition.DecimalPoint is not null)
+        {
+            paint.Color = key.OffColor;
+            canvas.DrawPath(definition.DecimalPoint, paint);
+        }
+        canvas.Restore();
+        return surface.Snapshot();
     }
 
     private static AlphaSkiaDefinition? LoadDefinition()
@@ -125,6 +165,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
     }
 
     private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint);
+    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int CellCount, int CellIndex, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
 
     private sealed class AlphaDefinitionRoot

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -47,18 +47,14 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var cellCount = Math.Max(1, Math.Max(cellMasks.Length, cellBrightness.Length));
         var width = Math.Max(1, (int)Math.Round(bounds.Width));
         var height = Math.Max(1, (int)Math.Round(bounds.Height));
-        for (var cellIndex = 0; cellIndex < cellCount; cellIndex++)
-        {
-            var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
-            var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
-            var brightnessBucket = (int)Math.Round(litAmount * 4d);
-            var key = new AlphaVisualCacheKey(width, height, cellCount, cellIndex, mask, brightnessBucket, onColor, offColor);
-            var visual = GetOrCreateVisual(key, definition);
-            context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
-        }
+        var masksHash = ComputeHash(cellMasks, cellCount);
+        var brightnessHash = ComputeBrightnessHash(cellBrightness, cellCount);
+        var key = new AlphaVisualCacheKey(width, height, cellCount, masksHash, brightnessHash, onColor, offColor);
+        var visual = GetOrCreateVisual(key, definition, cellMasks, cellBrightness);
+        context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
     }
 
-    private static SKImage GetOrCreateVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
+    private static SKImage GetOrCreateVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition, int[] cellMasks, double[] cellBrightness)
     {
         lock (VisualCacheGate)
         {
@@ -69,7 +65,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             }
 
             _diagnosticsCacheMisses++;
-            var created = BuildVisual(key, definition);
+            var created = BuildVisual(key, definition, cellMasks, cellBrightness);
             if (VisualCache.Count > MaxVisualCacheEntries)
             {
                 VisualCache.Clear();
@@ -80,7 +76,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         }
     }
 
-    private static SKImage BuildVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition)
+    private static SKImage BuildVisual(AlphaVisualCacheKey key, AlphaSkiaDefinition definition, int[] cellMasks, double[] cellBrightness)
     {
         using var surface = SKSurface.Create(new SKImageInfo(key.Width, key.Height));
         var canvas = surface.Canvas;
@@ -102,22 +98,52 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var originY = contentBounds.Top + ((contentBounds.Height - scaledCellHeight) * 0.5f);
         using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
         canvas.Save();
-        canvas.Translate(originX + (key.CellIndex * scaledPitch), originY);
-        canvas.Scale(scale, scale);
-        var litAmount = key.BrightnessBucket / 4d;
-        foreach (var segment in definition.Segments)
+        for (var cellIndex = 0; cellIndex < key.CellCount; cellIndex++)
         {
-            var lit = (key.Mask & (1 << segment.Index)) != 0;
-            paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
-            canvas.DrawPath(segment.Path, paint);
+            var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
+            var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
+            canvas.Save();
+            canvas.Translate(originX + (cellIndex * scaledPitch), originY);
+            canvas.Scale(scale, scale);
+            foreach (var segment in definition.Segments)
+            {
+                var lit = (mask & (1 << segment.Index)) != 0;
+                paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
+                canvas.DrawPath(segment.Path, paint);
+            }
+            if (definition.DecimalPoint is not null)
+            {
+                paint.Color = key.OffColor;
+                canvas.DrawPath(definition.DecimalPoint, paint);
+            }
+            canvas.Restore();
         }
-        if (definition.DecimalPoint is not null)
-        {
-            paint.Color = key.OffColor;
-            canvas.DrawPath(definition.DecimalPoint, paint);
-        }
-        canvas.Restore();
         return surface.Snapshot();
+    }
+
+    private static int ComputeHash(int[] values, int cellCount)
+    {
+        var hash = new HashCode();
+        hash.Add(cellCount);
+        for (var i = 0; i < cellCount; i++)
+        {
+            hash.Add(i < values.Length ? values[i] : 0);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    private static int ComputeBrightnessHash(double[] values, int cellCount)
+    {
+        var hash = new HashCode();
+        hash.Add(cellCount);
+        for (var i = 0; i < cellCount; i++)
+        {
+            var brightness = i < values.Length ? Math.Clamp(values[i], 0d, 1d) : 1d;
+            hash.Add((int)Math.Round(brightness * 4d));
+        }
+
+        return hash.ToHashCode();
     }
 
     private static AlphaSkiaDefinition? LoadDefinition()
@@ -165,7 +191,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
     }
 
     private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint);
-    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int CellCount, int CellIndex, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
+    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int CellCount, int MasksHash, int BrightnessHash, SKColor OnColor, SKColor OffColor);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
 
     private sealed class AlphaDefinitionRoot

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -15,14 +16,17 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
     private static int _diagnosticsTextLayoutCount;
     [ThreadStatic]
     private static int _diagnosticsTextDrawCount;
+    [ThreadStatic]
+    private static long _diagnosticsTextTicks;
     internal static int DiagnosticsTextLayoutCount => _diagnosticsTextLayoutCount;
     internal static int DiagnosticsTextDrawCount => _diagnosticsTextDrawCount;
+    internal static TimeSpan DiagnosticsTextElapsed => TimeSpan.FromTicks(_diagnosticsTextTicks);
     internal static void ResetDiagnosticsCounters()
     {
         _diagnosticsTextLayoutCount = 0;
         _diagnosticsTextDrawCount = 0;
+        _diagnosticsTextTicks = 0;
     }
-
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
     {
@@ -52,44 +56,53 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             return;
         }
 
-        var fontSize = ParseFontSize(element.TextBoxFontSize);
-        var textBounds = GetTextBounds(bounds);
-        using var textPaint = new SKPaint
+        var textStopwatch = Stopwatch.StartNew();
+        try
         {
-            Color = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White),
-            IsAntialias = true,
-            TextSize = (float)fontSize,
-            Typeface = ResolveTypeface(element.TextBoxFontName, element.TextBoxFontStyle)
-        };
-
-        var fontMetrics = textPaint.FontMetrics;
-        var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
-        var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
-        var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
-        var lines = WrapTextToPixelWidth(displayText, wrapWidth, textPaint);
-        _diagnosticsTextLayoutCount++;
-        if (lines.Count == 0)
-        {
-            return;
-        }
-
-        var totalTextHeight = lines.Count * lineHeight;
-        var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f
-            ? Math.Abs(fontMetrics.Ascent)
-            : fontSize;
-        var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
-        for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
-        {
-            var line = lines[lineIndex];
-            if (string.IsNullOrEmpty(line.Text))
+            var fontSize = ParseFontSize(element.TextBoxFontSize);
+            var textBounds = GetTextBounds(bounds);
+            using var textPaint = new SKPaint
             {
-                continue;
+                Color = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White),
+                IsAntialias = true,
+                TextSize = (float)fontSize,
+                Typeface = ResolveTypeface(element.TextBoxFontName, element.TextBoxFontStyle)
+            };
+
+            var fontMetrics = textPaint.FontMetrics;
+            var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
+            var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
+            var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
+            var lines = WrapTextToPixelWidth(displayText, wrapWidth, textPaint);
+            _diagnosticsTextLayoutCount++;
+            if (lines.Count == 0)
+            {
+                return;
             }
 
-            var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
-            var y = startY + (lineIndex * lineHeight);
-            context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
-            _diagnosticsTextDrawCount++;
+            var totalTextHeight = lines.Count * lineHeight;
+            var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f
+                ? Math.Abs(fontMetrics.Ascent)
+                : fontSize;
+            var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
+            for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
+            {
+                var line = lines[lineIndex];
+                if (string.IsNullOrEmpty(line.Text))
+                {
+                    continue;
+                }
+
+                var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
+                var y = startY + (lineIndex * lineHeight);
+                context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
+                _diagnosticsTextDrawCount++;
+            }
+        }
+        finally
+        {
+            textStopwatch.Stop();
+            _diagnosticsTextTicks += textStopwatch.ElapsedTicks;
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -11,6 +11,18 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
     private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
 
     public PanelElementKind Kind => PanelElementKind.Lamp;
+    [ThreadStatic]
+    private static int _diagnosticsTextLayoutCount;
+    [ThreadStatic]
+    private static int _diagnosticsTextDrawCount;
+    internal static int DiagnosticsTextLayoutCount => _diagnosticsTextLayoutCount;
+    internal static int DiagnosticsTextDrawCount => _diagnosticsTextDrawCount;
+    internal static void ResetDiagnosticsCounters()
+    {
+        _diagnosticsTextLayoutCount = 0;
+        _diagnosticsTextDrawCount = 0;
+    }
+
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
     {
@@ -55,6 +67,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
         var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
         var lines = WrapTextToPixelWidth(displayText, wrapWidth, textPaint);
+        _diagnosticsTextLayoutCount++;
         if (lines.Count == 0)
         {
             return;
@@ -76,6 +89,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
             var y = startY + (lineIndex * lineHeight);
             context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
+            _diagnosticsTextDrawCount++;
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -10,6 +10,7 @@ namespace OasisEditor.Rendering;
 internal sealed class LampElementRenderer : IPanelElementRenderer
 {
     private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<TextLayoutCacheKey, IReadOnlyList<PixelTextLine>> TextLayoutCache = new();
 
     public PanelElementKind Kind => PanelElementKind.Lamp;
     [ThreadStatic]
@@ -18,14 +19,22 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
     private static int _diagnosticsTextDrawCount;
     [ThreadStatic]
     private static long _diagnosticsTextTicks;
+    [ThreadStatic]
+    private static int _diagnosticsTextLayoutCacheHits;
+    [ThreadStatic]
+    private static int _diagnosticsTextLayoutCacheMisses;
     internal static int DiagnosticsTextLayoutCount => _diagnosticsTextLayoutCount;
     internal static int DiagnosticsTextDrawCount => _diagnosticsTextDrawCount;
     internal static TimeSpan DiagnosticsTextElapsed => TimeSpan.FromTicks(_diagnosticsTextTicks);
+    internal static int DiagnosticsTextLayoutCacheHits => _diagnosticsTextLayoutCacheHits;
+    internal static int DiagnosticsTextLayoutCacheMisses => _diagnosticsTextLayoutCacheMisses;
     internal static void ResetDiagnosticsCounters()
     {
         _diagnosticsTextLayoutCount = 0;
         _diagnosticsTextDrawCount = 0;
         _diagnosticsTextTicks = 0;
+        _diagnosticsTextLayoutCacheHits = 0;
+        _diagnosticsTextLayoutCacheMisses = 0;
     }
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -73,8 +82,12 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
             var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
             var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
-            var lines = WrapTextToPixelWidth(displayText, wrapWidth, textPaint);
-            _diagnosticsTextLayoutCount++;
+            var cacheKey = new TextLayoutCacheKey(
+                displayText,
+                textPaint.Typeface?.FamilyName ?? string.Empty,
+                textPaint.TextSize,
+                wrapWidth);
+            var lines = GetOrCreateTextLayout(cacheKey, displayText, wrapWidth, textPaint);
             if (lines.Count == 0)
             {
                 return;
@@ -206,6 +219,22 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
     }
 
     internal readonly record struct PixelTextLine(string Text, float Width);
+    private readonly record struct TextLayoutCacheKey(string Text, string FamilyName, float TextSize, double WrapWidth);
+
+    private static IReadOnlyList<PixelTextLine> GetOrCreateTextLayout(TextLayoutCacheKey cacheKey, string text, double wrapWidth, SKPaint paint)
+    {
+        if (TextLayoutCache.TryGetValue(cacheKey, out var cached))
+        {
+            _diagnosticsTextLayoutCacheHits++;
+            return cached;
+        }
+
+        _diagnosticsTextLayoutCacheMisses++;
+        _diagnosticsTextLayoutCount++;
+        var computed = WrapTextToPixelWidth(text, wrapWidth, paint);
+        TextLayoutCache[cacheKey] = computed;
+        return computed;
+    }
 
     private static SKTypeface ResolveTypeface(string? fontName, string? fontStyle)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -11,6 +11,8 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
 {
     private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<TextLayoutCacheKey, IReadOnlyList<PixelTextLine>> TextLayoutCache = new();
+    private static readonly ConcurrentDictionary<TextVisualCacheKey, SKImage> TextVisualCache = new();
+    private const int MaxTextVisualCacheEntries = 2048;
 
     public PanelElementKind Kind => PanelElementKind.Lamp;
     [ThreadStatic]
@@ -23,11 +25,17 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
     private static int _diagnosticsTextLayoutCacheHits;
     [ThreadStatic]
     private static int _diagnosticsTextLayoutCacheMisses;
+    [ThreadStatic]
+    private static int _diagnosticsTextVisualCacheHits;
+    [ThreadStatic]
+    private static int _diagnosticsTextVisualCacheMisses;
     internal static int DiagnosticsTextLayoutCount => _diagnosticsTextLayoutCount;
     internal static int DiagnosticsTextDrawCount => _diagnosticsTextDrawCount;
     internal static TimeSpan DiagnosticsTextElapsed => TimeSpan.FromTicks(_diagnosticsTextTicks);
     internal static int DiagnosticsTextLayoutCacheHits => _diagnosticsTextLayoutCacheHits;
     internal static int DiagnosticsTextLayoutCacheMisses => _diagnosticsTextLayoutCacheMisses;
+    internal static int DiagnosticsTextVisualCacheHits => _diagnosticsTextVisualCacheHits;
+    internal static int DiagnosticsTextVisualCacheMisses => _diagnosticsTextVisualCacheMisses;
     internal static void ResetDiagnosticsCounters()
     {
         _diagnosticsTextLayoutCount = 0;
@@ -35,6 +43,8 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         _diagnosticsTextTicks = 0;
         _diagnosticsTextLayoutCacheHits = 0;
         _diagnosticsTextLayoutCacheMisses = 0;
+        _diagnosticsTextVisualCacheHits = 0;
+        _diagnosticsTextVisualCacheMisses = 0;
     }
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -48,20 +58,13 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         var intensity = context.RuntimeState.GetLampIntensity(element.ObjectId);
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, SKColors.Red);
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(40, 0, 0));
-        var fill = Lerp(offColor, onColor, intensity);
-
-        using var paint = new SKPaint
-        {
-            Color = fill,
-            Style = SKPaintStyle.Fill,
-            IsAntialias = true
-        };
-
-        context.Canvas.DrawRect(bounds, paint);
+        var fillColor = Lerp(offColor, onColor, intensity);
 
         var displayText = element.DisplayText;
         if (string.IsNullOrWhiteSpace(displayText))
         {
+            using var paint = new SKPaint { Color = fillColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+            context.Canvas.DrawRect(bounds, paint);
             return;
         }
 
@@ -69,54 +72,92 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         try
         {
             var fontSize = ParseFontSize(element.TextBoxFontSize);
-            var textBounds = GetTextBounds(bounds);
-            using var textPaint = new SKPaint
-            {
-                Color = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White),
-                IsAntialias = true,
-                TextSize = (float)fontSize,
-                Typeface = ResolveTypeface(element.TextBoxFontName, element.TextBoxFontStyle)
-            };
-
-            var fontMetrics = textPaint.FontMetrics;
-            var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
-            var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
-            var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, bounds.Width, textPaint);
-            var cacheKey = new TextLayoutCacheKey(
+            var textColor = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White);
+            var visualKey = new TextVisualCacheKey(
+                element.ObjectId ?? string.Empty,
+                Math.Max(1, (int)Math.Round(bounds.Width)),
+                Math.Max(1, (int)Math.Round(bounds.Height)),
                 displayText,
-                textPaint.Typeface?.FamilyName ?? string.Empty,
-                textPaint.TextSize,
-                wrapWidth);
-            var lines = GetOrCreateTextLayout(cacheKey, displayText, wrapWidth, textPaint);
-            if (lines.Count == 0)
-            {
-                return;
-            }
+                element.TextBoxFontName ?? string.Empty,
+                element.TextBoxFontStyle ?? string.Empty,
+                (float)fontSize,
+                fillColor,
+                textColor,
+                intensity > 0d);
 
-            var totalTextHeight = lines.Count * lineHeight;
-            var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f
-                ? Math.Abs(fontMetrics.Ascent)
-                : fontSize;
-            var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
-            for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
+            if (!TextVisualCache.TryGetValue(visualKey, out var visual))
             {
-                var line = lines[lineIndex];
-                if (string.IsNullOrEmpty(line.Text))
+                _diagnosticsTextVisualCacheMisses++;
+                visual = BuildTextLampVisual(visualKey, displayText, fontSize, fillColor, textColor, element.TextBoxFontName, element.TextBoxFontStyle);
+                if (TextVisualCache.Count > MaxTextVisualCacheEntries)
                 {
-                    continue;
+                    TextVisualCache.Clear();
                 }
 
-                var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
-                var y = startY + (lineIndex * lineHeight);
-                context.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
-                _diagnosticsTextDrawCount++;
+                TextVisualCache[visualKey] = visual;
             }
+            else
+            {
+                _diagnosticsTextVisualCacheHits++;
+            }
+
+            context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
         }
         finally
         {
             textStopwatch.Stop();
             _diagnosticsTextTicks += textStopwatch.ElapsedTicks;
         }
+    }
+
+    private static SKImage BuildTextLampVisual(TextVisualCacheKey visualKey, string displayText, double fontSize, SKColor fillColor, SKColor textColor, string? fontName, string? fontStyle)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(visualKey.Width, visualKey.Height));
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+        var localBounds = SKRect.Create(0f, 0f, visualKey.Width, visualKey.Height);
+
+        using var paint = new SKPaint { Color = fillColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+        canvas.DrawRect(localBounds, paint);
+
+        using var textPaint = new SKPaint
+        {
+            Color = textColor,
+            IsAntialias = true,
+            TextSize = (float)fontSize,
+            Typeface = ResolveTypeface(fontName, fontStyle)
+        };
+
+        var textBounds = GetTextBounds(localBounds);
+        var fontMetrics = textPaint.FontMetrics;
+        var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
+        var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : fontSize * 1.2d);
+        var wrapWidth = GetEffectiveWrapWidth(displayText, textBounds.Width, localBounds.Width, textPaint);
+        var cacheKey = new TextLayoutCacheKey(displayText, textPaint.Typeface?.FamilyName ?? string.Empty, textPaint.TextSize, wrapWidth);
+        var lines = GetOrCreateTextLayout(cacheKey, displayText, wrapWidth, textPaint);
+        if (lines.Count == 0)
+        {
+            return surface.Snapshot();
+        }
+
+        var totalTextHeight = lines.Count * lineHeight;
+        var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f ? Math.Abs(fontMetrics.Ascent) : fontSize;
+        var startY = textBounds.Top + ((textBounds.Height - totalTextHeight) / 2d) + baselineOffset;
+        for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            if (string.IsNullOrEmpty(line.Text))
+            {
+                continue;
+            }
+
+            var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
+            var y = startY + (lineIndex * lineHeight);
+            canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
+            _diagnosticsTextDrawCount++;
+        }
+
+        return surface.Snapshot();
     }
 
     internal static List<PixelTextLine> WrapTextToPixelWidth(string text, double maxWidth, SKPaint paint)
@@ -220,6 +261,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
 
     internal readonly record struct PixelTextLine(string Text, float Width);
     private readonly record struct TextLayoutCacheKey(string Text, string FamilyName, float TextSize, double WrapWidth);
+    private readonly record struct TextVisualCacheKey(string ElementId, int Width, int Height, string Text, string FontName, string FontStyle, float TextSize, SKColor FillColor, SKColor TextColor, bool IsOnBucket);
 
     private static IReadOnlyList<PixelTextLine> GetOrCreateTextLayout(TextLayoutCacheKey cacheKey, string text, double wrapWidth, SKPaint paint)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SkiaSharp;
 
 namespace OasisEditor.Rendering;
@@ -5,14 +6,13 @@ namespace OasisEditor.Rendering;
 internal sealed class Panel2DRenderer : IPanel2DRenderer
 {
     private readonly IReadOnlyDictionary<PanelElementKind, IPanelElementRenderer> _renderersByKind;
+    private readonly string _viewName;
 
-    public Panel2DRenderer(IEnumerable<IPanelElementRenderer> renderers)
+    public Panel2DRenderer(IEnumerable<IPanelElementRenderer> renderers, string viewName = "SkiaView")
     {
         ArgumentNullException.ThrowIfNull(renderers);
-
-        _renderersByKind = renderers
-            .GroupBy(renderer => renderer.Kind)
-            .ToDictionary(group => group.Key, group => group.Last());
+        _viewName = string.IsNullOrWhiteSpace(viewName) ? "SkiaView" : viewName;
+        _renderersByKind = renderers.GroupBy(renderer => renderer.Kind).ToDictionary(group => group.Key, group => group.Last());
     }
 
     public void Render(SKCanvas canvas, IReadOnlyList<PanelElementModel> elements, PanelRuntimeState runtimeState, PanelViewportTransform viewportTransform)
@@ -21,7 +21,15 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
         ArgumentNullException.ThrowIfNull(elements);
         ArgumentNullException.ThrowIfNull(runtimeState);
 
+        LampElementRenderer.ResetDiagnosticsCounters();
+        var frame = SkiaRenderDiagnostics.BeginFrame(_viewName);
         var context = new PanelElementRenderContext(canvas, runtimeState, viewportTransform);
+        var lampElapsed = TimeSpan.Zero;
+        var alphaElapsed = TimeSpan.Zero;
+        var sevenElapsed = TimeSpan.Zero;
+        var reelElapsed = TimeSpan.Zero;
+        var lampCount = 0; var textLampCount = 0; var alphaCount = 0; var sevenCount = 0; var reelCount = 0;
+
         foreach (var element in elements)
         {
             if (!element.IsVisible)
@@ -29,10 +37,46 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
                 continue;
             }
 
-            if (_renderersByKind.TryGetValue(element.Kind, out var renderer))
+            if (!_renderersByKind.TryGetValue(element.Kind, out var renderer))
             {
-                renderer.Render(context, element);
+                continue;
+            }
+
+            var sw = Stopwatch.StartNew();
+            renderer.Render(context, element);
+            sw.Stop();
+
+            switch (element.Kind)
+            {
+                case PanelElementKind.Lamp:
+                    lampCount++;
+                    lampElapsed += sw.Elapsed;
+                    if (!string.IsNullOrWhiteSpace(element.DisplayText))
+                    {
+                        textLampCount++;
+                    }
+                    break;
+                case PanelElementKind.Alpha: alphaCount++; alphaElapsed += sw.Elapsed; break;
+                case PanelElementKind.SevenSegment: sevenCount++; sevenElapsed += sw.Elapsed; break;
+                case PanelElementKind.Reel: reelCount++; reelElapsed += sw.Elapsed; break;
             }
         }
+
+        frame.Complete(new SkiaRenderDiagnostics.FrameData(
+            _viewName,
+            TimeSpan.Zero,
+            lampElapsed,
+            lampElapsed,
+            alphaElapsed,
+            sevenElapsed,
+            reelElapsed,
+            elements.Count,
+            lampCount,
+            textLampCount,
+            alphaCount,
+            sevenCount,
+            reelCount,
+            LampElementRenderer.DiagnosticsTextLayoutCount,
+            LampElementRenderer.DiagnosticsTextDrawCount));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -99,6 +99,8 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
             sevenCount,
             reelCount,
             LampElementRenderer.DiagnosticsTextLayoutCount,
-            LampElementRenderer.DiagnosticsTextDrawCount));
+            LampElementRenderer.DiagnosticsTextDrawCount,
+            LampElementRenderer.DiagnosticsTextLayoutCacheHits,
+            LampElementRenderer.DiagnosticsTextLayoutCacheMisses));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -23,6 +23,7 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
 
         LampElementRenderer.ResetDiagnosticsCounters();
         SevenSegmentElementRenderer.ResetDiagnosticsCounters();
+        AlphaElementRenderer.ResetDiagnosticsCounters();
         var frame = SkiaRenderDiagnostics.BeginFrame(_viewName);
         var context = new PanelElementRenderContext(canvas, runtimeState, viewportTransform);
 
@@ -106,6 +107,8 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
             LampElementRenderer.DiagnosticsTextVisualCacheHits,
             LampElementRenderer.DiagnosticsTextVisualCacheMisses,
             SevenSegmentElementRenderer.DiagnosticsCacheHits,
-            SevenSegmentElementRenderer.DiagnosticsCacheMisses));
+            SevenSegmentElementRenderer.DiagnosticsCacheMisses,
+            AlphaElementRenderer.DiagnosticsCacheHits,
+            AlphaElementRenderer.DiagnosticsCacheMisses));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -22,6 +22,7 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
         ArgumentNullException.ThrowIfNull(runtimeState);
 
         LampElementRenderer.ResetDiagnosticsCounters();
+        SevenSegmentElementRenderer.ResetDiagnosticsCounters();
         var frame = SkiaRenderDiagnostics.BeginFrame(_viewName);
         var context = new PanelElementRenderContext(canvas, runtimeState, viewportTransform);
 
@@ -103,6 +104,8 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
             LampElementRenderer.DiagnosticsTextLayoutCacheHits,
             LampElementRenderer.DiagnosticsTextLayoutCacheMisses,
             LampElementRenderer.DiagnosticsTextVisualCacheHits,
-            LampElementRenderer.DiagnosticsTextVisualCacheMisses));
+            LampElementRenderer.DiagnosticsTextVisualCacheMisses,
+            SevenSegmentElementRenderer.DiagnosticsCacheHits,
+            SevenSegmentElementRenderer.DiagnosticsCacheMisses));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -24,11 +24,18 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
         LampElementRenderer.ResetDiagnosticsCounters();
         var frame = SkiaRenderDiagnostics.BeginFrame(_viewName);
         var context = new PanelElementRenderContext(canvas, runtimeState, viewportTransform);
+
+        var backgroundElapsed = TimeSpan.Zero;
         var lampElapsed = TimeSpan.Zero;
         var alphaElapsed = TimeSpan.Zero;
         var sevenElapsed = TimeSpan.Zero;
         var reelElapsed = TimeSpan.Zero;
-        var lampCount = 0; var textLampCount = 0; var alphaCount = 0; var sevenCount = 0; var reelCount = 0;
+        var backgroundCount = 0;
+        var lampCount = 0;
+        var textLampCount = 0;
+        var alphaCount = 0;
+        var sevenCount = 0;
+        var reelCount = 0;
 
         foreach (var element in elements)
         {
@@ -48,6 +55,10 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
 
             switch (element.Kind)
             {
+                case PanelElementKind.Background:
+                    backgroundCount++;
+                    backgroundElapsed += sw.Elapsed;
+                    break;
                 case PanelElementKind.Lamp:
                     lampCount++;
                     lampElapsed += sw.Elapsed;
@@ -56,21 +67,32 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
                         textLampCount++;
                     }
                     break;
-                case PanelElementKind.Alpha: alphaCount++; alphaElapsed += sw.Elapsed; break;
-                case PanelElementKind.SevenSegment: sevenCount++; sevenElapsed += sw.Elapsed; break;
-                case PanelElementKind.Reel: reelCount++; reelElapsed += sw.Elapsed; break;
+                case PanelElementKind.Alpha:
+                    alphaCount++;
+                    alphaElapsed += sw.Elapsed;
+                    break;
+                case PanelElementKind.SevenSegment:
+                    sevenCount++;
+                    sevenElapsed += sw.Elapsed;
+                    break;
+                case PanelElementKind.Reel:
+                    reelCount++;
+                    reelElapsed += sw.Elapsed;
+                    break;
             }
         }
 
         frame.Complete(new SkiaRenderDiagnostics.FrameData(
             _viewName,
             TimeSpan.Zero,
+            backgroundElapsed,
             lampElapsed,
-            lampElapsed,
+            LampElementRenderer.DiagnosticsTextElapsed,
             alphaElapsed,
             sevenElapsed,
             reelElapsed,
             elements.Count,
+            backgroundCount,
             lampCount,
             textLampCount,
             alphaCount,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -101,6 +101,8 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
             LampElementRenderer.DiagnosticsTextLayoutCount,
             LampElementRenderer.DiagnosticsTextDrawCount,
             LampElementRenderer.DiagnosticsTextLayoutCacheHits,
-            LampElementRenderer.DiagnosticsTextLayoutCacheMisses));
+            LampElementRenderer.DiagnosticsTextLayoutCacheMisses,
+            LampElementRenderer.DiagnosticsTextVisualCacheHits,
+            LampElementRenderer.DiagnosticsTextVisualCacheMisses));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -6,9 +6,23 @@ namespace OasisEditor.Rendering;
 
 internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
 {
+    private const int MaxVisualCacheEntries = 2048;
     private static readonly Lazy<SevenSegmentSkiaDefinition?> Definition = new(LoadDefinition);
+    private static readonly Dictionary<SegmentVisualCacheKey, SKImage> VisualCache = new();
+    private static readonly object VisualCacheGate = new();
+    [ThreadStatic]
+    private static int _diagnosticsCacheHits;
+    [ThreadStatic]
+    private static int _diagnosticsCacheMisses;
 
     public PanelElementKind Kind => PanelElementKind.SevenSegment;
+    internal static int DiagnosticsCacheHits => _diagnosticsCacheHits;
+    internal static int DiagnosticsCacheMisses => _diagnosticsCacheMisses;
+    internal static void ResetDiagnosticsCounters()
+    {
+        _diagnosticsCacheHits = 0;
+        _diagnosticsCacheMisses = 0;
+    }
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
     {
@@ -32,43 +46,69 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
         var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
         var offColor = SkiaColorParser.ParseOrDefault(element.OffColorHex, new SKColor(72, 24, 24));
 
+        var width = Math.Max(1, (int)Math.Round(bounds.Width));
+        var height = Math.Max(1, (int)Math.Round(bounds.Height));
+        var brightnessBucket = (int)Math.Round(Math.Clamp(litAmount, 0d, 1d) * 4d);
+        var cacheKey = new SegmentVisualCacheKey(width, height, segmentMask, brightnessBucket, onColor, offColor);
+        var visual = GetOrCreateVisual(cacheKey, definition);
+        context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
+    }
+
+    private static SKImage GetOrCreateVisual(SegmentVisualCacheKey cacheKey, SevenSegmentSkiaDefinition definition)
+    {
+        lock (VisualCacheGate)
+        {
+            if (VisualCache.TryGetValue(cacheKey, out var cached))
+            {
+                _diagnosticsCacheHits++;
+                return cached;
+            }
+
+            _diagnosticsCacheMisses++;
+            var created = BuildVisual(cacheKey, definition);
+            if (VisualCache.Count > MaxVisualCacheEntries)
+            {
+                VisualCache.Clear();
+            }
+
+            VisualCache[cacheKey] = created;
+            return created;
+        }
+    }
+
+    private static SKImage BuildVisual(SegmentVisualCacheKey cacheKey, SevenSegmentSkiaDefinition definition)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(cacheKey.Width, cacheKey.Height));
+        var canvas = surface.Canvas;
+        var bounds = SKRect.Create(0f, 0f, cacheKey.Width, cacheKey.Height);
         using var backgroundPaint = new SKPaint { Color = new SKColor(17, 24, 39), Style = SKPaintStyle.Fill, IsAntialias = true };
         using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
-
+        canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
         var marginX = bounds.Width * 0.1f;
         var marginY = bounds.Height * 0.1f;
-        var contentBounds = SKRect.Create(
-            bounds.Left + marginX,
-            bounds.Top + marginY,
-            Math.Max(1f, bounds.Width - (marginX * 2f)),
-            Math.Max(1f, bounds.Height - (marginY * 2f)));
-
+        var contentBounds = SKRect.Create(bounds.Left + marginX, bounds.Top + marginY, Math.Max(1f, bounds.Width - (marginX * 2f)), Math.Max(1f, bounds.Height - (marginY * 2f)));
         using var paint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
-
         var scale = Math.Min(contentBounds.Width / definition.Width, contentBounds.Height / definition.Height);
         var offsetX = contentBounds.Left + ((contentBounds.Width - (definition.Width * scale)) * 0.5f);
         var offsetY = contentBounds.Top + ((contentBounds.Height - (definition.Height * scale)) * 0.5f);
-
-        context.Canvas.Save();
-        context.Canvas.Translate(offsetX, offsetY);
-        context.Canvas.Scale(scale, scale);
-
+        canvas.Save();
+        canvas.Translate(offsetX, offsetY);
+        canvas.Scale(scale, scale);
+        var litAmount = cacheKey.BrightnessBucket / 4d;
         foreach (var segment in definition.Segments)
         {
-            var lit = (segmentMask & (1 << segment.Index)) != 0;
-            paint.Color = lit ? Lerp(offColor, onColor, litAmount) : offColor;
-            context.Canvas.DrawPath(segment.Path, paint);
+            var lit = (cacheKey.SegmentMask & (1 << segment.Index)) != 0;
+            paint.Color = lit ? Lerp(cacheKey.OffColor, cacheKey.OnColor, litAmount) : cacheKey.OffColor;
+            canvas.DrawPath(segment.Path, paint);
         }
-
         if (definition.DecimalPoint is not null)
         {
-            paint.Color = offColor;
-            context.Canvas.DrawPath(definition.DecimalPoint, paint);
+            paint.Color = cacheKey.OffColor;
+            canvas.DrawPath(definition.DecimalPoint, paint);
         }
-
-        context.Canvas.Restore();
+        canvas.Restore();
+        return surface.Snapshot();
     }
 
     private static SevenSegmentSkiaDefinition? LoadDefinition()
@@ -116,6 +156,7 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
     }
 
     private sealed record SevenSegmentSkiaDefinition(float Width, float Height, IReadOnlyList<SevenSegmentSkiaPath> Segments, SKPath? DecimalPoint);
+    private readonly record struct SegmentVisualCacheKey(int Width, int Height, int SegmentMask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
     private sealed record SevenSegmentSkiaPath(int Index, SKPath Path);
 
     private sealed class SevenSegmentDefinitionRoot

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace OasisEditor.Rendering;
+
+internal static class SkiaRenderDiagnostics
+{
+    private static readonly object Gate = new();
+    private static readonly Dictionary<string, RendererWindowStats> StatsByView = new(StringComparer.Ordinal);
+
+    public static bool IsEnabled { get; set; } = false;
+    public static TimeSpan ReportInterval { get; set; } = TimeSpan.FromSeconds(3);
+
+    public static event Action<string>? ReportReady;
+
+    public static FrameScope BeginFrame(string viewName)
+    {
+        if (!IsEnabled)
+        {
+            return FrameScope.Disabled;
+        }
+
+        return new FrameScope(viewName, Stopwatch.StartNew());
+    }
+
+    private static void PublishFrame(FrameData data)
+    {
+        lock (Gate)
+        {
+            if (!StatsByView.TryGetValue(data.ViewName, out var stats))
+            {
+                stats = new RendererWindowStats();
+                StatsByView[data.ViewName] = stats;
+            }
+
+            stats.Accumulate(data);
+            if (stats.ShouldReport(ReportInterval))
+            {
+                ReportReady?.Invoke(stats.BuildReportAndReset(data.ViewName));
+            }
+        }
+    }
+
+    internal readonly record struct FrameData(
+        string ViewName,
+        TimeSpan Total,
+        TimeSpan Lamps,
+        TimeSpan TextLamps,
+        TimeSpan Alpha,
+        TimeSpan SevenSegment,
+        TimeSpan Reels,
+        int ElementCount,
+        int LampCount,
+        int TextLampCount,
+        int AlphaCount,
+        int SevenSegmentCount,
+        int ReelCount,
+        int TextLayoutCount,
+        int TextDrawCount);
+
+    internal readonly struct FrameScope(string viewName, Stopwatch stopwatch)
+    {
+        public static FrameScope Disabled => default;
+        public bool Enabled => stopwatch is not null;
+
+        public void Complete(FrameData data)
+        {
+            if (!Enabled)
+            {
+                return;
+            }
+
+            PublishFrame(data with { ViewName = viewName, Total = stopwatch.Elapsed });
+        }
+    }
+
+    private sealed class RendererWindowStats
+    {
+        private DateTime _windowStartUtc = DateTime.UtcNow;
+        private int _frames;
+        private double _totalMs;
+        private double _lampMs;
+        private double _textLampMs;
+        private double _alphaMs;
+        private double _sevenMs;
+        private double _reelMs;
+        private int _elements;
+        private int _lamps;
+        private int _textLamps;
+        private int _alphas;
+        private int _sevens;
+        private int _reels;
+        private int _textLayouts;
+        private int _textDraws;
+
+        public void Accumulate(FrameData data)
+        {
+            _frames++;
+            _totalMs += data.Total.TotalMilliseconds;
+            _lampMs += data.Lamps.TotalMilliseconds;
+            _textLampMs += data.TextLamps.TotalMilliseconds;
+            _alphaMs += data.Alpha.TotalMilliseconds;
+            _sevenMs += data.SevenSegment.TotalMilliseconds;
+            _reelMs += data.Reels.TotalMilliseconds;
+            _elements += data.ElementCount;
+            _lamps += data.LampCount;
+            _textLamps += data.TextLampCount;
+            _alphas += data.AlphaCount;
+            _sevens += data.SevenSegmentCount;
+            _reels += data.ReelCount;
+            _textLayouts += data.TextLayoutCount;
+            _textDraws += data.TextDrawCount;
+        }
+
+        public bool ShouldReport(TimeSpan interval) => DateTime.UtcNow - _windowStartUtc >= interval && _frames > 0;
+
+        public string BuildReportAndReset(string viewName)
+        {
+            var seconds = Math.Max(0.001, (DateTime.UtcNow - _windowStartUtc).TotalSeconds);
+            var sb = new StringBuilder();
+            sb.Append($"[SkiaDiag] {viewName}: fps~{_frames / seconds:F1}, frameAvg={_totalMs / _frames:F2}ms, frameMax={_totalMs:F2}ms/{_frames}f");
+            sb.Append($", timing(ms): lamps={_lampMs / _frames:F2} textLamps={_textLampMs / _frames:F2} alpha={_alphaMs / _frames:F2} seg7={_sevenMs / _frames:F2} reels={_reelMs / _frames:F2}");
+            sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
+            sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
+
+            _windowStartUtc = DateTime.UtcNow;
+            _frames = 0;
+            _totalMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
+            _elements = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
+            return sb.ToString();
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -60,7 +60,9 @@ internal static class SkiaRenderDiagnostics
         int TextLayoutCount,
         int TextDrawCount,
         int TextLayoutCacheHits,
-        int TextLayoutCacheMisses);
+        int TextLayoutCacheMisses,
+        int TextVisualCacheHits,
+        int TextVisualCacheMisses);
 
     internal readonly struct FrameScope(string viewName, Stopwatch stopwatch)
     {
@@ -101,6 +103,8 @@ internal static class SkiaRenderDiagnostics
         private int _textDraws;
         private int _textLayoutCacheHits;
         private int _textLayoutCacheMisses;
+        private int _textVisualCacheHits;
+        private int _textVisualCacheMisses;
 
         public void Accumulate(FrameData data)
         {
@@ -124,6 +128,8 @@ internal static class SkiaRenderDiagnostics
             _textDraws += data.TextDrawCount;
             _textLayoutCacheHits += data.TextLayoutCacheHits;
             _textLayoutCacheMisses += data.TextLayoutCacheMisses;
+            _textVisualCacheHits += data.TextVisualCacheHits;
+            _textVisualCacheMisses += data.TextVisualCacheMisses;
         }
 
         public bool ShouldReport(TimeSpan interval) => DateTime.UtcNow - _windowStartUtc >= interval && _frames > 0;
@@ -137,12 +143,14 @@ internal static class SkiaRenderDiagnostics
             sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} background={_backgrounds / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
             sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
             sb.Append($", textLayoutCache/frame: hits={_textLayoutCacheHits / (double)_frames:F1} misses={_textLayoutCacheMisses / (double)_frames:F1}");
+            sb.Append($", textVisualCache/frame: hits={_textVisualCacheHits / (double)_frames:F1} misses={_textVisualCacheMisses / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
             _totalMs = _maxFrameMs = _backgroundMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
             _elements = _backgrounds = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
             _textLayoutCacheHits = _textLayoutCacheMisses = 0;
+            _textVisualCacheHits = _textVisualCacheMisses = 0;
             return sb.ToString();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -64,7 +64,9 @@ internal static class SkiaRenderDiagnostics
         int TextVisualCacheHits,
         int TextVisualCacheMisses,
         int SegmentVisualCacheHits,
-        int SegmentVisualCacheMisses);
+        int SegmentVisualCacheMisses,
+        int AlphaVisualCacheHits,
+        int AlphaVisualCacheMisses);
 
     internal readonly struct FrameScope(string viewName, Stopwatch stopwatch)
     {
@@ -109,6 +111,8 @@ internal static class SkiaRenderDiagnostics
         private int _textVisualCacheMisses;
         private int _segmentVisualCacheHits;
         private int _segmentVisualCacheMisses;
+        private int _alphaVisualCacheHits;
+        private int _alphaVisualCacheMisses;
 
         public void Accumulate(FrameData data)
         {
@@ -136,6 +140,8 @@ internal static class SkiaRenderDiagnostics
             _textVisualCacheMisses += data.TextVisualCacheMisses;
             _segmentVisualCacheHits += data.SegmentVisualCacheHits;
             _segmentVisualCacheMisses += data.SegmentVisualCacheMisses;
+            _alphaVisualCacheHits += data.AlphaVisualCacheHits;
+            _alphaVisualCacheMisses += data.AlphaVisualCacheMisses;
         }
 
         public bool ShouldReport(TimeSpan interval) => DateTime.UtcNow - _windowStartUtc >= interval && _frames > 0;
@@ -151,6 +157,7 @@ internal static class SkiaRenderDiagnostics
             sb.Append($", textLayoutCache/frame: hits={_textLayoutCacheHits / (double)_frames:F1} misses={_textLayoutCacheMisses / (double)_frames:F1}");
             sb.Append($", textVisualCache/frame: hits={_textVisualCacheHits / (double)_frames:F1} misses={_textVisualCacheMisses / (double)_frames:F1}");
             sb.Append($", segmentVisualCache/frame: hits={_segmentVisualCacheHits / (double)_frames:F1} misses={_segmentVisualCacheMisses / (double)_frames:F1}");
+            sb.Append($", alphaVisualCache/frame: hits={_alphaVisualCacheHits / (double)_frames:F1} misses={_alphaVisualCacheMisses / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
@@ -159,6 +166,7 @@ internal static class SkiaRenderDiagnostics
             _textLayoutCacheHits = _textLayoutCacheMisses = 0;
             _textVisualCacheHits = _textVisualCacheMisses = 0;
             _segmentVisualCacheHits = _segmentVisualCacheMisses = 0;
+            _alphaVisualCacheHits = _alphaVisualCacheMisses = 0;
             return sb.ToString();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -62,7 +62,9 @@ internal static class SkiaRenderDiagnostics
         int TextLayoutCacheHits,
         int TextLayoutCacheMisses,
         int TextVisualCacheHits,
-        int TextVisualCacheMisses);
+        int TextVisualCacheMisses,
+        int SegmentVisualCacheHits,
+        int SegmentVisualCacheMisses);
 
     internal readonly struct FrameScope(string viewName, Stopwatch stopwatch)
     {
@@ -105,6 +107,8 @@ internal static class SkiaRenderDiagnostics
         private int _textLayoutCacheMisses;
         private int _textVisualCacheHits;
         private int _textVisualCacheMisses;
+        private int _segmentVisualCacheHits;
+        private int _segmentVisualCacheMisses;
 
         public void Accumulate(FrameData data)
         {
@@ -130,6 +134,8 @@ internal static class SkiaRenderDiagnostics
             _textLayoutCacheMisses += data.TextLayoutCacheMisses;
             _textVisualCacheHits += data.TextVisualCacheHits;
             _textVisualCacheMisses += data.TextVisualCacheMisses;
+            _segmentVisualCacheHits += data.SegmentVisualCacheHits;
+            _segmentVisualCacheMisses += data.SegmentVisualCacheMisses;
         }
 
         public bool ShouldReport(TimeSpan interval) => DateTime.UtcNow - _windowStartUtc >= interval && _frames > 0;
@@ -144,6 +150,7 @@ internal static class SkiaRenderDiagnostics
             sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
             sb.Append($", textLayoutCache/frame: hits={_textLayoutCacheHits / (double)_frames:F1} misses={_textLayoutCacheMisses / (double)_frames:F1}");
             sb.Append($", textVisualCache/frame: hits={_textVisualCacheHits / (double)_frames:F1} misses={_textVisualCacheMisses / (double)_frames:F1}");
+            sb.Append($", segmentVisualCache/frame: hits={_segmentVisualCacheHits / (double)_frames:F1} misses={_segmentVisualCacheMisses / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
@@ -151,6 +158,7 @@ internal static class SkiaRenderDiagnostics
             _elements = _backgrounds = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
             _textLayoutCacheHits = _textLayoutCacheMisses = 0;
             _textVisualCacheHits = _textVisualCacheMisses = 0;
+            _segmentVisualCacheHits = _segmentVisualCacheMisses = 0;
             return sb.ToString();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -58,7 +58,9 @@ internal static class SkiaRenderDiagnostics
         int SevenSegmentCount,
         int ReelCount,
         int TextLayoutCount,
-        int TextDrawCount);
+        int TextDrawCount,
+        int TextLayoutCacheHits,
+        int TextLayoutCacheMisses);
 
     internal readonly struct FrameScope(string viewName, Stopwatch stopwatch)
     {
@@ -97,6 +99,8 @@ internal static class SkiaRenderDiagnostics
         private int _reels;
         private int _textLayouts;
         private int _textDraws;
+        private int _textLayoutCacheHits;
+        private int _textLayoutCacheMisses;
 
         public void Accumulate(FrameData data)
         {
@@ -118,6 +122,8 @@ internal static class SkiaRenderDiagnostics
             _reels += data.ReelCount;
             _textLayouts += data.TextLayoutCount;
             _textDraws += data.TextDrawCount;
+            _textLayoutCacheHits += data.TextLayoutCacheHits;
+            _textLayoutCacheMisses += data.TextLayoutCacheMisses;
         }
 
         public bool ShouldReport(TimeSpan interval) => DateTime.UtcNow - _windowStartUtc >= interval && _frames > 0;
@@ -130,11 +136,13 @@ internal static class SkiaRenderDiagnostics
             sb.Append($", timing(ms): background={_backgroundMs / _frames:F2} lamps={_lampMs / _frames:F2} textLamps={_textLampMs / _frames:F2} alpha={_alphaMs / _frames:F2} seg7={_sevenMs / _frames:F2} reels={_reelMs / _frames:F2}");
             sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} background={_backgrounds / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
             sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
+            sb.Append($", textLayoutCache/frame: hits={_textLayoutCacheHits / (double)_frames:F1} misses={_textLayoutCacheMisses / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
             _totalMs = _maxFrameMs = _backgroundMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
             _elements = _backgrounds = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
+            _textLayoutCacheHits = _textLayoutCacheMisses = 0;
             return sb.ToString();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -44,6 +44,7 @@ internal static class SkiaRenderDiagnostics
     internal readonly record struct FrameData(
         string ViewName,
         TimeSpan Total,
+        TimeSpan Background,
         TimeSpan Lamps,
         TimeSpan TextLamps,
         TimeSpan Alpha,
@@ -79,6 +80,8 @@ internal static class SkiaRenderDiagnostics
         private DateTime _windowStartUtc = DateTime.UtcNow;
         private int _frames;
         private double _totalMs;
+        private double _maxFrameMs;
+        private double _backgroundMs;
         private double _lampMs;
         private double _textLampMs;
         private double _alphaMs;
@@ -97,6 +100,8 @@ internal static class SkiaRenderDiagnostics
         {
             _frames++;
             _totalMs += data.Total.TotalMilliseconds;
+            _maxFrameMs = Math.Max(_maxFrameMs, data.Total.TotalMilliseconds);
+            _backgroundMs += data.Background.TotalMilliseconds;
             _lampMs += data.Lamps.TotalMilliseconds;
             _textLampMs += data.TextLamps.TotalMilliseconds;
             _alphaMs += data.Alpha.TotalMilliseconds;
@@ -118,14 +123,14 @@ internal static class SkiaRenderDiagnostics
         {
             var seconds = Math.Max(0.001, (DateTime.UtcNow - _windowStartUtc).TotalSeconds);
             var sb = new StringBuilder();
-            sb.Append($"[SkiaDiag] {viewName}: fps~{_frames / seconds:F1}, frameAvg={_totalMs / _frames:F2}ms, frameMax={_totalMs:F2}ms/{_frames}f");
-            sb.Append($", timing(ms): lamps={_lampMs / _frames:F2} textLamps={_textLampMs / _frames:F2} alpha={_alphaMs / _frames:F2} seg7={_sevenMs / _frames:F2} reels={_reelMs / _frames:F2}");
+            sb.Append($"[SkiaDiag] {viewName}: fps~{_frames / seconds:F1}, frameAvg={_totalMs / _frames:F2}ms, frameMax={_maxFrameMs:F2}ms");
+            sb.Append($", timing(ms): background={_backgroundMs / _frames:F2} lamps={_lampMs / _frames:F2} textLamps={_textLampMs / _frames:F2} alpha={_alphaMs / _frames:F2} seg7={_sevenMs / _frames:F2} reels={_reelMs / _frames:F2}");
             sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
             sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
-            _totalMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
+            _totalMs = _maxFrameMs = _backgroundMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
             _elements = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
             return sb.ToString();
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaRenderDiagnostics.cs
@@ -51,6 +51,7 @@ internal static class SkiaRenderDiagnostics
         TimeSpan SevenSegment,
         TimeSpan Reels,
         int ElementCount,
+        int BackgroundCount,
         int LampCount,
         int TextLampCount,
         int AlphaCount,
@@ -88,6 +89,7 @@ internal static class SkiaRenderDiagnostics
         private double _sevenMs;
         private double _reelMs;
         private int _elements;
+        private int _backgrounds;
         private int _lamps;
         private int _textLamps;
         private int _alphas;
@@ -108,6 +110,7 @@ internal static class SkiaRenderDiagnostics
             _sevenMs += data.SevenSegment.TotalMilliseconds;
             _reelMs += data.Reels.TotalMilliseconds;
             _elements += data.ElementCount;
+            _backgrounds += data.BackgroundCount;
             _lamps += data.LampCount;
             _textLamps += data.TextLampCount;
             _alphas += data.AlphaCount;
@@ -125,13 +128,13 @@ internal static class SkiaRenderDiagnostics
             var sb = new StringBuilder();
             sb.Append($"[SkiaDiag] {viewName}: fps~{_frames / seconds:F1}, frameAvg={_totalMs / _frames:F2}ms, frameMax={_maxFrameMs:F2}ms");
             sb.Append($", timing(ms): background={_backgroundMs / _frames:F2} lamps={_lampMs / _frames:F2} textLamps={_textLampMs / _frames:F2} alpha={_alphaMs / _frames:F2} seg7={_sevenMs / _frames:F2} reels={_reelMs / _frames:F2}");
-            sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
+            sb.Append($", counts/frame: elems={_elements / (double)_frames:F1} background={_backgrounds / (double)_frames:F1} lamps={_lamps / (double)_frames:F1} textLamps={_textLamps / (double)_frames:F1} alpha={_alphas / (double)_frames:F1} seg7={_sevens / (double)_frames:F1} reels={_reels / (double)_frames:F1}");
             sb.Append($", textWork/frame: layouts={_textLayouts / (double)_frames:F1} draws={_textDraws / (double)_frames:F1}");
 
             _windowStartUtc = DateTime.UtcNow;
             _frames = 0;
             _totalMs = _maxFrameMs = _backgroundMs = _lampMs = _textLampMs = _alphaMs = _sevenMs = _reelMs = 0;
-            _elements = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
+            _elements = _backgrounds = _lamps = _textLamps = _alphas = _sevens = _reels = _textLayouts = _textDraws = 0;
             return sb.ToString();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -23,7 +23,7 @@ public partial class PlayView : UserControl
     private bool _isSkiaPanning;
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()]);
+    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
 
     public PlayView()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -439,7 +439,7 @@ public partial class PlayView : UserControl
 
         Dispatcher.Invoke(() =>
         {
-            PlaySkiaSurface.InvalidateVisual();
+            RequestRender();
         });
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using SkiaSharp.Views.WPF;
@@ -23,11 +25,18 @@ public partial class PlayView : UserControl
     private bool _isSkiaPanning;
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
+    private bool _isRenderQueued;
+    private bool _isRenderDirty;
+    private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
+    private readonly DispatcherTimer _renderThrottleTimer;
+    private const double TargetFrameMillis = 16.0;
     private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
 
     public PlayView()
     {
         InitializeComponent();
+        _renderThrottleTimer = new DispatcherTimer(DispatcherPriority.Render, Dispatcher);
+        _renderThrottleTimer.Tick += OnRenderThrottleTick;
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         DataContextChanged += OnDataContextChanged;
@@ -43,6 +52,7 @@ public partial class PlayView : UserControl
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
+        _renderThrottleTimer.Stop();
         DetachPreProcessInputHandler();
     }
 
@@ -82,12 +92,13 @@ public partial class PlayView : UserControl
         }
 
         EmptyStateText.Visibility = Visibility.Collapsed;
-        PlaySkiaSurface.InvalidateVisual();
+        RequestRender();
     }
 
 
     private void OnPlaySkiaSurfacePaintSurface(object? sender, SKPaintSurfaceEventArgs eventArgs)
     {
+        _isRenderDirty = false;
         var canvas = eventArgs.Surface.Canvas;
         canvas.Clear(new SKColor(0x1E, 0x1E, 0x1E));
 
@@ -103,6 +114,45 @@ public partial class PlayView : UserControl
         canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
         _skiaRenderer.Render(canvas, selected.GetPanelElements(), selected.RuntimeState, viewport);
         canvas.Restore();
+    }
+
+    private void RequestRender()
+    {
+        _isRenderDirty = true;
+        if (_isRenderQueued || _renderThrottleTimer.IsEnabled)
+        {
+            return;
+        }
+
+        var elapsedMillis = _renderStopwatch.Elapsed.TotalMilliseconds;
+        if (elapsedMillis < TargetFrameMillis)
+        {
+            _renderThrottleTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(1.0, TargetFrameMillis - elapsedMillis));
+            _renderThrottleTimer.Start();
+            return;
+        }
+
+        QueueRenderNow();
+    }
+
+    private void OnRenderThrottleTick(object? sender, EventArgs e)
+    {
+        _renderThrottleTimer.Stop();
+        if (_isRenderDirty)
+        {
+            QueueRenderNow();
+        }
+    }
+
+    private void QueueRenderNow()
+    {
+        _isRenderQueued = true;
+        Dispatcher.BeginInvoke(() =>
+        {
+            _isRenderQueued = false;
+            _renderStopwatch.Restart();
+            PlaySkiaSurface.InvalidateVisual();
+        }, DispatcherPriority.Render);
     }
 
     private async void OnPlaySkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)
@@ -144,7 +194,7 @@ public partial class PlayView : UserControl
         }
         var delta = current - _skiaPanStart;
         _skiaPan = _skiaPanOrigin + (Vector)delta;
-        PlaySkiaSurface.InvalidateVisual();
+        RequestRender();
     }
 
     private async void OnPlaySkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
@@ -187,7 +237,7 @@ public partial class PlayView : UserControl
         _skiaPan = new Vector(
             pivot.X - (worldX * _skiaZoom),
             pivot.Y - (worldY * _skiaZoom));
-        PlaySkiaSurface.InvalidateVisual();
+        RequestRender();
         eventArgs.Handled = true;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -32,7 +32,7 @@ public partial class SkiaPanel2DEditView : UserControl
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
-    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()]);
+    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "EditView");
 
     public SkiaPanel2DEditView()
     {


### PR DESCRIPTION
### Motivation
- Gather actionable timing and counter data for the Skia renderer to locate hotspots (text lamps and alpha/segment rendering) before implementing caching optimizations.
- Provide a low-overhead, togglable diagnostics path that can be throttled to avoid spamming the Output Log during profiling sessions.

### Description
- Added `SkiaRenderDiagnostics` to aggregate per-frame and per-view timing/counters and emit a throttled summary via `ReportReady` (default interval `3s`) when enabled.  
- Instrumented `Panel2DRenderer` to measure per-element category timings and counts and to call the diagnostics aggregator with frame data.  
- Added lightweight text-work counters to `LampElementRenderer` (`TextLayout` / `TextDraw` counters and per-frame reset) and exposed them to the diagnostics pipeline.  
- Wired diagnostics into the UI by enabling `SkiaRenderDiagnostics` and subscribing to `ReportReady` in `MainWindowViewModel` so reports are forwarded to the Output Log; renderer instances are tagged with view names (`PlayView` / `EditView`) to separate metrics.

### Testing
- No automated build or unit tests were executed in this environment due to the repository's Windows/.NET/WPF toolchain constraint; local `dotnet build`/`dotnet test` should be run on Windows to validate compilation and test suites.  
- Verified repository changes were committed (commit message: `Add Skia renderer diagnostics instrumentation and throttled reporting`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cba2323688327abef6c4f67cb1cdc)