### PR TITLE
Parse MAME `reel` output and make band offsets continuous (-1..1)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
@@ -1,0 +1,21 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameReelRuntimeAdapterTests
+{
+    [Theory]
+    [InlineData(FruitMachinePlatformType.Impact, 12, -0.025d)]
+    [InlineData(FruitMachinePlatformType.Impact, 16, -0.08d)]
+    [InlineData(FruitMachinePlatformType.Impact, 24, 0d)]
+    public void ResolvePlatformBandOffsetNormalized_Impact_UsesConfiguredStopOffsets(
+        FruitMachinePlatformType platform,
+        int stops,
+        double expected)
+    {
+        var actual = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(platform, stops);
+
+        Assert.Equal(expected, actual, 6);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -22,7 +22,23 @@ public sealed class MameStdoutParserTests
     }
 
     [Fact]
-    public void ProcessLine_WhenSreelLine_AppliesReelState()
+    public void ProcessLine_WhenReelLine_AppliesReelState()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
+
+        parser.ProcessLine("reel3 = 94");
+
+        var call = Assert.Single(reelAdapter.Calls);
+        Assert.Equal(3, call.ReelId);
+        Assert.Equal(94, call.Value);
+        Assert.Empty(lampAdapter.Calls);
+    }
+
+    [Fact]
+    public void ProcessLine_WhenLegacySreelLine_IgnoresLine()
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
@@ -31,10 +47,7 @@ public sealed class MameStdoutParserTests
 
         parser.ProcessLine("sreel3 = 64170");
 
-        var call = Assert.Single(reelAdapter.Calls);
-        Assert.Equal(3, call.ReelId);
-        Assert.Equal(94, call.Value);
-        Assert.Empty(lampAdapter.Calls);
+        Assert.Empty(reelAdapter.Calls);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -343,7 +343,8 @@ public sealed class Panel2DRendererTests
     [InlineData(96, 12, 0d)]
     [InlineData(-1, 12, 95d / 96d)]
     [InlineData(24, 12, 0.25d)]
-    public void ReelOffset_ComputesExpectedWrappedOffset(int position, int stops, double expected)
+    [InlineData(24.5d, 12, 24.5d / 96d)]
+    public void ReelOffset_ComputesExpectedWrappedOffset(double position, int stops, double expected)
     {
         var actual = ReelElementRenderer.ComputeWrappedOffset(position, stops);
 
@@ -366,7 +367,8 @@ public sealed class Panel2DRendererTests
     [InlineData(24, 12, 48f, 12d)]
     [InlineData(-1, 12, 48f, 47.5d)]
     [InlineData(96, 12, 48f, 0d)]
-    public void ReelBandOffset_ComputesExpectedValue(int position, int stops, float bandHeight, double expected)
+    [InlineData(24.5d, 12, 48f, 12.25d)]
+    public void ReelBandOffset_ComputesExpectedValue(double position, int stops, float bandHeight, double expected)
     {
         var actual = ReelElementRenderer.ComputeBandOffset(position, stops, bandHeight);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -77,17 +77,17 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
                 foreach (var objectId in objectIds)
                 {
-                    if (!TryResolveEffectiveReelPosition(document, objectId, reelValue, out var effectiveReelValue, out var stops, out var normalizedPosition))
+                    if (!TryResolveEffectiveReelPosition(document, objectId, reelValue, out var effectiveReelPosition, out var stops, out var normalizedPosition))
                     {
                         continue;
                     }
 
                     if (_debugOutputEnabledProvider())
                     {
-                        _infoLogger($"[MAME-REEL] reel{reelId} raw={reelValue} effective={effectiveReelValue} normalized={normalizedPosition:0.###} stops={stops} objectId={objectId}");
+                        _infoLogger($"[MAME-REEL] reel{reelId} raw={reelValue} effective={effectiveReelPosition:0.###} normalized={normalizedPosition:0.###} stops={stops} objectId={objectId}");
                     }
 
-                    if (document.RuntimeState.SetReelPositionIfChanged(objectId, effectiveReelValue))
+                    if (document.RuntimeState.SetReelPositionIfChanged(objectId, effectiveReelPosition))
                     {
                         changedObjectIds.Add(objectId);
                     }
@@ -136,9 +136,9 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return cacheEntry.MappingByReelId;
     }
 
-    private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, out int effectiveReelValue, out int stops, out double normalizedPosition)
+    private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, out double effectiveReelPosition, out int stops, out double normalizedPosition)
     {
-        effectiveReelValue = 0;
+        effectiveReelPosition = 0d;
         stops = 0;
         normalizedPosition = 0d;
         var reelElement = document.GetPanelElements()
@@ -150,13 +150,13 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         }
 
         stops = reelElement.Stops.Value;
