### PR TITLE
Consolidate Emulation Pause/Throttle menu items into checkable toggles

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationCommandStateEvaluatorTests.cs
@@ -17,6 +17,7 @@ public sealed class MameEmulationCommandStateEvaluatorTests
         Assert.False(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.False(state.CanTogglePause);
         Assert.False(state.CanSetThrottle);
         Assert.False(state.CanReset);
     }
@@ -34,6 +35,7 @@ public sealed class MameEmulationCommandStateEvaluatorTests
         Assert.False(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.False(state.CanTogglePause);
         Assert.False(state.CanSetThrottle);
         Assert.False(state.CanReset);
     }
@@ -51,6 +53,7 @@ public sealed class MameEmulationCommandStateEvaluatorTests
         Assert.True(state.CanSaveState);
         Assert.True(state.CanPause);
         Assert.False(state.CanResume);
+        Assert.True(state.CanTogglePause);
         Assert.True(state.CanSetThrottle);
         Assert.True(state.CanReset);
     }
@@ -68,6 +71,7 @@ public sealed class MameEmulationCommandStateEvaluatorTests
         Assert.True(state.CanSaveState);
         Assert.False(state.CanPause);
         Assert.True(state.CanResume);
+        Assert.True(state.CanTogglePause);
         Assert.True(state.CanSetThrottle);
         Assert.True(state.CanReset);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -137,40 +137,51 @@
             </MenuItem>
             <MenuItem Header="_Emulation">
                 <MenuItem.Resources>
-                    <Style TargetType="{x:Type MenuItem}"
+                    <Style x:Key="EmulationMenuItemWithCheckSlotStyle"
+                           TargetType="{x:Type MenuItem}"
                            BasedOn="{StaticResource EditorMenuItemStyle}">
                         <Setter Property="Tag"
                                 Value="ReserveCheckGlyph" />
                     </Style>
                 </MenuItem.Resources>
                 <MenuItem Header="Start And _Load State"
-                          Command="{Binding StartAndLoadStateEmulationCommand}" />
+                          Command="{Binding StartAndLoadStateEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <MenuItem Header="Save State And E_xit"
-                          Command="{Binding SaveStateAndExitEmulationCommand}" />
+                          Command="{Binding SaveStateAndExitEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <Separator />
                 <MenuItem Header="_Start"
-                          Command="{Binding StartEmulationCommand}" />
+                          Command="{Binding StartEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <MenuItem Header="_Load State"
-                          Command="{Binding LoadStateEmulationCommand}" />
+                          Command="{Binding LoadStateEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <MenuItem Header="Save _State"
-                          Command="{Binding SaveStateEmulationCommand}" />
+                          Command="{Binding SaveStateEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <MenuItem Header="_Exit"
-                          Command="{Binding StopEmulationCommand}" />
+                          Command="{Binding StopEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <Separator />
                 <MenuItem Header="_Pause"
                           Command="{Binding TogglePauseEmulationCommand}"
                           IsCheckable="True"
-                          IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}" />
+                          IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <Separator />
                 <MenuItem Header="_Unthrottle"
                           Command="{Binding ToggleUnthrottleEmulationCommand}"
                           IsCheckable="True"
-                          IsChecked="{Binding IsUnthrottleEmulationChecked, Mode=OneWay}" />
+                          IsChecked="{Binding IsUnthrottleEmulationChecked, Mode=OneWay}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <Separator />
                 <MenuItem Header="Soft _Reset"
-                          Command="{Binding SoftResetEmulationCommand}" />
+                          Command="{Binding SoftResetEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
                 <MenuItem Header="_Hard Reset"
-                          Command="{Binding HardResetEmulationCommand}" />
+                          Command="{Binding HardResetEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
             </MenuItem>
         </Menu>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -151,14 +151,14 @@
                           Command="{Binding StopEmulationCommand}" />
                 <Separator />
                 <MenuItem Header="_Pause"
-                          Command="{Binding PauseEmulationCommand}" />
-                <MenuItem Header="_Resume"
-                          Command="{Binding ResumeEmulationCommand}" />
+                          Command="{Binding TogglePauseEmulationCommand}"
+                          IsCheckable="True"
+                          IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}" />
                 <Separator />
-                <MenuItem Header="_Throttle"
-                          Command="{Binding ThrottleEmulationCommand}" />
                 <MenuItem Header="_Unthrottle"
