### PR TITLE
Add MAME debugger protocol, service and UI integration

### DIFF
--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/command_processor.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/command_processor.lua
@@ -13,6 +13,7 @@ local command_throttled = require('oasis/system/commands/throttled')
 local command_state_load = require('oasis/system/commands/state_load')
 local command_state_save = require('oasis/system/commands/state_save')
 local command_state_save_and_exit = require('oasis/system/commands/state_save_and_exit')
+local command_debug = require('oasis/system/commands/debug')
 -- local command_snapshot_pixels = require('oasis/system/commands/snapshot_pixels')
 
 
@@ -29,6 +30,7 @@ function lib:invoke_command_line(line)
 		["state_save"]					= command_state_save,
 		["state_save_and_exit"]			= command_state_save_and_exit,
 		["set_input_value"]				= command_set_input_value,
+		["debug"]						= command_debug,
 		 
 		--["snapshot_pixels"]				= command_snapshot_pixels,
 		

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
@@ -1,0 +1,22 @@
+local lib = {}
+
+local protocol = require('oasis/system/debugger/debugger_protocol')
+local router = require('oasis/system/debugger/debugger_router')
+
+function lib:execute(args)
+    local json = args[2]
+    local request, decode_error = protocol:decode_request(json)
+    if not request then
+        protocol:write_response(0, false, nil, decode_error)
+        return
+    end
+
+    local ok, result = pcall(function() return router:handle(request) end)
+    if ok then
+        protocol:write_response(request.id, true, result or {})
+    else
+        protocol:write_response(request.id, false, nil, tostring(result))
+    end
+end
+
+return lib

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
@@ -4,7 +4,11 @@ local protocol = require('oasis/system/debugger/debugger_protocol')
 local router = require('oasis/system/debugger/debugger_router')
 
 function lib:execute(args)
-    local json = args[2]
+    local payload_parts = {}
+    for index = 2, #args do
+        table.insert(payload_parts, args[index])
+    end
+    local json = table.concat(payload_parts, " ")
     local request, decode_error = protocol:decode_request(json)
     if not request then
         protocol:write_response(0, false, nil, decode_error)

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
@@ -1,0 +1,108 @@
+local lib = {}
+
+lib.response_prefix = "@OASIS_DEBUG"
+lib.event_prefix = "@OASIS_DEBUG_EVENT"
+
+local function escape_string(value)
+    value = tostring(value)
+    value = value:gsub('\\', '\\\\')
+    value = value:gsub('"', '\\"')
+    value = value:gsub('\n', '\\n')
+    value = value:gsub('\r', '\\r')
+    value = value:gsub('\t', '\\t')
+    return '"' .. value .. '"'
+end
+
+function lib:encode_json(value)
+    local value_type = type(value)
+    if value_type == "nil" then
+        return "null"
+    end
+    if value_type == "boolean" or value_type == "number" then
+        return tostring(value)
+    end
+    if value_type == "string" then
+        return escape_string(value)
+    end
+    if value_type ~= "table" then
+        return escape_string(value)
+    end
+
+    local is_array = true
+    local max_index = 0
+    for key, _ in pairs(value) do
+        if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then
+            is_array = false
+            break
+        end
+        if key > max_index then
+            max_index = key
+        end
+    end
+
+    local parts = {}
+    if is_array then
+        for index = 1, max_index do
+            table.insert(parts, self:encode_json(value[index]))
+        end
+        return "[" .. table.concat(parts, ",") .. "]"
+    end
+
+    for key, item in pairs(value) do
+        table.insert(parts, escape_string(key) .. ":" .. self:encode_json(item))
+    end
+    return "{" .. table.concat(parts, ",") .. "}"
+end
+
+local function read_string(json, key)
+    return json:match('"' .. key .. '"%s*:%s*"([^"\\]*)"')
+end
+
+local function read_number(json, key)
+    local value = json:match('"' .. key .. '"%s*:%s*(-?%d+)')
+    if value then
+        return tonumber(value)
+    end
+    return nil
+end
+
+function lib:decode_request(json)
+    if type(json) ~= "string" or json == "" then
+        return nil, "Missing JSON request payload."
+    end
+
+    local request = {
+        id = read_number(json, "id"),
+        op = read_string(json, "op"),
+        cpu = read_string(json, "cpu")
+    }
+
+    request.params = {
+        cpu = read_string(json, "cpu")
+    }
+
+    if not request.id then
+        return nil, "Debugger request is missing numeric id."
+    end
+    if not request.op or request.op == "" then
+        return nil, "Debugger request is missing op."
+    end
+
+    return request, nil
+end
+
+function lib:write_response(id, ok, result, error_message)
+    local payload = {
+        id = id,
+        ok = ok,
+        result = result,
+        error = error_message
+    }
+    print(lib.response_prefix .. " " .. self:encode_json(payload))
+end
+
+function lib:write_event(event)
+    print(lib.event_prefix .. " " .. self:encode_json(event))
+end
+
+return lib

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
@@ -55,7 +55,7 @@ function lib:encode_json(value)
 end
 
 local function read_string(json, key)
-    return json:match('"' .. key .. '"%s*:%s*"([^"\\]*)"')
+    return json:match('"' .. key .. '"%s*:%s*"([^"]*)"')
 end
 
 local function read_number(json, key)

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
@@ -27,11 +27,11 @@ local function command_debugger(command)
     return nil
 end
 
-local function machine_is_paused()
-    local paused = try_call(function() return emu.paused() end)
-    if paused ~= nil then return paused end
-    paused = try_call(function() return manager.machine.paused end)
-    if paused ~= nil then return paused end
+local function debugger_execution_state()
+    local debugger = get_debugger()
+    if debugger then
+        return try_call(function() return debugger.execution_state end)
+    end
     return nil
 end
 
@@ -40,7 +40,7 @@ local function get_cpu_devices()
     local devices = try_call(function() return manager.machine.devices end)
     if devices then
         for tag, device in pairs(devices) do
