### PR TITLE
Harden MAME debugger stdin protocol

### DIFF
--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/command_processor.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/command_processor.lua
@@ -50,9 +50,13 @@ function lib:invoke_command_line(line)
 			command_lua(line:sub(2))
 		else
 			local args = utility:quoted_string_split(line)
+			local command_name = args[1] and args[1]:lower()
 			
-			if (commands[args[1]:lower()]) then
-				commands[args[1]:lower()]:execute(args)
+			if (command_name == "debug") then
+				local payload = line:match("^%s*%S+%s+(.+)$")
+				command_debug:execute(payload)
+			elseif (command_name and commands[command_name]) then
+				commands[command_name]:execute(args)
 			else
 				command_unknown(args)
 			end

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/commands/debug.lua
@@ -3,8 +3,7 @@ local lib = {}
 local protocol = require('oasis/system/debugger/debugger_protocol')
 local router = require('oasis/system/debugger/debugger_router')
 
-function lib:execute(args)
-	local payload = args[2]
+function lib:execute(payload)
 	if not payload then
 		protocol:write_response(0, false, {}, { code = "missing_payload", message = "Debugger command requires a JSON payload." })
 		return

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
@@ -73,6 +73,43 @@ function lib:encode(value)
 	return encode_value(value)
 end
 
+local function unescape_json_string(value)
+	value = value:gsub('\\"', '"')
+	value = value:gsub('\\\\', '\\')
+	value = value:gsub('\\/', '/')
+	value = value:gsub('\\b', '\b')
+	value = value:gsub('\\f', '\f')
+	value = value:gsub('\\n', '\n')
+	value = value:gsub('\\r', '\r')
+	value = value:gsub('\\t', '\t')
+	return value
+end
+
+local function match_json_string_field(payload, field)
+	local _, value_start = payload:find('"' .. field .. '"%s*:%s*"')
+	if not value_start then
+		return nil
+	end
+
+	local value = {}
+	local escaped = false
+	for i = value_start + 1, #payload do
+		local char = payload:sub(i, i)
+		if escaped then
+			value[#value + 1] = '\\' .. char
+			escaped = false
+		elseif char == '\\' then
+			escaped = true
+		elseif char == '"' then
+			return unescape_json_string(table.concat(value))
+		else
+			value[#value + 1] = char
+		end
+	end
+
+	return nil
+end
+
 function lib:decode(payload)
 	if json_module then
 		if json_module.parse then
@@ -87,8 +124,8 @@ function lib:decode(payload)
 	-- the simple request shape emitted by MameDebuggerProtocol.
 	local result = {}
 	local id = payload:match('"id"%s*:%s*(%-?%d+)')
-	local op = payload:match('"op"%s*:%s*"([^"]*)"')
-	local cpu = payload:match('"cpu"%s*:%s*"([^"]*)"')
+	local op = match_json_string_field(payload, "op")
+	local cpu = match_json_string_field(payload, "cpu")
 	if id then
 		result.id = tonumber(id)
 	end

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
@@ -15,6 +15,31 @@ public sealed class MameDebuggerProtocolTests
     }
 
     [Fact]
+    public void CreateCommand_PreservesJsonPayloadContainingSpacesAndQuotedStringsAfterDebugPrefix()
+    {
+        var command = MameDebuggerProtocol.CreateCommand(7, "status", ":main cpu \"A\"");
+
+        Assert.StartsWith("debug ", command);
+        var payload = command[(MameDebuggerProtocol.CommandName.Length + 1)..];
+        var request = System.Text.Json.JsonSerializer.Deserialize<MameDebuggerRequest>(payload, MameDebuggerProtocol.JsonOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal(7, request.Id);
+        Assert.Equal("status", request.Op);
+        Assert.Equal(":main cpu \"A\"", request.Cpu);
+    }
+
+    [Fact]
+    public void CreateCommand_DoesNotRequireQuotingJsonPayloadWithSpacesForLuaBridge()
+    {
+        var command = MameDebuggerProtocol.CreateCommand(8, "status", "cpu with spaces");
+
+        var rawPayloadAfterDebug = command[("debug ".Length)..];
+
+        Assert.Equal("{\"id\":8,\"op\":\"status\",\"cpu\":\"cpu with spaces\"}", rawPayloadAfterDebug);
+    }
+
+    [Fact]
     public void StdoutParser_DetectsResponseAndEventPrefixes()
     {
         var parser = new MameDebuggerStdoutParser();
@@ -40,6 +65,21 @@ public sealed class MameDebuggerProtocolTests
         Assert.True(status.Available);
         Assert.Equal(MameDebuggerExecutionState.Stopped, status.State);
         Assert.Equal(4660, status.Pc);
+    }
+
+    [Fact]
+    public async Task Service_PingAsync_SendsPingAndReturnsAvailability()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = new MameDebuggerService(runner);
+        var pingTask = service.PingAsync(CancellationToken.None);
+
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":1,\"ok\":true,\"result\":{\"pong\":true,\"available\":true}}");
+
+        var ping = await pingTask;
+        Assert.Equal("debug {\"id\":1,\"op\":\"ping\"}", Assert.Single(runner.Commands));
+        Assert.True(ping.Pong);
+        Assert.True(ping.Available);
     }
 
     private sealed class RecordingMameProcessRunner : IMameProcessRunner

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
@@ -62,4 +62,6 @@ public sealed record MameDebuggerStatus(
     string? Cpu,
     long? Pc);
 