-                          Command="{Binding UnthrottleEmulationCommand}" />
+                          Command="{Binding ToggleUnthrottleEmulationCommand}"
+                          IsCheckable="True"
+                          IsChecked="{Binding IsUnthrottleEmulationChecked, Mode=OneWay}" />
                 <Separator />
                 <MenuItem Header="Soft _Reset"
                           Command="{Binding SoftResetEmulationCommand}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -136,6 +136,13 @@
                           Command="{Binding OpenInputMapCommand}" />
             </MenuItem>
             <MenuItem Header="_Emulation">
+                <MenuItem.Resources>
+                    <Style TargetType="{x:Type MenuItem}"
+                           BasedOn="{StaticResource EditorMenuItemStyle}">
+                        <Setter Property="Tag"
+                                Value="ReserveCheckGlyph" />
+                    </Style>
+                </MenuItem.Resources>
                 <MenuItem Header="Start And _Load State"
                           Command="{Binding StartAndLoadStateEmulationCommand}" />
                 <MenuItem Header="Save State And E_xit"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -169,7 +169,6 @@
                           IsCheckable="True"
                           IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}"
                           Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
-                <Separator />
                 <MenuItem Header="_Unthrottle"
                           Command="{Binding ToggleUnthrottleEmulationCommand}"
                           IsCheckable="True"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -72,6 +72,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IMameProcessRunner _mameProcessRunner;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
     private bool _isAutoProvisioningMame;
+    private bool _isMameUnthrottled;
     private MameEmulationState _mameEmulationState = MameEmulationState.Stopped;
     private readonly IInputMapDiagnosticsService _inputMapDiagnosticsService = new InputMapDiagnosticsService(new MameInputPortResolver());
     private IReadOnlyList<InputMapDiagnostic> _inputMapDiagnostics = [];
@@ -129,10 +130,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         LoadStateEmulationCommand = new RelayCommand(LoadStateEmulation, CanLoadStateEmulation);
         SaveStateEmulationCommand = new RelayCommand(SaveStateEmulation, CanSaveStateEmulation);
         StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
-        PauseEmulationCommand = new RelayCommand(PauseEmulation, CanPauseEmulation);
-        ResumeEmulationCommand = new RelayCommand(ResumeEmulation, CanResumeEmulation);
-        ThrottleEmulationCommand = new RelayCommand(ThrottleEmulation, CanSetThrottleEmulation);
-        UnthrottleEmulationCommand = new RelayCommand(UnthrottleEmulation, CanSetThrottleEmulation);
+        TogglePauseEmulationCommand = new RelayCommand(TogglePauseEmulation, CanTogglePauseEmulation);
+        ToggleUnthrottleEmulationCommand = new RelayCommand(ToggleUnthrottleEmulation, CanSetThrottleEmulation);
         SoftResetEmulationCommand = new RelayCommand(SoftResetEmulation, CanResetEmulation);
         HardResetEmulationCommand = new RelayCommand(HardResetEmulation, CanResetEmulation);
 
@@ -246,6 +245,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 if (state is MameEmulationState.Stopping or MameEmulationState.Stopped or MameEmulationState.Failed)
                 {
                     _ = ReleaseAllPlayViewInputsAsync($"emulation state '{state}'", CancellationToken.None);
+                }
+
+                if (state is MameEmulationState.Starting or MameEmulationState.Stopped or MameEmulationState.Failed)
+                {
+                    IsUnthrottleEmulationChecked = false;
                 }
 
                 EmulationState = state;
@@ -389,10 +393,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand LoadStateEmulationCommand { get; }
     public ICommand SaveStateEmulationCommand { get; }
     public ICommand StopEmulationCommand { get; }
-    public ICommand PauseEmulationCommand { get; }
-    public ICommand ResumeEmulationCommand { get; }
-    public ICommand ThrottleEmulationCommand { get; }
-    public ICommand UnthrottleEmulationCommand { get; }
+    public ICommand TogglePauseEmulationCommand { get; }
+    public ICommand ToggleUnthrottleEmulationCommand { get; }
     public ICommand SoftResetEmulationCommand { get; }
     public ICommand HardResetEmulationCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
@@ -654,9 +656,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             if (SetProperty(ref _mameEmulationState, value))
             {
+                OnPropertyChanged(nameof(IsPauseEmulationChecked));
                 NotifyEmulationCommands();
             }
         }
+    }
+
+    public bool IsPauseEmulationChecked => EmulationState == MameEmulationState.Paused;
+
+    public bool IsUnthrottleEmulationChecked
+    {
+        get => _isMameUnthrottled;
+        private set => SetProperty(ref _isMameUnthrottled, value);
     }
 
     public string ProjectFilePath
