### PR TITLE
Expand MAME emulation menu commands

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
@@ -10,41 +10,65 @@ public sealed class MameEmulationCommandStateEvaluatorTests
         var state = MameEmulationCommandStateEvaluator.Evaluate(false, MameEmulationState.Stopped);
 
         Assert.False(state.CanStart);
+        Assert.False(state.CanStartAndLoadState);
         Assert.False(state.CanStop);
+        Assert.False(state.CanSaveStateAndExit);
+        Assert.False(state.CanLoadState);
+        Assert.False(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.False(state.CanSetThrottle);
+        Assert.False(state.CanReset);
     }
 
     [Fact]
-    public void Evaluate_WhenStoppedWithProject_StartEnabledOnly()
+    public void Evaluate_WhenStoppedWithProject_StartCommandsEnabledOnly()
     {
         var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Stopped);
 
         Assert.True(state.CanStart);
+        Assert.True(state.CanStartAndLoadState);
         Assert.False(state.CanStop);
+        Assert.False(state.CanSaveStateAndExit);
+        Assert.False(state.CanLoadState);
+        Assert.False(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.False(state.CanSetThrottle);
+        Assert.False(state.CanReset);
     }
 
     [Fact]
-    public void Evaluate_WhenRunning_StopAndPauseEnabled()
+    public void Evaluate_WhenRunning_RuntimeControlsEnabled()
     {
         var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Running);
 
         Assert.False(state.CanStart);
+        Assert.False(state.CanStartAndLoadState);
         Assert.True(state.CanStop);
+        Assert.True(state.CanSaveStateAndExit);
+        Assert.True(state.CanLoadState);
+        Assert.True(state.CanSaveState);
         Assert.True(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.True(state.CanSetThrottle);
+        Assert.True(state.CanReset);
     }
 
     [Fact]
