### PR TITLE
Add temporary debug logging for MAME reel stdout normalization

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -22,14 +22,14 @@ public sealed class MameStdoutParserTests
     }
 
     [Fact]
-    public void ProcessLine_WhenReelLine_AppliesReelState()
+    public void ProcessLine_WhenSreelLine_AppliesReelState()
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
         var segmentAdapter = new RecordingSegmentAdapter();
         var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
 
-        parser.ProcessLine("reel3 = 94");
+        parser.ProcessLine("sreel3 = 64170");
 
         var call = Assert.Single(reelAdapter.Calls);
         Assert.Equal(3, call.ReelId);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -831,7 +831,8 @@ internal static class CanvasMutationCommands
                 || !string.Equals(before.TextBoxFontSize, after.TextBoxFontSize, StringComparison.Ordinal)
                 || before.IsReversed != after.IsReversed
                 || before.Stops != after.Stops
-                || before.VisibleScale != after.VisibleScale)
+                || before.VisibleScale != after.VisibleScale
+                || before.BandOffset != after.BandOffset)
             {
                 changed |= PanelChangeProperties.Metadata;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -218,6 +218,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameReelStateParser(),
             new MameReelRuntimeAdapter(
                 () => OpenDocuments,
+                () => SelectedFruitMachinePlatform,
                 () => DebugOutputStdOut,
                 message => AddOutputEntry(message, OutputLogStatus.Info),
                 work =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -218,6 +218,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameReelStateParser(),
             new MameReelRuntimeAdapter(
                 () => OpenDocuments,
+                () => DebugOutputStdOut,
+                message => AddOutputEntry(message, OutputLogStatus.Info),
                 work =>
                 {
                     var dispatcher = Application.Current.Dispatcher;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -178,9 +178,9 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
     private static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)
     {
-        _ = stops;
         return platform switch
         {
+            FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
             _ => 0d
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -4,14 +4,22 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 {
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Func<bool> _debugOutputEnabledProvider;
+    private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, int> _pendingReelValues = new();
     private readonly Dictionary<Guid, ReelDocumentMappingCacheEntry> _reelMappingsByDocumentId = new();
     private bool _uiUpdateScheduled;
 
-    public MameReelRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    public MameReelRuntimeAdapter(
+        Func<IEnumerable<DocumentTabViewModel>> documentProvider,
+        Func<bool> debugOutputEnabledProvider,
+        Action<string> infoLogger,
+        Action<Action> uiDispatch)
     {
         _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _debugOutputEnabledProvider = debugOutputEnabledProvider ?? throw new ArgumentNullException(nameof(debugOutputEnabledProvider));
+        _infoLogger = infoLogger ?? throw new ArgumentNullException(nameof(infoLogger));
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
     }
 
@@ -63,6 +71,11 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
                 foreach (var objectId in objectIds)
                 {
+                    if (_debugOutputEnabledProvider() && TryGetReelDetails(document, objectId, reelValue, out var stops, out var normalizedPosition))
+                    {
+                        _infoLogger($"[MAME-REEL] reel{reelId} raw={reelValue} normalized={normalizedPosition:0.###} stops={stops} objectId={objectId}");
+                    }
+
                     if (document.RuntimeState.SetReelPositionIfChanged(objectId, reelValue))
                     {
                         changedObjectIds.Add(objectId);
@@ -110,6 +123,24 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
         cacheEntry.Replace(mapping);
         return cacheEntry.MappingByReelId;
+    }
+
+    private static bool TryGetReelDetails(DocumentTabViewModel document, string objectId, int rawReelValue, out int stops, out double normalizedPosition)
+    {
+        stops = 0;
+        normalizedPosition = 0d;
+        var reelElement = document.GetPanelElements()
+            .FirstOrDefault(element => element.Kind == PanelElementKind.Reel
+                && string.Equals(element.ObjectId, objectId, StringComparison.Ordinal));
+        if (reelElement is null || reelElement.Stops is null or <= 0)
+        {
+            return false;
+        }
+
+        stops = reelElement.Stops.Value;
+        var wrappedPosition = ((rawReelValue % stops) + stops) % stops;
+        normalizedPosition = wrappedPosition / (double)stops;
+        return true;
     }
 
     private sealed class ReelDocumentMappingCacheEntry

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -10,6 +10,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, int> _pendingReelValues = new();
+    private readonly Dictionary<int, int> _latestReelValues = new();
     private readonly Dictionary<Guid, ReelDocumentMappingCacheEntry> _reelMappingsByDocumentId = new();
     private bool _uiUpdateScheduled;
 
@@ -32,6 +33,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         lock (_pendingSync)
         {
             _pendingReelValues[reelId] = reelValue;
+            _latestReelValues[reelId] = reelValue;
             if (_uiUpdateScheduled)
             {
                 return;
@@ -125,7 +127,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
         if (cacheEntry is null)
         {
-            cacheEntry = new ReelDocumentMappingCacheEntry(document, mapping);
+            cacheEntry = new ReelDocumentMappingCacheEntry(document, mapping, OnDocumentPanelChanged);
             _reelMappingsByDocumentId[document.DocumentId] = cacheEntry;
             return cacheEntry.MappingByReelId;
         }
@@ -148,13 +150,13 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         }
 
         stops = reelElement.Stops.Value;
-        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.Stops.Value, reelElement.IsReversed == true);
+        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.Stops.Value, reelElement.IsReversed == true, reelElement.BandOffset ?? 0d);
         var wrappedPosition = ((effectiveReelValue % stops) + stops) % stops;
         normalizedPosition = wrappedPosition / (double)stops;
         return true;
     }
 
-    private int ResolveEffectiveReelValue(int rawReelValue, int stops, bool reelReversed)
+    private int ResolveEffectiveReelValue(int rawReelValue, int stops, bool reelReversed, double reelBandOffset)
     {
         var wrapped = ((rawReelValue % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
         var platformReversed = RequiresPlatformReversal(_platformProvider());
@@ -162,8 +164,9 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
             : wrapped;
-        var platformOffset = -ResolvePlatformBandOffsetNormalized(_platformProvider, stops);
-        var offsetSteps = (int)Math.Round(platformOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
+        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider(), stops);
+        var totalOffset = platformOffset + reelBandOffset;
+        var offsetSteps = (int)Math.Round(totalOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
         var offsetAdjusted = directionAdjusted + offsetSteps;
         return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
     }
@@ -173,23 +176,11 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return platform == FruitMachinePlatformType.MPU4;
     }
 
-    private static double ResolvePlatformBandOffsetNormalized(Func<FruitMachinePlatformType> platformProvider, int stops)
+    private static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)
     {
-        return platformProvider() switch
+        _ = stops;
+        return platform switch
         {
-            FruitMachinePlatformType.Impact => -0.11d,
-            FruitMachinePlatformType.MPU4 => stops switch
-            {
-                12 => -0.102d,
-                16 => -0.153d,
-                _ => 0d
-            },
-            FruitMachinePlatformType.Scorpion4 => stops switch
-            {
-                12 => 0.2d + ((1d / 12d) * 0.4d) - (1d / 12d),
-                16 => 0.1305d,
-                _ => 0d
-            },
             _ => 0d
         };
     }
@@ -197,9 +188,11 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
     private sealed class ReelDocumentMappingCacheEntry
     {
         private readonly DocumentTabViewModel _document;
-        public ReelDocumentMappingCacheEntry(DocumentTabViewModel document, IReadOnlyDictionary<int, string[]> mappingByReelId)
+        private readonly Action _panelChangedCallback;
+        public ReelDocumentMappingCacheEntry(DocumentTabViewModel document, IReadOnlyDictionary<int, string[]> mappingByReelId, Action panelChangedCallback)
         {
             _document = document;
+            _panelChangedCallback = panelChangedCallback;
             MappingByReelId = mappingByReelId;
             _document.PanelChanged += OnPanelChanged;
         }
@@ -207,7 +200,30 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         public IReadOnlyDictionary<int, string[]> MappingByReelId { get; private set; }
         public bool IsDirty { get; private set; }
         public void Replace(IReadOnlyDictionary<int, string[]> mappingByReelId) { MappingByReelId = mappingByReelId; IsDirty = false; }
-        public void OnPanelChanged(PanelChangeEvent _) => IsDirty = true;
+        public void OnPanelChanged(PanelChangeEvent _)
+        {
+            IsDirty = true;
+            _panelChangedCallback();
+        }
         public void Detach() => _document.PanelChanged -= OnPanelChanged;
     }
 }
+    private void OnDocumentPanelChanged()
+    {
+        lock (_pendingSync)
+        {
+            foreach (var (reelId, reelValue) in _latestReelValues)
+            {
+                _pendingReelValues[reelId] = reelValue;
+            }
+
+            if (_uiUpdateScheduled || _pendingReelValues.Count == 0)
+            {
+                return;
+            }
+
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -185,6 +185,26 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         };
     }
 
+    private void OnDocumentPanelChanged()
+    {
+        lock (_pendingSync)
+        {
+            foreach (var (reelId, reelValue) in _latestReelValues)
+            {
+                _pendingReelValues[reelId] = reelValue;
+            }
+
+            if (_uiUpdateScheduled || _pendingReelValues.Count == 0)
+            {
+                return;
+            }
+
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
     private sealed class ReelDocumentMappingCacheEntry
     {
         private readonly DocumentTabViewModel _document;
@@ -208,22 +228,3 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         public void Detach() => _document.PanelChanged -= OnPanelChanged;
     }
 }
-    private void OnDocumentPanelChanged()
-    {
-        lock (_pendingSync)
-        {
-            foreach (var (reelId, reelValue) in _latestReelValues)
-            {
-                _pendingReelValues[reelId] = reelValue;
-            }
-
-            if (_uiUpdateScheduled || _pendingReelValues.Count == 0)
-            {
-                return;
-            }
-
-            _uiUpdateScheduled = true;
-        }
-
-        _uiDispatch(ApplyPendingOnUiThread);
-    }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -2,8 +2,10 @@ namespace OasisEditor;
 
 public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 {
+    private const int ReelPositionsPerRevolution = 96;
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Func<FruitMachinePlatformType> _platformProvider;
     private readonly Func<bool> _debugOutputEnabledProvider;
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
@@ -13,11 +15,13 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
     public MameReelRuntimeAdapter(
         Func<IEnumerable<DocumentTabViewModel>> documentProvider,
+        Func<FruitMachinePlatformType> platformProvider,
         Func<bool> debugOutputEnabledProvider,
         Action<string> infoLogger,
         Action<Action> uiDispatch)
     {
         _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _platformProvider = platformProvider ?? throw new ArgumentNullException(nameof(platformProvider));
         _debugOutputEnabledProvider = debugOutputEnabledProvider ?? throw new ArgumentNullException(nameof(debugOutputEnabledProvider));
         _infoLogger = infoLogger ?? throw new ArgumentNullException(nameof(infoLogger));
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
@@ -71,12 +75,17 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
                 foreach (var objectId in objectIds)
                 {
-                    if (_debugOutputEnabledProvider() && TryGetReelDetails(document, objectId, reelValue, out var stops, out var normalizedPosition))
+                    if (!TryResolveEffectiveReelPosition(document, objectId, reelValue, out var effectiveReelValue, out var stops, out var normalizedPosition))
                     {
-                        _infoLogger($"[MAME-REEL] reel{reelId} raw={reelValue} normalized={normalizedPosition:0.###} stops={stops} objectId={objectId}");
+                        continue;
                     }
 
-                    if (document.RuntimeState.SetReelPositionIfChanged(objectId, reelValue))
+                    if (_debugOutputEnabledProvider())
+                    {
+                        _infoLogger($"[MAME-REEL] reel{reelId} raw={reelValue} effective={effectiveReelValue} normalized={normalizedPosition:0.###} stops={stops} objectId={objectId}");
+                    }
+
+                    if (document.RuntimeState.SetReelPositionIfChanged(objectId, effectiveReelValue))
                     {
                         changedObjectIds.Add(objectId);
                     }
@@ -125,8 +134,9 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return cacheEntry.MappingByReelId;
     }
 
-    private static bool TryGetReelDetails(DocumentTabViewModel document, string objectId, int rawReelValue, out int stops, out double normalizedPosition)
+    private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, out int effectiveReelValue, out int stops, out double normalizedPosition)
     {
+        effectiveReelValue = 0;
         stops = 0;
         normalizedPosition = 0d;
         var reelElement = document.GetPanelElements()
@@ -138,9 +148,25 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         }
 
         stops = reelElement.Stops.Value;
-        var wrappedPosition = ((rawReelValue % stops) + stops) % stops;
+        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.IsReversed == true);
+        var wrappedPosition = ((effectiveReelValue % stops) + stops) % stops;
         normalizedPosition = wrappedPosition / (double)stops;
         return true;
+    }
+
+    private int ResolveEffectiveReelValue(int rawReelValue, bool reelReversed)
+    {
+        var wrapped = ((rawReelValue % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
+        var platformReversed = RequiresPlatformReversal(_platformProvider());
+        var shouldReverse = platformReversed ^ reelReversed;
+        return shouldReverse && wrapped != 0
+            ? ReelPositionsPerRevolution - wrapped
+            : wrapped;
+    }
+
+    private static bool RequiresPlatformReversal(FruitMachinePlatformType platform)
+    {
+        return platform == FruitMachinePlatformType.MPU4;
     }
 
     private sealed class ReelDocumentMappingCacheEntry

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -162,7 +162,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
             : wrapped;
-        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider(), stops);
+        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider, stops);
         var offsetSteps = (int)Math.Round(platformOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
         var offsetAdjusted = directionAdjusted + offsetSteps;
         return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -148,25 +148,50 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         }
 
         stops = reelElement.Stops.Value;
-        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.IsReversed == true);
+        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.Stops.Value, reelElement.IsReversed == true);
         var wrappedPosition = ((effectiveReelValue % stops) + stops) % stops;
         normalizedPosition = wrappedPosition / (double)stops;
         return true;
     }
 
-    private int ResolveEffectiveReelValue(int rawReelValue, bool reelReversed)
+    private int ResolveEffectiveReelValue(int rawReelValue, int stops, bool reelReversed)
     {
         var wrapped = ((rawReelValue % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
         var platformReversed = RequiresPlatformReversal(_platformProvider());
         var shouldReverse = platformReversed ^ reelReversed;
-        return shouldReverse && wrapped != 0
+        var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
             : wrapped;
+        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider(), stops);
+        var offsetSteps = (int)Math.Round(platformOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
+        var offsetAdjusted = directionAdjusted + offsetSteps;
+        return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
     }
 
     private static bool RequiresPlatformReversal(FruitMachinePlatformType platform)
     {
         return platform == FruitMachinePlatformType.MPU4;
+    }
+
+    private static double ResolvePlatformBandOffsetNormalized(Func<FruitMachinePlatformType> platformProvider, int stops)
+    {
+        return platformProvider() switch
+        {
+            FruitMachinePlatformType.Impact => -0.11d,
+            FruitMachinePlatformType.MPU4 => stops switch
+            {
+                12 => -0.102d,
+                16 => -0.153d,
+                _ => 0d
+            },
+            FruitMachinePlatformType.Scorpion4 => stops switch
+            {
+                12 => 0.2d + ((1d / 12d) * 0.4d) - (1d / 12d),
+                16 => 0.1305d,
+                _ => 0d
+            },
+            _ => 0d
+        };
     }
 
     private sealed class ReelDocumentMappingCacheEntry

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -162,7 +162,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
             : wrapped;
-        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider, stops);
+        var platformOffset = -ResolvePlatformBandOffsetNormalized(_platformProvider, stops);
         var offsetSteps = (int)Math.Round(platformOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
         var offsetAdjusted = directionAdjusted + offsetSteps;
         return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -180,6 +180,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
     {
         return platform switch
         {
+            FruitMachinePlatformType.MPU4 when stops == 16 => -0.05d,
             FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
             _ => 0d
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
@@ -12,8 +12,6 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
     private const int SreelCycle = 65536;
     private const int LegacyReelPositionsPerRevolution = 96;
 
-    [GeneratedRegex(@"^reel\s*(\d+)\s*=\s*(-?\d+)$", RegexOptions.IgnoreCase)]
-    private static partial Regex ReelEqualsPattern();
     [GeneratedRegex(@"^sreel\s*(\d+)\s*=\s*(-?\d+)$", RegexOptions.IgnoreCase)]
     private static partial Regex SreelEqualsPattern();
 
@@ -37,39 +35,7 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
             return true;
         }
 
-        var regexMatch = ReelEqualsPattern().Match(trimmed);
-        if (regexMatch.Success
-            && int.TryParse(regexMatch.Groups[1].Value, out reelId)
-            && int.TryParse(regexMatch.Groups[2].Value, out reelValue))
-        {
-            return true;
-        }
-
-        var tokens = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (tokens.Length < 2)
-        {
-            return false;
-        }
-
-        var tokenWithPrefix = tokens[0];
-        if (!tokenWithPrefix.StartsWith("reel", StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        var reelToken = tokenWithPrefix["reel".Length..];
-        if (reelToken.Length == 0)
-        {
-            return false;
-        }
-
-        var valueToken = tokens[^1];
-        if (!int.TryParse(reelToken, out reelId) || !int.TryParse(valueToken, out reelValue))
-        {
-            return false;
-        }
-
-        return true;
+        return false;
     }
 
     private static int ConvertSreelToLegacyReelPosition(int sreelValue)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
@@ -9,8 +9,13 @@ public interface IMameReelStateParser
 
 public sealed partial class MameReelStateParser : IMameReelStateParser
 {
-    [GeneratedRegex(@"reel\s*(\d+)\s*=\s*(-?\d+)", RegexOptions.IgnoreCase)]
+    private const int SreelCycle = 65536;
+    private const int LegacyReelPositionsPerRevolution = 96;
+
+    [GeneratedRegex(@"^reel\s*(\d+)\s*=\s*(-?\d+)$", RegexOptions.IgnoreCase)]
     private static partial Regex ReelEqualsPattern();
+    [GeneratedRegex(@"^sreel\s*(\d+)\s*=\s*(-?\d+)$", RegexOptions.IgnoreCase)]
+    private static partial Regex SreelEqualsPattern();
 
     public bool TryParse(string line, out int reelId, out int reelValue)
     {
@@ -23,6 +28,15 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
         }
 
         var trimmed = line.Trim();
+        var sreelRegexMatch = SreelEqualsPattern().Match(trimmed);
+        if (sreelRegexMatch.Success
+            && int.TryParse(sreelRegexMatch.Groups[1].Value, out reelId)
+            && int.TryParse(sreelRegexMatch.Groups[2].Value, out var sreelValue))
+        {
+            reelValue = ConvertSreelToLegacyReelPosition(sreelValue);
+            return true;
+        }
+
         var regexMatch = ReelEqualsPattern().Match(trimmed);
         if (regexMatch.Success
             && int.TryParse(regexMatch.Groups[1].Value, out reelId)
@@ -56,5 +70,12 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
         }
 
         return true;
+    }
+
+    private static int ConvertSreelToLegacyReelPosition(int sreelValue)
+    {
+        var wrapped = ((sreelValue % SreelCycle) + SreelCycle) % SreelCycle;
+        return (int)Math.Round((wrapped / (double)SreelCycle) * LegacyReelPositionsPerRevolution, MidpointRounding.AwayFromZero)
+            % LegacyReelPositionsPerRevolution;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -32,6 +32,7 @@ internal sealed class PanelElementModel
     public bool? IsReversed { get; init; }
     public int? Stops { get; init; }
     public double? VisibleScale { get; init; }
+    public double? BandOffset { get; init; }
     public bool IsLocked { get; init; }
     public bool IsVisible { get; init; } = true;
     public PanelElementImportSourceModel? ImportSource { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -222,6 +222,12 @@ internal static class Panel2DDocumentStorage
                 errorMessage = $"Element '{normalizedElement.ObjectId}' has invalid visible scale '{normalizedElement.VisibleScale}'.";
                 return false;
             }
+            if (normalizedElement.BandOffset.HasValue && !IsValidBandOffset(normalizedElement.BandOffset.Value))
+            {
+                normalized = new Panel2DDocumentFile();
+                errorMessage = $"Element '{normalizedElement.ObjectId}' has invalid band offset '{normalizedElement.BandOffset}'.";
+                return false;
+            }
 
             if (normalizedElement.ImportSource is not null && string.IsNullOrWhiteSpace(normalizedElement.ImportSource.Format))
             {
@@ -269,6 +275,7 @@ internal static class Panel2DDocumentStorage
                 || element.IsReversed.HasValue
                 || element.Stops.HasValue
                 || element.VisibleScale.HasValue
+                || element.BandOffset.HasValue
                 || element.IsLocked
                 || element.IsVisible is false
                 || element.ImportSource is not null)
@@ -329,6 +336,7 @@ internal static class Panel2DDocumentStorage
             IsReversed = normalized.IsReversed,
             Stops = normalized.Stops,
             VisibleScale = normalized.VisibleScale,
+            BandOffset = normalized.BandOffset,
             IsLocked = normalized.IsLocked,
             IsVisible = normalized.IsVisible ?? true,
             ImportSource = normalized.ImportSource is null
@@ -376,6 +384,7 @@ internal static class Panel2DDocumentStorage
             IsReversed = element.IsReversed,
             Stops = element.Stops,
             VisibleScale = element.VisibleScale,
+            BandOffset = element.BandOffset,
             IsLocked = element.IsLocked,
             IsVisible = element.IsVisible,
             ImportSource = importSource,
@@ -393,6 +402,7 @@ internal static class Panel2DDocumentStorage
                 reversed: element.IsReversed,
                 stops: element.Stops,
                 visibleScale: element.VisibleScale,
+                bandOffset: element.BandOffset,
                 importSource: importSource)
         });
     }
@@ -449,6 +459,7 @@ internal static class Panel2DDocumentStorage
         var normalizedIsReversed = normalizedNative?.Reversed ?? element.IsReversed;
         var normalizedStops = normalizedNative?.Stops ?? element.Stops;
         var normalizedVisibleScale = normalizedNative?.VisibleScale ?? element.VisibleScale;
+        var normalizedBandOffset = normalizedNative?.BandOffset ?? element.BandOffset;
         var normalizedIsLocked = element.IsLocked;
         var normalizedIsVisible = element.IsVisible ?? true;
 
@@ -467,6 +478,7 @@ internal static class Panel2DDocumentStorage
                 normalizedIsReversed,
                 normalizedStops,
                 normalizedVisibleScale,
+                normalizedBandOffset,
                 normalizedImportSource)
             : normalizedNative with
             {
@@ -487,6 +499,7 @@ internal static class Panel2DDocumentStorage
                 Reversed = normalizedIsReversed,
                 Stops = normalizedStops,
                 VisibleScale = normalizedVisibleScale,
+                BandOffset = normalizedBandOffset,
                 ImportSource = normalizedImportSource
             };
 
@@ -511,6 +524,7 @@ internal static class Panel2DDocumentStorage
             IsReversed = normalizedIsReversed,
             Stops = normalizedStops,
             VisibleScale = normalizedVisibleScale,
+            BandOffset = normalizedBandOffset,
             IsLocked = normalizedIsLocked,
             IsVisible = normalizedIsVisible,
             ImportSource = normalizedImportSource,
@@ -580,6 +594,14 @@ internal static class Panel2DDocumentStorage
             && value > 0;
     }
 
+    private static bool IsValidBandOffset(double value)
+    {
+        return !double.IsNaN(value)
+            && !double.IsInfinity(value)
+            && value >= 0
+            && value <= 1;
+    }
+
     private static string? NormalizeOptionalString(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -635,6 +657,7 @@ internal static class Panel2DDocumentStorage
             Reversed = native.Reversed,
             Stops = native.Stops,
             VisibleScale = native.VisibleScale,
+            BandOffset = native.BandOffset,
             Outline = native.Outline,
             ImportSource = NormalizeImportSource(native.ImportSource)
         };
@@ -654,6 +677,7 @@ internal static class Panel2DDocumentStorage
         bool? reversed,
         int? stops,
         double? visibleScale,
+        double? bandOffset,
         PanelElementImportSourceFile? importSource)
     {
         if (assetPath is null
@@ -669,6 +693,7 @@ internal static class Panel2DDocumentStorage
             && reversed is null
             && stops is null
             && visibleScale is null
+            && bandOffset is null
             && importSource is null)
         {
             return null;
@@ -690,6 +715,7 @@ internal static class Panel2DDocumentStorage
             Reversed = reversed,
             Stops = stops,
             VisibleScale = visibleScale,
+            BandOffset = bandOffset,
             ImportSource = importSource
         };
     }
