### PR TITLE
Generalize segment display definitions for MAME (14/16‑seg) and add independent punctuation-bit support

### DIFF
--- a/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_14_segment_display_definition.json
+++ b/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_14_segment_display_definition.json
@@ -1,6 +1,6 @@
 {
   "schema": "oasis.segmentDisplayDefinition.v1",
-  "name": "16-segment LED display cell from 108870-16-segment-led.svg",
+  "name": "14-segment LED display (placeholder geometry derived from existing 16-segment asset)",
   "units": "source-svg-user-units-normalized",
   "source": {
     "fileName": "108870-16-segment-led.svg",
@@ -203,78 +203,8 @@
           "height": 30.3302
         },
         "bitIndex": 13
-      },
-      {
-        "index": 14,
-        "id": "S13",
-        "sourcePathIndex": 48,
-        "pathData": "M 37.657 36.4573 L 31.0911 39.8901 L 41.0676 17.4291 L 51.0328 9.6048 L 49.3255 19.2864 Z",
-        "bounds": {
-          "x": 31.0911,
-          "y": 9.6048,
-          "width": 19.9417,
-          "height": 30.2853
-        },
-        "bitIndex": 14
-      },
-      {
-        "index": 15,
-        "id": "S10",
-        "sourcePathIndex": 45,
-        "pathData": "M 30.983 41.1843 C 30.983 41.1843 35.5075 43.6053 35.5039 43.9009 C 35.5003 44.1966 41.3689 62.4839 41.3689 62.4839 L 39.8392 71.5141 C 39.8392 71.5141 32.3645 63.6751 32.7799 63.5619 C 33.1953 63.4487 30.983 41.1839 30.983 41.1839 Z",
-        "bounds": {
-          "x": 30.983,
-          "y": 41.1839,
-          "width": 10.3859,
-          "height": 30.3302
-        },
-        "bitIndex": 15
       }
-    ],
-    "decimalPoint": {
-      "id": "DP",
-      "sourcePathIndices": [
-        8,
-        25,
-        42
-      ],
-      "pathData": "M 57.3522 81.0832 C 57.3522 82.8959 55.8827 84.3654 54.07 84.3654 C 52.2573 84.3654 50.7878 82.8959 50.7878 81.0832 C 50.7878 79.2705 52.2573 77.801 54.07 77.801 C 55.8827 77.801 57.3522 79.2705 57.3522 81.0832 Z",
-      "bounds": {
-        "x": 50.7878,
-        "y": 77.801,
-        "width": 6.5644,
-        "height": 6.5644
-      },
-      "note": "Decimal point moved left by half its diameter from the prior top-right/bottom-edge alignment; segment paths unchanged.",
-      "positioning": {
-        "horizontalAlignment": "centerXOneRadiusLeftOfRightmostPointOfTopBarRightSegment",
-        "verticalAlignment": "centerYAtBottomEdgeOfBottomSegments",
-        "alignedToSegmentIndices": [
-          3,
-          6,
-          7
-        ],
-        "targetCenter": {
-          "x": 54.07,
-          "y": 81.0832
-        },
-        "previousCenter": {
-          "x": 73.8078,
-          "y": 76.9275
-        },
-        "translationFromPrevious": {
-          "x": -16.4556,
-          "y": 4.1557
-        },
-        "finalAdjustment": {
-          "description": "Moved decimal point left by half its diameter (one radius).",
-          "shiftX": -3.2822,
-          "diameter": 6.5644,
-          "radius": 3.2822
-        }
-      },
-      "bitIndex": 16
-    }
+    ]
   },
   "sampleText": {
     "cellCount": 3,
@@ -293,5 +223,5 @@
       }
     ]
   },
-  "mameComponentType": "led16seg"
+  "mameComponentType": "led14seg"
 }

--- a/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_14_segment_sc_display_definition.json
+++ b/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_14_segment_sc_display_definition.json
@@ -1,6 +1,6 @@
 {
   "schema": "oasis.segmentDisplayDefinition.v1",
-  "name": "16-segment LED display cell from 108870-16-segment-led.svg",
+  "name": "14-segment LED display with semicolon punctuation (placeholder geometry)",
   "units": "source-svg-user-units-normalized",
   "source": {
     "fileName": "108870-16-segment-led.svg",
@@ -203,77 +203,23 @@
           "height": 30.3302
         },
         "bitIndex": 13
-      },
-      {
-        "index": 14,
-        "id": "S13",
-        "sourcePathIndex": 48,
-        "pathData": "M 37.657 36.4573 L 31.0911 39.8901 L 41.0676 17.4291 L 51.0328 9.6048 L 49.3255 19.2864 Z",
-        "bounds": {
-          "x": 31.0911,
-          "y": 9.6048,
-          "width": 19.9417,
-          "height": 30.2853
-        },
-        "bitIndex": 14
-      },
-      {
-        "index": 15,
-        "id": "S10",
-        "sourcePathIndex": 45,
-        "pathData": "M 30.983 41.1843 C 30.983 41.1843 35.5075 43.6053 35.5039 43.9009 C 35.5003 44.1966 41.3689 62.4839 41.3689 62.4839 L 39.8392 71.5141 C 39.8392 71.5141 32.3645 63.6751 32.7799 63.5619 C 33.1953 63.4487 30.983 41.1839 30.983 41.1839 Z",
-        "bounds": {
-          "x": 30.983,
-          "y": 41.1839,
-          "width": 10.3859,
-          "height": 30.3302
-        },
-        "bitIndex": 15
       }
     ],
     "decimalPoint": {
       "id": "DP",
-      "sourcePathIndices": [
-        8,
-        25,
-        42
-      ],
-      "pathData": "M 57.3522 81.0832 C 57.3522 82.8959 55.8827 84.3654 54.07 84.3654 C 52.2573 84.3654 50.7878 82.8959 50.7878 81.0832 C 50.7878 79.2705 52.2573 77.801 54.07 77.801 C 55.8827 77.801 57.3522 79.2705 57.3522 81.0832 Z",
-      "bounds": {
-        "x": 50.7878,
-        "y": 77.801,
-        "width": 6.5644,
-        "height": 6.5644
-      },
-      "note": "Decimal point moved left by half its diameter from the prior top-right/bottom-edge alignment; segment paths unchanged.",
-      "positioning": {
-        "horizontalAlignment": "centerXOneRadiusLeftOfRightmostPointOfTopBarRightSegment",
-        "verticalAlignment": "centerYAtBottomEdgeOfBottomSegments",
-        "alignedToSegmentIndices": [
-          3,
-          6,
-          7
-        ],
-        "targetCenter": {
-          "x": 54.07,
-          "y": 81.0832
-        },
-        "previousCenter": {
-          "x": 73.8078,
-          "y": 76.9275
-        },
-        "translationFromPrevious": {
-          "x": -16.4556,
-          "y": 4.1557
-        },
-        "finalAdjustment": {
-          "description": "Moved decimal point left by half its diameter (one radius).",
-          "shiftX": -3.2822,
-          "diameter": 6.5644,
-          "radius": 3.2822
-        }
-      },
-      "bitIndex": 16
+      "bitIndex": 14,
+      "pathData": "M 52 74 A 3 3 0 1 0 58 74 A 3 3 0 1 0 52 74 Z",
+      "notes": [
+        "TODO: replace with MAME-derived led14segsc decimal-point geometry."
+      ]
+    },
+    "commaTail": {
+      "id": "CT",
+      "bitIndex": 15,
+      "pathData": "M 56 77 L 60 84 L 56 90 L 52 88 L 55 84 L 52 77 Z",
+      "notes": [
+        "TODO: replace with MAME-derived led14segsc comma-tail geometry."
+      ]
     }
   },
   "sampleText": {
@@ -293,5 +239,5 @@
       }
     ]
   },
