### PR TITLE
Implement MAME debugger register and memory backend

### DIFF
--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
@@ -144,6 +144,14 @@ function lib:decode(payload)
 			local value = payload_object:match('"' .. field .. '"%s*:%s*(%-?%d+)')
 			if value then
 				decoded_payload[field] = tonumber(value)
+				return
+			end
+			value = match_json_string_field(payload_object, field)
+			if value then
+				local parsed = tonumber(value) or tonumber(value:match('^0[xX]([0-9a-fA-F]+)$'), 16)
+				if parsed then
+					decoded_payload[field] = parsed
+				end
 			end
 		end
 
@@ -154,15 +162,34 @@ function lib:decode(payload)
 			end
 		end
 
+		local function read_number_array(field)
+			local array_payload = payload_object:match('"' .. field .. '"%s*:%s*(%b[])')
+			if not array_payload then
+				return
+			end
+
+			local values = {}
+			for value in array_payload:gmatch('%-?%d+') do
+				values[#values + 1] = tonumber(value)
+			end
+			decoded_payload[field] = values
+		end
+
 		read_string("cpu")
 		read_string("condition")
 		read_string("action")
 		read_string("type")
 		read_string("addressSpace")
+		read_string("name")
+		read_string("hex")
+		read_string("bytes")
 		read_number("address")
+		read_number("startAddress")
 		read_number("length")
+		read_number("value")
 		read_number("mameId")
 		read_number("debuggerId")
+		read_number_array("bytes")
 		result.payload = decoded_payload
 	end
 

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
@@ -8,6 +8,7 @@ local lib = {}
 -- unstable native list binding.
 local oasis_breakpoints = {}
 local oasis_watchpoints = {}
+local max_memory_transfer_length = 4096
 
 local function debugger()
 	if manager and manager.machine then
@@ -102,6 +103,169 @@ local function require_address_space(cpu, data)
 	end
 
 	return space, name
+end
+
+
+local function hex_value(value, digits)
+	if value == nil then
+		return nil
+	end
+	digits = digits or 0
+	if digits > 0 then
+		return string.format("0x%0" .. tostring(digits) .. "X", value)
+	end
+	return string.format("0x%X", value)
+end
+
+local function byte_hex(bytes)
+	local parts = {}
+	for i = 1, #bytes do
+		parts[#parts + 1] = string.format("%02X", bytes[i] & 0xff)
+	end
+	return table.concat(parts, " ")
+end
+
+local function register_model(entry, cpu_tag)
+	local size = nil
+	local bits = nil
+	local digits = 0
+	if entry.datasize and not entry.is_float then
+		size = entry.datasize
+		bits = size * 8
+		digits = size * 2
+	elseif entry.datamask and not entry.is_float then
+		local mask = entry.datamask
+		bits = 0
+		while mask > 0 do
+			bits = bits + 1
+			mask = mask >> 1
+		end
+		digits = math.max(1, math.floor((bits + 3) / 4))
+	end
+
+	local value = entry.value
+	return {
+		cpu = cpu_tag,
+		name = entry.symbol,
+		value = value,
+		displayValue = entry.is_float and tostring(value) or hex_value(value, digits),
+		size = size,
+		bits = bits,
+		editable = entry.writeable
+	}
+end
+
+local function require_state(cpu)
+	if not cpu.state then
+		error("CPU device '" .. tostring(cpu.tag) .. "' does not expose register state entries.")
+	end
+	return cpu.state
+end
+
+local function require_register(cpu, name)
+	if not name or name == "" then
+		error("Missing register name.")
+	end
+	local cpu_state = require_state(cpu)
+	local entry = cpu_state[name]
+	if not entry then
+		error("Register '" .. tostring(name) .. "' is not available on CPU '" .. tostring(cpu.tag) .. "'.")
+	end
+	return entry
+end
+
+local function register_list(cpu_tag, data)
+	local cpu, _, tag = require_cpu(cpu_tag)
+	local cpu_state = require_state(cpu)
+	local requested_name = data and data.name
+	if requested_name and requested_name ~= "" then
+		return { register_model(require_register(cpu, requested_name), tag) }
+	end
+
+	local result = {}
+	for _, entry in pairs(cpu_state) do
+		if entry.visible ~= false then
+			result[#result + 1] = register_model(entry, tag)
+		end
+	end
+	table.sort(result, function(a, b) return a.name < b.name end)
+	return result
+end
+
+local function bytes_from_hex(text)
+	local result = {}
+	if text == nil then
+		return result
+	end
+	text = tostring(text):gsub("0[xX]", "")
+	for byte in text:gmatch("%x%x") do
+		result[#result + 1] = tonumber(byte, 16)
+	end
+	return result
+end
+
+local function request_bytes(data)
+	local result = {}
+	if type(data.bytes) == "table" then
+		for i = 1, #data.bytes do
+			local byte = number_value(data.bytes[i], "bytes[" .. tostring(i) .. "]", true)
+			if byte < 0 or byte > 255 then
+				error("Memory byte at index " .. tostring(i) .. " must be in the range 0..255.")
+			end
+			result[#result + 1] = byte & 0xff
+		end
+	elseif type(data.bytes) == "string" then
+		result = bytes_from_hex(data.bytes)
+	elseif type(data.hex) == "string" then
+		result = bytes_from_hex(data.hex)
+	end
+	if #result == 0 then
+		error("Memory write requires at least one byte in 'bytes' or 'hex'.")
+	end
+	if #result > max_memory_transfer_length then
+		error("Memory write length " .. tostring(#result) .. " exceeds the guard rail of " .. tostring(max_memory_transfer_length) .. " bytes.")
+	end
+	return result
+end
+
+local function memory_block(cpu_tag, space_name, start_address, bytes)
+	return {
+		cpu = cpu_tag,
+		addressSpace = space_name,
+		startAddress = start_address,
+		length = #bytes,
+		bytes = bytes,
+		hex = byte_hex(bytes)
+	}
+end
+
+local function read_memory(cpu_tag, data)
+	local cpu, _, tag = require_cpu(cpu_tag)
+	local address = number_value(data.startAddress or data.address, "startAddress", true)
+	local length = number_value(data.length, "length", true)
+	if length <= 0 then
+		error("Memory read length must be positive.")
+	end
+	if length > max_memory_transfer_length then
+		error("Memory read length " .. tostring(length) .. " exceeds the guard rail of " .. tostring(max_memory_transfer_length) .. " bytes.")
+	end
+	local space, space_name = require_address_space(cpu, data)
+	local bytes = {}
+	for offset = 0, length - 1 do
+		bytes[#bytes + 1] = space:read_u8(address + offset) & 0xff
+	end
+	return memory_block(tag, space_name, address, bytes)
+end
+
+local function write_memory(cpu_tag, data)
+	local cpu, _, tag = require_cpu(cpu_tag)
+	local address = number_value(data.startAddress or data.address, "startAddress", true)
+	local bytes = request_bytes(data)
+	local space, space_name = require_address_space(cpu, data)
+	for offset = 0, #bytes - 1 do
+		space:write_u8(address + offset, bytes[offset + 1])
+	end
+	return memory_block(tag, space_name, address, bytes)
 end
 
 local function breakpoint_model(bp, cpu_tag)
@@ -365,6 +529,20 @@ function lib:handle(request)
 		end
 		oasis_watchpoints[id] = nil
 		return watchpoint_list(tag, data)
+	elseif op == "regs.get" then
+		return register_list(data.cpu or request.cpu, data)
+	elseif op == "regs.set" then
+		local cpu, _, tag = require_cpu(data.cpu or request.cpu)
+		local entry = require_register(cpu, data.name)
+		if entry.writeable == false then
+			error("Register '" .. tostring(data.name) .. "' on CPU '" .. tostring(tag) .. "' is not editable.")
+		end
+		entry.value = number_value(data.value, "value", true)
+		return register_model(entry, tag)
+	elseif op == "mem.read" then
+		return read_memory(data.cpu or request.cpu, data)
+	elseif op == "mem.write" then
+		return write_memory(data.cpu or request.cpu, data)
 	end
 
 	error("Unsupported debugger operation '" .. tostring(op) .. "'.")

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
@@ -153,6 +153,115 @@ public sealed class MameDebuggerProtocolTests
         Assert.True(ping.Available);
     }
 
+
+    [Fact]
+    public void ParseResponse_DeserializesRegisterModels()
+    {
+        var response = MameDebuggerProtocol.ParseResponse(
+            "{\"id\":5,\"ok\":true,\"result\":[{\"cpu\":\":maincpu\",\"name\":\"PC\",\"value\":4660,\"displayValue\":\"0x1234\",\"size\":2,\"bits\":16,\"editable\":true}]}");
+
+        var registers = response.Result!.Value.Deserialize<List<MameDebuggerRegister>>(MameDebuggerProtocol.JsonOptions)!;
+
+        var register = Assert.Single(registers);
+        Assert.Equal(":maincpu", register.Cpu);
+        Assert.Equal("PC", register.Name);
+        Assert.Equal(0x1234, register.Value);
+        Assert.Equal("0x1234", register.DisplayValue);
+        Assert.Equal(16, register.Bits);
+        Assert.True(register.Editable);
+    }
+
+    [Fact]
+    public void ParseResponse_DeserializesMemoryBlockModels()
+    {
+        var response = MameDebuggerProtocol.ParseResponse(
+            "{\"id\":6,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"addressSpace\":\"program\",\"startAddress\":4096,\"length\":4,\"bytes\":[1,32,127,255],\"hex\":\"01 20 7F FF\"}}");
+
+        var block = response.Result!.Value.Deserialize<MameDebuggerMemoryBlock>(MameDebuggerProtocol.JsonOptions)!;
+
+        Assert.Equal(":maincpu", block.Cpu);
+        Assert.Equal("program", block.AddressSpace);
+        Assert.Equal(0x1000, block.StartAddress);
+        Assert.Equal(4, block.Length);
+        Assert.Equal(new byte[] { 1, 32, 127, 255 }, block.Bytes);
+        Assert.Equal("01 20 7F FF", block.Hex);
+    }
+
+    [Fact]
+    public void CreateCommand_SerializesRegisterSetRequest()
+    {
+        var command = MameDebuggerProtocol.CreateCommand(10, "regs.set", new MameDebuggerRegisterRequest(":maincpu", "PC", 0x1234));
+        var payload = command[("debug ".Length)..];
+        var request = System.Text.Json.JsonSerializer.Deserialize<MameDebuggerRequest<MameDebuggerRegisterRequest>>(payload, MameDebuggerProtocol.JsonOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal(10, request.Id);
+        Assert.Equal("regs.set", request.Op);
+        Assert.Equal(":maincpu", request.Payload.Cpu);
+        Assert.Equal("PC", request.Payload.Name);
+        Assert.Equal(0x1234, request.Payload.Value);
+    }
+
+    [Fact]
+    public void CreateCommand_SerializesMemoryWriteRequestWithBytesAndHexEdgeCases()
+    {
+        var command = MameDebuggerProtocol.CreateCommand(
+            11,
+            "mem.write",
+            new MameDebuggerMemoryWriteRequest(":maincpu", 0x2000, [0, 16, 255], "program", "00 10 FF \"quoted\""));
+        var payload = command[("debug ".Length)..];
+        var request = System.Text.Json.JsonSerializer.Deserialize<MameDebuggerRequest<MameDebuggerMemoryWriteRequest>>(payload, MameDebuggerProtocol.JsonOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal(11, request.Id);
+        Assert.Equal("mem.write", request.Op);
+        Assert.Equal(0x2000, request.Payload.StartAddress);
+        Assert.Equal(new byte[] { 0, 16, 255 }, request.Payload.Bytes);
+        Assert.Equal("program", request.Payload.AddressSpace);
+        Assert.Equal("00 10 FF \"quoted\"", request.Payload.Hex);
+        Assert.Contains("\\\"quoted\\\"", command);
+    }
+
+    [Fact]
+    public async Task Service_RegisterAndMemoryRequests_CorrelateByRequestId()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = new MameDebuggerService(runner);
+        var registersTask = service.GetRegistersAsync(new MameDebuggerRegisterRequest(":maincpu"), CancellationToken.None);
+        var memoryTask = service.ReadMemoryAsync(new MameDebuggerMemoryReadRequest(":maincpu", 0x1000, 2, "program"), CancellationToken.None);
+
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":2,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"addressSpace\":\"program\",\"startAddress\":4096,\"length\":2,\"bytes\":[170,85],\"hex\":\"AA 55\"}}");
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":1,\"ok\":true,\"result\":[{\"cpu\":\":maincpu\",\"name\":\"PC\",\"value\":4660,\"displayValue\":\"0x1234\",\"editable\":true}]}");
+
+        var registers = await registersTask;
+        var block = await memoryTask;
+
+        Assert.Equal("PC", Assert.Single(registers).Name);
+        Assert.Equal(new byte[] { 170, 85 }, block.Bytes);
+        Assert.Equal("debug {\"id\":1,\"op\":\"regs.get\",\"payload\":{\"cpu\":\":maincpu\"}}", runner.Commands[0]);
+        Assert.Equal("debug {\"id\":2,\"op\":\"mem.read\",\"payload\":{\"cpu\":\":maincpu\",\"startAddress\":4096,\"length\":2,\"addressSpace\":\"program\"}}", runner.Commands[1]);
+    }
+
+    [Fact]
+    public async Task Service_SetRegisterAndWriteMemoryRequests_CorrelateByRequestId()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = new MameDebuggerService(runner);
+        var registerTask = service.SetRegisterAsync(new MameDebuggerRegisterRequest(":maincpu", "A", 0x42), CancellationToken.None);
+        var writeTask = service.WriteMemoryAsync(new MameDebuggerMemoryWriteRequest(":maincpu", 0x2000, [0x12, 0x34], "program"), CancellationToken.None);
+
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":2,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"addressSpace\":\"program\",\"startAddress\":8192,\"length\":2,\"bytes\":[18,52],\"hex\":\"12 34\"}}");
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":1,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"name\":\"A\",\"value\":66,\"displayValue\":\"0x42\",\"editable\":true}}");
+
+        var register = await registerTask;
+        var block = await writeTask;
+
+        Assert.Equal("A", register.Name);
+        Assert.Equal(new byte[] { 0x12, 0x34 }, block.Bytes);
+        Assert.Equal("debug {\"id\":1,\"op\":\"regs.set\",\"payload\":{\"cpu\":\":maincpu\",\"name\":\"A\",\"value\":66}}", runner.Commands[0]);
+        Assert.Equal("debug {\"id\":2,\"op\":\"mem.write\",\"payload\":{\"cpu\":\":maincpu\",\"startAddress\":8192,\"bytes\":[18,52],\"addressSpace\":\"program\"}}", runner.Commands[1]);
+    }
+
     private sealed class RecordingMameProcessRunner : IMameProcessRunner
     {
         public List<string> Commands { get; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
@@ -84,6 +84,41 @@ public sealed record MameDebuggerPing(bool Pong, bool Available);
 
 public sealed record MameDebuggerCpu(string Tag, string Name, bool IsCurrent);
 
+public sealed record MameDebuggerRegister(
+    string Cpu,
+    string Name,
+    long Value,
+    string DisplayValue,
+    int? Size = null,
+    int? Bits = null,
+    bool? Editable = null);
+
+public sealed record MameDebuggerRegisterRequest(
+    string? Cpu,
+    string? Name = null,
+    long? Value = null);
+
+public sealed record MameDebuggerMemoryReadRequest(
+    string? Cpu,
+    long StartAddress,
+    int Length,
+    string? AddressSpace = null);
+
+public sealed record MameDebuggerMemoryWriteRequest(
+    string? Cpu,
+    long StartAddress,
+    IReadOnlyList<byte>? Bytes = null,
+    string? AddressSpace = null,
+    string? Hex = null);
+
+public sealed record MameDebuggerMemoryBlock(
+    string Cpu,
+    string AddressSpace,
+    long StartAddress,
+    int Length,
+    IReadOnlyList<byte> Bytes,
+    string Hex);
+
 public sealed record MameDebuggerBreakpoint(
     long DebuggerId,
     long MameId,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
@@ -23,6 +23,10 @@ public interface IMameDebuggerService
     Task<MameDebuggerWatchpoint> EnableWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken);
     Task<MameDebuggerWatchpoint> DisableWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken);
     Task<IReadOnlyList<MameDebuggerWatchpoint>> ClearWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken);
+    Task<IReadOnlyList<MameDebuggerRegister>> GetRegistersAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken);
+    Task<MameDebuggerRegister> SetRegisterAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken);
+    Task<MameDebuggerMemoryBlock> ReadMemoryAsync(MameDebuggerMemoryReadRequest request, CancellationToken cancellationToken);
+    Task<MameDebuggerMemoryBlock> WriteMemoryAsync(MameDebuggerMemoryWriteRequest request, CancellationToken cancellationToken);
     void ProcessStdoutLine(string line);
     void SetDebuggerLaunchActive(bool isActive);
 }
