### PR TITLE
Play view: add reel drag preview (temporary offset) and cursor feedback

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelRuntimeStateTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelRuntimeStateTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PanelRuntimeStateTests
+{
+    [Fact]
+    public void GetEffectiveReelPosition_IncludesTemporaryOffset()
+    {
+        var runtimeState = new PanelRuntimeState();
+
+        runtimeState.SetReelPositionIfChanged(" reel-1 ", 12d);
+        runtimeState.SetTemporaryReelOffsetIfChanged("reel-1", 3.5d);
+
+        Assert.Equal(15.5d, runtimeState.GetEffectiveReelPosition("reel-1"));
+    }
+
+    [Fact]
+    public void ClearTemporaryReelOffsetIfChanged_RemovesOnlyTemporaryOffset()
+    {
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetReelPositionIfChanged("reel-1", 12d);
+        runtimeState.SetTemporaryReelOffsetIfChanged("reel-1", 3.5d);
+
+        var changed = runtimeState.ClearTemporaryReelOffsetIfChanged(" reel-1 ");
+
+        Assert.True(changed);
+        Assert.Equal(12d, runtimeState.GetReelPosition("reel-1"));
+        Assert.Equal(12d, runtimeState.GetEffectiveReelPosition("reel-1"));
+    }
+
+    [Fact]
+    public void Clear_RemovesTemporaryReelOffsets()
+    {
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetTemporaryReelOffsetIfChanged("reel-1", 3.5d);
+
+        runtimeState.Clear();
+
+        Assert.Empty(runtimeState.TemporaryReelOffsetByObjectId);
+        Assert.Equal(0d, runtimeState.GetEffectiveReelPosition("reel-1"));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -4,6 +4,7 @@ public sealed class PanelRuntimeState
 {
     private readonly Dictionary<string, double> _lampIntensityByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, double> _reelPositionByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, double> _temporaryReelOffsetByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, double[]> _segmentBrightnessByObjectId = new(StringComparer.Ordinal);
 
@@ -13,6 +14,7 @@ public sealed class PanelRuntimeState
 
     public IReadOnlyDictionary<string, double> LampIntensityByObjectId => _lampIntensityByObjectId;
     public IReadOnlyDictionary<string, double> ReelPositionByObjectId => _reelPositionByObjectId;
+    public IReadOnlyDictionary<string, double> TemporaryReelOffsetByObjectId => _temporaryReelOffsetByObjectId;
     public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
     public IReadOnlyDictionary<string, double[]> SegmentBrightnessByObjectId => _segmentBrightnessByObjectId;
 
@@ -53,6 +55,34 @@ public sealed class PanelRuntimeState
         return true;
     }
 
+    public bool SetTemporaryReelOffsetIfChanged(string objectId, double offset)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || double.IsNaN(offset) || double.IsInfinity(offset))
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        if (_temporaryReelOffsetByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && Math.Abs(previous - offset) < 0.0001d)
+        {
+            return false;
+        }
+
+        _temporaryReelOffsetByObjectId[normalizedObjectId] = offset;
+        return true;
+    }
+
+    public bool ClearTemporaryReelOffsetIfChanged(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return false;
+        }
+
+        return _temporaryReelOffsetByObjectId.Remove(objectId.Trim());
+    }
+
     public void SetLampIntensity(string objectId, double intensity)
     {
         SetLampIntensityIfChanged(objectId, intensity);
@@ -78,6 +108,28 @@ public sealed class PanelRuntimeState
         return _reelPositionByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
     }
 
+    public double GetTemporaryReelOffset(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return 0d;
+        }
+
+        return _temporaryReelOffsetByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
+    }
+
+    public double GetEffectiveReelPosition(string objectId)
+    {
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return 0d;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        return _reelPositionByObjectId.GetValueOrDefault(normalizedObjectId, 0d)
+            + _temporaryReelOffsetByObjectId.GetValueOrDefault(normalizedObjectId, 0d);
+    }
+
     public void ClearLampIntensity(string objectId)
     {
         if (!string.IsNullOrWhiteSpace(objectId))
@@ -91,6 +143,7 @@ public sealed class PanelRuntimeState
         LampTestObjectId = null;
         _lampIntensityByObjectId.Clear();
         _reelPositionByObjectId.Clear();
+        _temporaryReelOffsetByObjectId.Clear();
         _segmentMasksByObjectId.Clear();
         _segmentBrightnessByObjectId.Clear();
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -20,7 +20,7 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         }
 
         var stops = Math.Max(1, element.Stops.GetValueOrDefault(1));