@@ -748,6 +774,7 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public bool? IsReversed { get; init; }
     public int? Stops { get; init; }
     public double? VisibleScale { get; init; }
+    public double? BandOffset { get; init; }
     public bool IsLocked { get; init; }
     public bool? IsVisible { get; init; }
     public PanelElementImportSourceFile? ImportSource { get; init; }
@@ -776,6 +803,7 @@ internal sealed record PanelElementNativeFile
     public bool? Reversed { get; init; }
     public int? Stops { get; init; }
     public double? VisibleScale { get; init; }
+    public double? BandOffset { get; init; }
     public bool? Outline { get; init; }
     public PanelElementImportSourceFile? ImportSource { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -40,6 +40,7 @@ internal static class PanelElementModelCloner
             IsReversed = source.IsReversed,
             Stops = source.Stops,
             VisibleScale = source.VisibleScale,
+            BandOffset = source.BandOffset,
             IsLocked = isLocked ?? source.IsLocked,
             IsVisible = isVisible ?? source.IsVisible,
             ImportSource = CloneImportSource(source.ImportSource)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -45,6 +45,7 @@ internal sealed class PanelElementModelUpdate
     public PanelElementOptionalValue<bool?> IsReversed { get; init; }
     public PanelElementOptionalValue<int?> Stops { get; init; }
     public PanelElementOptionalValue<double?> VisibleScale { get; init; }
+    public PanelElementOptionalValue<double?> BandOffset { get; init; }
     public PanelElementOptionalValue<bool> IsLocked { get; init; }
     public PanelElementOptionalValue<bool> IsVisible { get; init; }
 }
