### PR TITLE
Support MFME lamp input imports

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -185,6 +185,11 @@ public sealed class MfmeExtractReaderTests
             Assert.Equal("lamp.png", lamp.FirstLampElement.BmpImageFilename);
             Assert.Equal("lamp-mask.png", lamp.FirstLampElement.BmpMaskImageFilename);
             Assert.True(lamp.FirstLampElement.Graphic);
+            Assert.True(lamp.HasButtonInput);
+            Assert.Equal("12", lamp.ButtonNumberAsString);
+            Assert.True(lamp.Inverted);
+            Assert.Equal("SPACE", lamp.Shortcut1);
+            Assert.Equal("S", lamp.Shortcut2);
 
             var reel = Assert.IsType<MfmeLegacyReelComponent>(components[2]);
             Assert.Equal(3, reel.Number);
@@ -325,6 +330,10 @@ public sealed class MfmeExtractReaderTests
               "TextColor": { "R": 1, "G": 1, "B": 1, "A": 1 },
               "OffImageColor": { "R": 0, "G": 0, "B": 0, "A": 1 },
               "Graphic": true,
+              "ButtonNumberAsString": "12",
+              "Inverted": true,
+              "Shortcut1": "SPACE",
+              "Shortcut2": "S",
               "LampElements": [
                 {
                   "NumberAsText": "12",

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportServiceTests.cs
@@ -82,7 +82,7 @@ public sealed class MfmeImportServiceTests
                     new MfmeLegacyLampElement("7", 7, new MfmeLegacyColor(1f, 1f, 0f, 1f), "lamp.bmp", null, Graphic: true),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
-                    NoOutline: false),
+                    NoOutline: false, HasButtonInput: false, HasCoinInput: false, ButtonNumberAsString: null, Inverted: false, Shortcut1: null, Shortcut2: null),
                 new UnsupportedLegacyComponent()
             ]
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -30,7 +30,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png", Graphic: true),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     new MfmeLegacyColor(1f, 1f, 1f, 1f),
-                    NoOutline: false),
+                    NoOutline: false, HasButtonInput: false, HasCoinInput: false, ButtonNumberAsString: null, Inverted: false, Shortcut1: null, Shortcut2: null),
                 new MfmeLegacyReelComponent(
                     new MfmeLegacyPoint(10, 30),
                     new MfmeLegacyPoint(90, 120),
@@ -183,7 +183,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     new MfmeLegacyLampElement("8", 8, new MfmeLegacyColor(0f, 1f, 0f, 1f), "lamp.png", "lamp-mask.png", Graphic: false),
                     new MfmeLegacyColor(0f, 0f, 0f, 1f),
                     null,
-                    NoOutline: false)
+                    NoOutline: false, HasButtonInput: false, HasCoinInput: false, ButtonNumberAsString: null, Inverted: false, Shortcut1: null, Shortcut2: null)
             ]
         };
 
@@ -201,6 +201,52 @@ public sealed class MfmeToOasisComponentMapperTests
         Assert.Equal("#FF00FF00", lamp.OnColorHex);
         Assert.Equal("#FF000000", lamp.OffColorHex);
     }
+
+    [Fact]
+    public void Map_LampWithButtonInput_CreatesLinkedInputDefinition()
+    {
+        var extract = new MfmeLegacyExtractData
+        {
+            ExtractRootPath = "C:/extract",
+            ManifestPath = "C:/extract/layout.json",
+            LayoutName = "layout",
+            Components =
+            [
+                new MfmeLegacyLampComponent(
+                    new MfmeLegacyPoint(100, 200),
+                    new MfmeLegacyPoint(30, 40),
+                    "Start",
+                    null,
+                    null,
+                    null,
+                    new MfmeLegacyLampElement("6", 6, new MfmeLegacyColor(1f, 0f, 0f, 1f), "start.png", null, Graphic: true),
+                    new MfmeLegacyColor(0f, 0f, 0f, 1f),
+                    null,
+                    NoOutline: false,
+                    HasButtonInput: true,
+                    HasCoinInput: false,
+                    ButtonNumberAsString: "6",
+                    Inverted: true,
+                    Shortcut1: "SPACE",
+                    Shortcut2: "S")
+            ]
+        };
+
+        var mapper = new MfmeToOasisComponentMapper();
+
+        var result = mapper.Map(extract);
+
+        var lamp = Assert.Single(result.Elements);
+        var inputDefinition = Assert.Single(result.InputDefinitions);
+        Assert.Equal(InputDefinitionKind.Button, inputDefinition.Kind);
+        Assert.Equal("6", inputDefinition.ButtonNumber);
+        Assert.True(inputDefinition.Inverted);
+        Assert.Equal("SPACE", inputDefinition.RawMfmeShortcut);
+        Assert.Equal("Space", inputDefinition.KeyboardShortcut);
+        Assert.Equal(Guid.Parse(lamp.ObjectId), inputDefinition.LinkedVisualElementId);
+        Assert.Equal("Shortcut2: S", inputDefinition.Notes);
+    }
+
     [Fact]
     public void Map_WithInvalidNumbersAndUnsupportedComponent_AddsWarnings()
     {
@@ -221,7 +267,7 @@ public sealed class MfmeToOasisComponentMapperTests
                     new MfmeLegacyLampElement("NaN", null, null, null, null, Graphic: false),
                     null,
                     null,
-                    NoOutline: true),
+                    NoOutline: true, HasButtonInput: false, HasCoinInput: false, ButtonNumberAsString: null, Inverted: false, Shortcut1: null, Shortcut2: null),
                 new MfmeLegacyReelComponent(
                     new MfmeLegacyPoint(1, 2),
                     new MfmeLegacyPoint(30, 40),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -173,6 +173,16 @@ internal static class MfmeExtractManifestParser
             $"{assetLabel} image file '{fileName}' for component index {componentIndex} was not found at '{candidatePath}'."));
     }
 
