### PR TITLE
Stop MAME via Oasis exit command

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
 namespace OasisEditor;
 
 public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 {
+    private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(3);
+
     private readonly Func<Process> _processFactory;
     private readonly Action<string>? _stdoutLogger;
     private readonly Action<string>? _stdinLogger;
@@ -84,11 +87,13 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
         {
             if (!process.HasExited)
             {
-                process.Kill(entireProcessTree: true);
-                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                var exitedCleanly = await TryStopCleanlyAsync(process, cancellationToken).ConfigureAwait(false);
+                if (!exitedCleanly && !process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
-
-            process.WaitForExit();
         }
         finally
         {
@@ -96,6 +101,38 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             _process = null;
             process.Dispose();
         }
+    }
+
+    private async Task<bool> TryStopCleanlyAsync(Process process, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await WriteStandardInputAsync(process, "exit", cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException or ObjectDisposedException)
+        {
+            return false;
+        }
+
+        var waitForExitTask = process.WaitForExitAsync(cancellationToken);
+        var timeoutTask = Task.Delay(GracefulExitTimeout, cancellationToken);
+        var completedTask = await Task.WhenAny(waitForExitTask, timeoutTask).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (completedTask != waitForExitTask)
+        {
+            return false;
+        }
+
+        await waitForExitTask.ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task WriteStandardInputAsync(Process process, string command, CancellationToken cancellationToken)
+    {
+        _stdinLogger?.Invoke(command);
+        await process.StandardInput.WriteLineAsync(new StringBuilder(command), cancellationToken).ConfigureAwait(false);
+        await process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
@@ -111,9 +148,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             throw new InvalidOperationException("Cannot write input because MAME process is not running.");
         }
 
-        _stdinLogger?.Invoke(command);
-        await process.StandardInput.WriteLineAsync(new StringBuilder(command), cancellationToken).ConfigureAwait(false);
-        await process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await WriteStandardInputAsync(process, command, cancellationToken).ConfigureAwait(false);
     }
 
     public void Dispose()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml.cs
@@ -9,6 +9,8 @@ namespace OasisEditor.Views;
 public partial class OutputLogView : UserControl
 {
     private INotifyCollectionChanged? _observedOutputEntries;
+    private OutputLogEntry? _pendingAutoScrollEntry;
+    private bool _isAutoScrollScheduled;
 
     public OutputLogView()
     {
@@ -59,10 +61,35 @@ public partial class OutputLogView : UserControl
 
         if (e.NewItems[e.NewItems.Count - 1] is OutputLogEntry entry)
         {
-            OutputList.ScrollIntoView(entry);
+            ScheduleAutoScroll(entry);
         }
     }
 
+    private void ScheduleAutoScroll(OutputLogEntry entry)
+    {
+        _pendingAutoScrollEntry = entry;
+        if (_isAutoScrollScheduled)
+        {
+            return;
+        }
+
+        _isAutoScrollScheduled = true;
+        Dispatcher.BeginInvoke((Action)PerformPendingAutoScroll);
+    }
+
+    private void PerformPendingAutoScroll()
+    {
+        _isAutoScrollScheduled = false;
+
+        var entry = _pendingAutoScrollEntry;
+        _pendingAutoScrollEntry = null;
+        if (entry is null || ViewModel?.AutoScroll != true)
+        {
+            return;
+        }
+
+        OutputList.ScrollIntoView(entry);
+    }
 
     private void OnOutputListPreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
     {


### PR DESCRIPTION
### Motivation
- Stop requests were causing the editor to block while waiting for the MAME process to synchronously exit, so a graceful shutdown path is needed to let the Oasis plugin perform NVRAM/save actions and exit quickly without freezing the UI.

### Description
- Implement a graceful stop attempt in `OasisEditor/MameProcessRunner.cs` by writing the Oasis plugin `exit` command to MAME stdin and waiting asynchronously for a short timeout before falling back to a forceful process-tree kill via `Process.Kill`.
- Add a `GracefulExitTimeout` constant and a `TryStopCleanlyAsync` helper that sends `"exit"` on stdin and awaits `WaitForExitAsync` with a timeout, returning whether the process exited cleanly.
- Centralize stdin write/flush logic into a private `WriteStandardInputAsync(Process, string, CancellationToken)` helper and refactor the public `WriteStandardInputAsync` to reuse it, and remove the synchronous `process.WaitForExit()` path that could stall the editor.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues and it passed.
- Attempted to run `dotnet test OasisEditor.sln` but `dotnet` is not available in this environment so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1a9f75ed548327879f03053bf5e7b2)