-  "mameComponentType": "led16seg"
+  "mameComponentType": "led14segsc"
 }

--- a/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_16_segment_sc_display_definition.json
+++ b/WindowsNetProjects/OasisEditor/Assets/SegmentDisplays/oasis_16_segment_sc_display_definition.json
@@ -1,6 +1,6 @@
 {
   "schema": "oasis.segmentDisplayDefinition.v1",
-  "name": "16-segment LED display cell from 108870-16-segment-led.svg",
+  "name": "16-segment LED display with semicolon punctuation (placeholder comma tail)",
   "units": "source-svg-user-units-normalized",
   "source": {
     "fileName": "108870-16-segment-led.svg",
@@ -274,6 +274,14 @@
         }
       },
       "bitIndex": 16
+    },
+    "commaTail": {
+      "id": "CT",
+      "bitIndex": 17,
+      "pathData": "M 54 74 L 58 80 L 54 88 L 50 86 L 53 80 L 50 74 Z",
+      "notes": [
+        "TODO: replace with MAME-derived led16segsc comma-tail geometry."
+      ]
     }
   },
   "sampleText": {
@@ -293,5 +301,5 @@
       }
     ]
   },
-  "mameComponentType": "led16seg"
+  "mameComponentType": "led16segsc"
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/AlphaSixteenSegmentDisplayVisual.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/AlphaSixteenSegmentDisplayVisual.cs
@@ -2,8 +2,8 @@ namespace OasisEditor;
 
 internal sealed class AlphaSixteenSegmentDisplayVisual : SegmentDisplayVisualBase
 {
-    public AlphaSixteenSegmentDisplayVisual()
-        : base(LoadDefinition())
+    public AlphaSixteenSegmentDisplayVisual(string? segmentDisplayType = null)
+        : base(LoadDefinition(segmentDisplayType))
     {
     }
 
@@ -17,8 +17,14 @@ internal sealed class AlphaSixteenSegmentDisplayVisual : SegmentDisplayVisualBas
         };
     }
 
