### PR TITLE
Fix Impact alpha VFD cell order

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -97,6 +97,27 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.All(brightness, value => Assert.Equal(0.25d, value));
     }
 
+    [Fact]
+    public void ApplySegmentState_ReversesImpactAlphaCellOrderBeforeRendering()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(
+            () => [document],
+            action => dispatches.Add(action),
+            () => FruitMachinePlatformType.Impact);
+
+        adapter.ApplySegmentState(0, 2, MameSegmentOutputType.Vfd);
+        adapter.ApplySegmentState(15, 1, MameSegmentOutputType.Vfd);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks("alpha-0", 16);
+        Assert.Equal(3, masks[0]);
+        Assert.Equal(4, masks[15]);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -214,7 +214,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameSegmentStateParser(),
             new MameSegmentRuntimeAdapter(
                 () => OpenDocuments,
-                DispatchToUiThread),
+                DispatchToUiThread,
+                () => SelectedFruitMachinePlatform),
             platformProvider: () => SelectedFruitMachinePlatform);
         _mameProcessRunner = new MameProcessRunner(
             stdoutLogger: line => ProcessMameStdoutLine(line, mameStdoutParser),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -4,6 +4,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 {
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Func<FruitMachinePlatformType> _platformProvider;
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> _pendingMasks = new();
     private readonly Dictionary<int, double> _pendingVfdBrightnessByDisplay = new();
@@ -12,10 +13,11 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Dictionary<int, double> _latestVfdBrightnessByDisplay = new();
     private bool _uiUpdateScheduled;
 
-    public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch, Func<FruitMachinePlatformType>? platformProvider = null)
     {
         _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
+        _platformProvider = platformProvider ?? (() => FruitMachinePlatformType.MPU4);
     }
 
     public void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType)
@@ -83,10 +85,12 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var cellCount = element.Kind == PanelElementKind.SevenSegment ? 1 : 16;
                 var cellMasks = new int[cellCount];
                 var cellBrightness = new double[cellCount];
+                var reversePlatformAlphaCells = element.Kind == PanelElementKind.Alpha && RequiresPlatformAlphaCellReversal(_platformProvider());
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
                     var source = element.Kind == PanelElementKind.SevenSegment ? _latestDigitMasksByCell : _latestVfdMasksByCell;
-                    if (source.TryGetValue(baseIndex + i, out var mask))
+                    var sourceOffset = reversePlatformAlphaCells ? cellMasks.Length - 1 - i : i;
+                    if (source.TryGetValue(baseIndex + sourceOffset, out var mask))
                     {
                         cellMasks[i] = element.Kind == PanelElementKind.SevenSegment
                             ? mask
@@ -117,6 +121,18 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);
             }
         }
+    }
+
+    private static bool RequiresPlatformAlphaCellReversal(FruitMachinePlatformType platform)
+    {
+        return platform switch
+        {
+            // Impact VFD cell IDs arrive from MAME in the opposite left-to-right order
+            // to the Oasis alpha display geometry. Keep the imported per-alpha Reversed
+            // flag as the user/layout transform, and correct the platform source order here.
+            FruitMachinePlatformType.Impact => true,
+            _ => false
+        };
     }
 
     private static int NormalizeMameMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType)


### PR DESCRIPTION
### Motivation
- MFME imports already preserve a per-alpha `Reversed` flag, but MAME/VFD source cell ordering for the Impact platform is opposite to the Oasis alpha geometry, causing alphas to render flipped at runtime.
- Make the runtime adapter platform-aware so platform-specific source-order corrections can be applied without changing imported layout data.

### Description
- Added a platform provider to `MameSegmentRuntimeAdapter` and a default of `MPU4` when none is supplied, and threaded `SelectedFruitMachinePlatform` into the adapter instantiation in `MainWindowViewModel`.
- Implemented `RequiresPlatformAlphaCellReversal(FruitMachinePlatformType)` and use it to compute a `sourceOffset` so VFD cell reads are reversed for Impact before mapping into per-alpha cell masks, leaving the imported `IsReversed`/`Reversed` flag untouched.
- Updated mask collection logic in `ApplyPendingOnUiThread` to index source cells using the platform-aware `sourceOffset` when appropriate.
- Added a unit test `ApplySegmentState_ReversesImpactAlphaCellOrderBeforeRendering` to `MameSegmentRuntimeAdapterTests` that exercises Impact alpha cell ordering behavior.

### Testing
- Added unit test `ApplySegmentState_ReversesImpactAlphaCellOrderBeforeRendering` to `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs` but did not run the test suite here because the `dotnet` SDK is not available in this environment (attempted `dotnet test` would run `WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj`).
- No automated test results are available from this environment; local CI or a dev machine with the .NET SDK should run `dotnet test` to validate the new test and existing suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c31dd832c8327b7aa905359fe5e0f)