@@ -81,6 +82,7 @@ internal static class PanelElementModelUpdater
             IsReversed = update.IsReversed.HasValue ? update.IsReversed.Value : source.IsReversed,
             Stops = update.Stops.HasValue ? update.Stops.Value : source.Stops,
             VisibleScale = update.VisibleScale.HasValue ? update.VisibleScale.Value : source.VisibleScale,
+            BandOffset = update.BandOffset.HasValue ? update.BandOffset.Value : source.BandOffset,
             IsLocked = update.IsLocked.HasValue ? update.IsLocked.Value : source.IsLocked,
             IsVisible = update.IsVisible.HasValue ? update.IsVisible.Value : source.IsVisible,
             ImportSource = source.ImportSource is null

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -53,6 +53,7 @@ internal static class PanelElementModelComparer
                && left.IsReversed == right.IsReversed
                && left.Stops == right.Stops
                && left.VisibleScale == right.VisibleScale
+               && left.BandOffset == right.BandOffset
                && left.IsLocked == right.IsLocked
                && left.IsVisible == right.IsVisible
                && AreEquivalent(left.ImportSource, right.ImportSource);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -114,11 +114,13 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
     private string _value;
     private string _committedValue;
     private readonly Func<double, string?>? _commit;
+    private readonly string _format;
 