@@ -1940,32 +1951,39 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private bool CanPauseEmulation()
+    private bool CanTogglePauseEmulation()
     {
-        return CurrentEmulationCommandState.CanPause;
+        return CurrentEmulationCommandState.CanTogglePause;
     }
 
-    private async void PauseEmulation()
+    private async void TogglePauseEmulation()
     {
-        await SendEmulationCommandAsync(
-            CanPauseEmulation,
+        if (IsPauseEmulationChecked)
+        {
+            var commandSucceeded = await SendEmulationCommandAsync(
+                CanTogglePauseEmulation,
+                "Emulation resume requested.",
+                "Emulation failed to resume",
+                cancellationToken => _mameEmulationService.ResumeAsync(cancellationToken));
+
+            if (!commandSucceeded)
+            {
+                OnPropertyChanged(nameof(IsPauseEmulationChecked));
+            }
+
+            return;
+        }
+
+        var pauseSucceeded = await SendEmulationCommandAsync(
+            CanTogglePauseEmulation,
             "Emulation pause requested.",
             "Emulation failed to pause",
             cancellationToken => _mameEmulationService.PauseAsync(cancellationToken));
-    }
 
-    private bool CanResumeEmulation()
-    {
-        return CurrentEmulationCommandState.CanResume;
-    }
-
-    private async void ResumeEmulation()
-    {
-        await SendEmulationCommandAsync(
-            CanResumeEmulation,
-            "Emulation resume requested.",
-            "Emulation failed to resume",
-            cancellationToken => _mameEmulationService.ResumeAsync(cancellationToken));
+        if (!pauseSucceeded)
+        {
+            OnPropertyChanged(nameof(IsPauseEmulationChecked));
+        }
     }
 
     private bool CanSetThrottleEmulation()
@@ -1973,22 +1991,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return CurrentEmulationCommandState.CanSetThrottle;
     }
 
-    private async void ThrottleEmulation()
+    private async void ToggleUnthrottleEmulation()
     {
-        await SendEmulationCommandAsync(
+        var shouldUnthrottle = !IsUnthrottleEmulationChecked;
+        var commandSucceeded = await SendEmulationCommandAsync(
             CanSetThrottleEmulation,
-            "Emulation throttle requested.",
-            "Emulation failed to enable throttle",
-            cancellationToken => _mameEmulationService.SetThrottleAsync(true, cancellationToken));
-    }
+            shouldUnthrottle ? "Emulation unthrottle requested." : "Emulation throttle requested.",
+            shouldUnthrottle ? "Emulation failed to disable throttle" : "Emulation failed to enable throttle",
+            cancellationToken => _mameEmulationService.SetThrottleAsync(!shouldUnthrottle, cancellationToken));
 
-    private async void UnthrottleEmulation()
-    {
-        await SendEmulationCommandAsync(
-            CanSetThrottleEmulation,
-            "Emulation unthrottle requested.",
-            "Emulation failed to disable throttle",
-            cancellationToken => _mameEmulationService.SetThrottleAsync(false, cancellationToken));
+        if (commandSucceeded)
+        {
+            IsUnthrottleEmulationChecked = shouldUnthrottle;
+        }
+        else
+        {
+            OnPropertyChanged(nameof(IsUnthrottleEmulationChecked));
+        }
     }
 
     private bool CanResetEmulation()
@@ -2014,7 +2033,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             cancellationToken => _mameEmulationService.HardResetAsync(cancellationToken));
     }
 