-    private static SegmentDisplayDefinition? LoadDefinition()
+    private static SegmentDisplayDefinition? LoadDefinition(string? segmentDisplayType)
     {
+        if (!string.IsNullOrWhiteSpace(segmentDisplayType)
+            && SegmentDisplayDefinitionLoader.TryGetDefinitionByType(segmentDisplayType, out var mappedDefinition))
+        {
+            return mappedDefinition;
+        }
+
         SegmentDisplayDefinitionLoader.TryGetSixteenSegmentDefinition(out var definition);
         return definition;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -122,18 +122,20 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
     private static int RemapMameMaskToWpfSegmentOrder(int rawMask)
     {
-        var normalizedMask = rawMask & 0xFFFF;
+        var normalizedMask = rawMask & 0x3FFFF;
+        var punctuationMask = normalizedMask & ~0xFFFF;
+        var mainSegmentsMask = normalizedMask & 0xFFFF;
 
-        if ((normalizedMask & 0xC000) == 0)
+        if ((mainSegmentsMask & 0xC000) == 0)
         {
-            return ExpandLed14SegIntoSixteenSegmentMask(normalizedMask);
+            return ExpandLed14SegIntoSixteenSegmentMask(mainSegmentsMask) | punctuationMask;
         }
 
         var remappedMask = 0;
 
         for (var bit = 0; bit < Led16SegBitToWpfSegmentIndexMap.Length; bit++)
         {
-            if ((normalizedMask & (1 << bit)) == 0)
+            if ((mainSegmentsMask & (1 << bit)) == 0)
             {
                 continue;
             }
@@ -141,7 +143,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
             remappedMask |= 1 << Led16SegBitToWpfSegmentIndexMap[bit];
         }
 
-        return remappedMask;
+        return remappedMask | punctuationMask;
     }
 
     private static int ExpandLed14SegIntoSixteenSegmentMask(int led14Mask)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -19,6 +19,7 @@ internal sealed class PanelElementModel
     public string? AssetPath { get; init; }
     public string? SecondaryAssetPath { get; init; }
     public int? DisplayNumber { get; init; }
+    public string? SegmentDisplayType { get; init; }
     public string? OnColorHex { get; init; }
     public string? OffColorHex { get; init; }
     public string? TextColorHex { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -20,6 +20,8 @@ internal sealed class PanelElementModel
     public string? SecondaryAssetPath { get; init; }
     public int? DisplayNumber { get; init; }
     public string? SegmentDisplayType { get; init; }
+    public bool ShowDecimalPoint { get; init; }
+    public bool ShowCommaTail { get; init; }
     public string? OnColorHex { get; init; }
     public string? OffColorHex { get; init; }
     public string? TextColorHex { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -316,6 +316,7 @@ internal static class Panel2DDocumentStorage
             AssetPath = normalized.AssetPath,
             SecondaryAssetPath = normalized.SecondaryAssetPath,
             DisplayNumber = normalized.DisplayNumber,
+            SegmentDisplayType = normalized.SegmentDisplayType,
             OnColorHex = normalized.OnColorHex,
             OffColorHex = normalized.OffColorHex,
             TextColorHex = normalized.TextColorHex,
@@ -360,6 +361,7 @@ internal static class Panel2DDocumentStorage
             AssetPath = element.AssetPath,
             SecondaryAssetPath = element.SecondaryAssetPath,
             DisplayNumber = element.DisplayNumber,
+            SegmentDisplayType = element.SegmentDisplayType,
             OnColorHex = element.OnColorHex,
             OffColorHex = element.OffColorHex,
             TextColorHex = element.TextColorHex,
@@ -424,6 +426,7 @@ internal static class Panel2DDocumentStorage
         var normalizedAssetPath = NormalizeOptionalString(normalizedNative?.AssetPath ?? element.AssetPath);
         var normalizedSecondaryAssetPath = NormalizeOptionalString(normalizedNative?.SecondaryAssetPath ?? element.SecondaryAssetPath);
         var normalizedDisplayNumber = normalizedNative?.Number ?? element.DisplayNumber;
+        var normalizedSegmentDisplayType = NormalizeOptionalString(normalizedNative?.SegmentDisplayType ?? element.SegmentDisplayType);
         var normalizedOnColorHex = NormalizeOptionalString(normalizedNative?.OnColorHex ?? normalizedNative?.DisplayColorHex ?? element.OnColorHex);
         var normalizedOffColorHex = NormalizeOptionalString(normalizedNative?.OffColorHex ?? element.OffColorHex);
         var normalizedTextColorHex = NormalizeOptionalString(normalizedNative?.TextColorHex ?? element.TextColorHex);
@@ -464,6 +467,7 @@ internal static class Panel2DDocumentStorage
                 AssetPath = normalizedAssetPath,
                 SecondaryAssetPath = normalizedSecondaryAssetPath,
                 Number = normalizedDisplayNumber,
+                SegmentDisplayType = normalizedSegmentDisplayType,
                 Text = normalizedDisplayText,
                 TextBoxFontName = normalizedTextBoxFontName,
                 TextBoxFontStyle = normalizedTextBoxFontStyle,
@@ -486,6 +490,7 @@ internal static class Panel2DDocumentStorage
             AssetPath = normalizedAssetPath,
             SecondaryAssetPath = normalizedSecondaryAssetPath,
             DisplayNumber = normalizedDisplayNumber,
+            SegmentDisplayType = normalizedSegmentDisplayType,
             OnColorHex = normalizedOnColorHex,
             OffColorHex = normalizedOffColorHex,
             TextColorHex = normalizedTextColorHex,
@@ -720,6 +725,7 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public string? AssetPath { get; init; }
     public string? SecondaryAssetPath { get; init; }
     public int? DisplayNumber { get; init; }
+    public string? SegmentDisplayType { get; init; }
     public string? OnColorHex { get; init; }
     public string? OffColorHex { get; init; }
     public string? TextColorHex { get; init; }
@@ -744,6 +750,7 @@ internal sealed record PanelElementNativeFile
     public string? AssetPath { get; init; }
     public string? SecondaryAssetPath { get; init; }
     public int? Number { get; init; }
+    public string? SegmentDisplayType { get; init; }
     public string? Text { get; init; }
     public string? TextBoxFontName { get; init; }
     public string? TextBoxFontStyle { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -317,6 +317,8 @@ internal static class Panel2DDocumentStorage
             SecondaryAssetPath = normalized.SecondaryAssetPath,
             DisplayNumber = normalized.DisplayNumber,
             SegmentDisplayType = normalized.SegmentDisplayType,
+            ShowDecimalPoint = normalized.ShowDecimalPoint ?? false,
+            ShowCommaTail = normalized.ShowCommaTail ?? false,
             OnColorHex = normalized.OnColorHex,
             OffColorHex = normalized.OffColorHex,
             TextColorHex = normalized.TextColorHex,
@@ -362,6 +364,8 @@ internal static class Panel2DDocumentStorage
             SecondaryAssetPath = element.SecondaryAssetPath,
             DisplayNumber = element.DisplayNumber,
             SegmentDisplayType = element.SegmentDisplayType,
+            ShowDecimalPoint = element.ShowDecimalPoint,
+            ShowCommaTail = element.ShowCommaTail,
             OnColorHex = element.OnColorHex,
             OffColorHex = element.OffColorHex,
             TextColorHex = element.TextColorHex,
@@ -427,6 +431,8 @@ internal static class Panel2DDocumentStorage
         var normalizedSecondaryAssetPath = NormalizeOptionalString(normalizedNative?.SecondaryAssetPath ?? element.SecondaryAssetPath);
         var normalizedDisplayNumber = normalizedNative?.Number ?? element.DisplayNumber;
         var normalizedSegmentDisplayType = NormalizeOptionalString(normalizedNative?.SegmentDisplayType ?? element.SegmentDisplayType);
+        var normalizedShowDecimalPoint = normalizedNative?.ShowDecimalPoint ?? element.ShowDecimalPoint ?? false;
+        var normalizedShowCommaTail = normalizedNative?.ShowCommaTail ?? element.ShowCommaTail ?? false;
         var normalizedOnColorHex = NormalizeOptionalString(normalizedNative?.OnColorHex ?? normalizedNative?.DisplayColorHex ?? element.OnColorHex);
         var normalizedOffColorHex = NormalizeOptionalString(normalizedNative?.OffColorHex ?? element.OffColorHex);
         var normalizedTextColorHex = NormalizeOptionalString(normalizedNative?.TextColorHex ?? element.TextColorHex);
@@ -468,6 +474,10 @@ internal static class Panel2DDocumentStorage
                 SecondaryAssetPath = normalizedSecondaryAssetPath,
                 Number = normalizedDisplayNumber,
                 SegmentDisplayType = normalizedSegmentDisplayType,
+            ShowDecimalPoint = normalizedShowDecimalPoint,
+            ShowCommaTail = normalizedShowCommaTail,
+                ShowDecimalPoint = normalizedShowDecimalPoint,
+                ShowCommaTail = normalizedShowCommaTail,
                 Text = normalizedDisplayText,
                 TextBoxFontName = normalizedTextBoxFontName,
                 TextBoxFontStyle = normalizedTextBoxFontStyle,
@@ -491,6 +501,8 @@ internal static class Panel2DDocumentStorage
             SecondaryAssetPath = normalizedSecondaryAssetPath,
             DisplayNumber = normalizedDisplayNumber,
             SegmentDisplayType = normalizedSegmentDisplayType,
+            ShowDecimalPoint = normalizedShowDecimalPoint,
+            ShowCommaTail = normalizedShowCommaTail,
             OnColorHex = normalizedOnColorHex,
             OffColorHex = normalizedOffColorHex,
             TextColorHex = normalizedTextColorHex,
@@ -726,6 +738,8 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public string? SecondaryAssetPath { get; init; }
     public int? DisplayNumber { get; init; }
     public string? SegmentDisplayType { get; init; }
+    public bool? ShowDecimalPoint { get; init; }
+    public bool? ShowCommaTail { get; init; }
     public string? OnColorHex { get; init; }
     public string? OffColorHex { get; init; }
     public string? TextColorHex { get; init; }
@@ -751,6 +765,8 @@ internal sealed record PanelElementNativeFile
     public string? SecondaryAssetPath { get; init; }
     public int? Number { get; init; }
     public string? SegmentDisplayType { get; init; }
+    public bool? ShowDecimalPoint { get; init; }
+    public bool? ShowCommaTail { get; init; }
     public string? Text { get; init; }
     public string? TextBoxFontName { get; init; }
     public string? TextBoxFontStyle { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -474,8 +474,6 @@ internal static class Panel2DDocumentStorage
                 SecondaryAssetPath = normalizedSecondaryAssetPath,
                 Number = normalizedDisplayNumber,
                 SegmentDisplayType = normalizedSegmentDisplayType,
-            ShowDecimalPoint = normalizedShowDecimalPoint,
-            ShowCommaTail = normalizedShowCommaTail,
                 ShowDecimalPoint = normalizedShowDecimalPoint,
                 ShowCommaTail = normalizedShowCommaTail,
                 Text = normalizedDisplayText,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -339,7 +339,7 @@ internal static class PanelElementFactory
             BorderBrush = Brushes.SlateGray,
             Background = TryCreateBrush("#111827", Brushes.Black),
             Padding = new Thickness(4),
-            Child = new AlphaSixteenSegmentDisplayVisual
+            Child = new AlphaSixteenSegmentDisplayVisual(element.SegmentDisplayType)
             {
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -320,7 +320,7 @@ internal static class PanelElementFactory
                 DisplayText = string.IsNullOrWhiteSpace(element.DisplayText) ? null : element.DisplayText,
                 LitBrush = TryCreateBrush(element.OnColorHex, Brushes.Red),
                 UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(32, 255, 0, 0))),
-                ShowDecimalPoint = element.ShowDecimalPoint ?? false,
+                ShowDecimalPoint = element.ShowDecimalPoint ?? true,
                 ShowCommaTail = element.ShowCommaTail ?? false
             }
         };
@@ -348,7 +348,7 @@ internal static class PanelElementFactory
                 DisplayText = element.DisplayText,
                 LitBrush = TryCreateBrush(element.OnColorHex, Brushes.Cyan),
                 UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(32, 0, 255, 255))),