-    public void Evaluate_WhenPaused_StopAndResumeEnabled()
+    public void Evaluate_WhenPaused_RuntimeControlsAndResumeEnabled()
     {
         var state = MameEmulationCommandStateEvaluator.Evaluate(true, MameEmulationState.Paused);
 
         Assert.False(state.CanStart);
+        Assert.False(state.CanStartAndLoadState);
         Assert.True(state.CanStop);
+        Assert.True(state.CanSaveStateAndExit);
+        Assert.True(state.CanLoadState);
+        Assert.True(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.True(state.CanResume);
+        Assert.True(state.CanSetThrottle);
+        Assert.True(state.CanReset);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationServiceTests.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameEmulationServiceTests
+{
+    [Fact]
+    public async Task StartAndLoadStateAsync_AddsLegacyStateArgument()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = new MameEmulationService(
+            new MameProcessStartInfoBuilder(),
+            runner,
+            () => new MameProcessLaunchRequest(
+                @"C:\MAME\mame.exe",
+                "m4test",
+                @"C:\MAME\roms",
+                @"C:\Plugins\oasis",
+                string.Empty));
+
+        await service.StartAndLoadStateAsync(CancellationToken.None);
+
+        Assert.Contains("-state oasis_save_state", runner.StartInfo?.Arguments);
+        Assert.Equal(MameEmulationState.Running, service.State);
+    }
+
+    [Theory]
+    [InlineData(nameof(IMameEmulationService.LoadStateAsync), "state_load oasis_save_state")]
+    [InlineData(nameof(IMameEmulationService.SaveStateAsync), "state_save oasis_save_state")]
+    [InlineData(nameof(IMameEmulationService.PauseAsync), "pause")]
+    [InlineData(nameof(IMameEmulationService.ResumeAsync), "resume")]
+    [InlineData(nameof(IMameEmulationService.SoftResetAsync), "soft_reset")]
+    [InlineData(nameof(IMameEmulationService.HardResetAsync), "hard_reset")]
+    public async Task RuntimeCommands_WriteLegacyLuaPluginCommand(string methodName, string expectedCommand)
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = await CreateStartedServiceAsync(runner);
+
+        await InvokeRuntimeCommandAsync(service, methodName);
+
+        Assert.Equal(expectedCommand, Assert.Single(runner.Commands));
+    }
+
+    [Theory]
+    [InlineData(true, "throttled true")]
+    [InlineData(false, "throttled false")]
+    public async Task SetThrottleAsync_WritesLegacyLuaPluginCommand(bool isThrottled, string expectedCommand)
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = await CreateStartedServiceAsync(runner);
+
+        await service.SetThrottleAsync(isThrottled, CancellationToken.None);
+
+        Assert.Equal(expectedCommand, Assert.Single(runner.Commands));
+    }
+
+    [Fact]
+    public async Task SaveStateAndExitAsync_WritesSaveAndExitBeforeStopping()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = await CreateStartedServiceAsync(runner);
+
+        await service.SaveStateAndExitAsync(CancellationToken.None);
+
+        Assert.Equal("state_save_and_exit oasis_save_state", Assert.Single(runner.Commands));
+        Assert.Equal(1, runner.StopCount);
+        Assert.Equal(MameEmulationState.Stopped, service.State);
+    }
+
+    private static async Task<MameEmulationService> CreateStartedServiceAsync(RecordingMameProcessRunner runner)
+    {
+        var service = new MameEmulationService(
+            new MameProcessStartInfoBuilder(),
+            runner,
+            () => new MameProcessLaunchRequest(
+                @"C:\MAME\mame.exe",
+                "m4test",
+                @"C:\MAME\roms",
+                @"C:\Plugins\oasis",
+                string.Empty));
+
+        await service.StartAsync(CancellationToken.None);
+        runner.Commands.Clear();
+        return service;
+    }
+
+    private static Task InvokeRuntimeCommandAsync(IMameEmulationService service, string methodName)
+    {
+        return methodName switch
+        {
+            nameof(IMameEmulationService.LoadStateAsync) => service.LoadStateAsync(CancellationToken.None),
+            nameof(IMameEmulationService.SaveStateAsync) => service.SaveStateAsync(CancellationToken.None),
+            nameof(IMameEmulationService.PauseAsync) => service.PauseAsync(CancellationToken.None),
+            nameof(IMameEmulationService.ResumeAsync) => service.ResumeAsync(CancellationToken.None),
+            nameof(IMameEmulationService.SoftResetAsync) => service.SoftResetAsync(CancellationToken.None),
+            nameof(IMameEmulationService.HardResetAsync) => service.HardResetAsync(CancellationToken.None),
+            _ => throw new ArgumentOutOfRangeException(nameof(methodName), methodName, null)
+        };
+    }
+
+    private sealed class RecordingMameProcessRunner : IMameProcessRunner
+    {
+        public ProcessStartInfo? StartInfo { get; private set; }
+        public List<string> Commands { get; } = [];
+        public int StopCount { get; private set; }
+
+        public Task StartAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+        {
+            StartInfo = startInfo;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -136,15 +136,34 @@
                           Command="{Binding OpenInputMapCommand}" />
             </MenuItem>
             <MenuItem Header="_Emulation">
+                <MenuItem Header="Start And _Load State"
+                          Command="{Binding StartAndLoadStateEmulationCommand}" />
+                <MenuItem Header="Save State And E_xit"
+                          Command="{Binding SaveStateAndExitEmulationCommand}" />
+                <Separator />
                 <MenuItem Header="_Start"
                           Command="{Binding StartEmulationCommand}" />
-                <MenuItem Header="S_top"
+                <MenuItem Header="_Load State"
+                          Command="{Binding LoadStateEmulationCommand}" />
+                <MenuItem Header="Save _State"
+                          Command="{Binding SaveStateEmulationCommand}" />
+                <MenuItem Header="_Exit"
                           Command="{Binding StopEmulationCommand}" />
                 <Separator />
                 <MenuItem Header="_Pause"
                           Command="{Binding PauseEmulationCommand}" />
                 <MenuItem Header="_Resume"
                           Command="{Binding ResumeEmulationCommand}" />
+                <Separator />
+                <MenuItem Header="_Throttle"
+                          Command="{Binding ThrottleEmulationCommand}" />
+                <MenuItem Header="_Unthrottle"
+                          Command="{Binding UnthrottleEmulationCommand}" />
+                <Separator />
+                <MenuItem Header="Soft _Reset"
+                          Command="{Binding SoftResetEmulationCommand}" />
+                <MenuItem Header="_Hard Reset"
+                          Command="{Binding HardResetEmulationCommand}" />
             </MenuItem>
         </Menu>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -123,10 +123,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
         ExitCommand = new RelayCommand(ExitApplication);
+        StartAndLoadStateEmulationCommand = new RelayCommand(StartAndLoadStateEmulation, CanStartAndLoadStateEmulation);
+        SaveStateAndExitEmulationCommand = new RelayCommand(SaveStateAndExitEmulation, CanSaveStateAndExitEmulation);
         StartEmulationCommand = new RelayCommand(StartEmulation, CanStartEmulation);
+        LoadStateEmulationCommand = new RelayCommand(LoadStateEmulation, CanLoadStateEmulation);
+        SaveStateEmulationCommand = new RelayCommand(SaveStateEmulation, CanSaveStateEmulation);
         StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
         PauseEmulationCommand = new RelayCommand(PauseEmulation, CanPauseEmulation);
         ResumeEmulationCommand = new RelayCommand(ResumeEmulation, CanResumeEmulation);
+        ThrottleEmulationCommand = new RelayCommand(ThrottleEmulation, CanSetThrottleEmulation);
+        UnthrottleEmulationCommand = new RelayCommand(UnthrottleEmulation, CanSetThrottleEmulation);
+        SoftResetEmulationCommand = new RelayCommand(SoftResetEmulation, CanResetEmulation);
+        HardResetEmulationCommand = new RelayCommand(HardResetEmulation, CanResetEmulation);
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
@@ -375,10 +383,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
     public ICommand ExitCommand { get; }
+    public ICommand StartAndLoadStateEmulationCommand { get; }
+    public ICommand SaveStateAndExitEmulationCommand { get; }
     public ICommand StartEmulationCommand { get; }
+    public ICommand LoadStateEmulationCommand { get; }
+    public ICommand SaveStateEmulationCommand { get; }
     public ICommand StopEmulationCommand { get; }
     public ICommand PauseEmulationCommand { get; }
     public ICommand ResumeEmulationCommand { get; }
+    public ICommand ThrottleEmulationCommand { get; }
+    public ICommand UnthrottleEmulationCommand { get; }
+    public ICommand SoftResetEmulationCommand { get; }
+    public ICommand HardResetEmulationCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -1778,9 +1794,58 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         Application.Current.Shutdown();
     }
 
+    private MameEmulationCommandState CurrentEmulationCommandState =>
+        MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState);
+
+    private bool CanStartAndLoadStateEmulation()
+    {
+        return CurrentEmulationCommandState.CanStartAndLoadState;
+    }
+
+    private async void StartAndLoadStateEmulation()
+    {
+        if (!CanStartAndLoadStateEmulation())
+        {
+            return;
+        }
+
+        AddOutputEntry("Emulation start and load state requested.", OutputLogStatus.Info);
+        try
+        {
+            await _mameEmulationService.StartAndLoadStateAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Emulation failed to start and load state: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
+    private bool CanSaveStateAndExitEmulation()
+    {
+        return CurrentEmulationCommandState.CanSaveStateAndExit;
+    }
+
+    private async void SaveStateAndExitEmulation()
+    {
+        if (!CanSaveStateAndExitEmulation())
+        {
+            return;
+        }
+
+        AddOutputEntry("Emulation save state and exit requested.", OutputLogStatus.Info);
+        try
+        {
+            await _mameEmulationService.SaveStateAndExitAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Emulation failed to save state and exit cleanly: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
     private bool CanStartEmulation()
     {
-        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStart;
+        return CurrentEmulationCommandState.CanStart;
     }
 
     private async void StartEmulation()
@@ -1801,9 +1866,37 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    private bool CanLoadStateEmulation()
+    {
+        return CurrentEmulationCommandState.CanLoadState;
+    }
+
+    private async void LoadStateEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanLoadStateEmulation,
+            "Emulation load state requested.",
+            "Emulation failed to load state",
+            cancellationToken => _mameEmulationService.LoadStateAsync(cancellationToken));
+    }
+
+    private bool CanSaveStateEmulation()
+    {
+        return CurrentEmulationCommandState.CanSaveState;
+    }
+
+    private async void SaveStateEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanSaveStateEmulation,
+            "Emulation save state requested.",
+            "Emulation failed to save state",
+            cancellationToken => _mameEmulationService.SaveStateAsync(cancellationToken));
+    }
+
     private bool CanStopEmulation()
     {
-        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanStop;
+        return CurrentEmulationCommandState.CanStop;
     }
 
     public void StopEmulationForWindowClose()