-        var reelPosition = context.RuntimeState.GetReelPosition(element.ObjectId);
+        var reelPosition = context.RuntimeState.GetEffectiveReelPosition(element.ObjectId);
         var wrappedOffset = ComputeWrappedOffset(reelPosition, stops);
 
         using var borderPaint = new SKPaint { Color = new SKColor(45, 45, 45), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
@@ -24,7 +24,8 @@
                               MouseDown="OnPlaySkiaSurfaceMouseDown"
                               MouseMove="OnPlaySkiaSurfaceMouseMove"
                               MouseUp="OnPlaySkiaSurfaceMouseUp"
-                              MouseWheel="OnPlaySkiaSurfaceMouseWheel" />
+                              MouseWheel="OnPlaySkiaSurfaceMouseWheel"
+                              LostMouseCapture="OnPlaySkiaSurfaceLostMouseCapture" />
 
                 <Canvas x:Name="PlayCanvas"
                     Width="1400"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -34,6 +34,7 @@ public partial class PlayView : UserControl
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
     private const double LegacyReelPositionsPerRevolution = 96d;
+    private const double ReelDragSpeedScale = 3d;
     private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
 
     public PlayView()
@@ -413,7 +414,7 @@ public partial class PlayView : UserControl
 
         var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, _activeReelDragElement.Stops.GetValueOrDefault(1));
         var dragDelta = current.Y - _reelDragStart.Y;