-    public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false, Func<double, string?>? commit = null)
+    public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false, Func<double, string?>? commit = null, string format = "0.###")
         : base(displayName, groupName, isReadOnly)
     {
-        _value = value.ToString("0.###", CultureInfo.InvariantCulture);
+        _format = format;
+        _value = value.ToString(_format, CultureInfo.InvariantCulture);
         _committedValue = _value;
         _commit = commit;
     }
@@ -155,7 +157,7 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
         }
 
         ErrorText = string.Empty;
-        _committedValue = parsed.ToString("0.###", CultureInfo.InvariantCulture);
+        _committedValue = parsed.ToString(_format, CultureInfo.InvariantCulture);
         _value = _committedValue;
         RaisePropertyChanged(nameof(Value));
     }
@@ -163,7 +165,7 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
     public void SetCommittedValue(double value)
     {
         ErrorText = string.Empty;
-        _committedValue = value.ToString("0.###", CultureInfo.InvariantCulture);
+        _committedValue = value.ToString(_format, CultureInfo.InvariantCulture);
         _value = _committedValue;
         RaisePropertyChanged(nameof(Value));
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -464,6 +464,12 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     selectedElement.VisibleScale.Value,
                     commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update visible scale", new PanelElementModelUpdate { VisibleScale = value })));
             }