-                ShowDecimalPoint = element.ShowDecimalPoint ?? false,
+                ShowDecimalPoint = element.ShowDecimalPoint ?? true,
                 ShowCommaTail = element.ShowCommaTail ?? false
             }
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -320,7 +320,8 @@ internal static class PanelElementFactory
                 DisplayText = string.IsNullOrWhiteSpace(element.DisplayText) ? null : element.DisplayText,
                 LitBrush = TryCreateBrush(element.OnColorHex, Brushes.Red),
                 UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(32, 255, 0, 0))),
-                ShowDecimalPoint = true
+                ShowDecimalPoint = element.ShowDecimalPoint ?? false,
+                ShowCommaTail = element.ShowCommaTail ?? false
             }
         };
     }
@@ -347,7 +348,8 @@ internal static class PanelElementFactory
                 DisplayText = element.DisplayText,
                 LitBrush = TryCreateBrush(element.OnColorHex, Brushes.Cyan),
                 UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(32, 0, 255, 255))),
-                ShowDecimalPoint = true
+                ShowDecimalPoint = element.ShowDecimalPoint ?? false,
+                ShowCommaTail = element.ShowCommaTail ?? false
             }
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -27,6 +27,7 @@ internal static class PanelElementModelCloner
             AssetPath = source.AssetPath,
             SecondaryAssetPath = source.SecondaryAssetPath,
             DisplayNumber = source.DisplayNumber,
+            SegmentDisplayType = source.SegmentDisplayType,
             OnColorHex = source.OnColorHex,
             OffColorHex = source.OffColorHex,
             TextColorHex = source.TextColorHex,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -28,6 +28,8 @@ internal static class PanelElementModelCloner
             SecondaryAssetPath = source.SecondaryAssetPath,
             DisplayNumber = source.DisplayNumber,
             SegmentDisplayType = source.SegmentDisplayType,
+            ShowDecimalPoint = source.ShowDecimalPoint,
+            ShowCommaTail = source.ShowCommaTail,
             OnColorHex = source.OnColorHex,
             OffColorHex = source.OffColorHex,
             TextColorHex = source.TextColorHex,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -33,6 +33,8 @@ internal sealed class PanelElementModelUpdate
     public PanelElementOptionalValue<string?> SecondaryAssetPath { get; init; }
     public PanelElementOptionalValue<int?> DisplayNumber { get; init; }
     public PanelElementOptionalValue<string?> SegmentDisplayType { get; init; }
+    public PanelElementOptionalValue<bool> ShowDecimalPoint { get; init; }
+    public PanelElementOptionalValue<bool> ShowCommaTail { get; init; }
     public PanelElementOptionalValue<string?> OnColorHex { get; init; }
     public PanelElementOptionalValue<string?> OffColorHex { get; init; }
     public PanelElementOptionalValue<string?> TextColorHex { get; init; }
@@ -67,6 +69,8 @@ internal static class PanelElementModelUpdater
             SecondaryAssetPath = update.SecondaryAssetPath.HasValue ? update.SecondaryAssetPath.Value : source.SecondaryAssetPath,
             DisplayNumber = update.DisplayNumber.HasValue ? update.DisplayNumber.Value : source.DisplayNumber,
             SegmentDisplayType = update.SegmentDisplayType.HasValue ? update.SegmentDisplayType.Value : source.SegmentDisplayType,
+            ShowDecimalPoint = update.ShowDecimalPoint.HasValue ? update.ShowDecimalPoint.Value : source.ShowDecimalPoint,
+            ShowCommaTail = update.ShowCommaTail.HasValue ? update.ShowCommaTail.Value : source.ShowCommaTail,
             OnColorHex = update.OnColorHex.HasValue ? update.OnColorHex.Value : source.OnColorHex,
             OffColorHex = update.OffColorHex.HasValue ? update.OffColorHex.Value : source.OffColorHex,
             TextColorHex = update.TextColorHex.HasValue ? update.TextColorHex.Value : source.TextColorHex,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -32,6 +32,7 @@ internal sealed class PanelElementModelUpdate
     public PanelElementOptionalValue<string?> AssetPath { get; init; }
     public PanelElementOptionalValue<string?> SecondaryAssetPath { get; init; }
     public PanelElementOptionalValue<int?> DisplayNumber { get; init; }
+    public PanelElementOptionalValue<string?> SegmentDisplayType { get; init; }
     public PanelElementOptionalValue<string?> OnColorHex { get; init; }
     public PanelElementOptionalValue<string?> OffColorHex { get; init; }
     public PanelElementOptionalValue<string?> TextColorHex { get; init; }
@@ -65,6 +66,7 @@ internal static class PanelElementModelUpdater
             AssetPath = update.AssetPath.HasValue ? update.AssetPath.Value : source.AssetPath,
             SecondaryAssetPath = update.SecondaryAssetPath.HasValue ? update.SecondaryAssetPath.Value : source.SecondaryAssetPath,
             DisplayNumber = update.DisplayNumber.HasValue ? update.DisplayNumber.Value : source.DisplayNumber,
+            SegmentDisplayType = update.SegmentDisplayType.HasValue ? update.SegmentDisplayType.Value : source.SegmentDisplayType,
             OnColorHex = update.OnColorHex.HasValue ? update.OnColorHex.Value : source.OnColorHex,
             OffColorHex = update.OffColorHex.HasValue ? update.OffColorHex.Value : source.OffColorHex,
             TextColorHex = update.TextColorHex.HasValue ? update.TextColorHex.Value : source.TextColorHex,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -41,6 +41,8 @@ internal static class PanelElementModelComparer
                && string.Equals(left.SecondaryAssetPath, right.SecondaryAssetPath, StringComparison.Ordinal)
                && left.DisplayNumber == right.DisplayNumber
                && string.Equals(left.SegmentDisplayType, right.SegmentDisplayType, StringComparison.Ordinal)
+               && left.ShowDecimalPoint == right.ShowDecimalPoint
+               && left.ShowCommaTail == right.ShowCommaTail
                && string.Equals(left.OnColorHex, right.OnColorHex, StringComparison.Ordinal)
                && string.Equals(left.OffColorHex, right.OffColorHex, StringComparison.Ordinal)
                && string.Equals(left.TextColorHex, right.TextColorHex, StringComparison.Ordinal)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -40,6 +40,7 @@ internal static class PanelElementModelComparer
                && string.Equals(left.AssetPath, right.AssetPath, StringComparison.Ordinal)
                && string.Equals(left.SecondaryAssetPath, right.SecondaryAssetPath, StringComparison.Ordinal)
                && left.DisplayNumber == right.DisplayNumber