@@ -1849,34 +1942,98 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanPauseEmulation()
     {
-        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanPause;
+        return CurrentEmulationCommandState.CanPause;
     }
 
     private async void PauseEmulation()
     {
-        if (!CanPauseEmulation())
-        {
-            return;
-        }
-
-        AddOutputEntry("Emulation pause requested.", OutputLogStatus.Info);
-        await _mameEmulationService.PauseAsync(CancellationToken.None);
+        await SendEmulationCommandAsync(
+            CanPauseEmulation,
+            "Emulation pause requested.",
+            "Emulation failed to pause",
+            cancellationToken => _mameEmulationService.PauseAsync(cancellationToken));
     }
 
     private bool CanResumeEmulation()
     {
-        return MameEmulationCommandStateEvaluator.Evaluate(HasLoadedProject, EmulationState).CanResume;
+        return CurrentEmulationCommandState.CanResume;
     }
 
     private async void ResumeEmulation()
     {
-        if (!CanResumeEmulation())
+        await SendEmulationCommandAsync(
+            CanResumeEmulation,
+            "Emulation resume requested.",
+            "Emulation failed to resume",
+            cancellationToken => _mameEmulationService.ResumeAsync(cancellationToken));
+    }
+
+    private bool CanSetThrottleEmulation()
+    {
+        return CurrentEmulationCommandState.CanSetThrottle;
+    }
+
+    private async void ThrottleEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanSetThrottleEmulation,
+            "Emulation throttle requested.",
+            "Emulation failed to enable throttle",
+            cancellationToken => _mameEmulationService.SetThrottleAsync(true, cancellationToken));
+    }
+
+    private async void UnthrottleEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanSetThrottleEmulation,
+            "Emulation unthrottle requested.",
+            "Emulation failed to disable throttle",
+            cancellationToken => _mameEmulationService.SetThrottleAsync(false, cancellationToken));
+    }
+
+    private bool CanResetEmulation()
+    {
+        return CurrentEmulationCommandState.CanReset;
+    }
+
+    private async void SoftResetEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanResetEmulation,
+            "Emulation soft reset requested.",
+            "Emulation failed to soft reset",
+            cancellationToken => _mameEmulationService.SoftResetAsync(cancellationToken));
+    }
+
+    private async void HardResetEmulation()
+    {
+        await SendEmulationCommandAsync(
+            CanResetEmulation,
+            "Emulation hard reset requested.",
+            "Emulation failed to hard reset",
+            cancellationToken => _mameEmulationService.HardResetAsync(cancellationToken));
+    }
+
+    private async Task SendEmulationCommandAsync(
+        Func<bool> canExecute,
+        string requestedMessage,
+        string failureMessage,
+        Func<CancellationToken, Task> command)
+    {
+        if (!canExecute())
         {
             return;
         }
 
-        AddOutputEntry("Emulation resume requested.", OutputLogStatus.Info);
-        await _mameEmulationService.ResumeAsync(CancellationToken.None);
+        AddOutputEntry(requestedMessage, OutputLogStatus.Info);
+        try
+        {
+            await command(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"{failureMessage}: {ex.Message}", OutputLogStatus.Error);
+        }
     }
 
     private MameProcessLaunchRequest? BuildMameLaunchRequest()
