### PR TITLE
Add live text search filter to Output log pane

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -41,4 +41,5 @@ public sealed class OutputLogPreferences
     public bool ShowWarningLogs { get; init; } = true;
     public bool ShowErrorLogs { get; init; } = true;
     public bool AutoScroll { get; init; } = true;
+    public string SearchText { get; init; } = string.Empty;
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -188,6 +188,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _outputLog.ShowWarningLogs = preferences.OutputLog.ShowWarningLogs;
             _outputLog.ShowErrorLogs = preferences.OutputLog.ShowErrorLogs;
             _outputLog.AutoScroll = preferences.OutputLog.AutoScroll;
+            _outputLog.SearchText = preferences.OutputLog.SearchText;
         }
         finally
         {
@@ -1680,7 +1681,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 ShowInfoLogs = _outputLog.ShowInfoLogs,
                 ShowWarningLogs = _outputLog.ShowWarningLogs,
                 ShowErrorLogs = _outputLog.ShowErrorLogs,
-                AutoScroll = _outputLog.AutoScroll
+                AutoScroll = _outputLog.AutoScroll,
+                SearchText = _outputLog.SearchText
             },
             ProjectWindowStates = existingPreferences.ProjectWindowStates
         });
@@ -2480,7 +2482,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (e.PropertyName is nameof(OutputLogViewModel.ShowInfoLogs)
             or nameof(OutputLogViewModel.ShowWarningLogs)
             or nameof(OutputLogViewModel.ShowErrorLogs)
-            or nameof(OutputLogViewModel.AutoScroll))
+            or nameof(OutputLogViewModel.AutoScroll)
+            or nameof(OutputLogViewModel.SearchText))
         {
             if (!_isLoadingPreferences)
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -19,6 +19,8 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     private bool _showWarningLogs = true;
     private bool _showErrorLogs = true;
     private bool _autoScroll = true;
+    private string _searchText = string.Empty;
+    private string _searchTextNormalized = string.Empty;
     private IReadOnlyList<OutputLogEntry> _selectedEntries = Array.Empty<OutputLogEntry>();
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -62,6 +64,24 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     {
         get => _showErrorLogs;
         set => SetFilter(ref _showErrorLogs, value);
+    }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            var normalized = value?.Trim() ?? string.Empty;
+            if (string.Equals(_searchText, normalized, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _searchText = normalized;
+            _searchTextNormalized = normalized.ToUpperInvariant();
+            OnPropertyChanged();
+            FilteredEntries.Refresh();
+        }
     }
 
     public OutputLogEntry? LastEntry
@@ -212,13 +232,25 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
             return false;
         }
 
-        return entry.Status switch
+        var matchesSeverity = entry.Status switch
         {
             OutputLogStatus.Info => ShowInfoLogs,
             OutputLogStatus.Warning => ShowWarningLogs,
             OutputLogStatus.Error => ShowErrorLogs,
             _ => true
         };
+
+        if (!matchesSeverity)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(_searchTextNormalized))
+        {
+            return true;
+        }
+
+        return entry.Message.Contains(_searchTextNormalized, StringComparison.OrdinalIgnoreCase);
     }
 
     private void SetFilter(ref bool field, bool value, [CallerMemberName] string? propertyName = null)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -40,9 +40,12 @@
                           Foreground="{DynamicResource TextPrimaryBrush}"
                           IsChecked="{Binding AutoScroll}"
                           Content="Autoscroll" />
-                            <TextBox Width="220"
+                <TextBlock Margin="8,0,6,0"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource TextPrimaryBrush}"
+                           Text="Search" />
+                <TextBox Width="220"
                          MinWidth="140"
-                         Margin="8,0,0,0"
                          VerticalAlignment="Center"
                          ToolTip="Filter log rows by text"
                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -40,6 +40,12 @@
                           Foreground="{DynamicResource TextPrimaryBrush}"
                           IsChecked="{Binding AutoScroll}"
                           Content="Autoscroll" />
+                            <TextBox Width="220"
+                         MinWidth="140"
+                         Margin="8,0,0,0"
+                         VerticalAlignment="Center"
+                         ToolTip="Filter log rows by text"
+                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1"


### PR DESCRIPTION
### Motivation
- Provide a live text search field in the Output pane so users can quickly narrow log rows while preserving the existing severity checkboxes and selection/copy behavior. 
- Keep filtering centralized and efficient by extending the existing `ICollectionView` filter pipeline rather than adding a separate path. 

### Description
- Added a `SearchText` property (and `_searchTextNormalized`) to `OutputLogViewModel` and refreshed `FilteredEntries` on change so typing updates the view live with `UpdateSourceTrigger=PropertyChanged`. 
- Updated `ShouldShowEntry` to require both severity match and case-insensitive substring matching of `Message`, returning true when the search text is empty. 
- Added a `TextBox` to `OutputLogView.xaml` immediately to the right of the existing severity/autoscroll checkboxes and bound it to `SearchText`. 
- Persisted `SearchText` in `OutputLogPreferences` and wired load/save in `MainWindowViewModel` so the filter state is restored across sessions. 

### Testing
- No automated build or unit tests were executed in this environment due to the repository's Windows/.NET toolchain constraint. 
- Changes were committed successfully (`Add live text filtering to output log pane`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1481775804832799e650aef1285fe3)