-    private async Task SendEmulationCommandAsync(
+    private async Task<bool> SendEmulationCommandAsync(
         Func<bool> canExecute,
         string requestedMessage,
         string failureMessage,
@@ -2022,17 +2041,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         if (!canExecute())
         {
-            return;
+            return false;
         }
 
         AddOutputEntry(requestedMessage, OutputLogStatus.Info);
         try
         {
             await command(CancellationToken.None);
+            return true;
         }
         catch (Exception ex)
         {
             AddOutputEntry($"{failureMessage}: {ex.Message}", OutputLogStatus.Error);
+            return false;
         }
     }
 
@@ -2710,10 +2731,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(LoadStateEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(SaveStateEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(StopEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(PauseEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(ResumeEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(ThrottleEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(UnthrottleEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(TogglePauseEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(ToggleUnthrottleEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(SoftResetEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(HardResetEmulationCommand);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationCommandState.cs
@@ -10,6 +10,7 @@ public sealed class MameEmulationCommandState
     public bool CanSaveState { get; init; }
     public bool CanPause { get; init; }
     public bool CanResume { get; init; }
+    public bool CanTogglePause { get; init; }
     public bool CanSetThrottle { get; init; }
     public bool CanReset { get; init; }
 }
@@ -34,6 +35,7 @@ public static class MameEmulationCommandStateEvaluator
             CanSaveState = canControlRunningMachine,
             CanPause = canPause,
             CanResume = canResume,
+            CanTogglePause = canControlRunningMachine,
             CanSetThrottle = canControlRunningMachine,
             CanReset = canControlRunningMachine
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
@@ -83,6 +83,12 @@
                                     Property="Visibility"
                                     Value="Collapsed" />
                         </Trigger>
+                        <Trigger Property="Tag"
+                                 Value="ReserveCheckGlyph">
+                            <Setter TargetName="CheckGlyph"
+                                    Property="Visibility"
+                                    Value="Hidden" />
+                        </Trigger>
                         <Trigger Property="IsCheckable"
                                  Value="True">
                             <Setter TargetName="CheckGlyph"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
@@ -42,6 +42,14 @@
                                 CornerRadius="4">
                             <DockPanel LastChildFill="True"
                                        TextElement.Foreground="{TemplateBinding Foreground}">
+                                <TextBlock x:Name="CheckGlyph"
+                                           Width="16"
+                                           Margin="0,0,4,0"
+                                           VerticalAlignment="Center"
+                                           FontWeight="SemiBold"
+                                           Text="✓"
+                                           TextAlignment="Center"
+                                           Visibility="Collapsed" />
                                 <ContentPresenter x:Name="GlyphContent"
                                                   VerticalAlignment="Center"
                                                   Margin="0,0,8,0"
@@ -75,6 +83,23 @@
                                     Property="Visibility"
                                     Value="Collapsed" />
                         </Trigger>
+                        <Trigger Property="IsCheckable"
+                                 Value="True">
+                            <Setter TargetName="CheckGlyph"
+                                    Property="Visibility"
+                                    Value="Hidden" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsCheckable"
+                                           Value="True" />
+                                <Condition Property="IsChecked"
+                                           Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="CheckGlyph"
+                                    Property="Visibility"
+                                    Value="Visible" />
+                        </MultiTrigger>
                         <Trigger Property="IsHighlighted"
                                  Value="True">
                             <Setter TargetName="MenuItemBorder"


### PR DESCRIPTION
### Motivation

- Simplify the Emulation menu by replacing the Pause/Resume and Throttle/Unthrottle pairs with single, toggleable menu items that show a checkmark to indicate the current toggle state.
- Ensure UI command state matches runtime state and that toggles only update when the underlying emulation command succeeds.

### Description

- Replaced separate `_Pause`/`_Resume` menu items with a single checkable `_Pause` MenuItem bound to `TogglePauseEmulationCommand` and `IsPauseEmulationChecked` (one-way). (updated `MainWindow.xaml`)
- Replaced separate `_Throttle`/`_Unthrottle` items with a single checkable `_Unthrottle` MenuItem bound to `ToggleUnthrottleEmulationCommand` and `IsUnthrottleEmulationChecked` (one-way). (updated `MainWindow.xaml`)
- Added `TogglePauseEmulationCommand` and `ToggleUnthrottleEmulationCommand`, `IsPauseEmulationChecked` and `IsUnthrottleEmulationChecked` state properties, and supporting logic in `MainWindowViewModel.cs`.
- `TogglePauseEmulation` inspects the current checked state and issues either `PauseAsync` or `ResumeAsync`, restoring the UI check state if the command fails; `ToggleUnthrottleEmulation` sends the inverse throttle command and only updates the checkmark after a successful command.
- `SendEmulationCommandAsync` now returns a `bool` indicating success so callers can update check state conditionally.
- Reset the unthrottle check state when emulation enters `Starting`, `Stopped`, or `Failed` states.
- Added `CanTogglePause` to `MameEmulationCommandState` and the evaluator so the new toggle command follows the same CanExecute rules; updated unit tests accordingly. (updated `MameEmulationCommandState.cs` and `MameEmulationCommandStateEvaluatorTests.cs`)

### Testing

- Updated unit test `MameEmulationCommandStateEvaluatorTests` to assert the new `CanTogglePause` behavior; tests were modified and included in the changes (could not run full test suite in this environment).
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`, but the `dotnet` CLI is not available in this environment so the test run could not be executed.
- Ran repository checks: `git diff --check` passed with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c4b1cb850832788a282ab39895325)