### PR TITLE
Fix MFME imported background/lamp graphics rendering in Skia panel renderer

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -183,6 +183,103 @@ public sealed class Panel2DRendererTests
         }
     }
 
+
+    [Fact]
+    public void Render_WithBackgroundRendererAndAvailableAsset_UsesBackgroundImage()
+    {
+        var renderer = new Panel2DRenderer([new BackgroundElementRenderer()]);
+        using var surface = SKSurface.Create(new SKImageInfo(64, 64));
+
+        var projectDirectory = Path.Combine(Path.GetTempPath(), $"oasis-background-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "Assets"));
+        var assetPath = Path.Combine(projectDirectory, "Assets", "background.png");
+        using (var imageSurface = SKSurface.Create(new SKImageInfo(16, 16)))
+        {
+            imageSurface.Canvas.Clear(SKColors.CornflowerBlue);
+            using var image = imageSurface.Snapshot();
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.OpenWrite(assetPath);
+            data.SaveTo(stream);
+        }
+
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            renderer.Render(
+                surface.Canvas,
+                [
+                    new PanelElementModel
+                    {
+                        Kind = PanelElementKind.Background,
+                        IsVisible = true,
+                        ObjectId = "background-1",
+                        Name = "Background",
+                        Width = 64,
+                        Height = 64,
+                        AssetPath = "Assets/background.png"
+                    }
+                ],
+                new PanelRuntimeState(),
+                PanelViewportTransform.Identity);
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Render_WithLampRendererAndAvailableAsset_UsesLampImage()
+    {
+        var renderer = new Panel2DRenderer([new LampElementRenderer()]);
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetLampIntensity("lamp-image-1", 1d);
+        using var surface = SKSurface.Create(new SKImageInfo(64, 64));
+
+        var projectDirectory = Path.Combine(Path.GetTempPath(), $"oasis-lamp-image-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "Assets"));
+        var assetPath = Path.Combine(projectDirectory, "Assets", "lamp.png");
+        using (var imageSurface = SKSurface.Create(new SKImageInfo(16, 16)))
+        {
+            imageSurface.Canvas.Clear(SKColors.OrangeRed);
+            using var image = imageSurface.Snapshot();
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.OpenWrite(assetPath);
+            data.SaveTo(stream);
+        }
+
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            renderer.Render(
+                surface.Canvas,
+                [
+                    new PanelElementModel
+                    {
+                        Kind = PanelElementKind.Lamp,
+                        IsVisible = true,
+                        ObjectId = "lamp-image-1",
+                        Name = "Lamp",
+                        Width = 24,
+                        Height = 24,
+                        AssetPath = "Assets/lamp.png",
+                        OnColorHex = "#FF0000",
+                        OffColorHex = "#220000"
+                    }
+                ],
+                runtimeState,
+                PanelViewportTransform.Identity);
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(0, 12, 0d)]
     [InlineData(96, 12, 0d)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -280,6 +280,64 @@ public sealed class Panel2DRendererTests
         }
     }
 
+
+    [Fact]
+    public void Render_WithLampRendererGraphicLampOff_DoesNotDrawBlackFallback()
+    {
+        var renderer = new Panel2DRenderer([new LampElementRenderer()]);
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetLampIntensity("lamp-image-off-1", 0d);
+        using var surface = SKSurface.Create(new SKImageInfo(64, 64));
+
+        var projectDirectory = Path.Combine(Path.GetTempPath(), $"oasis-lamp-image-off-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "Assets"));
+        var assetPath = Path.Combine(projectDirectory, "Assets", "lamp-off.png");
+        using (var imageSurface = SKSurface.Create(new SKImageInfo(16, 16)))
+        {
+            imageSurface.Canvas.Clear(SKColors.LawnGreen);
+            using var image = imageSurface.Snapshot();
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.OpenWrite(assetPath);
+            data.SaveTo(stream);
+        }
+
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            renderer.Render(
+                surface.Canvas,
+                [
+                    new PanelElementModel
+                    {
+                        Kind = PanelElementKind.Lamp,
+                        IsVisible = true,
+                        ObjectId = "lamp-image-off-1",
+                        Name = "Lamp Off",
+                        X = 8,
+                        Y = 8,
+                        Width = 24,
+                        Height = 24,
+                        AssetPath = "Assets/lamp-off.png",
+                        OnColorHex = "#FF0000",
+                        OffColorHex = "#220000"
+                    }
+                ],
+                runtimeState,
+                PanelViewportTransform.Identity);
+
+            using var snapshot = surface.Snapshot();
+            using var bitmap = SKBitmap.FromImage(snapshot);
+            var centerPixel = bitmap.GetPixel(20, 20);
+            Assert.Equal(0, centerPixel.Alpha);
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(0, 12, 0d)]
     [InlineData(96, 12, 0d)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/BackgroundElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/BackgroundElementRenderer.cs
@@ -1,9 +1,13 @@
 using SkiaSharp;
+using System.Collections.Concurrent;
+using System.IO;
 
 namespace OasisEditor.Rendering;
 
 internal sealed class BackgroundElementRenderer : IPanelElementRenderer
 {
+    private static readonly ConcurrentDictionary<string, SKImage?> CachedBackgroundImages = new(StringComparer.OrdinalIgnoreCase);
+
     public PanelElementKind Kind => PanelElementKind.Background;
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -11,6 +15,12 @@ internal sealed class BackgroundElementRenderer : IPanelElementRenderer
         var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
         if (bounds.Width <= 0f || bounds.Height <= 0f)
         {
+            return;
+        }
+
+        if (TryGetBackgroundImage(element.AssetPath, out var backgroundImage))
+        {
+            context.Canvas.DrawImage(backgroundImage, bounds);
             return;
         }
 
@@ -22,5 +32,67 @@ internal sealed class BackgroundElementRenderer : IPanelElementRenderer
         };
 
         context.Canvas.DrawRect(bounds, paint);
+    }
+
+    private static bool TryGetBackgroundImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        if (!TryResolveAssetPath(assetPath, out var resolvedPath))
+        {
+            return false;
+        }
+
+        var cached = CachedBackgroundImages.GetOrAdd(resolvedPath, LoadImage);
+        if (cached is null)
+        {
+            return false;
+        }
+
+        image = cached;
+        return true;
+    }
+
+    private static SKImage? LoadImage(string resolvedPath)
+    {
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            return null;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        return bitmap is null ? null : SKImage.FromBitmap(bitmap);
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
+        {
+            return false;
+        }
+
+        var relativePath = candidate
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+        return true;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -66,6 +66,11 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         {
             if (TryGetLampImage(element.AssetPath, out var lampImage))
             {
+                if (intensity <= 0d)
+                {
+                    return;
+                }
+
                 context.Canvas.DrawImage(lampImage, bounds);
                 if (intensity < 1d)
                 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -10,6 +10,7 @@ namespace OasisEditor.Rendering;
 internal sealed class LampElementRenderer : IPanelElementRenderer
 {
     private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, SKImage?> CachedLampImages = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<TextLayoutCacheKey, IReadOnlyList<PixelTextLine>> TextLayoutCache = new();
     private static readonly ConcurrentDictionary<TextVisualCacheKey, SKImage> TextVisualCache = new();
     private const int MaxTextVisualCacheEntries = 2048;
@@ -63,6 +64,23 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         var displayText = element.DisplayText;
         if (string.IsNullOrWhiteSpace(displayText))
         {
+            if (TryGetLampImage(element.AssetPath, out var lampImage))
+            {
+                context.Canvas.DrawImage(lampImage, bounds);
+                if (intensity < 1d)
+                {
+                    using var dimmerPaint = new SKPaint
+                    {
+                        Color = new SKColor(0, 0, 0, (byte)Math.Clamp(Math.Round((1d - intensity) * 255d), 0d, 255d)),
+                        Style = SKPaintStyle.Fill,
+                        IsAntialias = true
+                    };
+                    context.Canvas.DrawRect(bounds, dimmerPaint);
+                }
+
+                return;
+            }
+
             using var paint = new SKPaint { Color = fillColor, Style = SKPaintStyle.Fill, IsAntialias = true };
             context.Canvas.DrawRect(bounds, paint);
             return;
@@ -356,6 +374,69 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
 
         typeface = null!;
         return false;
+    }
+
+
+    private static bool TryGetLampImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        if (!TryResolveAssetPath(assetPath, out var resolvedPath))
+        {
+            return false;
+        }
+
+        var cached = CachedLampImages.GetOrAdd(resolvedPath, LoadImage);
+        if (cached is null)
+        {
+            return false;
+        }
+
+        image = cached;
+        return true;
+    }
+
+    private static SKImage? LoadImage(string resolvedPath)
+    {
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            return null;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        return bitmap is null ? null : SKImage.FromBitmap(bitmap);
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
+        {
+            return false;
+        }
+
+        var relativePath = candidate
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+        return true;
     }
 
     private static SKColor Lerp(SKColor from, SKColor to, double t)


### PR DESCRIPTION
### Motivation
- MFME-imported Background and graphic Lamp elements were rendering as solid fills even when image assets were provided, while Reels already supported asset-backed rendering, leading to incorrect visuals for imported layouts.
- Make background and lamp visuals consistent with reel behavior by resolving and drawing linked image assets when available.

### Description
- `BackgroundElementRenderer` now resolves `AssetPath`, loads the image via `SKCodec`/`SKBitmap` and draws the `SKImage` into the element bounds, with a `ConcurrentDictionary` image cache and existing solid-color fallback retained (files: `OasisEditor/Rendering/BackgroundElementRenderer.cs`).
- `LampElementRenderer` now supports graphic (non-text) lamps by resolving and drawing linked lamp images, applying an intensity-based dimming overlay for partial/off intensities, and falling back to the original color fill when no asset is available; a per-path `ConcurrentDictionary` cache and the same asset path resolution are added (files: `OasisEditor/Rendering/LampElementRenderer.cs`).
- Added two regression tests to `Panel2DRendererTests` that exercise background image rendering and lamp image rendering using temporary project directories and `PanelElementFactory.ProjectDirectoryPath` (file: `OasisEditor.Tests/Panel2DRendererTests.cs`).

### Testing
- No automated tests were executed in this environment due to the repository's Windows/.NET/WPF toolchain constraints, so `dotnet test` was not run here; the new tests were added but not executed.
- Please run `dotnet test OasisEditor.Tests` locally (or the solution test runner) to validate the new tests and ensure image-loading behavior passes under the native toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14be1ef7d8832799f9adb5beb12864)