### PR TITLE
Implement MAME disassembly backend (Phase 5): protocol, Lua handler, and service API

### DIFF
--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_protocol.lua
@@ -175,6 +175,18 @@ function lib:decode(payload)
 			decoded_payload[field] = values
 		end
 
+		local function read_boolean(field)
+			local value = payload_object:match('"' .. field .. '"%s*:%s*(true)')
+			if value then
+				decoded_payload[field] = true
+				return
+			end
+			value = payload_object:match('"' .. field .. '"%s*:%s*(false)')
+			if value then
+				decoded_payload[field] = false
+			end
+		end
+
 		read_string("cpu")
 		read_string("condition")
 		read_string("action")
@@ -186,9 +198,11 @@ function lib:decode(payload)
 		read_number("address")
 		read_number("startAddress")
 		read_number("length")
+		read_number("lineCount")
 		read_number("value")
 		read_number("mameId")
 		read_number("debuggerId")
+		read_boolean("centerAroundPc")
 		read_number_array("bytes")
 		result.payload = decoded_payload
 	end

--- a/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
+++ b/WindowsNetProjects/OasisEditor/Assets/MAME/plugins/oasis/system/debugger/debugger_router.lua
@@ -268,6 +268,182 @@ local function write_memory(cpu_tag, data)
 	return memory_block(tag, space_name, address, bytes)
 end
 