+
+            _propertyRows.Add(new InspectorDoublePropertyViewModel(
+                "Band Offset",
+                "Type-specific",
+                selectedElement.BandOffset ?? 0d,
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update band offset", new PanelElementModelUpdate { BandOffset = value })));
         }
 
         if (selectedElement.Kind is PanelElementKind.Reel or PanelElementKind.Alpha)
@@ -559,6 +565,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     break;
                 case "Reversed" when row is InspectorBoolPropertyViewModel reversedRow:
                     reversedRow.SetCommittedValue(selectedElement.IsReversed ?? false);
+                    break;
+                case "Band Offset" when row is InspectorDoublePropertyViewModel bandOffsetRow:
+                    bandOffsetRow.SetCommittedValue(selectedElement.BandOffset ?? 0d);
                     break;
                 case "Import Format" when row is InspectorInfoPropertyViewModel importFormatRow:
                     importFormatRow.SetCommittedValue(selectedElement.ImportSource?.Format ?? string.Empty);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -462,14 +462,16 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     "Visible Scale",
                     "Type-specific",
                     selectedElement.VisibleScale.Value,
-                    commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update visible scale", new PanelElementModelUpdate { VisibleScale = value })));
+                    commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update visible scale", new PanelElementModelUpdate { VisibleScale = value }),
+                    format: "G17"));
             }
 
             _propertyRows.Add(new InspectorDoublePropertyViewModel(
                 "Band Offset",
                 "Type-specific",
                 selectedElement.BandOffset ?? 0d,
-                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update band offset", new PanelElementModelUpdate { BandOffset = value })));
+                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update band offset", new PanelElementModelUpdate { BandOffset = value }),
+                format: "G17"));
         }
 
         if (selectedElement.Kind is PanelElementKind.Reel or PanelElementKind.Alpha)