+public sealed record MameDebuggerPing(bool Pong, bool Available);
+
 public sealed record MameDebuggerCpu(string Tag, string Name, bool IsCurrent);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
@@ -7,6 +7,7 @@ public interface IMameDebuggerService
 {
     MameDebuggerStateSnapshot State { get; }
     event EventHandler<MameDebuggerEvent>? DebuggerEventReceived;
+    Task<MameDebuggerPing> PingAsync(CancellationToken cancellationToken);
     Task<MameDebuggerStatus> GetStatusAsync(CancellationToken cancellationToken);
     Task<IReadOnlyList<MameDebuggerCpu>> GetCpuListAsync(CancellationToken cancellationToken);
     Task RunAsync(CancellationToken cancellationToken);
@@ -53,6 +54,12 @@ public sealed class MameDebuggerService : IMameDebuggerService
     public void SetDebuggerLaunchActive(bool isActive)
     {
         _state.MarkLaunchMode(isActive);
+    }
+
+    public async Task<MameDebuggerPing> PingAsync(CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("ping", cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<MameDebuggerPing>(response);
     }
 
     public async Task<MameDebuggerStatus> GetStatusAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- Ensure the Lua `debug` command forwards the raw JSON payload (which may contain spaces and quoted strings) instead of relying on tokenized `args[2]` to avoid truncated/incorrect payloads. 
- Make the Lua fallback JSON decoder more robust for string fields containing escapes and quotes when a JSON module is unavailable. 
- Expose a small service API to probe availability (`PingAsync`) and add tests that validate JSON payloads with spaces/quoted strings.

### Description
- Change Lua command dispatch in `command_processor.lua` to detect `debug` and pass the raw payload after the command name via `line:match("^%s*%S+%s+(.+)$")` instead of the earlier tokenized `args[2]`.
- Update `system/commands/debug.lua` to accept the raw `payload` parameter (instead of `args`) and preserve existing error responses for missing/invalid payloads.
- Harden the Lua fallback JSON decoder in `debugger_protocol.lua` by adding `match_json_string_field` and `unescape_json_string` helpers so string fields with escaped quotes and spaces are parsed correctly when no JSON library is present.
- Add `MameDebuggerPing` model and `PingAsync` to `IMameDebuggerService` / `MameDebuggerService` and wire the implementation to send the `ping` operation and deserialize the `pong` reply.
- Add unit tests to `MameDebuggerProtocolTests.cs` that verify JSON payloads containing spaces and quoted strings are preserved after the `debug ` prefix and a test for `PingAsync` request/response behavior.

### Testing
- Ran a local Python validation that constructs a `debug` command with a JSON payload containing spaces and escaped quotes and validated the raw payload extraction and Lua handler seam; this check passed.
- Verified `git diff --check` produced no whitespace errors; local commit created successfully (`Harden MAME debugger stdin protocol`).
- Added C# unit tests under `OasisEditor.Tests` but could not execute `dotnet test` in this environment because `dotnet` is not installed; `dotnet test` was attempted and failed with `dotnet: command not found`.
- Could not perform live MAME stdin-bridge verification (Run/Step while stopped after Debugger Break) because no MAME executable was available in the container, so manual runtime verification remains required on a machine with MAME.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f1e1a84ac8327ad57d601f74d868f)