+
+local function cpu_pc(cpu)
+	if cpu and cpu.state and cpu.state["PC"] then
+		local ok, value = pcall(function() return cpu.state["PC"].value end)
+		if ok then
+			return value
+		end
+	end
+	return nil
+end
+
+local function consolelog_length(dbg)
+	if not (dbg and dbg.consolelog) then
+		return 0
+	end
+	local ok, count = pcall(function() return #dbg.consolelog end)
+	if ok and count then
+		return count
+	end
+	return 0
+end
+
+local function new_consolelog_lines(dbg, before)
+	local result = {}
+	if not (dbg and dbg.consolelog) then
+		return result
+	end
+	local after = consolelog_length(dbg)
+	for i = before + 1, after do
+		local ok, line = pcall(function() return dbg.consolelog[i] end)
+		if ok and line ~= nil then
+			result[#result + 1] = tostring(line)
+		end
+	end
+	return result
+end
+
+local function parse_disassembly_line(cpu_tag, raw_line, current_pc, fallback_address)
+	local raw = tostring(raw_line or "")
+	local trimmed = raw:match("^%s*(.-)%s*$") or raw
+	local is_current = false
+	if trimmed:sub(1, 2) == "=>" then
+		is_current = true
+		trimmed = trimmed:sub(3):match("^%s*(.-)%s*$") or trimmed:sub(3)
+	elseif trimmed:sub(1, 1) == ">" then
+		is_current = true
+		trimmed = trimmed:sub(2):match("^%s*(.-)%s*$") or trimmed:sub(2)
+	end
+
+	local address_text, rest = trimmed:match("^([%x]+)%s*:%s*(.*)$")
+	local address = address_text and tonumber(address_text, 16) or fallback_address or 0
+	if current_pc ~= nil and address == current_pc then
+		is_current = true
+	end
+
+	local opcode_parts = {}
+	local instruction = rest
+	if rest then
+		local remaining = rest:match("^%s*(.-)%s*$") or rest
+		while true do
+			local token, next_remaining = remaining:match("^([%x][%x]+)%s+(.*)$")
+			if not token or (#token % 2) ~= 0 or #token > 8 then
+				break
+			end
+			opcode_parts[#opcode_parts + 1] = token:upper()
+			remaining = next_remaining
+		end
+		instruction = remaining ~= "" and remaining or nil
+	end
+
+	return {
+		cpu = cpu_tag,
+		address = address,
+		rawText = raw,
+		opcodeBytes = #opcode_parts > 0 and table.concat(opcode_parts, " ") or nil,
+		instructionText = instruction,
+		isCurrentPc = is_current,
+		symbol = nil,
+		comment = nil
+	}
+end
+
+local function read_disassembly_file(path)
+	local lines = {}
+	local file = io.open(path, "r")
+	if not file then
+		return lines
+	end
+	for line in file:lines() do
+		lines[#lines + 1] = line
+	end
+	file:close()
+	return lines
+end
+
+local function direct_disassemble(cpu, address, space_name)
+	-- The documented MAME Lua debugger API through 0.288 does not expose a stable
+	-- disassembly method.  Probe likely method names defensively so newer MAME
+	-- builds can use a direct API without breaking older builds.
+	local probes = {
+		function() return cpu.debug:disassemble(address, space_name) end,
+		function() return cpu:disassemble(address, space_name) end
+	}
+	if cpu.spaces and cpu.spaces[space_name] then
+		local space = cpu.spaces[space_name]
+		probes[#probes + 1] = function() return space:disassemble(address) end
+	end
+	for _, probe in ipairs(probes) do
+		local ok, text = pcall(probe)
+		if ok and type(text) == "string" and text ~= "" then
+			return text
+		end
+	end
+	return nil
+end
+
+local function disassemble_block(cpu_tag, data)
+	local cpu, _, tag = require_cpu(cpu_tag)
+	local line_count = number_value(data.lineCount or data.length or data.count, "lineCount", true)
+	if line_count <= 0 then
+		error("Disassembly lineCount must be positive.")
+	end
+	if line_count > 256 then
+		error("Disassembly lineCount " .. tostring(line_count) .. " exceeds the guard rail of 256 lines.")
+	end
+
+	local space_name = address_space_name(data)
+	local pc = cpu_pc(cpu)
+	local start_address = number_value(data.startAddress or data.address, "startAddress", false)
+	if start_address == nil then
+		if data.centerAroundPc ~= false and pc ~= nil then
+			start_address = pc
+		else
+			start_address = 0
+		end
+	end
+
+	local raw_lines = {}
+	local direct_text = direct_disassemble(cpu, start_address, space_name)
+	if direct_text then
+		raw_lines[#raw_lines + 1] = direct_text
+	else
+		local dbg = require_debugger()
+		local before = consolelog_length(dbg)
+		local filename = string.format("oasis_disasm_%d_%d.tmp", os.time(), math.random(100000, 999999))
+		local byte_length = math.max(line_count * 16, 16)
+		local command = string.format("dasm %s,%X,%X,1,%s", filename, start_address, byte_length, tag)
+		dbg.visible_cpu = cpu
+		dbg:command(command)
+		local command_log = new_consolelog_lines(dbg, before)
+		local file_lines = read_disassembly_file(filename)
+		os.remove(filename)
+		for i = 1, #file_lines do
+			raw_lines[#raw_lines + 1] = file_lines[i]
+		end
+		for i = 1, #command_log do
+			raw_lines[#raw_lines + 1] = command_log[i]
+		end
+	end
+
+	local lines = {}
+	for i = 1, math.min(#raw_lines, line_count) do
+		lines[#lines + 1] = parse_disassembly_line(tag, raw_lines[i], pc, start_address + i - 1)
+	end
+
+	return {
+		cpu = tag,
+		addressSpace = space_name,
+		startAddress = start_address,
+		lineCount = line_count,
+		currentPc = pc,
+		lines = lines,
+		rawLines = raw_lines
+	}
+end
+
 local function breakpoint_model(bp, cpu_tag)
 	return {
 		debuggerId = bp.index,
@@ -543,6 +719,8 @@ function lib:handle(request)
 		return read_memory(data.cpu or request.cpu, data)
 	elseif op == "mem.write" then
 		return write_memory(data.cpu or request.cpu, data)
+	elseif op == "disasm" then
+		return disassemble_block(data.cpu or request.cpu, data)
 	end
 
 	error("Unsupported debugger operation '" .. tostring(op) .. "'.")

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerProtocolTests.cs
@@ -262,6 +262,79 @@ public sealed class MameDebuggerProtocolTests
         Assert.Equal("debug {\"id\":2,\"op\":\"mem.write\",\"payload\":{\"cpu\":\":maincpu\",\"startAddress\":8192,\"bytes\":[18,52],\"addressSpace\":\"program\"}}", runner.Commands[1]);
     }
 
+    [Fact]
+    public void CreateCommand_SerializesDisassemblyRequestWithCpuAddressAndLineCount()
+    {
+        var command = MameDebuggerProtocol.CreateCommand(12, "disasm", new MameDebuggerDisassemblyRequest(":maincpu", 0x1234, 16, "program", false));
+        var payload = command[("debug ".Length)..];
+        var request = System.Text.Json.JsonSerializer.Deserialize<MameDebuggerRequest<MameDebuggerDisassemblyRequest>>(payload, MameDebuggerProtocol.JsonOptions);
+
+        Assert.NotNull(request);
+        Assert.Equal(12, request.Id);
+        Assert.Equal("disasm", request.Op);
+        Assert.Equal(":maincpu", request.Payload.Cpu);
+        Assert.Equal(0x1234, request.Payload.StartAddress);
+        Assert.Equal(16, request.Payload.LineCount);
+        Assert.Equal("program", request.Payload.AddressSpace);
+        Assert.False(request.Payload.CenterAroundPc.GetValueOrDefault());
+        Assert.Contains("\"cpu\":\":maincpu\"", command);
+        Assert.Contains("\"startAddress\":4660", command);
+        Assert.Contains("\"lineCount\":16", command);
+    }
+
+    [Fact]
+    public void ParseResponse_DeserializesDisassemblyBlockAndParsedLines()
+    {
+        var response = MameDebuggerProtocol.ParseResponse(
+            "{\"id\":7,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"addressSpace\":\"program\",\"startAddress\":4096,\"lineCount\":2,\"currentPc\":4098,\"rawLines\":[\"1000: 3E 12 ld a,$12\",\"1002: C3 00 10 jp $1000\"],\"lines\":[{\"cpu\":\":maincpu\",\"address\":4096,\"rawText\":\"1000: 3E 12 ld a,$12\",\"opcodeBytes\":\"3E 12\",\"instructionText\":\"ld a,$12\",\"isCurrentPc\":false},{\"cpu\":\":maincpu\",\"address\":4098,\"rawText\":\"1002: C3 00 10 jp $1000\",\"opcodeBytes\":\"C3 00 10\",\"instructionText\":\"jp $1000\",\"isCurrentPc\":true}]}}");
+
+        var block = response.Result!.Value.Deserialize<MameDebuggerDisassemblyBlock>(MameDebuggerProtocol.JsonOptions)!;
+
+        Assert.Equal(":maincpu", block.Cpu);
+        Assert.Equal("program", block.AddressSpace);
+        Assert.Equal(0x1000, block.StartAddress);
+        Assert.Equal(2, block.LineCount);
+        Assert.Equal(0x1002, block.CurrentPc);
+        Assert.Equal(2, block.Lines.Count);
+        Assert.Equal("3E 12", block.Lines[0].OpcodeBytes);
+        Assert.Equal("ld a,$12", block.Lines[0].InstructionText);
+        Assert.True(block.Lines[1].IsCurrentPc);
+        Assert.Equal(2, block.RawLines!.Count);
+    }
+
+    [Fact]
+    public void ParseResponse_DisassemblyLineHandlesRawOnlyFallback()
+    {
+        var response = MameDebuggerProtocol.ParseResponse(
+            "{\"id\":8,\"ok\":true,\"result\":{\"cpu\":\":audiocpu\",\"startAddress\":0,\"lineCount\":1,\"lines\":[{\"cpu\":\":audiocpu\",\"address\":0,\"rawText\":\"unparsed disassembly text\",\"isCurrentPc\":false}],\"rawLines\":[\"unparsed disassembly text\"]}}");
+
+        var block = response.Result!.Value.Deserialize<MameDebuggerDisassemblyBlock>(MameDebuggerProtocol.JsonOptions)!;
+        var line = Assert.Single(block.Lines);
+
+        Assert.Equal(":audiocpu", line.Cpu);
+        Assert.Equal("unparsed disassembly text", line.RawText);
+        Assert.Null(line.OpcodeBytes);
+        Assert.Null(line.InstructionText);
+        Assert.False(line.IsCurrentPc);
+    }
+
+    [Fact]
+    public async Task Service_DisassemblyRequests_CorrelateByRequestId()
+    {
+        var runner = new RecordingMameProcessRunner();
+        var service = new MameDebuggerService(runner);
+        var disasmTask = service.DisassembleAsync(new MameDebuggerDisassemblyRequest(":maincpu", null, 8, CenterAroundPc: true), CancellationToken.None);
+
+        service.ProcessStdoutLine("@OASIS_DEBUG {\"id\":1,\"ok\":true,\"result\":{\"cpu\":\":maincpu\",\"startAddress\":4660,\"lineCount\":8,\"currentPc\":4660,\"lines\":[{\"cpu\":\":maincpu\",\"address\":4660,\"rawText\":\"1234: 00 nop\",\"opcodeBytes\":\"00\",\"instructionText\":\"nop\",\"isCurrentPc\":true}]}}");
+
+        var block = await disasmTask;
+
+        Assert.Equal(":maincpu", block.Cpu);
+        Assert.Equal(0x1234, block.StartAddress);
+        Assert.Equal("nop", Assert.Single(block.Lines).InstructionText);
+        Assert.Equal("debug {\"id\":1,\"op\":\"disasm\",\"payload\":{\"cpu\":\":maincpu\",\"lineCount\":8,\"centerAroundPc\":true}}", Assert.Single(runner.Commands));
+    }
+
     private sealed class RecordingMameProcessRunner : IMameProcessRunner
     {
         public List<string> Commands { get; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerProtocol.cs
@@ -119,6 +119,32 @@ public sealed record MameDebuggerMemoryBlock(
     IReadOnlyList<byte> Bytes,
     string Hex);
 
+public sealed record MameDebuggerDisassemblyRequest(
+    string? Cpu,
+    long? StartAddress,
+    int LineCount,
+    string? AddressSpace = null,
+    bool? CenterAroundPc = null);
+
+public sealed record MameDebuggerDisassemblyLine(
+    string Cpu,
+    long Address,
+    string RawText,
+    string? OpcodeBytes = null,
+    string? InstructionText = null,
+    bool IsCurrentPc = false,
+    string? Symbol = null,
+    string? Comment = null);
+
+public sealed record MameDebuggerDisassemblyBlock(
+    string Cpu,
+    long StartAddress,
+    int LineCount,
+    long? CurrentPc,
+    IReadOnlyList<MameDebuggerDisassemblyLine> Lines,
+    IReadOnlyList<string>? RawLines = null,
+    string? AddressSpace = null);
+
 public sealed record MameDebuggerBreakpoint(
     long DebuggerId,
     long MameId,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/MameDebuggerService.cs
@@ -27,6 +27,7 @@ public interface IMameDebuggerService
     Task<MameDebuggerRegister> SetRegisterAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken);
     Task<MameDebuggerMemoryBlock> ReadMemoryAsync(MameDebuggerMemoryReadRequest request, CancellationToken cancellationToken);
     Task<MameDebuggerMemoryBlock> WriteMemoryAsync(MameDebuggerMemoryWriteRequest request, CancellationToken cancellationToken);
+    Task<MameDebuggerDisassemblyBlock> DisassembleAsync(MameDebuggerDisassemblyRequest request, CancellationToken cancellationToken);
     void ProcessStdoutLine(string line);
     void SetDebuggerLaunchActive(bool isActive);
 }
@@ -187,6 +188,12 @@ public sealed class MameDebuggerService : IMameDebuggerService
     {
         var response = await SendRequestAsync("mem.write", request, cancellationToken).ConfigureAwait(false);
         return DeserializeResult<MameDebuggerMemoryBlock>(response);
+    }
+
+    public async Task<MameDebuggerDisassemblyBlock> DisassembleAsync(MameDebuggerDisassemblyRequest request, CancellationToken cancellationToken)
+    {
+        var response = await SendRequestAsync("disasm", request, cancellationToken).ConfigureAwait(false);
+        return DeserializeResult<MameDebuggerDisassemblyBlock>(response);
     }
 
     public void ProcessStdoutLine(string line)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -213,6 +213,13 @@
                 <MenuItem Header="Debugger Add Test Breakpoint At _PC"
                           Command="{Binding AddTestDebuggerBreakpointCommand}"
                           Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                <Separator />
+                <MenuItem Header="Debugger Disassemble Around _PC"
+                          Command="{Binding DisassembleAroundCurrentPcCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                <MenuItem Header="Debugger Disassemble From _0x0"
+                          Command="{Binding DisassembleFixedAddressTestBlockCommand}"
+                          Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
             </MenuItem>
         </Menu>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -146,6 +146,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ListDebuggerBreakpointsCommand = new RelayCommand(ListDebuggerBreakpoints, CanControlDebugger);
         ListDebuggerWatchpointsCommand = new RelayCommand(ListDebuggerWatchpoints, CanControlDebugger);
         AddTestDebuggerBreakpointCommand = new RelayCommand(AddTestDebuggerBreakpoint, CanControlDebugger);
+        DisassembleAroundCurrentPcCommand = new RelayCommand(DisassembleAroundCurrentPc, CanControlDebugger);
+        DisassembleFixedAddressTestBlockCommand = new RelayCommand(DisassembleFixedAddressTestBlock, CanControlDebugger);
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
@@ -437,6 +439,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ListDebuggerBreakpointsCommand { get; }
     public ICommand ListDebuggerWatchpointsCommand { get; }
     public ICommand AddTestDebuggerBreakpointCommand { get; }
+    public ICommand DisassembleAroundCurrentPcCommand { get; }
+    public ICommand DisassembleFixedAddressTestBlockCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -2270,6 +2274,54 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             });
     }
 
+    private async void DisassembleAroundCurrentPc()
+    {
+        await SendDebuggerCommandAsync(
+            CanControlDebugger,
+            "Debugger disassembly requested around current PC.",
+            "Debugger disassembly around current PC failed",
+            async cancellationToken =>
+            {
+                var status = await _mameDebuggerService.GetStatusAsync(cancellationToken);
+                var block = await _mameDebuggerService.DisassembleAsync(
+                    new MameDebuggerDisassemblyRequest(status.Cpu, null, 16, CenterAroundPc: true),
+                    cancellationToken);
+                LogDisassemblyBlock("Debugger disassembly around PC", block);
+            });
+    }
+
+    private async void DisassembleFixedAddressTestBlock()
+    {
+        await SendDebuggerCommandAsync(
+            CanControlDebugger,
+            "Debugger fixed-address disassembly test requested.",
+            "Debugger fixed-address disassembly test failed",
+            async cancellationToken =>
+            {
+                var status = await _mameDebuggerService.GetStatusAsync(cancellationToken);
+                var block = await _mameDebuggerService.DisassembleAsync(
+                    new MameDebuggerDisassemblyRequest(status.Cpu, 0, 16, CenterAroundPc: false),
+                    cancellationToken);
+                LogDisassemblyBlock("Debugger disassembly from 0x0", block);
+            });
+    }
+
+    private void LogDisassemblyBlock(string prefix, MameDebuggerDisassemblyBlock block)
+    {
+        AddOutputEntry($"{prefix}: cpu={block.Cpu} start=0x{block.StartAddress:X} lines={block.Lines.Count}/{block.LineCount} pc={(block.CurrentPc.HasValue ? $"0x{block.CurrentPc.Value:X}" : "unknown")}", OutputLogStatus.Info);
+        foreach (var line in block.Lines.Take(8))
+        {
+            var current = line.IsCurrentPc ? "=> " : "   ";
+            var instruction = string.IsNullOrWhiteSpace(line.InstructionText) ? line.RawText : line.InstructionText;
+            var opcodes = string.IsNullOrWhiteSpace(line.OpcodeBytes) ? string.Empty : $" [{line.OpcodeBytes}]";
+            AddOutputEntry($"{current}{line.Cpu} 0x{line.Address:X}:{opcodes} {instruction}", OutputLogStatus.Info);
+        }
+        if (block.Lines.Count > 8)
+        {
+            AddOutputEntry($"{prefix}: {block.Lines.Count - 8} additional disassembly lines omitted from temporary Output preview.", OutputLogStatus.Info);
+        }
+    }
+
     private async Task LogDebuggerStatusAsync(string prefix, CancellationToken cancellationToken = default)
     {
         var status = await _mameDebuggerService.GetStatusAsync(cancellationToken);
@@ -3038,6 +3090,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(ListDebuggerBreakpointsCommand);
         RaiseEmulationCommandCanExecuteChanged(ListDebuggerWatchpointsCommand);
         RaiseEmulationCommandCanExecuteChanged(AddTestDebuggerBreakpointCommand);
+        RaiseEmulationCommandCanExecuteChanged(DisassembleAroundCurrentPcCommand);
+        RaiseEmulationCommandCanExecuteChanged(DisassembleFixedAddressTestBlockCommand);
     }
 
     private static void RaiseEmulationCommandCanExecuteChanged(ICommand command)


### PR DESCRIPTION
### Motivation
- Add Phase 5 disassembly backend support so the debugger protocol can request CPU-qualified disassembly from MAME and return structured, parseable results to the C# service.

### Description
- Added explicit C# protocol models `MameDebuggerDisassemblyRequest`, `MameDebuggerDisassemblyLine`, and `MameDebuggerDisassemblyBlock` and the service API `DisassembleAsync(...)` on `IMameDebuggerService` and `MameDebuggerService` so callers can request and receive structured disassembly blocks.
- Implemented Lua `disasm` routing in `oasis/system/debugger/debugger_router.lua` that CPU-qualifies requests, resolves start address (requested CPU, visible CPU, then `:maincpu`), uses `PC` when `centerAroundPc` is requested with no explicit start address, probes for direct device disassemble APIs defensively, and falls back to issuing the MAME `dasm` debugger command with conservative byte-span heuristics and file/consolelog capture when no direct API is found.
- Extended the Lua request decoder (`debugger_protocol.lua`) to preserve `lineCount` and `centerAroundPc` values during minimal parsing, added robust consolelog-delta capture and read-only file reading of `dasm` output, and implemented best-effort per-line parsing that returns both `rawText` and parsed `opcodeBytes`/`instructionText` when available.
- Added temporary Emulation menu commands and view-model plumbing (`DisassembleAroundCurrentPcCommand`, `DisassembleFixedAddressTestBlockCommand` and `LogDisassemblyBlock`) to exercise the backend and emit a short structured preview to the Output log (this is intentionally a temporary verification UI and not a dockable panel).

(Implementation notes required by the plan)
- MAME Lua/disassembly path used: the Lua backend probes likely direct methods (`cpu.debug:disassemble`, `cpu:disassemble`, `space:disassemble`) and otherwise uses `manager.machine.debugger:command("dasm ...")` together with `consolelog` delta capture and the generated temporary file readback.
- Example request JSON (centered around PC): `{"id":1,"op":"disasm","payload":{"cpu":":maincpu","lineCount":16,"centerAroundPc":true}}` and explicit-address request `{"id":2,"op":"disasm","payload":{"cpu":":maincpu","startAddress":4660,"lineCount":8,"addressSpace":"program","centerAroundPc":false}}`.
- Example structured response JSON: `{"id":1,"ok":true,"result":{"cpu":":maincpu","addressSpace":"program","startAddress":4660,"lineCount":8,"currentPc":4660,"lines":[{"cpu":":maincpu","address":4660,"rawText":"1234: 00 nop","opcodeBytes":"00","instructionText":"nop","isCurrentPc":true}],"rawLines":["1234: 00 nop"]}}`.
- Example raw `dasm` fallback output the parser expects (diagnostic/raw lines): `1000: 3E 12 ld a,$12` and `1002: C3 00 10 jp $1000` (both file lines and any consolelog command echoes are preserved in `rawLines`).
- Parsing limitations: no stable documented direct disassemble API in MAME 0.288, `dasm` accepts a byte length not an instruction count so a byte-span heuristic (`lineCount * 16`) is used and results are truncated to requested lines, opcode/instruction splitting is best-effort and `rawText` is always returned for diagnostics.
- CPU-specific limitations and discovered constraints: parser relies on MAME’s disassembler output because Z80/6809/68000 and other cores format opcodes differently and have variable-length instructions, so opcode splitting is conservative and instruction text is forwarded verbatim for later UI handling.
- Blockers before final dockable UI panels: need Windows/MAME smoke testing to validate `dasm` file generation and consolelog behavior on target builds, and further tuning for accurate PC-centering (line-count vs byte-span heuristics) before a polished disassembly panel is implemented.

### Testing
- Unit tests added/updated: disassembly request serialization, disassembly response parsing including parsed-lines and raw-only fallback, service request-id correlation for `disasm`, and payload/field coverage for CPU/address/lineCount; these test cases were added to `OasisEditor.Tests/MameDebuggerProtocolTests.cs`.
- Automated test runs attempted: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` could not run in this environment because `dotnet` is not installed (automated test execution skipped for this PR run).
- Lua syntax/lint attempted: `luac -p` check could not be executed here because Lua/`luac` is not available in the environment (syntax validation should be run in a MAME-capable environment before deployment).
- Local automated check: `git diff --check` passed with no trailing-whitespace or index errors.

If desired I can follow up with a small PR that moves the temporary menu commands into a dedicated debug-only command set or remove them before UI panels are implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f3415146483279e1f22497621270d)