### PR DESCRIPTION
### Motivation
- Reels driven by MAME emulation were misbehaving and require temporary instrumentation to observe raw stdout values alongside the editor-facing normalized reel position for diagnosis. 
- The logging must be opt-in and routed to the existing Output pane so it can be enabled during troubleshooting without changing normal behavior.

### Description
- Added `Func<bool> _debugOutputEnabledProvider` and `Action<string> _infoLogger` to `MameReelRuntimeAdapter` and wired them from `MainWindowViewModel` using the existing `DebugOutputStdOut` toggle. 
- Emit `[MAME-REEL]` Output entries when enabled that include reel number, raw MAME value, normalized position (`0..1`), stops, and target `objectId`. 
- Implemented `TryGetReelDetails` which looks up the reel element's `Stops` and computes a wrapped modulo normalization from the raw reel value so negative or out-of-range inputs map consistently.

### Testing
- No automated tests were executed in this environment due to the missing Windows/.NET/WPF toolchain. 
- Please run `dotnet build` locally to verify compilation and `dotnet test` (for example `dotnet test OasisEditor.Tests`) to validate unit tests. 
- When running the editor with MAME emulation and `DebugOutputStdOut` enabled, confirm the Output pane receives `[MAME-REEL]` rows and that the normalized values correspond to expected positions for the reel `Stops` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a148701f43483278eca25d8b0935c6e)