### PR TITLE
Set Scorpion4 12-stop default reel offset to 0.2

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -181,6 +181,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return platform switch
         {
             FruitMachinePlatformType.MPU4 when stops == 16 => -0.05d,
+            FruitMachinePlatformType.Scorpion4 when stops == 12 => 0.2d,
             FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
             _ => 0d
         };


### PR DESCRIPTION
### Motivation
- Ensure correct internal default band offset for Scorpion4 reels with 12 stops by setting the normalized offset to `0.2` so reel positioning resolves as expected.

### Description
- Added `FruitMachinePlatformType.Scorpion4 when stops == 12 => 0.2d` to `ResolvePlatformBandOffsetNormalized` in `WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs`, leaving existing `Scorpion4` 16-stop and `MPU4` mappings unchanged.

### Testing
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`, but `dotnet` is not installed in this environment so automated tests could not be executed; the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14bba355cc832792357f9d36a8cdda)