-        var temporaryOffset = _reelDragStartTemporaryOffset - (dragDelta * positionsPerRevolution / bandHeight);
+        var temporaryOffset = _reelDragStartTemporaryOffset - (dragDelta * positionsPerRevolution * ReelDragSpeedScale / bandHeight);
         if (selected.RuntimeState.SetTemporaryReelOffsetIfChanged(_activeReelDragElement.ObjectId, temporaryOffset))
         {
             RequestRender();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -25,11 +25,15 @@ public partial class PlayView : UserControl
     private bool _isSkiaPanning;
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
+    private PanelElementModel? _activeReelDragElement;
+    private Point _reelDragStart;
+    private double _reelDragStartTemporaryOffset;
     private bool _isRenderQueued;
     private bool _isRenderDirty;
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
+    private const double LegacyReelPositionsPerRevolution = 96d;
     private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
 
     public PlayView()
@@ -161,7 +165,15 @@ public partial class PlayView : UserControl
 
         if (eventArgs.ChangedButton == MouseButton.Left)
         {
-            if (ViewModel is not null && TryResolveSkiaVisualElementId(eventArgs.GetPosition(PlaySkiaSurface), out var visualElementId))
+            var current = eventArgs.GetPosition(PlaySkiaSurface);
+            if (TryResolveSkiaReelElement(current, out var reelElement))
+            {
+                BeginReelDrag(reelElement, current);
+                eventArgs.Handled = true;
+                return;
+            }
+
+            if (ViewModel is not null && TryResolveSkiaVisualElementId(current, out var visualElementId))
             {
                 await ViewModel.TryHandlePlayViewPointerDownAsync(visualElementId, isFocused: true, CancellationToken.None);
                 eventArgs.Handled = true;
@@ -185,8 +197,22 @@ public partial class PlayView : UserControl
     private void OnPlaySkiaSurfaceMouseMove(object sender, MouseEventArgs eventArgs)
     {
         var current = eventArgs.GetPosition(PlaySkiaSurface);
-        var isClickable = TryResolveSkiaVisualElementId(current, out _);
-        PlaySkiaSurface.Cursor = isClickable ? Cursors.Hand : Cursors.Arrow;
+        if (_activeReelDragElement is not null)
+        {
+            UpdateReelDrag(current);
+            eventArgs.Handled = true;
+            return;
+        }
+
+        if (TryResolveSkiaReelElement(current, out _))
+        {
+            PlaySkiaSurface.Cursor = Cursors.ScrollNS;
+        }
+        else
+        {
+            var isClickable = TryResolveSkiaVisualElementId(current, out _);
+            PlaySkiaSurface.Cursor = isClickable ? Cursors.Hand : Cursors.Arrow;
+        }
 
         if (!_isSkiaPanning)
         {
@@ -201,6 +227,13 @@ public partial class PlayView : UserControl
     {
         if (eventArgs.ChangedButton == MouseButton.Left)
         {
+            if (_activeReelDragElement is not null)
+            {
+                EndReelDrag();
+                eventArgs.Handled = true;
+                return;
+            }
+
             if (ViewModel is not null && TryResolveSkiaVisualElementId(eventArgs.GetPosition(PlaySkiaSurface), out var visualElementId))
             {
                 await ViewModel.TryHandlePlayViewPointerUpAsync(visualElementId, isFocused: true, CancellationToken.None);
@@ -327,6 +360,15 @@ public partial class PlayView : UserControl
         CanvasPanZoomBehavior.HandleLostMouseCapture(PlayCanvas);
     }
 
+    private void OnPlaySkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    {
+        _isSkiaPanning = false;
+        if (_activeReelDragElement is not null)
+        {
+            EndReelDrag(releaseMouseCapture: false);
+        }
+    }
+
     private async void OnPlayCanvasLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs eventArgs)
     {
         if (ViewModel is null)
@@ -347,6 +389,68 @@ public partial class PlayView : UserControl
         await ViewModel.ReleaseAllPlayViewInputsAsync("Play View close", CancellationToken.None);
     }
 
+    private void BeginReelDrag(PanelElementModel reelElement, Point current)
+    {
+        _activeReelDragElement = reelElement;
+        _reelDragStart = current;
+        _reelDragStartTemporaryOffset = ViewModel?.SelectedDocument?.RuntimeState.GetTemporaryReelOffset(reelElement.ObjectId) ?? 0d;
+        PlaySkiaSurface.Cursor = Cursors.ScrollNS;
+        PlaySkiaSurface.CaptureMouse();
+    }
+
+    private void UpdateReelDrag(Point current)
+    {
+        if (_activeReelDragElement is null || ViewModel?.SelectedDocument is not { } selected)
+        {
+            return;
+        }
+
+        var bandHeight = ResolveReelBandHeight(_activeReelDragElement);
+        if (bandHeight <= 0d)
+        {
+            return;
+        }
+
+        var positionsPerRevolution = Math.Max(LegacyReelPositionsPerRevolution, _activeReelDragElement.Stops.GetValueOrDefault(1));
+        var dragDelta = current.Y - _reelDragStart.Y;
+        var temporaryOffset = _reelDragStartTemporaryOffset - (dragDelta * positionsPerRevolution / bandHeight);
+        if (selected.RuntimeState.SetTemporaryReelOffsetIfChanged(_activeReelDragElement.ObjectId, temporaryOffset))
+        {
+            RequestRender();
+        }
+    }
+
+    private void EndReelDrag(bool releaseMouseCapture = true)
+    {
+        var reelElement = _activeReelDragElement;
+        _activeReelDragElement = null;
+
+        if (reelElement is not null
+            && ViewModel?.SelectedDocument is { } selected
+            && selected.RuntimeState.ClearTemporaryReelOffsetIfChanged(reelElement.ObjectId))
+        {
+            RequestRender();
+        }
+
+        if (releaseMouseCapture && PlaySkiaSurface.IsMouseCaptured)
+        {
+            PlaySkiaSurface.ReleaseMouseCapture();
+        }
+
+        PlaySkiaSurface.Cursor = Cursors.Arrow;
+    }
+
+    private static double ResolveReelBandHeight(PanelElementModel reelElement)
+    {
+        var visibleScale = reelElement.VisibleScale;
+        if (!visibleScale.HasValue || double.IsNaN(visibleScale.Value) || double.IsInfinity(visibleScale.Value))
+        {
+            return reelElement.Height;
+        }
+
+        return reelElement.Height / Math.Clamp(visibleScale.Value, 0.01d, 1d);
+    }
+
     private bool TryResolveVisualElementId(DependencyObject? source, out Guid visualElementId)
     {
         while (source is not null && source != PlayCanvas)
@@ -364,6 +468,34 @@ public partial class PlayView : UserControl
         return false;
     }
 
+
+    private bool TryResolveSkiaReelElement(Point screenPoint, out PanelElementModel reelElement)
+    {
+        var selected = ViewModel?.SelectedDocument;
+        if (selected is null)
+        {
+            reelElement = new PanelElementModel();
+            return false;
+        }
+
+        var documentPoint = ToDocumentPoint(screenPoint);
+        foreach (var element in selected.GetPanelElements().Reverse())
+        {
+            if (element.Kind != PanelElementKind.Reel || !element.IsVisible)
+            {
+                continue;
+            }
+
+            if (ContainsDocumentPoint(element, documentPoint))
+            {
+                reelElement = element;
+                return true;
+            }
+        }
+
+        reelElement = new PanelElementModel();
+        return false;
+    }
 
     private bool TryResolveSkiaVisualElementId(Point screenPoint, out Guid visualElementId)
     {
@@ -385,8 +517,7 @@ public partial class PlayView : UserControl
             return false;
         }
 
-        var viewport = new PanelViewportTransform(_skiaZoom, _skiaPan.X, _skiaPan.Y);
-        var documentPoint = viewport.ScreenToDocument(screenPoint);
+        var documentPoint = ToDocumentPoint(screenPoint);
 
         foreach (var element in selected.GetPanelElements().Reverse())
         {
@@ -395,10 +526,7 @@ public partial class PlayView : UserControl
                 continue;
             }
 
-            if (documentPoint.X >= element.X
-                && documentPoint.X <= element.X + element.Width
-                && documentPoint.Y >= element.Y
-                && documentPoint.Y <= element.Y + element.Height)
+            if (ContainsDocumentPoint(element, documentPoint))
             {
                 visualElementId = elementId;
                 return true;
@@ -407,6 +535,20 @@ public partial class PlayView : UserControl
 
         visualElementId = Guid.Empty;
         return false;
+    }
+
+    private Point ToDocumentPoint(Point screenPoint)
+    {
+        var viewport = new PanelViewportTransform(_skiaZoom, _skiaPan.X, _skiaPan.Y);
+        return viewport.ScreenToDocument(screenPoint);
+    }
+
+    private static bool ContainsDocumentPoint(PanelElementModel element, Point documentPoint)
+    {
+        return documentPoint.X >= element.X
+            && documentPoint.X <= element.X + element.Width
+            && documentPoint.Y >= element.Y
+            && documentPoint.Y <= element.Y + element.Height;
     }
 
     private void UpdateSelectedDocumentSubscription(DocumentTabViewModel? selected)


### PR DESCRIPTION
### Motivation
- Enable interactively previewing reel band shifts in Play view by dragging a reel without changing its saved `BandOffset`, and provide cursor feedback when hovering reels.

### Description
- Add transient offset storage to `PanelRuntimeState` with `SetTemporaryReelOffsetIfChanged`, `ClearTemporaryReelOffsetIfChanged`, `GetTemporaryReelOffset`, and `GetEffectiveReelPosition` so temporary adjustments layer on top of runtime positions and are cleared on `Clear` (file `PanelRuntimeState.cs`).
- Make reel rendering use the effective position by switching from `GetReelPosition` to `GetEffectiveReelPosition` in `ReelElementRenderer` so temporary offsets affect the visual only (file `Rendering/ReelElementRenderer.cs`).
- Implement reel hit-testing and drag interaction in Play view: hover shows a vertical/grab cursor, left-button down on a reel starts a drag (`BeginReelDrag`), vertical movement updates a temporary offset (`UpdateReelDrag`), and releasing or losing capture clears the temporary offset (`EndReelDrag`); screen↔document coordinate helpers and band-height based conversion are added (file `Views/PlayView.xaml.cs` and `Views/PlayView.xaml`).
- Add unit tests covering temporary offset behavior (`PanelRuntimeStateTests.cs`).

### Testing
- Ran `git diff --check` to validate workspace changes (no issues).
- Added unit tests `WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelRuntimeStateTests.cs` but running `dotnet test` in this environment failed because `dotnet` is not available; the tests were created and would exercise `GetEffectiveReelPosition`, clearing temporary offsets, and `Clear` behavior when executed in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1c53b8ac448327b47c91cdb89cdd33)