### PR TITLE
Fix MAME shutdown dispatch race and suppress late stdout callbacks

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -74,6 +74,7 @@ public partial class MainWindow : Window
 
     private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
+        _viewModel.StopEmulationForWindowClose();
         SaveWindowPlacement();
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -203,51 +203,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 () => OpenDocuments,
                 () => DebugOutputLamps,
                 message => AddOutputEntry(message, OutputLogStatus.Info),
-                work =>
-                {
-                    var dispatcher = Application.Current.Dispatcher;
-                    if (dispatcher.CheckAccess())
-                    {
-                        work();
-                    }
-                    else
-                    {
-                        dispatcher.Invoke(work);
-                    }
-                }),
+                DispatchToUiThread),
             new MameReelStateParser(),
             new MameReelRuntimeAdapter(
                 () => OpenDocuments,
                 () => SelectedFruitMachinePlatform,
                 () => DebugOutputStdOut,
                 message => AddOutputEntry(message, OutputLogStatus.Info),
-                work =>
-                {
-                    var dispatcher = Application.Current.Dispatcher;
-                    if (dispatcher.CheckAccess())
-                    {
-                        work();
-                    }
-                    else
-                    {
-                        dispatcher.Invoke(work);
-                    }
-                }),
+                DispatchToUiThread),
             new MameSegmentStateParser(),
             new MameSegmentRuntimeAdapter(
                 () => OpenDocuments,
-                work =>
-                {
-                    var dispatcher = Application.Current.Dispatcher;
-                    if (dispatcher.CheckAccess())
-                    {
-                        work();
-                    }
-                    else
-                    {
-                        dispatcher.Invoke(work);
-                    }
-                }),
+                DispatchToUiThread),
             platformProvider: () => SelectedFruitMachinePlatform);
         _mameProcessRunner = new MameProcessRunner(
             stdoutLogger: line => ProcessMameStdoutLine(line, mameStdoutParser),
@@ -265,7 +232,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             BuildMameLaunchRequest);
         _mameEmulationService.StateChanged += (_, state) =>
         {
-            Application.Current.Dispatcher.Invoke(() =>
+            DispatchToUiThread(() =>
             {
                 if (state is MameEmulationState.Stopping or MameEmulationState.Stopped or MameEmulationState.Failed)
                 {
@@ -1740,6 +1707,25 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ToolWindowCloseRequested?.Invoke(EditorToolWindowId.Preferences);
     }
 
+    private static void DispatchToUiThread(Action work)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            return;
+        }
+
+        if (dispatcher.CheckAccess())
+        {
+            work();
+            return;
+        }
+
+        _ = dispatcher.BeginInvoke(work);
+    }
+
     private void CloseProjectSettings()
     {
         ToolWindowCloseRequested?.Invoke(EditorToolWindowId.ProjectSettings);
@@ -1757,7 +1743,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        StopEmulationForShutdown();
+        StopEmulationForWindowClose();
 
         ClosePreferences();
         CloseProjectSettings();
@@ -1786,7 +1772,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void ExitApplication()
     {
-        StopEmulationForShutdown();
+        StopEmulationForWindowClose();
 
         Application.Current.Shutdown();
     }
@@ -1819,9 +1805,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStop;
     }
 
-    private void StopEmulationForShutdown()
+    public void StopEmulationForWindowClose()
     {
-        if (!CanStopEmulation())
+        if (_mameEmulationService.State == MameEmulationState.Stopped)
         {
             return;
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
@@ -13,6 +13,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
     private readonly Action<string>? _stdinLogger;
     private readonly Action<string>? _stderrLogger;
     private Process? _process;
+    private volatile bool _acceptOutput;
     private bool _outputReadStarted;
     private bool _errorReadStarted;
 
@@ -54,6 +55,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
                 throw new InvalidOperationException("Failed to start MAME process.");
             }
 
+            _acceptOutput = true;
             process.BeginOutputReadLine();
             _outputReadStarted = true;
 
@@ -67,6 +69,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             process.OutputDataReceived -= OnOutputDataReceived;
             process.ErrorDataReceived -= OnErrorDataReceived;
             process.Dispose();
+            _acceptOutput = false;
             _outputReadStarted = false;
             _errorReadStarted = false;
             throw;
@@ -82,6 +85,8 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
         {
             return;
         }
+
+        _acceptOutput = false;
 
         try
         {
@@ -153,6 +158,8 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 
     public void Dispose()
     {
+        _acceptOutput = false;
+
         var process = _process;
         if (process is not null)
         {
@@ -165,7 +172,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 
     private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
     {
-        if (!string.IsNullOrEmpty(e.Data))
+        if (_acceptOutput && !string.IsNullOrEmpty(e.Data))
         {
             _stdoutLogger?.Invoke(e.Data);
         }
@@ -173,7 +180,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 
     private void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
     {
-        if (!string.IsNullOrEmpty(e.Data))
+        if (_acceptOutput && !string.IsNullOrEmpty(e.Data))
         {
             _stderrLogger?.Invoke(e.Data);
         }
@@ -205,6 +212,7 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             }
         }
 
+        _acceptOutput = false;
         process.OutputDataReceived -= OnOutputDataReceived;
         process.ErrorDataReceived -= OnErrorDataReceived;
         _outputReadStarted = false;


### PR DESCRIPTION
### Motivation
- Prevent a NullReferenceException during editor exit when MAME emulation is running by avoiding direct use of `Application.Current.Dispatcher` after WPF shutdown has started.
- Ensure the editor runs the same graceful MAME shutdown path when the main window is closed so MAME.exe is not left orphaned.
- Stop late stdout/stderr callbacks from racing with shutdown and performing UI work after the app is tearing down.

### Description
- Add a shutdown-aware helper `DispatchToUiThread(Action)` to route runtime UI callbacks via a safe dispatcher check and `BeginInvoke` when appropriate, and replace ad-hoc dispatcher usage with it in `MainWindowViewModel`.
- Wire the main window `OnClosing` to call `StopEmulationForWindowClose()` so closing the window follows the same emulation shutdown flow as Exit/Close Project and make that method public.
- Update `MameProcessRunner` to introduce a volatile `_acceptOutput` flag that is set when the process starts and cleared during stop/dispose/detach, and guard stdout/stderr callbacks with this flag to suppress late callbacks.
- Use the emulation service state check in the window-close flow to avoid redundant stop attempts when emulation is already stopped.

### Testing
- `git diff --check` was run and returned clean results (success).
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` but the `dotnet` CLI is not available in the container so tests were not executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1aaee7357083278fba1cdebdf62e0c)