-        effectiveReelValue = ResolveEffectiveReelValue(rawReelValue, reelElement.Stops.Value, reelElement.IsReversed == true, reelElement.BandOffset ?? 0d);
-        var wrappedPosition = ((effectiveReelValue % stops) + stops) % stops;
-        normalizedPosition = wrappedPosition / (double)stops;
+        effectiveReelPosition = ResolveEffectiveReelPosition(rawReelValue, reelElement.Stops.Value, reelElement.IsReversed == true, reelElement.BandOffset ?? 0d);
+        var wrappedPosition = ((effectiveReelPosition % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
+        normalizedPosition = wrappedPosition / ReelPositionsPerRevolution;
         return true;
     }
 
-    private int ResolveEffectiveReelValue(int rawReelValue, int stops, bool reelReversed, double reelBandOffset)
+    private double ResolveEffectiveReelPosition(int rawReelValue, int stops, bool reelReversed, double reelBandOffset)
     {
         var wrapped = ((rawReelValue % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
         var platformReversed = RequiresPlatformReversal(_platformProvider());
@@ -166,7 +166,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
             : wrapped;
         var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider(), stops);
         var totalOffset = platformOffset + reelBandOffset;
-        var offsetSteps = (int)Math.Round(totalOffset * ReelPositionsPerRevolution, MidpointRounding.AwayFromZero);
+        var offsetSteps = totalOffset * ReelPositionsPerRevolution;
         var offsetAdjusted = directionAdjusted + offsetSteps;
         return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -176,11 +176,13 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return platform == FruitMachinePlatformType.MPU4;
     }
 
-    private static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)
+    internal static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)
     {
         return platform switch
         {
             FruitMachinePlatformType.MPU4 when stops == 16 => -0.05d,
+            FruitMachinePlatformType.Impact when stops == 12 => -0.025d,
+            FruitMachinePlatformType.Impact when stops == 16 => -0.08d,
             FruitMachinePlatformType.Scorpion4 when stops == 12 => 0.2d,
             FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
             _ => 0d

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
@@ -9,11 +9,11 @@ public interface IMameReelStateParser
 
 public sealed partial class MameReelStateParser : IMameReelStateParser
 {
-    private const int SreelCycle = 65536;
-    private const int LegacyReelPositionsPerRevolution = 96;
+    private const int MinReelPosition = 0;
+    private const int MaxReelPosition = 95;
 
-    [GeneratedRegex(@"^sreel\s*(\d+)\s*=\s*(-?\d+)$", RegexOptions.IgnoreCase)]
-    private static partial Regex SreelEqualsPattern();
+    [GeneratedRegex(@"^reel\s*(\d+)(?:\s*=\s*|\s+)(-?\d+)\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex ReelPattern();
 
     public bool TryParse(string line, out int reelId, out int reelValue)
     {
@@ -25,23 +25,23 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
             return false;
         }
 
-        var trimmed = line.Trim();
-        var sreelRegexMatch = SreelEqualsPattern().Match(trimmed);
-        if (sreelRegexMatch.Success
-            && int.TryParse(sreelRegexMatch.Groups[1].Value, out reelId)
-            && int.TryParse(sreelRegexMatch.Groups[2].Value, out var sreelValue))
+        var match = ReelPattern().Match(line.Trim());
+        if (!match.Success
+            || !int.TryParse(match.Groups[1].Value, out reelId)
+            || !int.TryParse(match.Groups[2].Value, out reelValue))
         {
-            reelValue = ConvertSreelToLegacyReelPosition(sreelValue);
-            return true;
+            reelId = 0;
+            reelValue = 0;
+            return false;
         }
 
-        return false;
-    }
+        if (reelValue is < MinReelPosition or > MaxReelPosition)
+        {
+            reelId = 0;
+            reelValue = 0;
+            return false;
+        }
 
-    private static int ConvertSreelToLegacyReelPosition(int sreelValue)
-    {
-        var wrapped = ((sreelValue % SreelCycle) + SreelCycle) % SreelCycle;
-        return (int)Math.Round((wrapped / (double)SreelCycle) * LegacyReelPositionsPerRevolution, MidpointRounding.AwayFromZero)
-            % LegacyReelPositionsPerRevolution;
+        return true;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -598,7 +598,7 @@ internal static class Panel2DDocumentStorage
     {
         return !double.IsNaN(value)
             && !double.IsInfinity(value)
-            && value >= 0
+            && value >= -1
             && value <= 1;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -12,6 +12,11 @@ internal static class PanelElementValidation
         return IsFinite(value) && value > 0;
     }
 
+    public static bool IsValidBandOffset(double value)
+    {
+        return IsFinite(value) && value >= -1d && value <= 1d;
+    }
+
     public static bool IsValidForInspectorUpdate(PanelElementModel element)
     {
         ArgumentNullException.ThrowIfNull(element);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -3,7 +3,7 @@ namespace OasisEditor;
 public sealed class PanelRuntimeState
 {
     private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, int> _reelPositionByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, double> _reelPositionByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, double[]> _segmentBrightnessByObjectId = new(StringComparer.Ordinal);
 
@@ -12,7 +12,7 @@ public sealed class PanelRuntimeState
     public bool IsLampTestActive => !string.IsNullOrWhiteSpace(LampTestObjectId);
 
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
-    public IReadOnlyDictionary<string, int> ReelPositionByObjectId => _reelPositionByObjectId;
+    public IReadOnlyDictionary<string, double> ReelPositionByObjectId => _reelPositionByObjectId;
     public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
     public IReadOnlyDictionary<string, double[]> SegmentBrightnessByObjectId => _segmentBrightnessByObjectId;
 
@@ -35,7 +35,7 @@ public sealed class PanelRuntimeState
         return true;
     }
 
-    public bool SetReelPositionIfChanged(string objectId, int position)
+    public bool SetReelPositionIfChanged(string objectId, double position)
     {
         if (string.IsNullOrWhiteSpace(objectId))
         {
@@ -43,7 +43,8 @@ public sealed class PanelRuntimeState
         }
 
         var normalizedObjectId = objectId.Trim();
-        if (_reelPositionByObjectId.TryGetValue(normalizedObjectId, out var previous) && previous == position)
+        if (_reelPositionByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && Math.Abs(previous - position) < 0.0001d)
         {
             return false;
         }
@@ -67,14 +68,14 @@ public sealed class PanelRuntimeState
         return _lampIntensityByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
     }
 
-    public int GetReelPosition(string objectId)
+    public double GetReelPosition(string objectId)
     {
         if (string.IsNullOrWhiteSpace(objectId))
         {
             return 0;
         }
 
-        return _reelPositionByObjectId.GetValueOrDefault(objectId.Trim(), 0);
+        return _reelPositionByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
     }
 
     public void ClearLampIntensity(string objectId)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -45,7 +45,7 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         context.Canvas.DrawRect(bounds, borderPaint);
     }
 
-    internal static double ComputeWrappedOffset(int position, int stops)
+    internal static double ComputeWrappedOffset(double position, int stops)
     {
         var safeStops = Math.Max(1, stops);
         var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, safeStops);
@@ -79,7 +79,7 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         }
     }
 
-    private static void DrawStripImage(SKCanvas canvas, SKRect bounds, SKImage stripImage, double wrappedOffset, int reelPosition, int stops, double? visibleScale)
+    private static void DrawStripImage(SKCanvas canvas, SKRect bounds, SKImage stripImage, double wrappedOffset, double reelPosition, int stops, double? visibleScale)
     {
         var destinationHeight = ResolveBandHeight(bounds.Height, visibleScale);
         var top = bounds.Top - (float)ComputeBandOffset(reelPosition, stops, destinationHeight);
@@ -97,7 +97,7 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         return (float)(reelHeight / safeVisibleScale);
     }
 
-    public static double ComputeBandOffset(int position, int stops, float bandHeight)
+    public static double ComputeBandOffset(double position, int stops, float bandHeight)
     {
         var safeStops = Math.Max(1, stops);
         var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, safeStops);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -344,7 +344,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 }
 
 internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
-internal readonly record struct ReelVisualState(int Position);
+internal readonly record struct ReelVisualState(double Position);
 internal readonly record struct SegmentVisualState(int[] CellMasks);
 
 public sealed record PanelVisualStateChangedEvent(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -470,7 +470,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 "Band Offset",
                 "Type-specific",
                 selectedElement.BandOffset ?? 0d,
-                commit: value => TryApplyUpdate(selectedElement.ObjectId, "Update band offset", new PanelElementModelUpdate { BandOffset = value }),
+                commit: value => TryApplyBandOffsetUpdate(selectedElement.ObjectId, value),
                 format: "G17"));
         }
 