@@ -159,6 +163,30 @@ public sealed class MameDebuggerService : IMameDebuggerService
     {
         var response = await SendRequestAsync("wp.clear", request, cancellationToken).ConfigureAwait(false);
         return DeserializeResult<List<MameDebuggerWatchpoint>>(response);
+    }
+
+    public async Task<IReadOnlyList<MameDebuggerRegister>> GetRegistersAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("regs.get", request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<List<MameDebuggerRegister>>(response);
+    }
+
+    public async Task<MameDebuggerRegister> SetRegisterAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("regs.set", request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<MameDebuggerRegister>(response);
+    }
+
+    public async Task<MameDebuggerMemoryBlock> ReadMemoryAsync(MameDebuggerMemoryReadRequest request, CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("mem.read", request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<MameDebuggerMemoryBlock>(response);
+    }
+
+    public async Task<MameDebuggerMemoryBlock> WriteMemoryAsync(MameDebuggerMemoryWriteRequest request, CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("mem.write", request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<MameDebuggerMemoryBlock>(response);
     }
 
     public void ProcessStdoutLine(string line)


### PR DESCRIPTION
### Motivation
- Implement Phase 4 backend/service support so the debugger can enumerate and modify CPU registers and read/write memory via the existing stdin/stdout protocol.
- Provide structured C# service APIs and robust Lua handlers so UI panels added later can rely on typed models and predictable protocol shapes.

### Description
- Added explicit C# protocol models: `MameDebuggerRegister`, `MameDebuggerRegisterRequest`, `MameDebuggerMemoryReadRequest`, `MameDebuggerMemoryWriteRequest`, and `MameDebuggerMemoryBlock`, and exposed service APIs `GetRegistersAsync`, `SetRegisterAsync`, `ReadMemoryAsync`, and `WriteMemoryAsync` that map to `regs.get`, `regs.set`, `mem.read`, and `mem.write` respectively.
- Implemented Lua router support for registers and memory in `debugger_router.lua`, including CPU/address-space resolution, register enumeration and write-through state updates, memory byte reads/writes using `address_space:read_u8`/`write_u8`, hex/byte decoding helpers, and a guarded maximum transfer length to avoid large dumps.
- Extended the Lua fallback JSON decoder in `debugger_protocol.lua` to parse numeric fields supplied as strings, JSON number arrays (`bytes`), and hex strings to make the stdin protocol robust against payload shape variations.
- Added unit tests in `MameDebuggerProtocolTests` to cover `regs.get`/`regs.set` and `mem.read`/`mem.write` request/response shapes, payload edge cases (bytes/hex/quoted strings), and request-id correlation for service calls.

Register Lua API assumptions
- Registers are read/written via device state entries at `manager.machine.devices[tag].state[symbol]` rather than via parsing human-readable debugger command output, and `regs.get` returns visible state entries (`entry.visible ~= false`).
- `register` model fields returned include `cpu`, `name`, `value`, `displayValue` (hex or string), optional `size`/`bits` where available, and `editable` derived from `entry.writeable`.
- `regs.set` writes by assigning `entry.value` and returns the updated register model, and unavailable or non-writeable registers are surfaced as structured protocol errors.

Memory / address-space Lua API assumptions
- Address spaces are accessed from `manager.machine.devices[tag].spaces[name]` with a default `program` space when omitted, and missing/invalid spaces produce structured protocol errors.
- `mem.read` supports arbitrary start address and positive `length` but enforces a guard rail (default 4096 bytes) to avoid accidental huge reads, and `mem.write` accepts JSON `bytes` arrays or hex string payloads and validates byte ranges.
- Memory responses return `cpu`, `addressSpace`, `startAddress`, `length`, `bytes` (array of 0..255), and a display-friendly `hex` string.

Example request/response JSON
- regs.get request: `{"id":1,"op":"regs.get","payload":{"cpu":":maincpu"}}`
- regs.get response sample:
```
{"id":1,"ok":true,"result":[{"cpu":":maincpu","name":"PC","value":4660,"displayValue":"0x1234","size":2,"bits":16,"editable":true}]}
```
- mem.read request: `{"id":3,"op":"mem.read","payload":{"cpu":":maincpu","addressSpace":"program","startAddress":4096,"length":4}}`
- mem.read response sample:
```
{"id":3,"ok":true,"result":{"cpu":":maincpu","addressSpace":"program","startAddress":4096,"length":4,"bytes":[1,32,127,255],"hex":"01 20 7F FF"}}
```
- regs.set and mem.write follow the same shapes with `regs.set` returning a single register model and `mem.write` returning a `MameDebuggerMemoryBlock` that echoes bytes written.

CPU-specific limitations discovered
- No live Z80/6809/68000 MAME process was available in this environment, so register symbol naming, `datasize`/`datamask` availability, and per-core writeability flags were not validated against real targets.
- The implementation depends on MAME device-state metadata which can vary by core; cores that do not expose `datasize`/`datamask` or standard address-space names may require per-core handling later.

Blockers before Phase 5 (disassembly)
- No protocol/service blockers were found for Phase 5, but Phase 5 requires verifying that direct address-space reads align with the disassembler address semantics for each CPU and validating register naming conventions per core.

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs, which passed.
- Updated and added unit tests in `OasisEditor.Tests/MameDebuggerProtocolTests` to cover register and memory parsing and request serialization, but `dotnet test` could not be executed in this container because `dotnet` is not installed (test compilation/run skipped).
- Performed local repository checks and committed changes (commit `77015d0`) and prepared this PR; runtime/manual verification with a debugger-enabled MAME launch is still required to validate behavior on real CPU targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f2f4dd0348327be8334875c87e65d)