+               && string.Equals(left.SegmentDisplayType, right.SegmentDisplayType, StringComparison.Ordinal)
                && string.Equals(left.OnColorHex, right.OnColorHex, StringComparison.Ordinal)
                && string.Equals(left.OffColorHex, right.OffColorHex, StringComparison.Ordinal)
                && string.Equals(left.TextColorHex, right.TextColorHex, StringComparison.Ordinal)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -5,7 +5,7 @@ namespace OasisEditor.Rendering;
 internal sealed class AlphaElementRenderer : IPanelElementRenderer
 {
     private const int MaxVisualCacheEntries = 4096;
-    private static readonly Lazy<AlphaSkiaDefinition?> Definition = new(LoadDefinition);
+    private static readonly Dictionary<string, Lazy<AlphaSkiaDefinition?>> DefinitionsByType = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<AlphaVisualCacheKey, SKImage> VisualCache = new();
     private static readonly object VisualCacheGate = new();
     [ThreadStatic]
@@ -30,7 +30,8 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             return;
         }
 
-        var definition = Definition.Value;
+        var displayType = string.IsNullOrWhiteSpace(element.SegmentDisplayType) ? "led16seg" : element.SegmentDisplayType!;
+        var definition = GetDefinition(displayType);
         if (definition is null)
         {
             return;
@@ -72,7 +73,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
             var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
             var brightnessBucket = (int)Math.Round(litAmount * 4d);
-            var key = new AlphaVisualCacheKey(cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor);
+            var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor);
             var visual = GetOrCreateVisual(key, definition);
             var cellRect = SKRect.Create(originX + (cellIndex * scaledPitch), originY, scaledCellWidth, scaledCellHeight);
             context.Canvas.DrawImage(visual, cellRect);
@@ -138,9 +139,24 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         return surface.Snapshot();
     }
 
-    private static AlphaSkiaDefinition? LoadDefinition()
+    private static AlphaSkiaDefinition? GetDefinition(string displayType)
     {
-        if (!SegmentDisplayDefinitionLoader.TryGetSixteenSegmentDefinition(out var definition) || definition.Cell is null || definition.Cell.Size is null || definition.Cell.Segments is null)
+        lock (VisualCacheGate)
+        {
+            if (!DefinitionsByType.TryGetValue(displayType, out var lazy))
+            {
+                lazy = new Lazy<AlphaSkiaDefinition?>(() => LoadDefinition(displayType));
+                DefinitionsByType[displayType] = lazy;
+            }
+
+            return lazy.Value;
+        }
+    }
+
+    private static AlphaSkiaDefinition? LoadDefinition(string displayType)
+    {
+        if (!SegmentDisplayDefinitionLoader.TryGetDefinitionByType(displayType, out var definition)
+            || definition.Cell is null || definition.Cell.Size is null || definition.Cell.Segments is null)
         {
             return null;
         }
@@ -177,6 +193,6 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
     }
 
     private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint, int DecimalPointBitIndex, SKPath? CommaTail, int CommaTailBitIndex);
-    private readonly record struct AlphaVisualCacheKey(int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
+    private readonly record struct AlphaVisualCacheKey(string DisplayType, int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -73,7 +73,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             var mask = cellIndex < cellMasks.Length ? cellMasks[cellIndex] : 0;
             var litAmount = cellIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[cellIndex], 0d, 1d) : 1d;
             var brightnessBucket = (int)Math.Round(litAmount * 4d);
-            var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor);
+            var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor, element.ShowDecimalPoint, element.ShowCommaTail);
             var visual = GetOrCreateVisual(key, definition);
             var cellRect = SKRect.Create(originX + (cellIndex * scaledPitch), originY, scaledCellWidth, scaledCellHeight);
             context.Canvas.DrawImage(visual, cellRect);
@@ -122,14 +122,14 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
             canvas.DrawPath(segment.Path, paint);
         }
-        if (definition.DecimalPoint is not null)
+        if (definition.DecimalPoint is not null && key.ShowDecimalPoint)
         {
             var lit = (key.Mask & (1 << definition.DecimalPointBitIndex)) != 0;
             paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
             canvas.DrawPath(definition.DecimalPoint, paint);
         }
 
-        if (definition.CommaTail is not null)
+        if (definition.CommaTail is not null && key.ShowCommaTail)
         {
             var lit = (key.Mask & (1 << definition.CommaTailBitIndex)) != 0;
             paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
@@ -193,6 +193,6 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
     }
 
     private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint, int DecimalPointBitIndex, SKPath? CommaTail, int CommaTailBitIndex);
-    private readonly record struct AlphaVisualCacheKey(string DisplayType, int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
+    private readonly record struct AlphaVisualCacheKey(string DisplayType, int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor, bool ShowDecimalPoint, bool ShowCommaTail);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Text.Json;
 using SkiaSharp;
 
 namespace OasisEditor.Rendering;
@@ -125,8 +123,16 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         }
         if (definition.DecimalPoint is not null)
         {
-            paint.Color = key.OffColor;
+            var lit = (key.Mask & (1 << definition.DecimalPointBitIndex)) != 0;
+            paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
             canvas.DrawPath(definition.DecimalPoint, paint);
+        }
+
+        if (definition.CommaTail is not null)
+        {
+            var lit = (key.Mask & (1 << definition.CommaTailBitIndex)) != 0;
+            paint.Color = lit ? Lerp(key.OffColor, key.OnColor, litAmount) : key.OffColor;
+            canvas.DrawPath(definition.CommaTail, paint);
         }
         canvas.Restore();
         return surface.Snapshot();
@@ -134,39 +140,33 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
 
     private static AlphaSkiaDefinition? LoadDefinition()
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "Assets", "SegmentDisplays", "oasis_16_segment_display_definition.json");
-        if (!File.Exists(path))
+        if (!SegmentDisplayDefinitionLoader.TryGetSixteenSegmentDefinition(out var definition) || definition.Cell is null || definition.Cell.Size is null || definition.Cell.Segments is null)
         {
             return null;
         }
 
-        var json = File.ReadAllText(path);
-        var root = JsonSerializer.Deserialize<AlphaDefinitionRoot>(json, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
-        var cell = root?.Cell;
-        if (cell?.Size is null || cell.Segments is null || cell.Segments.Count != 16)
-        {
-            return null;
-        }
-
-        var paths = new List<AlphaSkiaPath>(cell.Segments.Count);
-        foreach (var segment in cell.Segments)
+        var paths = new List<AlphaSkiaPath>(definition.Cell.Segments.Count);
+        foreach (var segment in definition.Cell.Segments)
         {
             if (string.IsNullOrWhiteSpace(segment.PathData))
             {
                 return null;
             }
 
-            paths.Add(new AlphaSkiaPath(segment.Index, SKPath.ParseSvgPathData(segment.PathData)));
+            paths.Add(new AlphaSkiaPath(segment.BitIndex ?? segment.Index, SKPath.ParseSvgPathData(segment.PathData)));
         }
 
-        var decimalPath = string.IsNullOrWhiteSpace(cell.DecimalPoint?.PathData)
+        var decimalPoint = string.IsNullOrWhiteSpace(definition.Cell.DecimalPoint?.PathData)
             ? null
-            : SKPath.ParseSvgPathData(cell.DecimalPoint.PathData);
+            : SKPath.ParseSvgPathData(definition.Cell.DecimalPoint.PathData);
+        var decimalPointBitIndex = definition.Cell.DecimalPoint?.BitIndex ?? 16;
 
-        return new AlphaSkiaDefinition((float)cell.Size.Width, (float)cell.Size.Height, (float)cell.RecommendedPitch, paths, decimalPath);
+        var commaTail = string.IsNullOrWhiteSpace(definition.Cell.CommaTail?.PathData)
+            ? null
+            : SKPath.ParseSvgPathData(definition.Cell.CommaTail.PathData);
+        var commaTailBitIndex = definition.Cell.CommaTail?.BitIndex ?? 17;
+
+        return new AlphaSkiaDefinition((float)definition.Cell.Size.Width, (float)definition.Cell.Size.Height, (float)definition.Cell.RecommendedPitch, paths, decimalPoint, decimalPointBitIndex, commaTail, commaTailBitIndex);
     }
 
     private static SKColor Lerp(SKColor from, SKColor to, double t)