@@ -2547,24 +2704,25 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void NotifyEmulationCommands()
     {
-        if (StartEmulationCommand is RelayCommand startEmulationCommand)
-        {
-            startEmulationCommand.RaiseCanExecuteChanged();
-        }
+        RaiseEmulationCommandCanExecuteChanged(StartAndLoadStateEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(SaveStateAndExitEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(StartEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(LoadStateEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(SaveStateEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(StopEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(PauseEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(ResumeEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(ThrottleEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(UnthrottleEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(SoftResetEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(HardResetEmulationCommand);
+    }
 
-        if (StopEmulationCommand is RelayCommand stopEmulationCommand)
+    private static void RaiseEmulationCommandCanExecuteChanged(ICommand command)
+    {
+        if (command is RelayCommand relayCommand)
         {
-            stopEmulationCommand.RaiseCanExecuteChanged();
-        }
-
-        if (PauseEmulationCommand is RelayCommand pauseEmulationCommand)
-        {
-            pauseEmulationCommand.RaiseCanExecuteChanged();
-        }
-
-        if (ResumeEmulationCommand is RelayCommand resumeEmulationCommand)
-        {
-            resumeEmulationCommand.RaiseCanExecuteChanged();
+            relayCommand.RaiseCanExecuteChanged();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
@@ -3,9 +3,15 @@ namespace OasisEditor;
 public sealed class MameEmulationCommandState
 {
     public bool CanStart { get; init; }
+    public bool CanStartAndLoadState { get; init; }
     public bool CanStop { get; init; }
+    public bool CanSaveStateAndExit { get; init; }
+    public bool CanLoadState { get; init; }
+    public bool CanSaveState { get; init; }
     public bool CanPause { get; init; }
     public bool CanResume { get; init; }
+    public bool CanSetThrottle { get; init; }
+    public bool CanReset { get; init; }
 }
 
 public static class MameEmulationCommandStateEvaluator
@@ -13,6 +19,7 @@ public static class MameEmulationCommandStateEvaluator
     public static MameEmulationCommandState Evaluate(bool hasLoadedProject, MameEmulationState state)
     {
         var canStart = hasLoadedProject && state is MameEmulationState.Stopped or MameEmulationState.Failed;
+        var canControlRunningMachine = state is MameEmulationState.Running or MameEmulationState.Paused;
         var canStop = state is MameEmulationState.Starting or MameEmulationState.Running or MameEmulationState.Paused or MameEmulationState.Stopping;
         var canPause = state == MameEmulationState.Running;
         var canResume = state == MameEmulationState.Paused;
@@ -20,9 +27,15 @@ public static class MameEmulationCommandStateEvaluator
         return new MameEmulationCommandState
         {
             CanStart = canStart,
+            CanStartAndLoadState = canStart,
             CanStop = canStop,
+            CanSaveStateAndExit = canControlRunningMachine,
+            CanLoadState = canControlRunningMachine,
+            CanSaveState = canControlRunningMachine,
             CanPause = canPause,
-            CanResume = canResume
+            CanResume = canResume,
+            CanSetThrottle = canControlRunningMachine,
+            CanReset = canControlRunningMachine
         };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationService.cs
@@ -4,6 +4,8 @@ namespace OasisEditor;
 
 public sealed class MameEmulationService : IMameEmulationService
 {
+    private const string OasisSaveStateName = "oasis_save_state";
+
     private readonly IMameProcessStartInfoBuilder _startInfoBuilder;
     private readonly IMameProcessRunner _processRunner;
     private readonly Func<MameProcessLaunchRequest?> _requestFactory;
@@ -33,7 +35,17 @@ public sealed class MameEmulationService : IMameEmulationService
 
     public event EventHandler<MameEmulationState>? StateChanged;
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        return StartCoreAsync(loadState: false, cancellationToken);
+    }
+
+    public Task StartAndLoadStateAsync(CancellationToken cancellationToken)
+    {
+        return StartCoreAsync(loadState: true, cancellationToken);
+    }
+
+    private async Task StartCoreAsync(bool loadState, CancellationToken cancellationToken)
     {
         SetState(MameEmulationState.Starting);
         try
@@ -42,6 +54,17 @@ public sealed class MameEmulationService : IMameEmulationService
             if (request is null)
             {
                 throw new InvalidOperationException("No valid MAME launch request is available.");
+            }
+
+            if (loadState)
+            {
+                var stateArgument = $"-state {OasisSaveStateName}";
+                request = request with
+                {
+                    AdditionalArguments = string.IsNullOrWhiteSpace(request.AdditionalArguments)
+                        ? stateArgument
+                        : $"{request.AdditionalArguments.Trim()} {stateArgument}"
+                };
             }
 
             var startInfo = _startInfoBuilder.Build(request);
@@ -67,18 +90,53 @@ public sealed class MameEmulationService : IMameEmulationService
         SetState(MameEmulationState.Stopped);
     }
 
-    public Task PauseAsync(CancellationToken cancellationToken)
+    public async Task SaveStateAndExitAsync(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        SetState(MameEmulationState.Paused);
-        return Task.CompletedTask;
+        await SendCommandAsync($"state_save_and_exit {OasisSaveStateName}", cancellationToken).ConfigureAwait(false);
+        await StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public Task ResumeAsync(CancellationToken cancellationToken)
+    public Task LoadStateAsync(CancellationToken cancellationToken)
+    {
+        return SendCommandAsync($"state_load {OasisSaveStateName}", cancellationToken);
+    }
+
+    public Task SaveStateAsync(CancellationToken cancellationToken)
+    {
+        return SendCommandAsync($"state_save {OasisSaveStateName}", cancellationToken);
+    }
+
+    public async Task PauseAsync(CancellationToken cancellationToken)
+    {
+        await SendCommandAsync("pause", cancellationToken).ConfigureAwait(false);
+        SetState(MameEmulationState.Paused);
+    }
+
+    public async Task ResumeAsync(CancellationToken cancellationToken)
+    {
+        await SendCommandAsync("resume", cancellationToken).ConfigureAwait(false);
+        SetState(MameEmulationState.Running);
+    }
+
+    public Task SetThrottleAsync(bool isThrottled, CancellationToken cancellationToken)
+    {
+        return SendCommandAsync($"throttled {isThrottled.ToString().ToLowerInvariant()}", cancellationToken);
+    }
+
+    public Task SoftResetAsync(CancellationToken cancellationToken)
+    {
+        return SendCommandAsync("soft_reset", cancellationToken);
+    }
+
+    public Task HardResetAsync(CancellationToken cancellationToken)
+    {
+        return SendCommandAsync("hard_reset", cancellationToken);
+    }
+
+    private Task SendCommandAsync(string command, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        SetState(MameEmulationState.Running);
-        return Task.CompletedTask;
+        return _processRunner.WriteStandardInputAsync(command, cancellationToken);
     }
 
     private void SetState(MameEmulationState state)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -7,9 +7,16 @@ public interface IMameEmulationService
     MameEmulationState State { get; }
     event EventHandler<MameEmulationState>? StateChanged;
     Task StartAsync(CancellationToken cancellationToken);
+    Task StartAndLoadStateAsync(CancellationToken cancellationToken);
     Task StopAsync(CancellationToken cancellationToken);
+    Task SaveStateAndExitAsync(CancellationToken cancellationToken);
+    Task LoadStateAsync(CancellationToken cancellationToken);
+    Task SaveStateAsync(CancellationToken cancellationToken);
     Task PauseAsync(CancellationToken cancellationToken);
     Task ResumeAsync(CancellationToken cancellationToken);
+    Task SetThrottleAsync(bool isThrottled, CancellationToken cancellationToken);
+    Task SoftResetAsync(CancellationToken cancellationToken);
+    Task HardResetAsync(CancellationToken cancellationToken);
 }
 
 public interface IMameProcessRunner


### PR DESCRIPTION
### Motivation
- Replicate the legacy Unity Layout Editor `Emulation` menu (menu order and separators) and expose the missing runtime controls in the WPF editor.
- Route each new menu action through the existing MAME runtime plumbing so menu commands map to the Oasis Lua plugin stdin protocol used by MAME.
- Provide guarded, command-driven handlers in the view-model so menu items are only enabled when appropriate.
- Add coverage for the new behavior via unit tests to preserve compatibility with the legacy runtime protocol.

### Description
- Updated the Emulation menu UI in `MainWindow.xaml` to match the legacy ordering and separators and to add `Start And Load State`, `Save State And Exit`, `Load State`, `Save State`, `Throttle/Unthrottle`, `Soft Reset` and `Hard Reset` items bound to view-model commands.
- Extended `MainWindowViewModel` to declare and initialize new `ICommand` properties and added handlers for `StartAndLoadStateEmulation`, `SaveStateAndExitEmulation`, `LoadStateEmulation`, `SaveStateEmulation`, `ThrottleEmulation`, `UnthrottleEmulation`, `SoftResetEmulation`, and `HardResetEmulation`, plus a `SendEmulationCommandAsync` helper and can-execute wiring via `MameEmulationCommandStateEvaluator`.
- Expanded the runtime contract `IMameEmulationService` and implemented the corresponding methods in `MameEmulationService` to send legacy Oasis Lua plugin commands (`state_load`, `state_save`, `state_save_and_exit`, `throttled`, `soft_reset`, `hard_reset`) and to support starting with the legacy `-state oasis_save_state` argument when requested.
- Updated `MameEmulationCommandState`/`MameEmulationCommandStateEvaluator` to expose fine-grained flags for the new menu items, and added xUnit tests to assert evaluator and service behaviors.

### Testing
- Added/updated xUnit tests: `MameEmulationServiceTests` (new) and `MameEmulationCommandStateEvaluatorTests` (updated) that assert process arguments and written stdin commands; tests were added to the test project but could not be executed in this environment because `dotnet` is not installed.
- Performed automated checks: `git diff --check` passed and `MainWindow.xaml` parsed successfully with an XML parser (`python3` `xml.etree.ElementTree`), indicating the XAML is well-formed.
- Notes: unit tests were created and validated for correctness in code, but running them locally requires a .NET SDK; an attempted `dotnet test` failed here with `/bin/bash: dotnet: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c45f34f048327976f0912870511f9)