+    private static bool HasButtonInput(JsonElement component)
+    {
+        return ReadBool(component, "HasButtonInput") || !string.IsNullOrWhiteSpace(ReadString(component, "ButtonNumberAsString"));
+    }
+
+    private static bool HasCoinInput(JsonElement component)
+    {
+        return ReadBool(component, "HasCoinInput") || !string.IsNullOrWhiteSpace(ReadString(component, "CoinNote"));
+    }
+
     private static bool TryParseSupportedComponent(string sourceType, JsonElement component, out MfmeLegacyComponentBase parsedComponent)
     {
         var position = ReadPoint(component, "Position");
@@ -200,7 +210,13 @@ internal static class MfmeExtractManifestParser
                     ReadFirstLampElement(component, ReadOptionalBool(component, "Graphic")),
                     ReadColor(component, "OffImageColor"),
                     ReadColor(component, "TextColor"),
-                    ReadBool(component, "NoOutline"));
+                    ReadBool(component, "NoOutline"),
+                    HasButtonInput(component),
+                    HasCoinInput(component),
+                    ReadString(component, "ButtonNumberAsString"),
+                    ReadBool(component, "Inverted"),
+                    ReadString(component, "Shortcut1"),
+                    ReadString(component, "Shortcut2"));
                 return true;
 
             case "extractcomponentbutton":
@@ -211,8 +227,8 @@ internal static class MfmeExtractManifestParser
                     ReadString(component, "TextBoxFontName"),
                     ReadString(component, "TextBoxFontStyle"),
                     ReadString(component, "TextBoxFontSize"),
-                    ReadBool(component, "HasButtonInput"),
-                    ReadBool(component, "HasCoinInput"),
+                    HasButtonInput(component),
+                    HasCoinInput(component),
                     ReadString(component, "ButtonNumberAsString"),
                     ReadBool(component, "Inverted"),
                     ReadString(component, "Shortcut1"),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -45,7 +45,13 @@ internal sealed record MfmeLegacyLampComponent(
     MfmeLegacyLampElement? FirstLampElement,
     MfmeLegacyColor? OffImageColor,
     MfmeLegacyColor? TextColor,
-    bool NoOutline)
+    bool NoOutline,
+    bool HasButtonInput,
+    bool HasCoinInput,
+    string? ButtonNumberAsString,
+    bool Inverted,
+    string? Shortcut1,
+    string? Shortcut2)
     : MfmeLegacyComponentBase(
         "Lamp",
         Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -23,8 +23,16 @@ internal sealed class MfmeToOasisComponentMapper
                     elements.Add(MapBackground(background));
                     break;
                 case MfmeLegacyLampComponent lamp:
-                    elements.Add(MapLamp(lamp, warnings));
-                    break;
+                    {
+                        var mappedLamp = MapLamp(lamp, warnings);
+                        elements.Add(mappedLamp);
+                        var input = BuildInputDefinition(lamp, mappedLamp.ObjectId);
+                        if (input is not null)
+                        {
+                            inputDefinitions.Add(input);
+                        }
+                        break;
+                    }
                 case MfmeLegacyButtonComponent button:
                     {
                         var mappedButtonLamp = MapButtonAsLamp(button, warnings);
@@ -142,19 +150,59 @@ internal sealed class MfmeToOasisComponentMapper
             component.FirstLampElement,
             component.OffImageColor,
             component.TextColor,
-            component.NoOutline);
+            component.NoOutline,
+            component.HasButtonInput,
+            component.HasCoinInput,
+            component.ButtonNumberAsString,
+            component.Inverted,
+            component.Shortcut1,
+            component.Shortcut2);
 
         return MapLamp(lampEquivalent, warnings);
     }
 