@@ -584,6 +584,16 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private string? TryApplyColorUpdate(string objectId, string description, PanelElementModelUpdate update)
     {
         return TryApplyUpdate(objectId, description, update, suppressInspectorRefresh: true);
+    }
+
+    private string? TryApplyBandOffsetUpdate(string objectId, double value)
+    {
+        if (!PanelElementValidation.IsValidBandOffset(value))
+        {
+            return "Enter a value from -1 to 1.";
+        }
+
+        return TryApplyUpdate(objectId, "Update band offset", new PanelElementModelUpdate { BandOffset = value });
     }
 
     private string? TryApplyUpdate(string objectId, string description, PanelElementModelUpdate update, bool suppressInspectorRefresh = false)


### PR DESCRIPTION
### Motivation
- Migrate from the legacy `sreel` output (and its 65536-based quantisation) to the new `reel` stdout lines that already report positions in the 0–95 range. 
- Preserve fractional band-offset adjustments instead of quantising them to 96 integer steps so visual alignment can be continuous across the reel diameter. 
- Restrict inspector/document band-offset values to a safe normalized range of `-1` to `+1` and validate them at edit/save time.

### Description
- Replace `sreel` parsing with a `reel` parser in `MameReelStateParser` that accepts `reel<N> = <value>` and validates values are between `0` and `95` inclusive. (`MameReelStateParser.cs`) 
- Make runtime reel positions continuous by storing positions as `double` instead of `int` in `PanelRuntimeState` and update accessors accordingly. (`PanelRuntimeState.cs`, `DocumentTabViewModel` visual state) 
- Update `MameReelRuntimeAdapter` to compute an effective (fractional) reel position by applying platform and per-reel band offsets as continuous normalized offsets and return/propagate a `double` effective position. (`MameReelRuntimeAdapter.cs`) 
- Update reel rendering to accept fractional positions and compute wrapped offsets and band offsets with `double` precision so drawn strip images reflect fractional offsets. (`Rendering/ReelElementRenderer.cs`) 
- Constrain and validate band-offset edits in the Inspector through a dedicated `TryApplyBandOffsetUpdate` path and add `IsValidBandOffset` validation logic; update persisted document validation to accept `-1..+1`. (`ViewModels/InspectorViewModel.cs`, `PanelElementValidation.cs`, `Panel2DDocumentStorage.cs`) 
- Update unit tests to assert new `reel` parsing and fractional-band-offset behavior, and add a test to ensure legacy `sreel` lines are ignored. (`OasisEditor.Tests/MameStdoutParserTests.cs`, `OasisEditor.Tests/Panel2DRendererTests.cs`) 

### Testing
- Attempted to run the solution tests with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln --no-restore`, but `dotnet` is not available in the execution environment so unit tests were not executed. (No test failures reported because tests were not run.) 
- Performed a code-style/consistency check via repository diff checks; no diff-check issues were reported locally before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c29ad6d808327847a8e9ed425d411)