@@ -176,37 +176,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         return new SKColor(Blend(from.Red, to.Red), Blend(from.Green, to.Green), Blend(from.Blue, to.Blue), 255);
     }
 
-    private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint);
+    private sealed record AlphaSkiaDefinition(float Width, float Height, float RecommendedPitch, IReadOnlyList<AlphaSkiaPath> Segments, SKPath? DecimalPoint, int DecimalPointBitIndex, SKPath? CommaTail, int CommaTailBitIndex);
     private readonly record struct AlphaVisualCacheKey(int Width, int Height, int Mask, int BrightnessBucket, SKColor OnColor, SKColor OffColor);
     private sealed record AlphaSkiaPath(int Index, SKPath Path);
-
-    private sealed class AlphaDefinitionRoot
-    {
-        public AlphaCell? Cell { get; set; }
-    }
-
-    private sealed class AlphaCell
-    {
-        public AlphaSize? Size { get; set; }
-        public double RecommendedPitch { get; set; }
-        public List<AlphaPath>? Segments { get; set; }
-        public AlphaDecimalPoint? DecimalPoint { get; set; }
-    }
-
-    private sealed class AlphaSize
-    {
-        public double Width { get; set; }
-        public double Height { get; set; }
-    }
-
-    private sealed class AlphaPath
-    {
-        public int Index { get; set; }
-        public string? PathData { get; set; }
-    }
-
-    private sealed class AlphaDecimalPoint
-    {
-        public string? PathData { get; set; }
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinition.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinition.cs
@@ -15,6 +15,9 @@ internal sealed class SegmentDisplayDefinition
     [JsonPropertyName("units")]
     public string? Units { get; set; }
 
+    [JsonPropertyName("mameComponentType")]
+    public string? MameComponentType { get; set; }
+
     [JsonPropertyName("cell")]
     public SegmentDisplayCellDefinition? Cell { get; set; }
 }
@@ -31,7 +34,10 @@ internal sealed class SegmentDisplayCellDefinition
     public List<SegmentDisplaySegmentDefinition>? Segments { get; set; }
 
     [JsonPropertyName("decimalPoint")]
-    public SegmentDisplayDecimalPointDefinition? DecimalPoint { get; set; }
+    public SegmentDisplayPunctuationDefinition? DecimalPoint { get; set; }
+
+    [JsonPropertyName("commaTail")]
+    public SegmentDisplayPunctuationDefinition? CommaTail { get; set; }
 }
 
 internal sealed class SegmentDisplaySegmentDefinition
@@ -42,6 +48,9 @@ internal sealed class SegmentDisplaySegmentDefinition
     [JsonPropertyName("id")]
     public string? Id { get; set; }
 
+    [JsonPropertyName("bitIndex")]
+    public int? BitIndex { get; set; }
+
     [JsonPropertyName("pathData")]
     public string? PathData { get; set; }
 
@@ -49,8 +58,14 @@ internal sealed class SegmentDisplaySegmentDefinition
     public Geometry? Geometry { get; set; }
 }
 
-internal sealed class SegmentDisplayDecimalPointDefinition
+internal sealed class SegmentDisplayPunctuationDefinition
 {
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("bitIndex")]
+    public int? BitIndex { get; set; }
+
     [JsonPropertyName("pathData")]
     public string? PathData { get; set; }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinitionLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinitionLoader.cs
@@ -11,39 +11,56 @@ internal static class SegmentDisplayDefinitionLoader
         PropertyNameCaseInsensitive = true
     };
 
-    private static readonly Lazy<SegmentDisplayDefinition?> LazySixteenSegmentDefinition =
-        new(() => TryLoadDefinition("Assets/SegmentDisplays/oasis_16_segment_display_definition.json", 16));
-
-    private static readonly Lazy<SegmentDisplayDefinition?> LazySevenSegmentDefinition =
-        new(() => TryLoadDefinition("Assets/SegmentDisplays/oasis_7_segment_display_definition.json", 7));
-
-    public static bool TryGetSixteenSegmentDefinition(out SegmentDisplayDefinition definition)
+    private static readonly IReadOnlyDictionary<string, SegmentDisplayAssetSpec> AssetSpecs = new Dictionary<string, SegmentDisplayAssetSpec>(StringComparer.OrdinalIgnoreCase)
     {
-        definition = LazySixteenSegmentDefinition.Value!;
-        return definition is not null;
-    }
+        ["led14seg"] = new("Assets/SegmentDisplays/oasis_14_segment_display_definition.json", 14, null, null),
+        ["led14segsc"] = new("Assets/SegmentDisplays/oasis_14_segment_sc_display_definition.json", 14, 14, 15),
+        ["led16seg"] = new("Assets/SegmentDisplays/oasis_16_segment_display_definition.json", 16, null, null),
+        ["led16segsc"] = new("Assets/SegmentDisplays/oasis_16_segment_sc_display_definition.json", 16, 16, 17),
+        ["7seg"] = new("Assets/SegmentDisplays/oasis_7_segment_display_definition.json", 7, null, null)
+    };
 
-    public static bool TryGetSevenSegmentDefinition(out SegmentDisplayDefinition definition)
-    {
-        definition = LazySevenSegmentDefinition.Value!;
-        return definition is not null;
-    }
+    private static readonly Lazy<IReadOnlyDictionary<string, SegmentDisplayDefinition>> LazyDefinitions = new(LoadDefinitions);
 
-    private static SegmentDisplayDefinition? TryLoadDefinition(string relativePath, int expectedSegmentCount)
+    public static bool TryGetSixteenSegmentDefinition(out SegmentDisplayDefinition definition) => TryGetDefinitionByType("led16seg", out definition);
+    public static bool TryGetSevenSegmentDefinition(out SegmentDisplayDefinition definition) => TryGetDefinitionByType("7seg", out definition);
+
+    public static bool TryGetDefinitionByType(string displayType, out SegmentDisplayDefinition definition)
     {
-        var definitionPath = Path.Combine(AppContext.BaseDirectory, relativePath);
-        if (!File.Exists(definitionPath))
+        if (LazyDefinitions.Value.TryGetValue(displayType, out definition!))
         {
-            return null;
+            return true;
         }
 
-        var json = File.ReadAllText(definitionPath);
-        var definition = JsonSerializer.Deserialize<SegmentDisplayDefinition>(json, JsonOptions);
+        definition = null!;
+        return false;
+    }
 