-            local is_cpu = try_call(function() return device.execute ~= nil end)
+            local is_cpu = try_call(function() return device.debug ~= nil end)
             if is_cpu then
                 table.insert(cpus, {
                     tag = tostring(tag),
@@ -57,6 +57,13 @@ local function current_cpu_tag()
     if state.current_cpu then
         return state.current_cpu
     end
+
+    local visible_cpu = try_call(function() return get_debugger().visible_cpu end)
+    if visible_cpu then
+        local tag = try_call(function() return visible_cpu.tag end)
+        if tag then return tostring(tag) end
+    end
+
     local cpus = get_cpu_devices()
     if #cpus > 0 then
         return cpus[1].tag
@@ -82,11 +89,11 @@ local function get_pc(cpu_tag)
 end
 
 local function build_status(message)
-    local paused = machine_is_paused()
+    local raw_state = debugger_execution_state()
     local execution_state = "unknown"
-    if paused == true then
+    if raw_state == "stop" then
         execution_state = "stopped"
-    elseif paused == false then
+    elseif raw_state == "run" then
         execution_state = "running"
     end
 
@@ -132,9 +139,13 @@ function lib:handle(request)
     end
 
     if op == "run" then
-        command_debugger("go")
-        local resumed = try_call(function() return emu.unpause() end)
-        if resumed == nil then try_call(function() emu.resume() end) end
+        local cpu = get_cpu(current_cpu_tag())
+        local ran = try_call(function() cpu.debug:go() end)
+        if ran == nil then
+            local debugger = get_debugger()
+            try_call(function() debugger.execution_state = "run" end)
+            command_debugger("go")
+        end
         local status = build_status(nil)
         if status.executionState == "unknown" then status.executionState = "running"; status.state = "running" end
         emit_transition(status)
@@ -142,8 +153,8 @@ function lib:handle(request)
     end
 
     if op == "break" then
-        command_debugger("stop")
-        try_call(function() emu.pause() end)
+        local debugger = get_debugger()
+        try_call(function() debugger.execution_state = "stop" end)
         local status = build_status(nil)
         if status.executionState == "unknown" then status.executionState = "stopped"; status.state = "stopped" end
         emit_transition(status)
@@ -151,9 +162,13 @@ function lib:handle(request)
     end
 
     if op == "step" then
-        local cpu = request.cpu or (request.params and request.params.cpu) or current_cpu_tag()
-        state.current_cpu = cpu
-        command_debugger("step")
+        local cpu_tag = request.cpu or (request.params and request.params.cpu) or current_cpu_tag()
+        state.current_cpu = cpu_tag
+        local cpu = get_cpu(cpu_tag)
+        local stepped = try_call(function() cpu.debug:step() end)
+        if stepped == nil then
+            command_debugger("step")
+        end
         local status = build_status(nil)
         status.executionState = "stopped"
         status.state = "stopped"

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
@@ -1,0 +1,167 @@
+local lib = {}
+
+local protocol = require('oasis/system/debugger/debugger_protocol')
+local state = require('oasis/system/debugger/debugger_state')
+
+local function try_call(callback)
+    local ok, result = pcall(callback)
+    if ok then
+        return result
+    end
+    return nil
+end
+
+local function get_debugger()
+    return try_call(function() return manager.machine.debugger end)
+end
+
+local function debugger_available()
+    return get_debugger() ~= nil
+end
+
+local function command_debugger(command)
+    local debugger = get_debugger()
+    if debugger and debugger.command then
+        return try_call(function() debugger:command(command) end)
+    end
+    return nil
+end
+
+local function machine_is_paused()
+    local paused = try_call(function() return emu.paused() end)
+    if paused ~= nil then return paused end
+    paused = try_call(function() return manager.machine.paused end)
+    if paused ~= nil then return paused end
+    return nil
+end
+
+local function get_cpu_devices()
+    local cpus = {}
+    local devices = try_call(function() return manager.machine.devices end)
+    if devices then
+        for tag, device in pairs(devices) do
+            local is_cpu = try_call(function() return device.execute ~= nil end)
+            if is_cpu then
+                table.insert(cpus, {
+                    tag = tostring(tag),
+                    name = tostring(try_call(function() return device.name end) or tag),
+                    isCurrent = #cpus == 0
+                })
+            end
+        end
+    end
+    return cpus
+end
+
+local function current_cpu_tag()
+    if state.current_cpu then
+        return state.current_cpu
+    end
+    local cpus = get_cpu_devices()
+    if #cpus > 0 then
+        return cpus[1].tag
+    end
+    return nil
+end
+
+local function get_cpu(cpu_tag)
+    if not cpu_tag then return nil end
+    return try_call(function() return manager.machine.devices[cpu_tag] end)
+end
+
+local function get_pc(cpu_tag)
+    local cpu = get_cpu(cpu_tag)
+    if not cpu then return nil end
+
+    local pc = try_call(function() return cpu.state["PC"].value end)
+    if pc ~= nil then return pc end
+    pc = try_call(function() return cpu.state["CURPC"].value end)
+    if pc ~= nil then return pc end
+    pc = try_call(function() return cpu:state_string(0) end)
+    return tonumber(pc)
+end
+
+local function build_status(message)
+    local paused = machine_is_paused()
+    local execution_state = "unknown"
+    if paused == true then
+        execution_state = "stopped"
+    elseif paused == false then
+        execution_state = "running"
+    end
+
+    local cpu = current_cpu_tag()
+    return {
+        isAvailable = debugger_available(),
+        executionState = execution_state,
+        state = execution_state,
+        currentCpu = cpu,
+        cpu = cpu,
+        programCounter = get_pc(cpu),
+        pc = get_pc(cpu),
+        message = message
+    }
+end
+
+local function emit_transition(status)
+    if state:update(status) then
+        protocol:write_event({
+            event = status.executionState,
+            state = status.executionState,
+            cpu = status.currentCpu,
+            pc = status.programCounter
+        })
+    end
+end
+
+function lib:handle(request)
+    local op = request.op
+
+    if op == "ping" then
+        return { pong = "pong" }
+    end
+
+    if op == "status" then
+        local status = build_status(nil)
+        state:update(status)
+        return status
+    end
+
+    if op == "cpus" then
+        return get_cpu_devices()
+    end
+
+    if op == "run" then
+        command_debugger("go")
+        local resumed = try_call(function() return emu.unpause() end)
+        if resumed == nil then try_call(function() emu.resume() end) end
+        local status = build_status(nil)
+        if status.executionState == "unknown" then status.executionState = "running"; status.state = "running" end
+        emit_transition(status)
+        return status
+    end
+
+    if op == "break" then
+        command_debugger("stop")
+        try_call(function() emu.pause() end)
+        local status = build_status(nil)
+        if status.executionState == "unknown" then status.executionState = "stopped"; status.state = "stopped" end
+        emit_transition(status)
+        return status
+    end
+
+    if op == "step" then
+        local cpu = request.cpu or (request.params and request.params.cpu) or current_cpu_tag()
+        state.current_cpu = cpu
+        command_debugger("step")
+        local status = build_status(nil)
+        status.executionState = "stopped"
+        status.state = "stopped"
+        emit_transition(status)
+        return status
+    end
+
+    error("Unsupported debugger operation '" .. tostring(op) .. "'.")
+end
+
+return lib

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_state.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_state.lua
@@ -1,0 +1,15 @@
+local lib = {}
+
+lib.last_state = "unknown"
+lib.current_cpu = nil
+lib.current_pc = nil
+
+function lib:update(status)
+    local previous_state = self.last_state
+    self.last_state = status.state or "unknown"
+    self.current_cpu = status.currentCpu or status.current_cpu or status.cpu
+    self.current_pc = status.programCounter or status.pc
+    return previous_state ~= self.last_state
+end
+
+return lib

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
@@ -1,0 +1,39 @@
+using OasisEditor.Features.MameDebugger;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameDebuggerProtocolTests
+{
+    [Fact]
+    public void Parser_DetectsDebuggerResponsePrefix()
+    {
+        var parser = new MameDebuggerStdoutParser();
+
+        var parsed = parser.TryParse("@OASIS_DEBUG {\"id\":7,\"ok\":true,\"result\":{\"pong\":\"pong\"}}", out var message);
+
+        Assert.True(parsed);
+        Assert.False(message.IsEvent);
+        Assert.Equal(7, message.Payload.GetProperty("id").GetInt32());
+    }
+
+    [Fact]
+    public void Parser_DetectsDebuggerEventBeforeResponsePrefix()
+    {
+        var parser = new MameDebuggerStdoutParser();
+
+        var parsed = parser.TryParse("@OASIS_DEBUG_EVENT {\"event\":\"stopped\",\"state\":\"stopped\"}", out var message);
+
+        Assert.True(parsed);
+        Assert.True(message.IsEvent);
+        Assert.Equal("stopped", message.Payload.GetProperty("event").GetString());
+    }
+
+    [Fact]
+    public void Protocol_CreatesStructuredDebugCommand()
+    {
+        var line = MameDebuggerProtocol.CreateCommandLine(11, "status");
+
+        Assert.Equal("debug {\"id\":11,\"op\":\"status\"}", line);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
@@ -105,7 +105,7 @@ public sealed class MameProcessStartInfoBuilderDebuggerTests
         var startInfo = builder.Build(request);
 
         Assert.Contains("-debug", startInfo.Arguments);
-        Assert.Contains("-debugger gdbstub", startInfo.Arguments);
+        Assert.DoesNotContain("-debugger gdbstub", startInfo.Arguments);
         Assert.Contains("-debugscript", startInfo.Arguments);
         Assert.Contains(scriptPath, startInfo.Arguments);
         Assert.Equal($"go{Environment.NewLine}", File.ReadAllText(scriptPath));

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
@@ -85,3 +85,25 @@ public sealed class MameProcessStartInfoBuilderTests
         Assert.Equal(@"C:\Mame", startInfo.WorkingDirectory);
     }
 }
+
+public sealed class MameProcessStartInfoBuilderDebuggerTests
+{
+    [Fact]
+    public void Build_DebuggerRequest_IncludesDebugPrerequisites()
+    {
+        var builder = new MameProcessStartInfoBuilder();
+        var request = new MameProcessLaunchRequest(
+            @"C:\Mame\mame.exe",
+            "myrom",
+            @"C:\roms",
+            @"C:\plugins",
+            string.Empty,
+            IsDebuggerEnabled: true);
+
+        var startInfo = builder.Build(request);
+
+        Assert.Contains("-debug", startInfo.Arguments);
+        Assert.Contains("-plugin oasis", startInfo.Arguments);
+        Assert.Contains("-output console", startInfo.Arguments);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameProcessStartInfoBuilderTests.cs
@@ -92,17 +92,23 @@ public sealed class MameProcessStartInfoBuilderDebuggerTests
     public void Build_DebuggerRequest_IncludesDebugPrerequisites()
     {
         var builder = new MameProcessStartInfoBuilder();
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"oasis-debugger-{Guid.NewGuid():N}.cmd");
         var request = new MameProcessLaunchRequest(
             @"C:\Mame\mame.exe",
             "myrom",
             @"C:\roms",
             @"C:\plugins",
             string.Empty,
-            IsDebuggerEnabled: true);
+            IsDebuggerEnabled: true,
+            DebuggerScriptPath: scriptPath);
 
         var startInfo = builder.Build(request);
 
         Assert.Contains("-debug", startInfo.Arguments);
+        Assert.Contains("-debugger gdbstub", startInfo.Arguments);
+        Assert.Contains("-debugscript", startInfo.Arguments);
+        Assert.Contains(scriptPath, startInfo.Arguments);
+        Assert.Equal($"go{Environment.NewLine}", File.ReadAllText(scriptPath));
         Assert.Contains("-plugin oasis", startInfo.Arguments);
         Assert.Contains("-output console", startInfo.Arguments);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OasisEditor.Features.MameDebugger;
+
+public static class MameDebuggerProtocol
+{
+    public const string ResponsePrefix = "@OASIS_DEBUG";
+    public const string EventPrefix = "@OASIS_DEBUG_EVENT";
+    public const string CommandName = "debug";
+
+    public static readonly JsonSerializerOptions JsonOptions = CreateJsonOptions();
+
+    private static JsonSerializerOptions CreateJsonOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        return options;
+    }
+
+    public static string CreateCommandLine(long id, string op, object? parameters = null)
+    {
+        var request = new Dictionary<string, object?>
+        {
+            ["id"] = id,
+            ["op"] = op
+        };
+
+        if (parameters is not null)
+        {
+            request["params"] = parameters;
+        }
+
+        return $"{CommandName} {JsonSerializer.Serialize(request, JsonOptions)}";
+    }
+}
+
+public enum MameDebuggerExecutionState
+{
+    Unknown,
+    Running,
+    Stopped
+}
+
+public sealed record MameDebuggerCpuInfo(string Tag, string Name, bool IsCurrent);
+
+public sealed record MameDebuggerStatus(
+    bool IsAvailable,
+    MameDebuggerExecutionState ExecutionState,
+    string? CurrentCpu,
+    long? ProgramCounter,
+    string? Message);
+
+public sealed record MameDebuggerEvent(
+    string Event,
+    MameDebuggerExecutionState ExecutionState,
+    string? Cpu,
+    long? ProgramCounter,
+    JsonElement Payload);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerResponseRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerResponseRouter.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace OasisEditor.Features.MameDebugger;
+
+public sealed class MameDebuggerResponseRouter
+{
+    private readonly ConcurrentDictionary<long, TaskCompletionSource<JsonElement>> _pendingRequests = new();
+
+    public Task<JsonElement> Register(long requestId, CancellationToken cancellationToken)
+    {
+        var completion = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pendingRequests.TryAdd(requestId, completion))
+        {
+            throw new InvalidOperationException($"A debugger request with id {requestId} is already pending.");
+        }
+
+        if (cancellationToken.CanBeCanceled)
+        {
+            cancellationToken.Register(static state =>
+            {
+                var context = ((MameDebuggerResponseRouter Router, long RequestId, CancellationToken Token))state!;
+                if (context.Router._pendingRequests.TryRemove(context.RequestId, out var removed))
+                {
+                    removed.TrySetCanceled(context.Token);
+                }
+            }, (this, requestId, cancellationToken));
+        }
+
+        return completion.Task;
+    }
+
+    public bool TryRouteResponse(JsonElement response)
+    {
+        if (!response.TryGetProperty("id", out var idElement) || !idElement.TryGetInt64(out var requestId))
+        {
+            return false;
+        }
+
+        if (!_pendingRequests.TryRemove(requestId, out var completion))
+        {
+            return false;
+        }
+
+        if (response.TryGetProperty("ok", out var okElement) && okElement.ValueKind == JsonValueKind.False)
+        {
+            var error = response.TryGetProperty("error", out var errorElement)
+                ? errorElement.ToString()
+                : "MAME debugger request failed.";
+            completion.TrySetException(new InvalidOperationException(error));
+            return true;
+        }
+
+        completion.TrySetResult(response.Clone());
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
@@ -1,0 +1,191 @@
+using System.Threading;
+using System.Text.Json;
+
+namespace OasisEditor.Features.MameDebugger;
+
+public interface IMameDebuggerTransport
+{
+    Task SendAsync(string line, CancellationToken cancellationToken);
+}
+
+public sealed class MameDebuggerStdioTransport : IMameDebuggerTransport
+{
+    private readonly IMameProcessRunner _processRunner;
+
+    public MameDebuggerStdioTransport(IMameProcessRunner processRunner)
+    {
+        _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+    }
+
+    public Task SendAsync(string line, CancellationToken cancellationToken)
+    {
+        return _processRunner.WriteStandardInputAsync(line, cancellationToken);
+    }
+}
+
+public sealed class MameDebuggerService
+{
+    private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IMameDebuggerTransport _transport;
+    private readonly MameDebuggerResponseRouter _responseRouter;
+    private readonly MameDebuggerStdoutParser _stdoutParser;
+    private readonly MameDebuggerState _state;
+    private readonly Func<bool> _debuggerSupportActiveProvider;
+    private readonly Action<string>? _diagnosticLogger;
+    private long _nextRequestId;
+
+    public MameDebuggerService(
+        IMameDebuggerTransport transport,
+        MameDebuggerResponseRouter responseRouter,
+        MameDebuggerStdoutParser stdoutParser,
+        MameDebuggerState state,
+        Func<bool> debuggerSupportActiveProvider,
+        Action<string>? diagnosticLogger = null)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _responseRouter = responseRouter ?? throw new ArgumentNullException(nameof(responseRouter));
+        _stdoutParser = stdoutParser ?? throw new ArgumentNullException(nameof(stdoutParser));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+        _debuggerSupportActiveProvider = debuggerSupportActiveProvider ?? throw new ArgumentNullException(nameof(debuggerSupportActiveProvider));
+        _diagnosticLogger = diagnosticLogger;
+    }
+
+    public event EventHandler<MameDebuggerEvent>? DebuggerEventReceived;
+
+    public bool IsDebuggerSupportActive => _debuggerSupportActiveProvider();
+
+    public Task RunAsync() => RunAsync(CancellationToken.None);
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var status = await SendRequestAsync<MameDebuggerStatus>("run", cancellationToken: cancellationToken).ConfigureAwait(false);
+        _state.ApplyStatus(status);
+    }
+
+    public Task BreakAsync() => BreakAsync(CancellationToken.None);
+
+    public async Task BreakAsync(CancellationToken cancellationToken)
+    {
+        var status = await SendRequestAsync<MameDebuggerStatus>("break", cancellationToken: cancellationToken).ConfigureAwait(false);
+        _state.ApplyStatus(status);
+    }
+
+    public Task StepAsync() => StepAsync(null, CancellationToken.None);
+
+    public async Task StepAsync(string? cpu = null, CancellationToken cancellationToken = default)
+    {
+        var parameters = string.IsNullOrWhiteSpace(cpu) ? null : new { cpu };
+        var status = await SendRequestAsync<MameDebuggerStatus>("step", parameters, cancellationToken).ConfigureAwait(false);
+        _state.ApplyStatus(status);
+    }
+
+    public Task<MameDebuggerStatus> GetStatusAsync() => GetStatusAsync(CancellationToken.None);
+
+    public async Task<MameDebuggerStatus> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        if (!IsDebuggerSupportActive)
+        {
+            return new MameDebuggerStatus(false, MameDebuggerExecutionState.Unknown, null, null, "Current MAME process was not launched with -debug.");
+        }
+
+        var status = await SendRequestAsync<MameDebuggerStatus>("status", cancellationToken: cancellationToken).ConfigureAwait(false);
+        _state.ApplyStatus(status);
+        return status;
+    }
+
+    public Task<IReadOnlyList<MameDebuggerCpuInfo>> GetCpuListAsync() => GetCpuListAsync(CancellationToken.None);
+
+    public async Task<IReadOnlyList<MameDebuggerCpuInfo>> GetCpuListAsync(CancellationToken cancellationToken)
+    {
+        var cpus = await SendRequestAsync<MameDebuggerCpuInfo[]>("cpus", cancellationToken: cancellationToken).ConfigureAwait(false);
+        return cpus;
+    }
+
+    public async Task<bool> PingAsync(CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync<PingResponse>("ping", cancellationToken: cancellationToken).ConfigureAwait(false);
+        return string.Equals(response.Pong, "pong", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool ProcessStdoutLine(string line)
+    {
+        if (!_stdoutParser.TryParse(line, out var message))
+        {
+            return false;
+        }
+
+        _diagnosticLogger?.Invoke($"[MAME-DEBUGGER-IN] {line}");
+
+        if (message.IsEvent)
+        {
+            var debuggerEvent = CreateEvent(message.Payload);
+            _state.ApplyEvent(debuggerEvent);
+            DebuggerEventReceived?.Invoke(this, debuggerEvent);
+            return true;
+        }
+
+        _responseRouter.TryRouteResponse(message.Payload);
+        return true;
+    }
+
+    private async Task<T> SendRequestAsync<T>(string op, object? parameters = null, CancellationToken cancellationToken = default)
+    {
+        EnsureDebuggerSupportActive(op);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(DefaultRequestTimeout);
+
+        var requestId = Interlocked.Increment(ref _nextRequestId);
+        var commandLine = MameDebuggerProtocol.CreateCommandLine(requestId, op, parameters);
+        var responseTask = _responseRouter.Register(requestId, timeout.Token);
+
+        _diagnosticLogger?.Invoke($"[MAME-DEBUGGER-OUT] {commandLine}");
+        await _transport.SendAsync(commandLine, timeout.Token).ConfigureAwait(false);
+
+        JsonElement response;
+        try
+        {
+            response = await responseTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Timed out waiting for MAME debugger response to operation '{op}'.");
+        }
+        var result = response.TryGetProperty("result", out var resultElement) ? resultElement : response;
+        var value = result.Deserialize<T>(MameDebuggerProtocol.JsonOptions);
+        return value ?? throw new InvalidOperationException($"Debugger response for '{op}' did not contain a valid result.");
+    }
+
+    private void EnsureDebuggerSupportActive(string op)
+    {
+        if (!IsDebuggerSupportActive)
+        {
+            throw new InvalidOperationException($"Cannot send debugger operation '{op}' because the current MAME process was not launched with -debug.");
+        }
+    }
+
+    private static MameDebuggerEvent CreateEvent(JsonElement payload)
+    {
+        var eventName = payload.TryGetProperty("event", out var eventElement) ? eventElement.GetString() ?? string.Empty : string.Empty;
+        var state = payload.TryGetProperty("state", out var stateElement)
+            ? ParseExecutionState(stateElement.GetString())
+            : MameDebuggerExecutionState.Unknown;
+        var cpu = payload.TryGetProperty("cpu", out var cpuElement) ? cpuElement.GetString() : null;
+        long? pc = payload.TryGetProperty("pc", out var pcElement) && pcElement.TryGetInt64(out var pcValue) ? pcValue : null;
+
+        return new MameDebuggerEvent(eventName, state, cpu, pc, payload.Clone());
+    }
+
+    private static MameDebuggerExecutionState ParseExecutionState(string? value)
+    {
+        return value?.ToLowerInvariant() switch
+        {
+            "running" => MameDebuggerExecutionState.Running,
+            "stopped" => MameDebuggerExecutionState.Stopped,
+            _ => MameDebuggerExecutionState.Unknown
+        };
+    }
+
+    private sealed record PingResponse(string Pong);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerState.cs
@@ -1,0 +1,34 @@
+namespace OasisEditor.Features.MameDebugger;
+
+public sealed class MameDebuggerState
+{
+    private readonly object _gate = new();
+
+    public MameDebuggerExecutionState ExecutionState { get; private set; } = MameDebuggerExecutionState.Unknown;
+    public string? CurrentCpu { get; private set; }
+    public long? ProgramCounter { get; private set; }
+
+    public void ApplyStatus(MameDebuggerStatus status)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+
+        lock (_gate)
+        {
+            ExecutionState = status.ExecutionState;
+            CurrentCpu = status.CurrentCpu;
+            ProgramCounter = status.ProgramCounter;
+        }
+    }
+
+    public void ApplyEvent(MameDebuggerEvent debuggerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(debuggerEvent);
+
+        lock (_gate)
+        {
+            ExecutionState = debuggerEvent.ExecutionState;
+            CurrentCpu = debuggerEvent.Cpu ?? CurrentCpu;
+            ProgramCounter = debuggerEvent.ProgramCounter;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerStdoutParser.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+
+namespace OasisEditor.Features.MameDebugger;
+
+public sealed class MameDebuggerStdoutParser
+{
+    public bool TryParse(string line, out MameDebuggerProtocolMessage message)
+    {
+        message = default;
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        if (TryReadPayload(line, MameDebuggerProtocol.EventPrefix, out var eventPayload))
+        {
+            message = new MameDebuggerProtocolMessage(true, eventPayload);
+            return true;
+        }
+
+        if (TryReadPayload(line, MameDebuggerProtocol.ResponsePrefix, out var responsePayload))
+        {
+            message = new MameDebuggerProtocolMessage(false, responsePayload);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadPayload(string line, string prefix, out JsonElement payload)
+    {
+        payload = default;
+
+        if (!line.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var json = line[prefix.Length..].Trim();
+        if (json.Length == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            payload = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}
+
+public readonly record struct MameDebuggerProtocolMessage(bool IsEvent, JsonElement Payload);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -154,6 +154,28 @@
                 <MenuItem Header="_Start"
                           Command="{Binding StartEmulationCommand}"
                           Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                <MenuItem Header="Start With _Debugger"
+                          Command="{Binding StartDebuggerEmulationCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                <MenuItem Header="MAME _Debugger"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}">
+                    <MenuItem Header="_Status"
+                              Command="{Binding DebuggerStatusCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_CPUs"
+                              Command="{Binding DebuggerCpuListCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <Separator />
+                    <MenuItem Header="_Run"
+                              Command="{Binding DebuggerRunCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Break"
+                              Command="{Binding DebuggerBreakCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Step"
+                              Command="{Binding DebuggerStepCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                </MenuItem>
                 <MenuItem Header="_Load State"
                           Command="{Binding LoadStateEmulationCommand}"
                           Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2240,7 +2240,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             MameRomName,
             MameRuntimePaths.EnsureManagedRomRootDirectory(),
             MameRuntimePaths.ResolveBundledLuaPluginSourcePath(),
-            MameCommandLineOverrides);
+            MameCommandLineOverrides,
+            DebuggerScriptPath: MameRuntimePaths.ResolveDebuggerStartupScriptPath());
     }
 
     private void LoadStartupProject(string startupProjectFilePath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Collections.Specialized;
 using Microsoft.Win32;
+using OasisEditor.Features.MameDebugger;
 using OasisEditor.Features.MfmeImport;
 using EditorCommands = OasisEditor.Commands;
 using OasisEditor.Views;
@@ -79,6 +80,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private PlayViewInputRouter? _playViewInputRouter;
     private PlayViewKeyboardInputRouter? _playViewKeyboardInputRouter;
     private PlayViewPointerInputRouter? _playViewPointerInputRouter;
+    private readonly MameDebuggerService _mameDebuggerService;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -127,6 +129,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         StartAndLoadStateEmulationCommand = new RelayCommand(StartAndLoadStateEmulation, CanStartAndLoadStateEmulation);
         SaveStateAndExitEmulationCommand = new RelayCommand(SaveStateAndExitEmulation, CanSaveStateAndExitEmulation);
         StartEmulationCommand = new RelayCommand(StartEmulation, CanStartEmulation);
+        StartDebuggerEmulationCommand = new RelayCommand(StartDebuggerEmulation, CanStartEmulation);
+        DebuggerRunCommand = new RelayCommand(DebuggerRun, CanUseMameDebugger);
+        DebuggerBreakCommand = new RelayCommand(DebuggerBreak, CanUseMameDebugger);
+        DebuggerStepCommand = new RelayCommand(DebuggerStep, CanUseMameDebugger);
+        DebuggerStatusCommand = new RelayCommand(DebuggerStatus, CanQueryMameDebugger);
+        DebuggerCpuListCommand = new RelayCommand(DebuggerCpuList, CanQueryMameDebugger);
         LoadStateEmulationCommand = new RelayCommand(LoadStateEmulation, CanLoadStateEmulation);
         SaveStateEmulationCommand = new RelayCommand(SaveStateEmulation, CanSaveStateEmulation);
         StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
@@ -238,6 +246,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameProcessStartInfoBuilder(),
             _mameProcessRunner,
             BuildMameLaunchRequest);
+        _mameDebuggerService = new MameDebuggerService(
+            new MameDebuggerStdioTransport(_mameProcessRunner),
+            new MameDebuggerResponseRouter(),
+            new MameDebuggerStdoutParser(),
+            new MameDebuggerState(),
+            () => _mameEmulationService.IsDebuggerSupportActive,
+            message => AddOutputEntry(message, OutputLogStatus.Info));
+        _mameDebuggerService.DebuggerEventReceived += (_, debuggerEvent) =>
+        {
+            DispatchToUiThread(() => AddOutputEntry(
+                $"MAME debugger event: {debuggerEvent.Event} state={debuggerEvent.ExecutionState} cpu={debuggerEvent.Cpu ?? "unknown"} pc={FormatDebuggerProgramCounter(debuggerEvent.ProgramCounter)}",
+                OutputLogStatus.Info));
+        };
         _mameEmulationService.StateChanged += (_, state) =>
         {
             DispatchToUiThread(() =>
@@ -390,6 +411,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand StartAndLoadStateEmulationCommand { get; }
     public ICommand SaveStateAndExitEmulationCommand { get; }
     public ICommand StartEmulationCommand { get; }
+    public ICommand StartDebuggerEmulationCommand { get; }
+    public ICommand DebuggerRunCommand { get; }
+    public ICommand DebuggerBreakCommand { get; }
+    public ICommand DebuggerStepCommand { get; }
+    public ICommand DebuggerStatusCommand { get; }
+    public ICommand DebuggerCpuListCommand { get; }
     public ICommand LoadStateEmulationCommand { get; }
     public ICommand SaveStateEmulationCommand { get; }
     public ICommand StopEmulationCommand { get; }
@@ -1708,6 +1735,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 AddOutputEntry($"[MAME-STDOUT] {segment}", OutputLogStatus.Info);
             }
 
+            if (_mameDebuggerService.ProcessStdoutLine(segment))
+            {
+                continue;
+            }
+
             parser.ProcessLine(segment);
         }
     }
@@ -1875,6 +1907,145 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             AddOutputEntry($"Emulation failed to start: {ex.Message}", OutputLogStatus.Error);
         }
+    }
+
+
+    private async void StartDebuggerEmulation()
+    {
+        if (!CanStartEmulation())
+        {
+            return;
+        }
+
+        AddOutputEntry("Debugger emulation start requested.", OutputLogStatus.Info);
+        try
+        {
+            await _mameEmulationService.StartDebuggerAsync(CancellationToken.None);
+            AddOutputEntry("MAME debugger support is active for this process.", OutputLogStatus.Info);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"Debugger emulation failed to start: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
+    private bool CanQueryMameDebugger()
+    {
+        return _mameEmulationService.State is MameEmulationState.Running or MameEmulationState.Paused;
+    }
+
+    private bool CanUseMameDebugger()
+    {
+        return CanQueryMameDebugger() && _mameEmulationService.IsDebuggerSupportActive;
+    }
+
+    private async void DebuggerRun()
+    {
+        await SendDebuggerCommandAsync(
+            CanUseMameDebugger,
+            "MAME debugger run requested.",
+            "MAME debugger failed to run",
+            cancellationToken => _mameDebuggerService.RunAsync(cancellationToken));
+    }
+
+    private async void DebuggerBreak()
+    {
+        await SendDebuggerCommandAsync(
+            CanUseMameDebugger,
+            "MAME debugger break requested.",
+            "MAME debugger failed to break",
+            cancellationToken => _mameDebuggerService.BreakAsync(cancellationToken));
+    }
+
+    private async void DebuggerStep()
+    {
+        await SendDebuggerCommandAsync(
+            CanUseMameDebugger,
+            "MAME debugger step requested.",
+            "MAME debugger failed to step",
+            cancellationToken => _mameDebuggerService.StepAsync(cancellationToken: cancellationToken));
+    }
+
+    private async void DebuggerStatus()
+    {
+        if (!CanQueryMameDebugger())
+        {
+            return;
+        }
+
+        AddOutputEntry("MAME debugger status requested.", OutputLogStatus.Info);
+        try
+        {
+            var status = await _mameDebuggerService.GetStatusAsync(CancellationToken.None);
+            AddOutputEntry(FormatDebuggerStatus(status), status.IsAvailable ? OutputLogStatus.Info : OutputLogStatus.Warning);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"MAME debugger failed to get status: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
+    private async void DebuggerCpuList()
+    {
+        if (!CanUseMameDebugger())
+        {
+            return;
+        }
+
+        AddOutputEntry("MAME debugger CPU list requested.", OutputLogStatus.Info);
+        try
+        {
+            var cpus = await _mameDebuggerService.GetCpuListAsync(CancellationToken.None);
+            var cpuSummary = cpus.Count == 0
+                ? "no CPUs reported"
+                : string.Join(", ", cpus.Select(cpu => $"{cpu.Tag} ({cpu.Name})"));
+            AddOutputEntry($"MAME debugger CPUs: {cpuSummary}.", OutputLogStatus.Info);
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"MAME debugger failed to get CPU list: {ex.Message}", OutputLogStatus.Error);
+        }
+    }
+
+    private async Task<bool> SendDebuggerCommandAsync(
+        Func<bool> canExecute,
+        string requestedMessage,
+        string failureMessage,
+        Func<CancellationToken, Task> command)
+    {
+        if (!canExecute())
+        {
+            AddOutputEntry(
+                _mameEmulationService.IsDebuggerSupportActive
+                    ? "MAME debugger command skipped: emulation is not running."
+                    : "MAME debugger command skipped: current MAME process was not launched with -debug.",
+                OutputLogStatus.Warning);
+            return false;
+        }
+
+        AddOutputEntry(requestedMessage, OutputLogStatus.Info);
+        try
+        {
+            await command(CancellationToken.None);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AddOutputEntry($"{failureMessage}: {ex.Message}", OutputLogStatus.Error);
+            return false;
+        }
+    }
+
+    private static string FormatDebuggerStatus(MameDebuggerStatus status)
+    {
+        var availability = status.IsAvailable ? "available" : "unavailable";
+        var cpu = status.CurrentCpu ?? "unknown";
+        return $"MAME debugger status: {availability}; state={status.ExecutionState}; cpu={cpu}; pc={FormatDebuggerProgramCounter(status.ProgramCounter)}; message={status.Message ?? "none"}.";
+    }
+
+    private static string FormatDebuggerProgramCounter(long? programCounter)
+    {
+        return programCounter.HasValue ? $"0x{programCounter.Value:X}" : "unknown";
     }
 
     private bool CanLoadStateEmulation()
@@ -2728,6 +2899,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(StartAndLoadStateEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(SaveStateAndExitEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(StartEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(StartDebuggerEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(DebuggerRunCommand);
+        RaiseEmulationCommandCanExecuteChanged(DebuggerBreakCommand);
+        RaiseEmulationCommandCanExecuteChanged(DebuggerStepCommand);
+        RaiseEmulationCommandCanExecuteChanged(DebuggerStatusCommand);
+        RaiseEmulationCommandCanExecuteChanged(DebuggerCpuListCommand);
         RaiseEmulationCommandCanExecuteChanged(LoadStateEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(SaveStateEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(StopEmulationCommand);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationService.cs
@@ -11,6 +11,7 @@ public sealed class MameEmulationService : IMameEmulationService
     private readonly Func<MameProcessLaunchRequest?> _requestFactory;
     private readonly object _stateGate = new();
     private MameEmulationState _state = MameEmulationState.Stopped;
+    private bool _isDebuggerSupportActive;
 
     public MameEmulationService(
         IMameProcessStartInfoBuilder startInfoBuilder,
@@ -35,17 +36,38 @@ public sealed class MameEmulationService : IMameEmulationService
 
     public event EventHandler<MameEmulationState>? StateChanged;
 
+    public bool IsDebuggerSupportActive
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                return _isDebuggerSupportActive;
+            }
+        }
+    }
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        return StartCoreAsync(loadState: false, cancellationToken);
+        return StartCoreAsync(loadState: false, debuggerEnabled: false, cancellationToken);
     }
 
     public Task StartAndLoadStateAsync(CancellationToken cancellationToken)
     {
-        return StartCoreAsync(loadState: true, cancellationToken);
+        return StartCoreAsync(loadState: true, debuggerEnabled: false, cancellationToken);
     }
 
-    private async Task StartCoreAsync(bool loadState, CancellationToken cancellationToken)
+    public Task StartDebuggerAsync(CancellationToken cancellationToken)
+    {
+        return StartCoreAsync(loadState: false, debuggerEnabled: true, cancellationToken);
+    }
+
+    public Task StartDebuggerAndLoadStateAsync(CancellationToken cancellationToken)
+    {
+        return StartCoreAsync(loadState: true, debuggerEnabled: true, cancellationToken);
+    }
+
+    private async Task StartCoreAsync(bool loadState, bool debuggerEnabled, CancellationToken cancellationToken)
     {
         SetState(MameEmulationState.Starting);
         try
@@ -54,6 +76,11 @@ public sealed class MameEmulationService : IMameEmulationService
             if (request is null)
             {
                 throw new InvalidOperationException("No valid MAME launch request is available.");
+            }
+
+            if (debuggerEnabled)
+            {
+                request = request with { IsDebuggerEnabled = true };
             }
 
             if (loadState)
@@ -69,10 +96,12 @@ public sealed class MameEmulationService : IMameEmulationService
 
             var startInfo = _startInfoBuilder.Build(request);
             await _processRunner.StartAsync(startInfo, cancellationToken).ConfigureAwait(false);
+            SetDebuggerSupportActive(request.IsDebuggerEnabled);
             SetState(MameEmulationState.Running);
         }
         catch
         {
+            SetDebuggerSupportActive(false);
             SetState(MameEmulationState.Failed);
             throw;
         }
@@ -87,6 +116,7 @@ public sealed class MameEmulationService : IMameEmulationService
 
         SetState(MameEmulationState.Stopping);
         await _processRunner.StopAsync(cancellationToken).ConfigureAwait(false);
+        SetDebuggerSupportActive(false);
         SetState(MameEmulationState.Stopped);
     }
 
@@ -137,6 +167,14 @@ public sealed class MameEmulationService : IMameEmulationService
     {
         cancellationToken.ThrowIfCancellationRequested();
         return _processRunner.WriteStandardInputAsync(command, cancellationToken);
+    }
+
+    private void SetDebuggerSupportActive(bool isActive)
+    {
+        lock (_stateGate)
+        {
+            _isDebuggerSupportActive = isActive;
+        }
     }
 
     private void SetState(MameEmulationState state)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace OasisEditor;
@@ -7,6 +8,8 @@ namespace OasisEditor;
 public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 {
     private static readonly TimeSpan GracefulExitTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DebuggerWindowHidePollInterval = TimeSpan.FromMilliseconds(250);
+    private const int SwHide = 0;
 
     private readonly Func<Process> _processFactory;
     private readonly Action<string>? _stdoutLogger;
@@ -63,6 +66,15 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
             _errorReadStarted = true;
 
             _process = process;
+
+            if (IsDebuggerLaunch(startInfo))
+            {
+                // Keep MAME's native debugger windows hidden while Oasis drives the
+                // debugger through the Lua stdin/stdout protocol.  This preserves the
+                // normal emulation/runtime output path while avoiding the visible
+                // Windows debugger UI.
+                _ = HideDebuggerWindowsWhileRunningAsync(process);
+            }
         }
         catch
         {
@@ -77,6 +89,60 @@ public sealed class MameProcessRunner : IMameProcessRunner, IDisposable
 
         return Task.CompletedTask;
     }
+
+    private static bool IsDebuggerLaunch(ProcessStartInfo startInfo)
+    {
+        return startInfo.Arguments.Contains("-debug", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task HideDebuggerWindowsWhileRunningAsync(Process process)
+    {
+        while (!HasExitedOrDisposed(process))
+        {
+            HideVisibleProcessWindows(process.Id);
+            await Task.Delay(DebuggerWindowHidePollInterval).ConfigureAwait(false);
+        }
+    }
+
+    private static bool HasExitedOrDisposed(Process process)
+    {
+        try
+        {
+            return process.HasExited;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    private static void HideVisibleProcessWindows(int processId)
+    {
+        EnumWindows((windowHandle, _) =>
+        {
+            _ = GetWindowThreadProcessId(windowHandle, out var windowProcessId);
+            if (windowProcessId == processId && IsWindowVisible(windowHandle))
+            {
+                _ = ShowWindow(windowHandle, SwHide);
+            }
+
+            return true;
+        }, IntPtr.Zero);
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr extraData);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr windowHandle, out int processId);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr windowHandle);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr windowHandle, int command);
+
+    private delegate bool EnumWindowsProc(IntPtr windowHandle, IntPtr extraData);
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
@@ -18,6 +18,17 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         if (request.IsDebuggerEnabled)
         {
             arguments.Append(" -debug");
+            // MAME's default Windows debugger module opens the native debugger UI.
+            // Use the GDB stub module as a headless debugger backend while Oasis
+            // continues to communicate over the existing Lua stdin/stdout bridge.
+            arguments.Append(" -debugger gdbstub");
+
+            if (!string.IsNullOrWhiteSpace(request.DebuggerScriptPath))
+            {
+                EnsureDebuggerStartupScript(request.DebuggerScriptPath);
+                arguments.Append(" -debugscript ");
+                arguments.Append(EscapeArgument(request.DebuggerScriptPath));
+            }
         }
 
         arguments.Append(" -output console");
@@ -44,6 +55,20 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Hidden
         };
+    }
+
+    private static void EnsureDebuggerStartupScript(string scriptPath)
+    {
+        var scriptDirectory = Path.GetDirectoryName(scriptPath);
+        if (!string.IsNullOrWhiteSpace(scriptDirectory))
+        {
+            Directory.CreateDirectory(scriptDirectory);
+        }
+
+        // MAME enters the debugger after the initial reset when -debug is active.
+        // Resume immediately so the emulated machine starts running until Oasis
+        // explicitly sends a break/step command.
+        File.WriteAllText(scriptPath, "go" + Environment.NewLine);
     }
 
     private static string EscapeArgument(string value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
@@ -18,10 +18,6 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         if (request.IsDebuggerEnabled)
         {
             arguments.Append(" -debug");
-            // MAME's default Windows debugger module opens the native debugger UI.
-            // Use the GDB stub module as a headless debugger backend while Oasis
-            // continues to communicate over the existing Lua stdin/stdout bridge.
-            arguments.Append(" -debugger gdbstub");
 
             if (!string.IsNullOrWhiteSpace(request.DebuggerScriptPath))
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
@@ -15,6 +15,11 @@ public sealed class MameProcessStartInfoBuilder : IMameProcessStartInfoBuilder
         arguments.Append(EscapeArgument(request.MameRomName));
         arguments.Append(" -rompath ");
         arguments.Append(EscapeArgument(request.MameRomRootPath));
+        if (request.IsDebuggerEnabled)
+        {
+            arguments.Append(" -debug");
+        }
+
         arguments.Append(" -output console");
         arguments.Append(" -plugin oasis");
         arguments.Append(" -skip_gameinfo");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -8,6 +8,9 @@ public interface IMameEmulationService
     event EventHandler<MameEmulationState>? StateChanged;
     Task StartAsync(CancellationToken cancellationToken);
     Task StartAndLoadStateAsync(CancellationToken cancellationToken);
+    Task StartDebuggerAsync(CancellationToken cancellationToken);
+    Task StartDebuggerAndLoadStateAsync(CancellationToken cancellationToken);
+    bool IsDebuggerSupportActive { get; }
     Task StopAsync(CancellationToken cancellationToken);
     Task SaveStateAndExitAsync(CancellationToken cancellationToken);
     Task LoadStateAsync(CancellationToken cancellationToken);
@@ -57,4 +60,5 @@ public sealed record MameProcessLaunchRequest(
     string MameRomName,
     string MameRomRootPath,
     string OasisPluginPath,
-    string AdditionalArguments);
+    string AdditionalArguments,
+    bool IsDebuggerEnabled = false);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -61,4 +61,5 @@ public sealed record MameProcessLaunchRequest(
     string MameRomRootPath,
     string OasisPluginPath,
     string AdditionalArguments,
-    bool IsDebuggerEnabled = false);
+    bool IsDebuggerEnabled = false,
+    string? DebuggerScriptPath = null);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimePaths.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimePaths.cs
@@ -14,6 +14,11 @@ public static class MameRuntimePaths
         return root;
     }
 
+    public static string ResolveDebuggerStartupScriptPath()
+    {
+        return Path.Combine(EnsureManagedRuntimeRootDirectory(), "debugger", "oasis_debugger_startup.cmd");
+    }
+
     public static string ResolveBundledLuaPluginSourcePath()
     {
         var appBaseDirectory = AppContext.BaseDirectory;


### PR DESCRIPTION
### Motivation
- Provide a structured MAME debugger protocol and plumbing so the editor can communicate with MAME's debugger when processes are launched with `-debug`.
- Surface debugger controls and status in the UI and route debugger stdout events/responses into the editor's systems.

### Description
- Added Lua-side support for a `debug` command and a simple debugger protocol/router/state in `oasis/system/debugger` to decode JSON requests and emit prefixed responses/events; wired the `debug` command into the command processor via `command_processor.lua` and the new `commands/debug.lua` handler.
- Implemented a managed debugger stack: `MameDebuggerProtocol`, `MameDebuggerStdoutParser`, `MameDebuggerResponseRouter`, `MameDebuggerService`, and `MameDebuggerState` under `OasisEditor.Features.MameDebugger` to serialize commands, parse stdout prefixed messages, route responses to awaiting callers, and surface events to subscribers.
- Integrated debugger into runtime and UI: added `-debug` support to `MameProcessStartInfoBuilder`, added `IMameEmulationService` debugger start APIs and state tracking in `MameEmulationService`, and hooked up commands/menu items and ViewModel methods in `MainWindow.xaml` and `MainWindowViewModel.cs` for starting with debugger, run/break/step/status/cpu list commands, and output logging of events.
- Added basic state handling and event emission on the Lua side and translation into managed `MameDebuggerEvent`/`MameDebuggerStatus` records for use by the UI and services.

### Testing
- Added unit tests in `OasisEditor.Tests`: `MameDebuggerProtocolTests` (tests `Parser_DetectsDebuggerResponsePrefix`, `Parser_DetectsDebuggerEventBeforeResponsePrefix`, and `Protocol_CreatesStructuredDebugCommand`) and extended `MameProcessStartInfoBuilderTests` with `Build_DebuggerRequest_IncludesDebugPrerequisites` to verify `-debug` and plugin/output flags are included.
- Ran the unit test suite (`dotnet test`) including the new tests and the modified `MameProcessStartInfoBuilder` tests, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1dd22262148327bc9bae8006a509bb)