### PR TITLE
Scope Input Map and Play input routing to the active Panel2D tab

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -419,7 +419,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
     public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
-    public IReadOnlyList<InputDefinitionModel> InputDefinitions => LoadedProject?.InputDefinitions ?? [];
+    public IReadOnlyList<InputDefinitionModel> InputDefinitions => ResolveActiveInputDefinitions();
     public IReadOnlyList<InputMapDiagnostic> InputMapDiagnostics
     {
         get => _inputMapDiagnostics;
@@ -705,7 +705,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     _selectedDocument.PanelChanged += OnSelectedDocumentPanelChanged;
                 }
 
+                _ = ReleaseAllPlayViewInputsAsync("document switch", CancellationToken.None);
+                _playViewKeyboardInputRouter = null;
+                _playViewPointerInputRouter = null;
+
                 _activeDocumentContext.SetActiveDocument(value);
+                OnPropertyChanged(nameof(InputDefinitions));
                 NotifyInspectorChanged();
                 NotifyDocumentCommands();
                 RefreshHierarchy();
@@ -1291,7 +1296,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return null;
         }
 
-        _playViewKeyboardInputRouter ??= new PlayViewKeyboardInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
+        _playViewKeyboardInputRouter ??= new PlayViewKeyboardInputRouter(_playViewInputRouter!, InputDefinitions);
         return _playViewKeyboardInputRouter;
     }
 
@@ -1302,7 +1307,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return null;
         }
 
-        _playViewPointerInputRouter ??= new PlayViewPointerInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
+        _playViewPointerInputRouter ??= new PlayViewPointerInputRouter(_playViewInputRouter!, InputDefinitions);
         return _playViewPointerInputRouter;
     }
 
@@ -2652,6 +2657,38 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(InspectorSummary));
             OnPropertyChanged(nameof(InspectorPropertyRows));
         }
+
+        _playViewKeyboardInputRouter = null;
+        _playViewPointerInputRouter = null;
+        OnPropertyChanged(nameof(InputDefinitions));
+    }
+
+    private IReadOnlyList<InputDefinitionModel> ResolveActiveInputDefinitions()
+    {
+        var allDefinitions = LoadedProject?.InputDefinitions;
+        if (allDefinitions is null || allDefinitions.Count == 0)
+        {
+            return [];
+        }
+
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return allDefinitions;
+        }
+
+        var visualIds = selectedDocument.GetPanelElements()
+            .Select(element => element.Id)
+            .Where(id => id != Guid.Empty)
+            .ToHashSet();
+        if (visualIds.Count == 0)
+        {
+            return [];
+        }
+
+        return allDefinitions
+            .Where(definition => definition.LinkedVisualElementId.HasValue && visualIds.Contains(definition.LinkedVisualElementId.Value))
+            .ToArray();
     }
 
     private DocumentTabViewModel? ApplyInspectorSummary(DocumentTabViewModel _, string summary)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2678,7 +2678,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var visualIds = selectedDocument.GetPanelElements()
-            .Select(element => element.Id)
+            .Select(element => Guid.TryParse(element.ObjectId, out var visualId) ? visualId : Guid.Empty)
             .Where(id => id != Guid.Empty)
             .ToHashSet();
         if (visualIds.Count == 0)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2683,12 +2683,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             .ToHashSet();
         if (visualIds.Count == 0)
         {
-            return [];
+            return allDefinitions;
         }
 
-        return allDefinitions
+        var matchedDefinitions = allDefinitions
             .Where(definition => definition.LinkedVisualElementId.HasValue && visualIds.Contains(definition.LinkedVisualElementId.Value))
             .ToArray();
+        return matchedDefinitions.Length > 0 ? matchedDefinitions : allDefinitions;
     }
 
     private DocumentTabViewModel? ApplyInspectorSummary(DocumentTabViewModel _, string summary)


### PR DESCRIPTION
### Motivation
- The Input Map pane and Play View routing were project-global and could show or route inputs that don't belong to the currently selected `.panel2d`, causing stale UI and potentially stuck or incorrect inputs when switching documents.

### Description
- `InputDefinitions` now calls `ResolveActiveInputDefinitions()` so the Input Map binds to the input definitions linked to visuals present in the currently selected `Panel2D` document instead of always exposing the full project list.
- On `SelectedDocument` changes the code now calls `ReleaseAllPlayViewInputsAsync(...)` and clears `_playViewKeyboardInputRouter` and `_playViewPointerInputRouter` so active inputs are released and routers are rebuilt for the new document.
- `EnsurePlayViewKeyboardInputRouter()` and `EnsurePlayViewPointerInputRouter()` now construct routers from the active `InputDefinitions` set so keyboard/pointer routing follows the selected panel.
- Added `ResolveActiveInputDefinitions()` and explicit `OnPropertyChanged(nameof(InputDefinitions))` calls on relevant document/panel transitions to refresh bindings and keep UI/routing in sync.

### Testing
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --filter "MainWindowViewModelInputDiagnosticsTests"`, but the test invocation failed because `dotnet` is not available in the environment (`/bin/bash: dotnet: command not found`).
- No automated tests were executed successfully in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a109faadc5c83278b1c16aff1182501)