+    private static IReadOnlyDictionary<string, SegmentDisplayDefinition> LoadDefinitions()
+    {
+        var definitions = new Dictionary<string, SegmentDisplayDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, spec) in AssetSpecs)
+        {
+            var definition = TryLoadDefinition(spec);
+            if (definition is not null)
+            {
+                definitions[key] = definition;
+            }
+        }
+
+        return definitions;
+    }
+
+    private static SegmentDisplayDefinition? TryLoadDefinition(SegmentDisplayAssetSpec spec)
+    {
+        var definitionPath = Path.Combine(AppContext.BaseDirectory, spec.RelativePath);
+        if (!File.Exists(definitionPath)) return null;
+
+        var definition = JsonSerializer.Deserialize<SegmentDisplayDefinition>(File.ReadAllText(definitionPath), JsonOptions);
         try
         {
-            Validate(definition, expectedSegmentCount);
-            return definition!;
+            Validate(definition, spec);
+            return definition;
         }
         catch
         {
@@ -51,34 +68,47 @@ internal static class SegmentDisplayDefinitionLoader
         }
     }
 
-    private static void Validate(SegmentDisplayDefinition? definition, int expectedSegmentCount)
+    private static void Validate(SegmentDisplayDefinition? definition, SegmentDisplayAssetSpec spec)
     {
-        if (definition?.Cell?.Size is null)
-        {
-            throw new InvalidOperationException("Segment definition is missing cell.size.");
-        }
-
+        if (definition?.Cell?.Size is null) throw new InvalidOperationException("Segment definition is missing cell.size.");
         var segments = definition.Cell.Segments;
-        if (segments is null || segments.Count != expectedSegmentCount)
+        if (segments is null || segments.Count != spec.ExpectedMainSegmentCount)
         {
-            throw new InvalidOperationException($"Segment definition must contain exactly {expectedSegmentCount} segments.");
+            throw new InvalidOperationException($"Segment definition must contain exactly {spec.ExpectedMainSegmentCount} segments.");
         }
 
         foreach (var segment in segments)
         {
-            if (string.IsNullOrWhiteSpace(segment.PathData))
-            {
-                throw new InvalidOperationException($"Segment {segment.Index} is missing pathData.");
-            }
-
+            if (string.IsNullOrWhiteSpace(segment.PathData)) throw new InvalidOperationException($"Segment {segment.Index} is missing pathData.");
             segment.Geometry = Geometry.Parse(segment.PathData);
             segment.Geometry.Freeze();
         }
 
-        if (!string.IsNullOrWhiteSpace(definition.Cell.DecimalPoint?.PathData))
+        ParsePunctuation(definition.Cell.DecimalPoint, spec.RequiredDecimalPointBitIndex, "decimalPoint");
+        ParsePunctuation(definition.Cell.CommaTail, spec.RequiredCommaTailBitIndex, "commaTail");
+    }
+
+    private static void ParsePunctuation(SegmentDisplayPunctuationDefinition? punctuation, int? requiredBitIndex, string fieldName)
+    {
+        if (requiredBitIndex.HasValue)
         {
-            definition.Cell.DecimalPoint.Geometry = Geometry.Parse(definition.Cell.DecimalPoint.PathData);
-            definition.Cell.DecimalPoint.Geometry.Freeze();
+            if (punctuation is null || string.IsNullOrWhiteSpace(punctuation.PathData))
+            {
+                throw new InvalidOperationException($"Segment definition must contain {fieldName} for this display type.");
+            }
+
+            if (punctuation.BitIndex.GetValueOrDefault(requiredBitIndex.Value) != requiredBitIndex.Value)
+            {
+                throw new InvalidOperationException($"Segment definition {fieldName}.bitIndex must be {requiredBitIndex.Value}.");
+            }
+        }
+
+        if (punctuation is not null && !string.IsNullOrWhiteSpace(punctuation.PathData))
+        {
+            punctuation.Geometry = Geometry.Parse(punctuation.PathData);
+            punctuation.Geometry.Freeze();
         }
     }
+
+    private sealed record SegmentDisplayAssetSpec(string RelativePath, int ExpectedMainSegmentCount, int? RequiredDecimalPointBitIndex, int? RequiredCommaTailBitIndex);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -61,7 +61,8 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
                     continue;
                 }
 
-                var lit = (segmentMask & (1 << segment.Index)) != 0;
+                var bitIndex = segment.BitIndex ?? segment.Index;
+                var lit = (segmentMask & (1 << bitIndex)) != 0;
                 drawingContext.PushTransform(cellTransform);
                 var brush = lit ? ResolveLitBrush(brightness) : UnlitBrush;
                 drawingContext.DrawGeometry(brush, SegmentPen, segment.Geometry);
@@ -70,8 +71,19 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
 
             if (ShowDecimalPoint && _definition.Cell.DecimalPoint?.Geometry is not null)
             {
+                var bitIndex = _definition.Cell.DecimalPoint.BitIndex ?? 16;
+                var lit = (segmentMask & (1 << bitIndex)) != 0;
                 drawingContext.PushTransform(cellTransform);
-                drawingContext.DrawGeometry(UnlitBrush, SegmentPen, _definition.Cell.DecimalPoint.Geometry);
+                drawingContext.DrawGeometry(lit ? ResolveLitBrush(brightness) : UnlitBrush, SegmentPen, _definition.Cell.DecimalPoint.Geometry);
+                drawingContext.Pop();
+            }
+
+            if (ShowDecimalPoint && _definition.Cell.CommaTail?.Geometry is not null)
+            {
+                var bitIndex = _definition.Cell.CommaTail.BitIndex ?? 17;
+                var lit = (segmentMask & (1 << bitIndex)) != 0;
+                drawingContext.PushTransform(cellTransform);
+                drawingContext.DrawGeometry(lit ? ResolveLitBrush(brightness) : UnlitBrush, SegmentPen, _definition.Cell.CommaTail.Geometry);
                 drawingContext.Pop();
             }
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayVisualBase.cs
@@ -21,6 +21,7 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
     public string? DisplayText { get; set; }
     public int[]? CellSegmentMasks { get; set; }
     public bool ShowDecimalPoint { get; set; }
+    public bool ShowCommaTail { get; set; }
     public double[]? CellBrightness { get; set; }
 
     protected override void OnRender(DrawingContext drawingContext)
@@ -78,7 +79,7 @@ internal abstract class SegmentDisplayVisualBase : FrameworkElement
                 drawingContext.Pop();
             }
 
-            if (ShowDecimalPoint && _definition.Cell.CommaTail?.Geometry is not null)
+            if (ShowCommaTail && _definition.Cell.CommaTail?.Geometry is not null)
             {
                 var bitIndex = _definition.Cell.CommaTail.BitIndex ?? 17;
                 var lit = (segmentMask & (1 << bitIndex)) != 0;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -463,3 +463,48 @@ public sealed class InspectorInfoPropertyViewModel : InspectorPropertyRowViewMod
         Value = value;
     }
 }