+    private static InputDefinitionModel? BuildInputDefinition(MfmeLegacyLampComponent component, string linkedObjectId)
+    {
+        return BuildInputDefinition(
+            component.HasButtonInput,
+            component.HasCoinInput,
+            component.ButtonNumberAsString,
+            component.Inverted,
+            component.Shortcut1,
+            component.Shortcut2,
+            component.TextBoxText,
+            linkedObjectId);
+    }
+
     private static InputDefinitionModel? BuildInputDefinition(MfmeLegacyButtonComponent component, string linkedObjectId)
     {
-        if (!component.HasButtonInput && !component.HasCoinInput)
+        return BuildInputDefinition(
+            component.HasButtonInput,
+            component.HasCoinInput,
+            component.ButtonNumberAsString,
+            component.Inverted,
+            component.Shortcut1,
+            component.Shortcut2,
+            component.TextBoxText,
+            linkedObjectId);
+    }
+
+    private static InputDefinitionModel? BuildInputDefinition(
+        bool hasButtonInput,
+        bool hasCoinInput,
+        string? buttonNumberAsString,
+        bool inverted,
+        string? shortcut1,
+        string? shortcut2,
+        string? displayText,
+        string linkedObjectId)
+    {
+        if (!hasButtonInput && !hasCoinInput)
         {
             return null;
         }
 
-        var rawShortcut = component.Shortcut1?.Trim() ?? string.Empty;
+        var rawShortcut = shortcut1?.Trim() ?? string.Empty;
         var keyboardShortcut = string.Empty;
         if (MfmeShortcutKeyMapper.TryMap(rawShortcut, out var mappedKey))
         {
@@ -164,15 +212,15 @@ internal sealed class MfmeToOasisComponentMapper
         return new InputDefinitionModel
         {
             Id = Guid.NewGuid().ToString("N"),
-            Name = string.IsNullOrWhiteSpace(component.TextBoxText) ? "Imported Input" : component.TextBoxText.Trim(),
-            Kind = component.HasCoinInput ? InputDefinitionKind.Coin : InputDefinitionKind.Button,
-            ButtonNumber = component.ButtonNumberAsString?.Trim() ?? string.Empty,
-            CoinInput = component.HasCoinInput,
-            Inverted = component.Inverted,
+            Name = string.IsNullOrWhiteSpace(displayText) ? "Imported Input" : displayText.Trim(),
+            Kind = hasCoinInput ? InputDefinitionKind.Coin : InputDefinitionKind.Button,
+            ButtonNumber = buttonNumberAsString?.Trim() ?? string.Empty,
+            CoinInput = hasCoinInput,
+            Inverted = inverted,
             RawMfmeShortcut = rawShortcut,
             KeyboardShortcut = keyboardShortcut,
             LinkedVisualElementId = Guid.TryParse(linkedObjectId, out var linkedId) ? linkedId : null,
-            Notes = string.IsNullOrWhiteSpace(component.Shortcut2) ? string.Empty : $"Shortcut2: {component.Shortcut2.Trim()}"
+            Notes = string.IsNullOrWhiteSpace(shortcut2) ? string.Empty : $"Shortcut2: {shortcut2.Trim()}"
         };
     }
 


### PR DESCRIPTION
### Motivation
- MFME extracts can encode input wiring on both text-based `Button` components and graphical `Lamp` components, but only `Button` imports produced clickable/keyboard-routable inputs in Play view.
- Preserve and surface MFME lamp input metadata (button number, coin flag, inversion, shortcuts) so graphical lamps become interactive and keyboard-mapped like buttons.

### Description
- Extend the MFME DTO `MfmeLegacyLampComponent` to include input fields: `HasButtonInput`, `HasCoinInput`, `ButtonNumberAsString`, `Inverted`, `Shortcut1`, and `Shortcut2` in `MfmeLegacyExtractComponentDtos.cs`.
- Update the manifest parser in `MfmeExtractManifestParser.cs` to detect and read lamp input metadata (added `HasButtonInput`/`HasCoinInput` helpers and populate the new lamp DTO fields).
- Change mapper behavior in `MfmeToOasisComponentMapper.cs` to create `InputDefinitionModel` entries for `Lamp` components (reuse shared `BuildInputDefinition` logic so both `Lamp` and `Button` imports produce linked inputs), and pass lamp input metadata through the `Button->Lamp` conversion path.
- Add/adjust unit tests to cover parsing of lamp input fields and mapping graphical lamps into linked `InputDefinitionModel` entries in `MfmeExtractReaderTests.cs`, `MfmeToOasisComponentMapperTests.cs`, and `MfmeImportServiceTests.cs`.

### Testing
- Ran `git diff --check` to validate no whitespace/index issues and it succeeded.
- Attempted to run unit tests via `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` but the `dotnet` SDK is not installed in this environment so tests could not be executed here.
- Added/updated unit tests exercising the new parsing and mapping paths (not executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c218bda108327b279ebaf3c59154c)