+
+public sealed class InspectorChoicePropertyViewModel : InspectorPropertyRowViewModel
+{
+    private string _value;
+    private readonly Func<string, string?>? _commit;
+    private bool _isApplyingChange;
+
+    public InspectorChoicePropertyViewModel(string displayName, string groupName, IReadOnlyList<string> choices, string value, bool isReadOnly = false, Func<string, string?>? commit = null)
+        : base(displayName, groupName, isReadOnly)
+    {
+        Choices = choices;
+        _value = value;
+        _commit = commit;
+    }
+
+    public IReadOnlyList<string> Choices { get; }
+
+    public string Value
+    {
+        get => _value;
+        set
+        {
+            if (IsReadOnly || _isApplyingChange || !SetProperty(ref _value, value))
+            {
+                return;
+            }
+
+            var error = _commit?.Invoke(value);
+            if (string.IsNullOrWhiteSpace(error))
+            {
+                ErrorText = string.Empty;
+                return;
+            }
+
+            ErrorText = error;
+        }
+    }
+
+    public void SetCommittedValue(string value)
+    {
+        ErrorText = string.Empty;
+        _value = value;
+        RaisePropertyChanged(nameof(Value));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -468,7 +468,6 @@ public sealed class InspectorChoicePropertyViewModel : InspectorPropertyRowViewM
 {
     private string _value;
     private readonly Func<string, string?>? _commit;
-    private bool _isApplyingChange;
 
     public InspectorChoicePropertyViewModel(string displayName, string groupName, IReadOnlyList<string> choices, string value, bool isReadOnly = false, Func<string, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
@@ -485,7 +484,7 @@ public sealed class InspectorChoicePropertyViewModel : InspectorPropertyRowViewM
         get => _value;
         set
         {
-            if (IsReadOnly || _isApplyingChange || !SetProperty(ref _value, value))
+            if (IsReadOnly || !SetProperty(ref _value, value))
             {
                 return;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -415,6 +415,32 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update display text", new PanelElementModelUpdate { DisplayText = NormalizeOptionalText(value) })));
         }
 
+        if (selectedElement.Kind is PanelElementKind.Alpha)
+        {
+            var selectedDisplayKind = string.Equals(selectedElement.SegmentDisplayType, "led14seg", StringComparison.OrdinalIgnoreCase)
+                ? "14 Segment"
+                : "16 Segment";
+            _propertyRows.Add(new InspectorChoicePropertyViewModel(
+                "Segment Type",
+                "Type-specific",
+                ["14 Segment", "16 Segment"],
+                selectedDisplayKind,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update segment type", new PanelElementModelUpdate
+                {
+                    SegmentDisplayType = string.Equals(value, "14 Segment", StringComparison.Ordinal) ? "led14seg" : "led16seg"
+                })));
+            _propertyRows.Add(new InspectorBoolPropertyViewModel(
+                "Decimal Point",
+                "Type-specific",
+                selectedElement.ShowDecimalPoint,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update decimal point visibility", new PanelElementModelUpdate { ShowDecimalPoint = value })));
+            _propertyRows.Add(new InspectorBoolPropertyViewModel(
+                "Comma",
+                "Type-specific",
+                selectedElement.ShowCommaTail,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update comma visibility", new PanelElementModelUpdate { ShowCommaTail = value })));
+        }
+
         if (selectedElement.Kind is PanelElementKind.Lamp)
         {
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Text Font Name", "Type-specific", selectedElement.TextBoxFontName ?? "Tahoma"));
@@ -506,6 +532,15 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     break;
                 case "Display Text" when row is InspectorTextPropertyViewModel displayTextRow:
                     displayTextRow.SetCommittedValue(selectedElement.DisplayText);
+                    break;
+                case "Segment Type" when row is InspectorChoicePropertyViewModel segmentTypeRow:
+                    segmentTypeRow.SetCommittedValue(string.Equals(selectedElement.SegmentDisplayType, "led14seg", StringComparison.OrdinalIgnoreCase) ? "14 Segment" : "16 Segment");
+                    break;
+                case "Decimal Point" when row is InspectorBoolPropertyViewModel decimalPointRow:
+                    decimalPointRow.SetCommittedValue(selectedElement.ShowDecimalPoint);
+                    break;
+                case "Comma" when row is InspectorBoolPropertyViewModel commaRow:
+                    commaRow.SetCommittedValue(selectedElement.ShowCommaTail);
                     break;
                 case "Text Font Name" when row is InspectorInfoPropertyViewModel fontNameRow:
                     fontNameRow.SetCommittedValue(selectedElement.TextBoxFontName ?? "Tahoma");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -94,7 +94,18 @@
             </Grid>
         </DataTemplate>
 
-        <DataTemplate DataType="{x:Type vm:InspectorInfoPropertyViewModel}">
+        
+        <DataTemplate DataType="{x:Type vm:InspectorChoicePropertyViewModel}">
+            <Grid Margin="0,2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="140" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding DisplayName}" />
+                <ComboBox Grid.Column="1" ItemsSource="{Binding Choices}" SelectedItem="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </Grid>
+        </DataTemplate>
+<DataTemplate DataType="{x:Type vm:InspectorInfoPropertyViewModel}">
             <Grid Margin="0,3,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="120" />


### PR DESCRIPTION
### Motivation
- Support MAME-compatible segment component types (`led14seg`, `led14segsc`, `led16seg`, `led16segsc`) and their canonical bit mappings so imported MAME layouts render correctly.
- Preserve existing OasisEditor behavior and assets while adding additive support for `sc` punctuation (decimal point and comma tail) as independently addressable bits.
- Prefer additive, non-breaking changes so existing 7-seg and 16-seg users remain functional while enabling future replacement with MAME-derived geometry.

### Description
- Extended the segment definition model in `WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinition.cs` to add `mameComponentType`, per-segment optional `bitIndex`, and a shared `SegmentDisplayPunctuationDefinition` used for `decimalPoint` and new `commaTail` (geometry cached and frozen as before). 
- Reworked the loader into a spec-driven `SegmentDisplayDefinitionLoader` that maps display types to assets (`led14seg`, `led14segsc`, `led16seg`, `led16segsc`, plus `7seg`), validates main segment counts, enforces required punctuation bit indices for `sc` variants, and parses/freezes punctuation geometries (`WindowsNetProjects/OasisEditor/OasisEditor/SegmentDisplayDefinitionLoader.cs`).
- Added additive JSON assets (placeholders where noted) under `Assets/SegmentDisplays`: `oasis_14_segment_display_definition.json`, `oasis_14_segment_sc_display_definition.json`, and `oasis_16_segment_sc_display_definition.json`, and updated the existing `oasis_16_segment_display_definition.json` with `bitIndex` and `mameComponentType` metadata to maintain compatibility.
- Updated alpha rendering to consume the common loader and render `decimalPoint` and `commaTail` independently by their configured `bitIndex` (`WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs`).
- Adjusted MAME mask remapping in `MameSegmentRuntimeAdapter` so masks are no longer truncated to 16 bits; high bits (punctuation bits up to bit 17) are preserved and carried through remapping so `led16segsc` masks are supported up to bit 17 (`WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs`).
- All changes are additive and keep the existing `TryGetSixteenSegmentDefinition`/`TryGetSevenSegmentDefinition` entry points for backward compatibility.

### Testing
- Attempted a local build with `cd WindowsNetProjects/OasisEditor/OasisEditor && dotnet build`, but the environment lacks the `dotnet` SDK and the build could not be executed (`dotnet: command not found`).
- No automated unit or CI tests were run in this environment; changes include validation logic in `SegmentDisplayDefinitionLoader` that will reject malformed assets at load time, and placeholder assets include `TODO` notes to be replaced by canonical MAME geometry in follow-ups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f4553868c8327a83cd5ac8ba9532c)