### PR TITLE
Add dockable MAME debugger panels

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerPanelViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameDebuggerPanelViewModelTests.cs
@@ -1,0 +1,119 @@
+using OasisEditor.Features.MameDebugger;
+using OasisEditor.Features.MameDebugger.ViewModels;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameDebuggerPanelViewModelTests
+{
+    [Fact]
+    public async Task ControlRefreshStatusUpdatesDisplayedState()
+    {
+        var service = new FakeMameDebuggerService
+        {
+            Snapshot = new MameDebuggerStateSnapshot(true, true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234),
+            Status = new MameDebuggerStatus(true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234)
+        };
+        var logs = new List<string>();
+        var viewModel = new DebuggerControlViewModel(service, (message, _) => logs.Add(message));
+
+        await viewModel.RefreshStatusAsync();
+
+        Assert.Equal("Stopped", viewModel.StateText);
+        Assert.Equal(":maincpu", viewModel.CurrentCpuText);
+        Assert.Equal("0x1234", viewModel.CurrentPcText);
+        Assert.Contains(logs, log => log.Contains("Debugger status", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RegistersRefreshUsesCurrentStatusCpu()
+    {
+        var service = new FakeMameDebuggerService
+        {
+            Snapshot = new MameDebuggerStateSnapshot(true, true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234),
+            Status = new MameDebuggerStatus(true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234),
+            Registers =
+            [
+                new MameDebuggerRegister(":maincpu", "PC", 0x1234, "1234", Editable: false),
+                new MameDebuggerRegister(":maincpu", "A", 0x56, "56", Editable: true)
+            ]
+        };
+        var viewModel = new DebuggerRegistersViewModel(service, (_, _) => { });
+
+        await viewModel.RefreshAsync();
+
+        Assert.Equal(":maincpu", service.LastRegisterRequest?.Cpu);
+        Assert.Collection(
+            viewModel.Registers,
+            register => Assert.Equal("PC", register.Name),
+            register => Assert.Equal("A", register.Name));
+    }
+
+    [Fact]
+    public async Task DisassemblyRefreshFromInvalidAddressLogsWarningWithoutBackendCall()
+    {
+        var service = new FakeMameDebuggerService
+        {
+            Snapshot = new MameDebuggerStateSnapshot(true, true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234),
+            Status = new MameDebuggerStatus(true, MameDebuggerExecutionState.Stopped, ":maincpu", 0x1234)
+        };
+        var logs = new List<(string Message, OutputLogStatus Status)>();
+        var viewModel = new DebuggerDisassemblyViewModel(service, (message, status) => logs.Add((message, status)))
+        {
+            StartAddressText = "not-an-address"
+        };
+
+        await viewModel.RefreshFromAddressAsync();
+
+        Assert.Equal(0, service.DisassembleCallCount);
+        Assert.Contains(logs, log => log.Status == OutputLogStatus.Warning && log.Message.Contains("not a valid", StringComparison.Ordinal));
+    }
+
+    private sealed class FakeMameDebuggerService : IMameDebuggerService
+    {
+        public MameDebuggerStateSnapshot Snapshot { get; set; } = new(true, false, MameDebuggerExecutionState.Unknown, null, null);
+        public MameDebuggerStatus Status { get; set; } = new(false, MameDebuggerExecutionState.Unknown, null, null);
+        public IReadOnlyList<MameDebuggerRegister> Registers { get; set; } = [];
+        public MameDebuggerRegisterRequest? LastRegisterRequest { get; private set; }
+        public int DisassembleCallCount { get; private set; }
+
+        public MameDebuggerStateSnapshot State => Snapshot;
+        public event EventHandler<MameDebuggerEvent>? DebuggerEventReceived;
+
+        public Task<MameDebuggerPing> PingAsync(CancellationToken cancellationToken) => Task.FromResult(new MameDebuggerPing(true, Status.Available));
+        public Task<MameDebuggerStatus> GetStatusAsync(CancellationToken cancellationToken) => Task.FromResult(Status);
+        public Task<IReadOnlyList<MameDebuggerCpu>> GetCpuListAsync(CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<MameDebuggerCpu>>([]);
+        public Task RunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task BreakAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StepAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<MameDebuggerBreakpoint> SetBreakpointAsync(MameDebuggerBreakpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<IReadOnlyList<MameDebuggerBreakpoint>> GetBreakpointsAsync(string? cpu, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<MameDebuggerBreakpoint>>([]);
+        public Task<MameDebuggerBreakpoint> EnableBreakpointAsync(MameDebuggerBreakpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<MameDebuggerBreakpoint> DisableBreakpointAsync(MameDebuggerBreakpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<IReadOnlyList<MameDebuggerBreakpoint>> ClearBreakpointAsync(MameDebuggerBreakpointRequest request, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<MameDebuggerBreakpoint>>([]);
+        public Task<MameDebuggerWatchpoint> SetWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<IReadOnlyList<MameDebuggerWatchpoint>> GetWatchpointsAsync(string? cpu, CancellationToken cancellationToken, string? addressSpace = null) => Task.FromResult<IReadOnlyList<MameDebuggerWatchpoint>>([]);
+        public Task<MameDebuggerWatchpoint> EnableWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<MameDebuggerWatchpoint> DisableWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<IReadOnlyList<MameDebuggerWatchpoint>> ClearWatchpointAsync(MameDebuggerWatchpointRequest request, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<MameDebuggerWatchpoint>>([]);
+        public Task<IReadOnlyList<MameDebuggerRegister>> GetRegistersAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken)
+        {
+            LastRegisterRequest = request;
+            return Task.FromResult(Registers);
+        }
+
+        public Task<MameDebuggerRegister> SetRegisterAsync(MameDebuggerRegisterRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<MameDebuggerMemoryBlock> ReadMemoryAsync(MameDebuggerMemoryReadRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<MameDebuggerMemoryBlock> WriteMemoryAsync(MameDebuggerMemoryWriteRequest request, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task<MameDebuggerDisassemblyBlock> DisassembleAsync(MameDebuggerDisassemblyRequest request, CancellationToken cancellationToken)
+        {
+            DisassembleCallCount++;
+            return Task.FromResult(new MameDebuggerDisassemblyBlock(request.Cpu ?? ":maincpu", request.StartAddress ?? 0, request.LineCount, 0, []));
+        }
+
+        public void ProcessStdoutLine(string line) { }
+        public void SetDebuggerLaunchActive(bool isActive) => Snapshot = Snapshot with { IsDebuggerLaunchActive = isActive };
+
+        public void RaiseEvent(MameDebuggerEvent debuggerEvent) => DebuggerEventReceived?.Invoke(this, debuggerEvent);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/ViewModels/DebuggerPanelViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/ViewModels/DebuggerPanelViewModels.cs
@@ -1,0 +1,704 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Input;
+using OasisEditor;
+
+namespace OasisEditor.Features.MameDebugger.ViewModels;
+
+public sealed class MameDebuggerShellViewModel : INotifyPropertyChanged
+{
+    private readonly IMameDebuggerService _debuggerService;
+    private readonly Action<string, OutputLogStatus> _log;
+
+    public MameDebuggerShellViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+    {
+        _debuggerService = debuggerService ?? throw new ArgumentNullException(nameof(debuggerService));
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+        Control = new DebuggerControlViewModel(debuggerService, Log);
+        Disassembly = new DebuggerDisassemblyViewModel(debuggerService, Log);
+        Registers = new DebuggerRegistersViewModel(debuggerService, Log);
+        Memory = new DebuggerMemoryViewModel(debuggerService, Log);
+        Breakpoints = new DebuggerBreakpointsViewModel(debuggerService, Log);
+        Watchpoints = new DebuggerWatchpointsViewModel(debuggerService, Log);
+        _debuggerService.DebuggerEventReceived += OnDebuggerEventReceived;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public DebuggerControlViewModel Control { get; }
+    public DebuggerDisassemblyViewModel Disassembly { get; }
+    public DebuggerRegistersViewModel Registers { get; }
+    public DebuggerMemoryViewModel Memory { get; }
+    public DebuggerBreakpointsViewModel Breakpoints { get; }
+    public DebuggerWatchpointsViewModel Watchpoints { get; }
+
+    public void NotifyCommandStateChanged()
+    {
+        Control.NotifyCommandStateChanged();
+        Disassembly.NotifyCommandStateChanged();
+        Registers.NotifyCommandStateChanged();
+        Memory.NotifyCommandStateChanged();
+        Breakpoints.NotifyCommandStateChanged();
+        Watchpoints.NotifyCommandStateChanged();
+    }
+
+    private void OnDebuggerEventReceived(object? sender, MameDebuggerEvent debuggerEvent)
+    {
+        DispatchToUiThread(() =>
+        {
+            Control.ApplySnapshot(_debuggerService.State);
+            NotifyCommandStateChanged();
+            if (debuggerEvent.Event.Equals("stopped", StringComparison.OrdinalIgnoreCase)
+                || debuggerEvent.Event.Equals("step", StringComparison.OrdinalIgnoreCase))
+            {
+                _ = Control.RefreshStatusAsync(logRequest: false);
+                _ = Disassembly.RefreshAroundPcAsync(logRequest: false);
+                _ = Registers.RefreshAsync(logRequest: false);
+            }
+        });
+    }
+
+    private static void DispatchToUiThread(Action work)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished || dispatcher.CheckAccess())
+        {
+            work();
+            return;
+        }
+
+        _ = dispatcher.BeginInvoke(work);
+    }
+
+    private void Log(string message, OutputLogStatus status) => _log(message, status);
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+
+public abstract class DebuggerPanelViewModelBase : INotifyPropertyChanged
+{
+    protected DebuggerPanelViewModelBase(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+    {
+        DebuggerService = debuggerService ?? throw new ArgumentNullException(nameof(debuggerService));
+        Log = log ?? throw new ArgumentNullException(nameof(log));
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected IMameDebuggerService DebuggerService { get; }
+    protected Action<string, OutputLogStatus> Log { get; }
+
+    public virtual void NotifyCommandStateChanged()
+    {
+    }
+
+    protected bool IsDebuggerUsable()
+    {
+        var state = DebuggerService.State;
+        return state.IsDebuggerLaunchActive;
+    }
+
+    protected async Task RunDebuggerActionAsync(string requestedMessage, string failurePrefix, Func<CancellationToken, Task> action, bool logRequest = true)
+    {
+        if (!IsDebuggerUsable())
+        {
+            Log("MAME debugger is unavailable. Start emulation in debugger mode before using debugger panels.", OutputLogStatus.Warning);
+            return;
+        }
+
+        if (logRequest)
+        {
+            Log(requestedMessage, OutputLogStatus.Info);
+        }
+
+        try
+        {
+            await action(CancellationToken.None).ConfigureAwait(true);
+            NotifyCommandStateChanged();
+        }
+        catch (Exception ex)
+        {
+            Log($"{failurePrefix}: {ex.Message}", OutputLogStatus.Error);
+            NotifyCommandStateChanged();
+        }
+    }
+
+    protected void RaiseCommands(params ICommand[] commands)
+    {
+        foreach (var command in commands)
+        {
+            if (command is RelayCommand relayCommand)
+            {
+                relayCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    protected static bool TryParseInteger(string? text, out long value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return long.TryParse(trimmed[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+        }
+
+        return long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    protected static string ToHex(long value) => $"0x{value:X}";
+}
+
+public sealed class DebuggerControlViewModel : DebuggerPanelViewModelBase
+{
+    private string? _selectedCpu;
+    private string _stateText = "Unknown";
+    private string _currentCpuText = "unknown";
+    private string _currentPcText = "unknown";
+    private bool _isAvailable;
+
+    public DebuggerControlViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        RefreshStatusCommand = new RelayCommand(async () => await RefreshStatusAsync(), IsDebuggerUsable);
+        RefreshCpusCommand = new RelayCommand(async () => await RefreshCpusAsync(), IsDebuggerUsable);
+        RunCommand = new RelayCommand(async () => await RunAsync(), IsDebuggerUsable);
+        BreakCommand = new RelayCommand(async () => await BreakAsync(), IsDebuggerUsable);
+        StepCommand = new RelayCommand(async () => await StepAsync(), IsDebuggerUsable);
+        ApplySnapshot(debuggerService.State);
+    }
+
+    public ObservableCollection<MameDebuggerCpu> Cpus { get; } = [];
+    public ICommand RefreshStatusCommand { get; }
+    public ICommand RefreshCpusCommand { get; }
+    public ICommand RunCommand { get; }
+    public ICommand BreakCommand { get; }
+    public ICommand StepCommand { get; }
+
+    public string? SelectedCpu
+    {
+        get => _selectedCpu;
+        set { if (_selectedCpu != value) { _selectedCpu = value; OnPropertyChanged(); } }
+    }
+
+    public string StateText
+    {
+        get => _stateText;
+        private set { if (_stateText != value) { _stateText = value; OnPropertyChanged(); } }
+    }
+
+    public string CurrentCpuText
+    {
+        get => _currentCpuText;
+        private set { if (_currentCpuText != value) { _currentCpuText = value; OnPropertyChanged(); } }
+    }
+
+    public string CurrentPcText
+    {
+        get => _currentPcText;
+        private set { if (_currentPcText != value) { _currentPcText = value; OnPropertyChanged(); } }
+    }
+
+    public bool IsAvailable
+    {
+        get => _isAvailable;
+        private set { if (_isAvailable != value) { _isAvailable = value; OnPropertyChanged(); } }
+    }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(RefreshStatusCommand, RefreshCpusCommand, RunCommand, BreakCommand, StepCommand);
+
+    public void ApplySnapshot(MameDebuggerStateSnapshot snapshot)
+    {
+        IsAvailable = snapshot.IsDebuggerAvailable;
+        StateText = snapshot.ExecutionState.ToString();
+        CurrentCpuText = snapshot.CurrentCpu ?? "unknown";
+        CurrentPcText = snapshot.CurrentPc.HasValue ? ToHex(snapshot.CurrentPc.Value) : "unknown";
+        if (string.IsNullOrWhiteSpace(SelectedCpu))
+        {
+            SelectedCpu = snapshot.CurrentCpu;
+        }
+    }
+
+    public Task RefreshStatusAsync(bool logRequest = true)
+        => RunDebuggerActionAsync("Debugger panel status refresh requested.", "Debugger panel status refresh failed", async cancellationToken =>
+        {
+            var status = await DebuggerService.GetStatusAsync(cancellationToken).ConfigureAwait(true);
+            ApplySnapshot(DebuggerService.State);
+            Log($"Debugger status: available={status.Available}, state={status.State}, cpu={status.Cpu ?? "unknown"}, pc={(status.Pc.HasValue ? ToHex(status.Pc.Value) : "unknown")}.", status.Available ? OutputLogStatus.Info : OutputLogStatus.Warning);
+        }, logRequest);
+
+    public Task RefreshCpusAsync(bool logRequest = true)
+        => RunDebuggerActionAsync("Debugger panel CPU refresh requested.", "Debugger panel CPU refresh failed", async cancellationToken =>
+        {
+            var cpus = await DebuggerService.GetCpuListAsync(cancellationToken).ConfigureAwait(true);
+            Cpus.Clear();
+            foreach (var cpu in cpus)
+            {
+                Cpus.Add(cpu);
+            }
+
+            SelectedCpu = cpus.FirstOrDefault(cpu => cpu.IsCurrent)?.Tag ?? cpus.FirstOrDefault()?.Tag ?? SelectedCpu;
+            if (cpus.Count == 0)
+            {
+                Log("Debugger CPU list returned no CPU devices.", OutputLogStatus.Warning);
+            }
+        }, logRequest);
+
+    private Task RunAsync() => RunDebuggerActionAsync("Debugger run requested from Control panel.", "Debugger run failed", async cancellationToken =>
+    {
+        await DebuggerService.RunAsync(cancellationToken).ConfigureAwait(true);
+        ApplySnapshot(DebuggerService.State);
+    });
+
+    private Task BreakAsync() => RunDebuggerActionAsync("Debugger break requested from Control panel.", "Debugger break failed", async cancellationToken =>
+    {
+        await DebuggerService.BreakAsync(cancellationToken).ConfigureAwait(true);
+        ApplySnapshot(DebuggerService.State);
+    });
+
+    private Task StepAsync() => RunDebuggerActionAsync("Debugger step requested from Control panel.", "Debugger step failed", async cancellationToken =>
+    {
+        await DebuggerService.StepAsync(cancellationToken).ConfigureAwait(true);
+        ApplySnapshot(DebuggerService.State);
+    });
+}
+
+public sealed class DebuggerDisassemblyViewModel : DebuggerPanelViewModelBase
+{
+    private string _startAddressText = "0x0";
+    private string _lineCountText = "32";
+    private MameDebuggerDisassemblyLine? _selectedLine;
+
+    public DebuggerDisassemblyViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        RefreshAroundPcCommand = new RelayCommand(async () => await RefreshAroundPcAsync(), IsDebuggerUsable);
+        RefreshFromAddressCommand = new RelayCommand(async () => await RefreshFromAddressAsync(), IsDebuggerUsable);
+    }
+
+    public ObservableCollection<MameDebuggerDisassemblyLine> Lines { get; } = [];
+    public ICommand RefreshAroundPcCommand { get; }
+    public ICommand RefreshFromAddressCommand { get; }
+
+    public string StartAddressText
+    {
+        get => _startAddressText;
+        set { if (_startAddressText != value) { _startAddressText = value; OnPropertyChanged(); } }
+    }
+
+    public string LineCountText
+    {
+        get => _lineCountText;
+        set { if (_lineCountText != value) { _lineCountText = value; OnPropertyChanged(); } }
+    }
+
+    public MameDebuggerDisassemblyLine? SelectedLine
+    {
+        get => _selectedLine;
+        set { if (_selectedLine != value) { _selectedLine = value; OnPropertyChanged(); } }
+    }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(RefreshAroundPcCommand, RefreshFromAddressCommand);
+
+    public Task RefreshAroundPcAsync(bool logRequest = true)
+        => RunDebuggerActionAsync("Disassembly refresh around current PC requested.", "Disassembly refresh failed", async cancellationToken =>
+        {
+            var status = await DebuggerService.GetStatusAsync(cancellationToken).ConfigureAwait(true);
+            var block = await DebuggerService.DisassembleAsync(new MameDebuggerDisassemblyRequest(status.Cpu, null, ParseLineCount(), CenterAroundPc: true), cancellationToken).ConfigureAwait(true);
+            ApplyBlock(block);
+        }, logRequest);
+
+    public Task RefreshFromAddressAsync()
+        => RunDebuggerActionAsync("Disassembly refresh from address requested.", "Disassembly refresh from address failed", async cancellationToken =>
+        {
+            if (!TryParseInteger(StartAddressText, out var address))
+            {
+                Log($"Disassembly start address '{StartAddressText}' is not a valid decimal or 0x-prefixed value.", OutputLogStatus.Warning);
+                return;
+            }
+
+            var status = await DebuggerService.GetStatusAsync(cancellationToken).ConfigureAwait(true);
+            var block = await DebuggerService.DisassembleAsync(new MameDebuggerDisassemblyRequest(status.Cpu, address, ParseLineCount(), CenterAroundPc: false), cancellationToken).ConfigureAwait(true);
+            ApplyBlock(block);
+        });
+
+    private void ApplyBlock(MameDebuggerDisassemblyBlock block)
+    {
+        Lines.Clear();
+        foreach (var line in block.Lines)
+        {
+            Lines.Add(line);
+        }
+
+        SelectedLine = block.Lines.FirstOrDefault(line => line.IsCurrentPc);
+        StartAddressText = ToHex(block.StartAddress);
+        Log($"Disassembly refreshed: cpu={block.Cpu}, start={ToHex(block.StartAddress)}, lines={block.Lines.Count}/{block.LineCount}.", OutputLogStatus.Info);
+    }
+
+    private int ParseLineCount()
+    {
+        return int.TryParse(LineCountText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count)
+            ? Math.Clamp(count, 1, 256)
+            : 32;
+    }
+}
+
+public sealed class DebuggerRegistersViewModel : DebuggerPanelViewModelBase
+{
+    public DebuggerRegistersViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        RefreshCommand = new RelayCommand(async () => await RefreshAsync(), IsDebuggerUsable);
+    }
+
+    public ObservableCollection<MameDebuggerRegister> Registers { get; } = [];
+    public ICommand RefreshCommand { get; }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(RefreshCommand);
+
+    public Task RefreshAsync(bool logRequest = true)
+        => RunDebuggerActionAsync("Register refresh requested.", "Register refresh failed", async cancellationToken =>
+        {
+            var status = await DebuggerService.GetStatusAsync(cancellationToken).ConfigureAwait(true);
+            var registers = await DebuggerService.GetRegistersAsync(new MameDebuggerRegisterRequest(status.Cpu), cancellationToken).ConfigureAwait(true);
+            Registers.Clear();
+            foreach (var register in registers)
+            {
+                Registers.Add(register);
+            }
+
+            Log($"Registers refreshed: cpu={status.Cpu ?? "current"}, count={registers.Count}.", OutputLogStatus.Info);
+        }, logRequest);
+}
+
+public sealed class DebuggerMemoryViewModel : DebuggerPanelViewModelBase
+{
+    private string? _cpuText;
+    private string _addressSpaceText = "program";
+    private string _startAddressText = "0x0";
+    private string _lengthText = "64";
+    private string _hexText = string.Empty;
+
+    public DebuggerMemoryViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        ReadCommand = new RelayCommand(async () => await ReadAsync(), IsDebuggerUsable);
+    }
+
+    public ICommand ReadCommand { get; }
+
+    public string? CpuText
+    {
+        get => _cpuText;
+        set { if (_cpuText != value) { _cpuText = value; OnPropertyChanged(); } }
+    }
+
+    public string AddressSpaceText
+    {
+        get => _addressSpaceText;
+        set { if (_addressSpaceText != value) { _addressSpaceText = value; OnPropertyChanged(); } }
+    }
+
+    public string StartAddressText
+    {
+        get => _startAddressText;
+        set { if (_startAddressText != value) { _startAddressText = value; OnPropertyChanged(); } }
+    }
+
+    public string LengthText
+    {
+        get => _lengthText;
+        set { if (_lengthText != value) { _lengthText = value; OnPropertyChanged(); } }
+    }
+
+    public string HexText
+    {
+        get => _hexText;
+        private set { if (_hexText != value) { _hexText = value; OnPropertyChanged(); } }
+    }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(ReadCommand);
+
+    private Task ReadAsync()
+        => RunDebuggerActionAsync("Memory read requested.", "Memory read failed", async cancellationToken =>
+        {
+            if (!TryParseInteger(StartAddressText, out var startAddress))
+            {
+                Log($"Memory start address '{StartAddressText}' is not a valid decimal or 0x-prefixed value.", OutputLogStatus.Warning);
+                return;
+            }
+
+            if (!int.TryParse(LengthText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var length) || length <= 0)
+            {
+                Log($"Memory length '{LengthText}' is not a valid positive byte count.", OutputLogStatus.Warning);
+                return;
+            }
+
+            length = Math.Clamp(length, 1, 4096);
+            var cpu = string.IsNullOrWhiteSpace(CpuText) ? DebuggerService.State.CurrentCpu : CpuText.Trim();
+            var addressSpace = string.IsNullOrWhiteSpace(AddressSpaceText) ? null : AddressSpaceText.Trim();
+            var block = await DebuggerService.ReadMemoryAsync(new MameDebuggerMemoryReadRequest(cpu, startAddress, length, addressSpace), cancellationToken).ConfigureAwait(true);
+            HexText = FormatHexDump(block);
+            CpuText = block.Cpu;
+            AddressSpaceText = block.AddressSpace;
+            StartAddressText = ToHex(block.StartAddress);
+            LengthText = block.Length.ToString(CultureInfo.InvariantCulture);
+            Log($"Memory read: cpu={block.Cpu}, space={block.AddressSpace}, start={ToHex(block.StartAddress)}, length={block.Length}.", OutputLogStatus.Info);
+        });
+
+    private static string FormatHexDump(MameDebuggerMemoryBlock block)
+    {
+        var lines = new List<string>();
+        for (var offset = 0; offset < block.Bytes.Count; offset += 16)
+        {
+            var bytes = block.Bytes.Skip(offset).Take(16).ToArray();
+            lines.Add($"{block.StartAddress + offset:X8}: {string.Join(" ", bytes.Select(b => b.ToString("X2", CultureInfo.InvariantCulture)))}");
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}
+
+public sealed class DebuggerBreakpointsViewModel : DebuggerPanelViewModelBase
+{
+    private string _addressText = "0x0";
+    private MameDebuggerBreakpoint? _selectedBreakpoint;
+
+    public DebuggerBreakpointsViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        RefreshCommand = new RelayCommand(async () => await RefreshAsync(), IsDebuggerUsable);
+        AddCommand = new RelayCommand(async () => await AddAsync(), IsDebuggerUsable);
+        EnableCommand = new RelayCommand(async () => await SetEnabledAsync(true), () => IsDebuggerUsable() && SelectedBreakpoint is not null);
+        DisableCommand = new RelayCommand(async () => await SetEnabledAsync(false), () => IsDebuggerUsable() && SelectedBreakpoint is not null);
+        ClearCommand = new RelayCommand(async () => await ClearAsync(), IsDebuggerUsable);
+    }
+
+    public ObservableCollection<MameDebuggerBreakpoint> Breakpoints { get; } = [];
+    public ICommand RefreshCommand { get; }
+    public ICommand AddCommand { get; }
+    public ICommand EnableCommand { get; }
+    public ICommand DisableCommand { get; }
+    public ICommand ClearCommand { get; }
+
+    public string AddressText
+    {
+        get => _addressText;
+        set { if (_addressText != value) { _addressText = value; OnPropertyChanged(); } }
+    }
+
+    public MameDebuggerBreakpoint? SelectedBreakpoint
+    {
+        get => _selectedBreakpoint;
+        set { if (_selectedBreakpoint != value) { _selectedBreakpoint = value; OnPropertyChanged(); NotifyCommandStateChanged(); } }
+    }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(RefreshCommand, AddCommand, EnableCommand, DisableCommand, ClearCommand);
+
+    private Task RefreshAsync()
+        => RunDebuggerActionAsync("Breakpoint refresh requested.", "Breakpoint refresh failed", async cancellationToken =>
+        {
+            var breakpoints = await DebuggerService.GetBreakpointsAsync(null, cancellationToken).ConfigureAwait(true);
+            Breakpoints.Clear();
+            foreach (var breakpoint in breakpoints)
+            {
+                Breakpoints.Add(breakpoint);
+            }
+
+            Log($"Breakpoints refreshed: count={breakpoints.Count}.", OutputLogStatus.Info);
+        });
+
+    private Task AddAsync()
+        => RunDebuggerActionAsync("Breakpoint add requested.", "Breakpoint add failed", async cancellationToken =>
+        {
+            if (!TryParseInteger(AddressText, out var address))
+            {
+                Log($"Breakpoint address '{AddressText}' is not a valid decimal or 0x-prefixed value.", OutputLogStatus.Warning);
+                return;
+            }
+
+            var breakpoint = await DebuggerService.SetBreakpointAsync(new MameDebuggerBreakpointRequest(DebuggerService.State.CurrentCpu, address), cancellationToken).ConfigureAwait(true);
+            Breakpoints.Add(breakpoint);
+            SelectedBreakpoint = breakpoint;
+            Log($"Breakpoint #{breakpoint.MameId} added on {breakpoint.Cpu} at {ToHex(breakpoint.Address)}.", OutputLogStatus.Info);
+        });
+
+    private Task SetEnabledAsync(bool enabled)
+        => RunDebuggerActionAsync(enabled ? "Breakpoint enable requested." : "Breakpoint disable requested.", enabled ? "Breakpoint enable failed" : "Breakpoint disable failed", async cancellationToken =>
+        {
+            if (SelectedBreakpoint is null)
+            {
+                return;
+            }
+
+            var request = new MameDebuggerBreakpointRequest(SelectedBreakpoint.Cpu, SelectedBreakpoint.Address, MameId: SelectedBreakpoint.MameId, DebuggerId: SelectedBreakpoint.DebuggerId);
+            _ = enabled
+                ? await DebuggerService.EnableBreakpointAsync(request, cancellationToken).ConfigureAwait(true)
+                : await DebuggerService.DisableBreakpointAsync(request, cancellationToken).ConfigureAwait(true);
+            await RefreshAsync().ConfigureAwait(true);
+        });
+
+    private Task ClearAsync()
+        => RunDebuggerActionAsync("Breakpoint clear requested.", "Breakpoint clear failed", async cancellationToken =>
+        {
+            var targets = SelectedBreakpoint is null ? Breakpoints.ToArray() : [SelectedBreakpoint];
+            IReadOnlyList<MameDebuggerBreakpoint> remaining = Breakpoints.ToArray();
+            foreach (var target in targets)
+            {
+                var request = new MameDebuggerBreakpointRequest(target.Cpu, target.Address, MameId: target.MameId, DebuggerId: target.DebuggerId);
+                remaining = await DebuggerService.ClearBreakpointAsync(request, cancellationToken).ConfigureAwait(true);
+            }
+
+            Breakpoints.Clear();
+            foreach (var breakpoint in remaining)
+            {
+                Breakpoints.Add(breakpoint);
+            }
+
+            SelectedBreakpoint = null;
+            Log($"Breakpoint clear completed: cleared={targets.Length}, remaining={remaining.Count}.", OutputLogStatus.Info);
+        });
+}
+
+public sealed class DebuggerWatchpointsViewModel : DebuggerPanelViewModelBase
+{
+    private string _addressText = "0x0";
+    private string _lengthText = "1";
+    private MameDebuggerWatchpointType _selectedType = MameDebuggerWatchpointType.ReadWrite;
+    private string _addressSpaceText = "program";
+    private MameDebuggerWatchpoint? _selectedWatchpoint;
+
+    public DebuggerWatchpointsViewModel(IMameDebuggerService debuggerService, Action<string, OutputLogStatus> log)
+        : base(debuggerService, log)
+    {
+        RefreshCommand = new RelayCommand(async () => await RefreshAsync(), IsDebuggerUsable);
+        AddCommand = new RelayCommand(async () => await AddAsync(), IsDebuggerUsable);
+        EnableCommand = new RelayCommand(async () => await SetEnabledAsync(true), () => IsDebuggerUsable() && SelectedWatchpoint is not null);
+        DisableCommand = new RelayCommand(async () => await SetEnabledAsync(false), () => IsDebuggerUsable() && SelectedWatchpoint is not null);
+        ClearCommand = new RelayCommand(async () => await ClearAsync(), IsDebuggerUsable);
+    }
+
+    public ObservableCollection<MameDebuggerWatchpoint> Watchpoints { get; } = [];
+    public IReadOnlyList<MameDebuggerWatchpointType> WatchpointTypes { get; } = Enum.GetValues<MameDebuggerWatchpointType>();
+    public ICommand RefreshCommand { get; }
+    public ICommand AddCommand { get; }
+    public ICommand EnableCommand { get; }
+    public ICommand DisableCommand { get; }
+    public ICommand ClearCommand { get; }
+
+    public string AddressText
+    {
+        get => _addressText;
+        set { if (_addressText != value) { _addressText = value; OnPropertyChanged(); } }
+    }
+
+    public string LengthText
+    {
+        get => _lengthText;
+        set { if (_lengthText != value) { _lengthText = value; OnPropertyChanged(); } }
+    }
+
+    public MameDebuggerWatchpointType SelectedType
+    {
+        get => _selectedType;
+        set { if (_selectedType != value) { _selectedType = value; OnPropertyChanged(); } }
+    }
+
+    public string AddressSpaceText
+    {
+        get => _addressSpaceText;
+        set { if (_addressSpaceText != value) { _addressSpaceText = value; OnPropertyChanged(); } }
+    }
+
+    public MameDebuggerWatchpoint? SelectedWatchpoint
+    {
+        get => _selectedWatchpoint;
+        set { if (_selectedWatchpoint != value) { _selectedWatchpoint = value; OnPropertyChanged(); NotifyCommandStateChanged(); } }
+    }
+
+    public override void NotifyCommandStateChanged() => RaiseCommands(RefreshCommand, AddCommand, EnableCommand, DisableCommand, ClearCommand);
+
+    private Task RefreshAsync()
+        => RunDebuggerActionAsync("Watchpoint refresh requested.", "Watchpoint refresh failed", async cancellationToken =>
+        {
+            var watchpoints = await DebuggerService.GetWatchpointsAsync(null, cancellationToken, NullIfWhiteSpace(AddressSpaceText)).ConfigureAwait(true);
+            Watchpoints.Clear();
+            foreach (var watchpoint in watchpoints)
+            {
+                Watchpoints.Add(watchpoint);
+            }
+
+            Log($"Watchpoints refreshed: count={watchpoints.Count}.", OutputLogStatus.Info);
+        });
+
+    private Task AddAsync()
+        => RunDebuggerActionAsync("Watchpoint add requested.", "Watchpoint add failed", async cancellationToken =>
+        {
+            if (!TryParseInteger(AddressText, out var address))
+            {
+                Log($"Watchpoint address '{AddressText}' is not a valid decimal or 0x-prefixed value.", OutputLogStatus.Warning);
+                return;
+            }
+
+            if (!TryParseInteger(LengthText, out var length) || length <= 0)
+            {
+                Log($"Watchpoint length '{LengthText}' is not a valid positive value.", OutputLogStatus.Warning);
+                return;
+            }
+
+            var watchpoint = await DebuggerService.SetWatchpointAsync(new MameDebuggerWatchpointRequest(DebuggerService.State.CurrentCpu, address, length, SelectedType, AddressSpace: NullIfWhiteSpace(AddressSpaceText)), cancellationToken).ConfigureAwait(true);
+            Watchpoints.Add(watchpoint);
+            SelectedWatchpoint = watchpoint;
+            Log($"Watchpoint #{watchpoint.MameId} added on {watchpoint.Cpu} at {ToHex(watchpoint.Address)} length={watchpoint.Length} type={watchpoint.Type}.", OutputLogStatus.Info);
+        });
+
+    private Task SetEnabledAsync(bool enabled)
+        => RunDebuggerActionAsync(enabled ? "Watchpoint enable requested." : "Watchpoint disable requested.", enabled ? "Watchpoint enable failed" : "Watchpoint disable failed", async cancellationToken =>
+        {
+            if (SelectedWatchpoint is null)
+            {
+                return;
+            }
+
+            var request = new MameDebuggerWatchpointRequest(SelectedWatchpoint.Cpu, SelectedWatchpoint.Address, SelectedWatchpoint.Length, SelectedWatchpoint.Type, AddressSpace: SelectedWatchpoint.AddressSpace, MameId: SelectedWatchpoint.MameId, DebuggerId: SelectedWatchpoint.DebuggerId);
+            _ = enabled
+                ? await DebuggerService.EnableWatchpointAsync(request, cancellationToken).ConfigureAwait(true)
+                : await DebuggerService.DisableWatchpointAsync(request, cancellationToken).ConfigureAwait(true);
+            await RefreshAsync().ConfigureAwait(true);
+        });
+
+    private Task ClearAsync()
+        => RunDebuggerActionAsync("Watchpoint clear requested.", "Watchpoint clear failed", async cancellationToken =>
+        {
+            var targets = SelectedWatchpoint is null ? Watchpoints.ToArray() : [SelectedWatchpoint];
+            IReadOnlyList<MameDebuggerWatchpoint> remaining = Watchpoints.ToArray();
+            foreach (var target in targets)
+            {
+                var request = new MameDebuggerWatchpointRequest(target.Cpu, target.Address, target.Length, target.Type, AddressSpace: target.AddressSpace, MameId: target.MameId, DebuggerId: target.DebuggerId);
+                remaining = await DebuggerService.ClearWatchpointAsync(request, cancellationToken).ConfigureAwait(true);
+            }
+
+            Watchpoints.Clear();
+            foreach (var watchpoint in remaining)
+            {
+                Watchpoints.Add(watchpoint);
+            }
+
+            SelectedWatchpoint = null;
+            Log($"Watchpoint clear completed: cleared={targets.Length}, remaining={remaining.Count}.", OutputLogStatus.Info);
+        });
+
+    private static string? NullIfWhiteSpace(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml
@@ -16,7 +16,7 @@
                 <DataGridTextColumn Header="#" Binding="{Binding MameId}" Width="60" />
                 <DataGridTextColumn Header="CPU" Binding="{Binding Cpu}" Width="120" />
                 <DataGridTextColumn Header="Address" Binding="{Binding Address, StringFormat={}{0:X}}" Width="110" />
-                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="80" />
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, Mode=OneWay}" Width="80" />
                 <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="70" />
                 <DataGridTextColumn Header="Condition" Binding="{Binding Condition}" Width="*" />
             </DataGrid.Columns>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerBreakpointsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,8,0" />
+            <TextBlock Text="Address" VerticalAlignment="Center" Margin="0,0,4,0" />
+            <TextBox Text="{Binding AddressText, UpdateSourceTrigger=PropertyChanged}" Width="90" Margin="0,0,8,0" FontFamily="Consolas" />
+            <Button Content="Add" Command="{Binding AddCommand}" Margin="0,0,8,0" />
+            <Button Content="Enable" Command="{Binding EnableCommand}" Margin="0,0,8,0" />
+            <Button Content="Disable" Command="{Binding DisableCommand}" Margin="0,0,8,0" />
+            <Button Content="Clear Selected/All" Command="{Binding ClearCommand}" />
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Breakpoints}" SelectedItem="{Binding SelectedBreakpoint}" AutoGenerateColumns="False" IsReadOnly="True" CanUserAddRows="False" FontFamily="Consolas">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="#" Binding="{Binding MameId}" Width="60" />
+                <DataGridTextColumn Header="CPU" Binding="{Binding Cpu}" Width="120" />
+                <DataGridTextColumn Header="Address" Binding="{Binding Address, StringFormat={}{0:X}}" Width="110" />
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="80" />
+                <DataGridTextColumn Header="Hits" Binding="{Binding HitCount}" Width="70" />
+                <DataGridTextColumn Header="Condition" Binding="{Binding Condition}" Width="*" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerBreakpointsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerBreakpointsView : UserControl
+{
+    public DebuggerBreakpointsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerControlView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerControlView.xaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerControlView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel>
+        <TextBlock Text="Debugger Control" FontWeight="SemiBold" Margin="0,0,0,8" />
+        <UniformGrid Columns="4" Margin="0,0,0,8">
+            <Button Content="Run" Command="{Binding RunCommand}" Margin="0,0,6,0" />
+            <Button Content="Break" Command="{Binding BreakCommand}" Margin="0,0,6,0" />
+            <Button Content="Step" Command="{Binding StepCommand}" Margin="0,0,6,0" />
+            <Button Content="Status" Command="{Binding RefreshStatusCommand}" />
+        </UniformGrid>
+        <DockPanel Margin="0,0,0,8">
+            <Button DockPanel.Dock="Right" Content="Refresh CPUs" Command="{Binding RefreshCpusCommand}" Margin="8,0,0,0" />
+            <ComboBox ItemsSource="{Binding Cpus}" SelectedValue="{Binding SelectedCpu, Mode=TwoWay}" SelectedValuePath="Tag" DisplayMemberPath="Tag" />
+        </DockPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock Text="Available:" FontWeight="SemiBold" Margin="0,0,8,4" />
+            <TextBlock Grid.Column="1" Text="{Binding IsAvailable}" Margin="0,0,0,4" />
+            <TextBlock Grid.Row="1" Text="State:" FontWeight="SemiBold" Margin="0,0,8,4" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding StateText}" Margin="0,0,0,4" />
+            <TextBlock Grid.Row="2" Text="CPU:" FontWeight="SemiBold" Margin="0,0,8,4" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding CurrentCpuText}" Margin="0,0,0,4" />
+            <TextBlock Grid.Row="3" Text="PC:" FontWeight="SemiBold" Margin="0,0,8,0" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding CurrentPcText}" FontFamily="Consolas" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerControlView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerControlView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerControlView : UserControl
+{
+    public DebuggerControlView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerDisassemblyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerDisassemblyView.xaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerDisassemblyView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="Around PC" Command="{Binding RefreshAroundPcCommand}" Margin="0,0,8,0" />
+            <TextBlock Text="Address" VerticalAlignment="Center" Margin="0,0,4,0" />
+            <TextBox Text="{Binding StartAddressText, UpdateSourceTrigger=PropertyChanged}" Width="90" Margin="0,0,8,0" FontFamily="Consolas" />
+            <TextBlock Text="Lines" VerticalAlignment="Center" Margin="0,0,4,0" />
+            <TextBox Text="{Binding LineCountText, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="0,0,8,0" />
+            <Button Content="From Address" Command="{Binding RefreshFromAddressCommand}" />
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Lines}" SelectedItem="{Binding SelectedLine}" AutoGenerateColumns="False" IsReadOnly="True" HeadersVisibility="Column" CanUserAddRows="False" GridLinesVisibility="Horizontal" FontFamily="Consolas">
+            <DataGrid.Resources>
+                <Style TargetType="DataGridRow">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsCurrentPc}" Value="True">
+                            <Setter Property="Background" Value="#3A5A20" />
+                            <Setter Property="FontWeight" Value="Bold" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.Resources>
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Address" Binding="{Binding Address, StringFormat={}{0:X}}" Width="90" />
+                <DataGridTextColumn Header="Opcode Bytes" Binding="{Binding OpcodeBytes}" Width="140" />
+                <DataGridTextColumn Header="Instruction" Binding="{Binding InstructionText}" Width="2*" />
+                <DataGridTextColumn Header="Raw" Binding="{Binding RawText}" Width="2*" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerDisassemblyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerDisassemblyView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerDisassemblyView : UserControl
+{
+    public DebuggerDisassemblyView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerMemoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <WrapPanel Margin="0,0,0,6">
+                <TextBlock Text="CPU" VerticalAlignment="Center" Margin="0,0,4,0" />
+                <TextBox Text="{Binding CpuText, UpdateSourceTrigger=PropertyChanged}" Width="110" Margin="0,0,8,0" />
+                <TextBlock Text="Space" VerticalAlignment="Center" Margin="0,0,4,0" />
+                <TextBox Text="{Binding AddressSpaceText, UpdateSourceTrigger=PropertyChanged}" Width="90" Margin="0,0,8,0" />
+                <TextBlock Text="Start" VerticalAlignment="Center" Margin="0,0,4,0" />
+                <TextBox Text="{Binding StartAddressText, UpdateSourceTrigger=PropertyChanged}" Width="90" Margin="0,0,8,0" FontFamily="Consolas" />
+                <TextBlock Text="Length" VerticalAlignment="Center" Margin="0,0,4,0" />
+                <TextBox Text="{Binding LengthText, UpdateSourceTrigger=PropertyChanged}" Width="55" Margin="0,0,8,0" />
+                <Button Content="Read" Command="{Binding ReadCommand}" />
+            </WrapPanel>
+        </StackPanel>
+        <TextBox Text="{Binding HexText}" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" TextWrapping="NoWrap" />
+    </DockPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml
@@ -15,6 +15,6 @@
                 <Button Content="Read" Command="{Binding ReadCommand}" />
             </WrapPanel>
         </StackPanel>
-        <TextBox Text="{Binding HexText}" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" TextWrapping="NoWrap" />
+        <TextBox Text="{Binding HexText, Mode=OneWay}" IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" TextWrapping="NoWrap" />
     </DockPanel>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerMemoryView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerMemoryView : UserControl
+{
+    public DebuggerMemoryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml
@@ -8,7 +8,7 @@
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="120" />
                 <DataGridTextColumn Header="Value" Binding="{Binding Value, StringFormat={}{0:X}}" Width="140" />
                 <DataGridTextColumn Header="Display" Binding="{Binding DisplayValue}" Width="*" />
-                <DataGridCheckBoxColumn Header="Editable" Binding="{Binding Editable}" Width="80" />
+                <DataGridCheckBoxColumn Header="Editable" Binding="{Binding Editable, Mode=OneWay}" Width="80" />
             </DataGrid.Columns>
         </DataGrid>
     </DockPanel>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml
@@ -1,0 +1,15 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerRegistersView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel>
+        <Button DockPanel.Dock="Top" Content="Refresh Registers" Command="{Binding RefreshCommand}" HorizontalAlignment="Left" Margin="0,0,0,8" />
+        <DataGrid ItemsSource="{Binding Registers}" AutoGenerateColumns="False" IsReadOnly="True" CanUserAddRows="False" FontFamily="Consolas">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="120" />
+                <DataGridTextColumn Header="Value" Binding="{Binding Value, StringFormat={}{0:X}}" Width="140" />
+                <DataGridTextColumn Header="Display" Binding="{Binding DisplayValue}" Width="*" />
+                <DataGridCheckBoxColumn Header="Editable" Binding="{Binding Editable}" Width="80" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerRegistersView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerRegistersView : UserControl
+{
+    public DebuggerRegistersView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="OasisEditor.Features.MameDebugger.Views.DebuggerWatchpointsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel>
+        <WrapPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,8,4" />
+            <TextBlock Text="Address" VerticalAlignment="Center" Margin="0,0,4,4" />
+            <TextBox Text="{Binding AddressText, UpdateSourceTrigger=PropertyChanged}" Width="90" Margin="0,0,8,4" FontFamily="Consolas" />
+            <TextBlock Text="Length" VerticalAlignment="Center" Margin="0,0,4,4" />
+            <TextBox Text="{Binding LengthText, UpdateSourceTrigger=PropertyChanged}" Width="55" Margin="0,0,8,4" />
+            <TextBlock Text="Type" VerticalAlignment="Center" Margin="0,0,4,4" />
+            <ComboBox ItemsSource="{Binding WatchpointTypes}" SelectedItem="{Binding SelectedType}" Width="100" Margin="0,0,8,4" />
+            <TextBlock Text="Space" VerticalAlignment="Center" Margin="0,0,4,4" />
+            <TextBox Text="{Binding AddressSpaceText, UpdateSourceTrigger=PropertyChanged}" Width="85" Margin="0,0,8,4" />
+            <Button Content="Add" Command="{Binding AddCommand}" Margin="0,0,8,4" />
+            <Button Content="Enable" Command="{Binding EnableCommand}" Margin="0,0,8,4" />
+            <Button Content="Disable" Command="{Binding DisableCommand}" Margin="0,0,8,4" />
+            <Button Content="Clear Selected/All" Command="{Binding ClearCommand}" Margin="0,0,0,4" />
+        </WrapPanel>
+        <DataGrid ItemsSource="{Binding Watchpoints}" SelectedItem="{Binding SelectedWatchpoint}" AutoGenerateColumns="False" IsReadOnly="True" CanUserAddRows="False" FontFamily="Consolas">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="#" Binding="{Binding MameId}" Width="60" />
+                <DataGridTextColumn Header="CPU" Binding="{Binding Cpu}" Width="110" />
+                <DataGridTextColumn Header="Address" Binding="{Binding Address, StringFormat={}{0:X}}" Width="100" />
+                <DataGridTextColumn Header="Length" Binding="{Binding Length}" Width="70" />
+                <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="90" />
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="80" />
+                <DataGridTextColumn Header="Space" Binding="{Binding AddressSpace}" Width="90" />
+                <DataGridTextColumn Header="Latest Hit" Binding="{Binding LatestHit}" Width="*" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml
@@ -24,7 +24,7 @@
                 <DataGridTextColumn Header="Address" Binding="{Binding Address, StringFormat={}{0:X}}" Width="100" />
                 <DataGridTextColumn Header="Length" Binding="{Binding Length}" Width="70" />
                 <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="90" />
-                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="80" />
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, Mode=OneWay}" Width="80" />
                 <DataGridTextColumn Header="Space" Binding="{Binding AddressSpace}" Width="90" />
                 <DataGridTextColumn Header="Latest Hit" Binding="{Binding LatestHit}" Width="*" />
             </DataGrid.Columns>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MameDebugger/Views/DebuggerWatchpointsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace OasisEditor.Features.MameDebugger.Views;
+
+public partial class DebuggerWatchpointsView : UserControl
+{
+    public DebuggerWatchpointsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -134,6 +134,19 @@
                           Command="{Binding OpenPlayViewCommand}" />
                 <MenuItem Header="_Input Map"
                           Command="{Binding OpenInputMapCommand}" />
+                <Separator />
+                <MenuItem Header="Debugger _Control"
+                          Command="{Binding OpenDebuggerControlCommand}" />
+                <MenuItem Header="Debugger _Disassembly"
+                          Command="{Binding OpenDebuggerDisassemblyCommand}" />
+                <MenuItem Header="Debugger _Registers"
+                          Command="{Binding OpenDebuggerRegistersCommand}" />
+                <MenuItem Header="Debugger _Memory"
+                          Command="{Binding OpenDebuggerMemoryCommand}" />
+                <MenuItem Header="Debugger _Breakpoints"
+                          Command="{Binding OpenDebuggerBreakpointsCommand}" />
+                <MenuItem Header="Debugger _Watchpoints"
+                          Command="{Binding OpenDebuggerWatchpointsCommand}" />
             </MenuItem>
             <MenuItem Header="_Emulation">
                 <MenuItem.Resources>
@@ -187,6 +200,27 @@
                 <MenuItem Header="_Hard Reset"
                           Command="{Binding HardResetEmulationCommand}"
                           Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                <Separator />
+                <MenuItem Header="Open Debugger _Panels">
+                    <MenuItem Header="_Control"
+                              Command="{Binding OpenDebuggerControlCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Disassembly"
+                              Command="{Binding OpenDebuggerDisassemblyCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Registers"
+                              Command="{Binding OpenDebuggerRegistersCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Memory"
+                              Command="{Binding OpenDebuggerMemoryCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Breakpoints"
+                              Command="{Binding OpenDebuggerBreakpointsCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                    <MenuItem Header="_Watchpoints"
+                              Command="{Binding OpenDebuggerWatchpointsCommand}"
+                              Style="{StaticResource EmulationMenuItemWithCheckSlotStyle}" />
+                </MenuItem>
                 <Separator />
                 <MenuItem Header="Debugger _Status"
                           Command="{Binding RefreshDebuggerStatusCommand}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows.Media;
 using System.Collections.Specialized;
 using Microsoft.Win32;
 using OasisEditor.Features.MameDebugger;
+using OasisEditor.Features.MameDebugger.ViewModels;
 using OasisEditor.Features.MfmeImport;
 using EditorCommands = OasisEditor.Commands;
 using OasisEditor.Views;
@@ -72,6 +73,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IMameEmulationService _mameEmulationService;
     private readonly IMameProcessRunner _mameProcessRunner;
     private readonly IMameDebuggerService _mameDebuggerService;
+    private readonly MameDebuggerShellViewModel _mameDebuggerShell;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
     private bool _isAutoProvisioningMame;
     private bool _isMameUnthrottled;
@@ -113,6 +115,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenProjectSettingsCommand = new RelayCommand(OpenProjectSettings);
         OpenInputMapCommand = new RelayCommand(OpenInputMap);
         OpenPlayViewCommand = new RelayCommand(OpenPlayView);
+        OpenDebuggerControlCommand = new RelayCommand(OpenDebuggerControl);
+        OpenDebuggerDisassemblyCommand = new RelayCommand(OpenDebuggerDisassembly);
+        OpenDebuggerRegistersCommand = new RelayCommand(OpenDebuggerRegisters);
+        OpenDebuggerMemoryCommand = new RelayCommand(OpenDebuggerMemory);
+        OpenDebuggerBreakpointsCommand = new RelayCommand(OpenDebuggerBreakpoints);
+        OpenDebuggerWatchpointsCommand = new RelayCommand(OpenDebuggerWatchpoints);
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
         BrowseMameExecutableCommand = new RelayCommand(BrowseMameExecutable);
         ValidateMamePreferencesCommand = new RelayCommand(ValidateMamePreferences);
@@ -251,6 +259,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameDebuggerService = new MameDebuggerService(
             _mameProcessRunner,
             message => AddOutputEntry(message, OutputLogStatus.Info));
+        _mameDebuggerShell = new MameDebuggerShellViewModel(_mameDebuggerService, AddOutputEntry);
         _mameDebuggerService.DebuggerEventReceived += (_, debuggerEvent) =>
         {
             DispatchToUiThread(() =>
@@ -259,6 +268,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     $"MAME debugger event: {debuggerEvent.Event} state={debuggerEvent.State ?? "unknown"} cpu={debuggerEvent.Cpu ?? "unknown"} pc={debuggerEvent.Pc?.ToString() ?? "unknown"}.",
                     OutputLogStatus.Info);
                 NotifyEmulationCommands();
+                _mameDebuggerShell.NotifyCommandStateChanged();
             });
         };
         _mameEmulationService = new MameEmulationService(
@@ -405,6 +415,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenProjectSettingsCommand { get; }
     public ICommand OpenInputMapCommand { get; }
     public ICommand OpenPlayViewCommand { get; }
+    public ICommand OpenDebuggerControlCommand { get; }
+    public ICommand OpenDebuggerDisassemblyCommand { get; }
+    public ICommand OpenDebuggerRegistersCommand { get; }
+    public ICommand OpenDebuggerMemoryCommand { get; }
+    public ICommand OpenDebuggerBreakpointsCommand { get; }
+    public ICommand OpenDebuggerWatchpointsCommand { get; }
     public ICommand ClosePreferencesCommand { get; }
     public ICommand BrowseMameExecutableCommand { get; }
     public ICommand ValidateMamePreferencesCommand { get; }
@@ -446,6 +462,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
     public ObservableCollection<OutputLogEntry> OutputEntries { get; }
     public OutputLogViewModel OutputLog => _outputLog;
+    public MameDebuggerShellViewModel DebuggerShell => _mameDebuggerShell;
     public IReadOnlyList<AssetDirectoryNodeViewModel> AssetDirectoryTree => _assetBrowser.AssetDirectoryTree;
 
 
@@ -1780,6 +1797,42 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry("Opened Play View pane.", OutputLogStatus.Info);
     }
 
+    private void OpenDebuggerControl()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerControl);
+        AddOutputEntry("Opened Debugger Control pane.", OutputLogStatus.Info);
+    }
+
+    private void OpenDebuggerDisassembly()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerDisassembly);
+        AddOutputEntry("Opened Disassembly pane.", OutputLogStatus.Info);
+    }
+
+    private void OpenDebuggerRegisters()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerRegisters);
+        AddOutputEntry("Opened Registers pane.", OutputLogStatus.Info);
+    }
+
+    private void OpenDebuggerMemory()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerMemory);
+        AddOutputEntry("Opened Memory pane.", OutputLogStatus.Info);
+    }
+
+    private void OpenDebuggerBreakpoints()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerBreakpoints);
+        AddOutputEntry("Opened Breakpoints pane.", OutputLogStatus.Info);
+    }
+
+    private void OpenDebuggerWatchpoints()
+    {
+        ToolWindowOpenRequested?.Invoke(EditorToolWindowId.DebuggerWatchpoints);
+        AddOutputEntry("Opened Watchpoints pane.", OutputLogStatus.Info);
+    }
+
     private void ClosePreferences()
     {
         ToolWindowCloseRequested?.Invoke(EditorToolWindowId.Preferences);
@@ -3092,6 +3145,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(AddTestDebuggerBreakpointCommand);
         RaiseEmulationCommandCanExecuteChanged(DisassembleAroundCurrentPcCommand);
         RaiseEmulationCommandCanExecuteChanged(DisassembleFixedAddressTestBlockCommand);
+        _mameDebuggerShell.NotifyCommandStateChanged();
     }
 
     private static void RaiseEmulationCommandCanExecuteChanged(ICommand command)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -6,6 +6,7 @@
              xmlns:layout="clr-namespace:AvalonDock.Layout;assembly=AvalonDock"
              xmlns:themes="clr-namespace:AvalonDock.Themes;assembly=AvalonDock.Themes.VS2013"
              xmlns:views="clr-namespace:OasisEditor.Views"
+             xmlns:debuggerViews="clr-namespace:OasisEditor.Features.MameDebugger.Views"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
              d:DesignHeight="450"
@@ -89,6 +90,33 @@
                                     <views:ProjectSettingsView />
                                 </Border>
                             </layout:LayoutAnchorable>
+
+                            <layout:LayoutAnchorable Title="Debugger Control"
+                                                     ContentId="DebuggerControl"
+                                                     CanClose="True">
+                                <Border Padding="10"
+                                        Background="{DynamicResource InspectorBackgroundBrush}">
+                                    <debuggerViews:DebuggerControlView DataContext="{Binding DebuggerShell.Control}" />
+                                </Border>
+                            </layout:LayoutAnchorable>
+
+                            <layout:LayoutAnchorable Title="Registers"
+                                                     ContentId="DebuggerRegisters"
+                                                     CanClose="True">
+                                <Border Padding="10"
+                                        Background="{DynamicResource InspectorBackgroundBrush}">
+                                    <debuggerViews:DebuggerRegistersView DataContext="{Binding DebuggerShell.Registers}" />
+                                </Border>
+                            </layout:LayoutAnchorable>
+
+                            <layout:LayoutAnchorable Title="Memory"
+                                                     ContentId="DebuggerMemory"
+                                                     CanClose="True">
+                                <Border Padding="10"
+                                        Background="{DynamicResource InspectorBackgroundBrush}">
+                                    <debuggerViews:DebuggerMemoryView DataContext="{Binding DebuggerShell.Memory}" />
+                                </Border>
+                            </layout:LayoutAnchorable>
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 
@@ -108,6 +136,33 @@
                             <Border Padding="10"
                                     Background="{DynamicResource ToolBarBackgroundBrush}">
                                 <views:OutputLogView DataContext="{Binding OutputLog}" />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
+                        <layout:LayoutAnchorable Title="Disassembly"
+                                                 ContentId="DebuggerDisassembly"
+                                                 CanClose="True">
+                            <Border Padding="10"
+                                    Background="{DynamicResource ToolBarBackgroundBrush}">
+                                <debuggerViews:DebuggerDisassemblyView DataContext="{Binding DebuggerShell.Disassembly}" />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
+                        <layout:LayoutAnchorable Title="Breakpoints"
+                                                 ContentId="DebuggerBreakpoints"
+                                                 CanClose="True">
+                            <Border Padding="10"
+                                    Background="{DynamicResource ToolBarBackgroundBrush}">
+                                <debuggerViews:DebuggerBreakpointsView DataContext="{Binding DebuggerShell.Breakpoints}" />
+                            </Border>
+                        </layout:LayoutAnchorable>
+
+                        <layout:LayoutAnchorable Title="Watchpoints"
+                                                 ContentId="DebuggerWatchpoints"
+                                                 CanClose="True">
+                            <Border Padding="10"
+                                    Background="{DynamicResource ToolBarBackgroundBrush}">
+                                <debuggerViews:DebuggerWatchpointsView DataContext="{Binding DebuggerShell.Watchpoints}" />
                             </Border>
                         </layout:LayoutAnchorable>
                     </layout:LayoutAnchorablePane>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -7,10 +7,7 @@ namespace OasisEditor.Views;
 
 public partial class EditorShellView : UserControl
 {
-    private bool _preferencesHideOnCloseConfigured;
-    private bool _projectSettingsHideOnCloseConfigured;
-    private bool _inputMapHideOnCloseConfigured;
-    private bool _playViewHideOnCloseConfigured;
+    private readonly HashSet<EditorToolWindowId> _hideOnCloseConfigured = [];
 
     public EditorShellView()
     {
@@ -20,6 +17,12 @@ public partial class EditorShellView : UserControl
         HideToolWindow(EditorToolWindowId.ProjectSettings);
         HideToolWindow(EditorToolWindowId.InputMap);
         HideToolWindow(EditorToolWindowId.PlayView);
+        HideToolWindow(EditorToolWindowId.DebuggerControl);
+        HideToolWindow(EditorToolWindowId.DebuggerDisassembly);
+        HideToolWindow(EditorToolWindowId.DebuggerRegisters);
+        HideToolWindow(EditorToolWindowId.DebuggerMemory);
+        HideToolWindow(EditorToolWindowId.DebuggerBreakpoints);
+        HideToolWindow(EditorToolWindowId.DebuggerWatchpoints);
     }
 
     public void ShowOrFocusToolWindow(EditorToolWindowId toolWindowId)
@@ -89,6 +92,12 @@ public partial class EditorShellView : UserControl
         ConfigureHideOnClose(EditorToolWindowId.ProjectSettings);
         ConfigureHideOnClose(EditorToolWindowId.InputMap);
         ConfigureHideOnClose(EditorToolWindowId.PlayView);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerControl);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerDisassembly);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerRegisters);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerMemory);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerBreakpoints);
+        ConfigureHideOnClose(EditorToolWindowId.DebuggerWatchpoints);
 
         if (DataContext is not MainWindowViewModel viewModel)
         {
@@ -109,49 +118,12 @@ public partial class EditorShellView : UserControl
     private void ConfigureHideOnClose(EditorToolWindowId toolWindowId)
     {
         var target = FindToolWindow(toolWindowId);
-        if (target is null)
-        {
-            return;
-        }
-
-        if (toolWindowId == EditorToolWindowId.Preferences && _preferencesHideOnCloseConfigured)
-        {
-            return;
-        }
-
-        if (toolWindowId == EditorToolWindowId.ProjectSettings && _projectSettingsHideOnCloseConfigured)
-        {
-            return;
-        }
-
-        if (toolWindowId == EditorToolWindowId.InputMap && _inputMapHideOnCloseConfigured)
-        {
-            return;
-        }
-
-        if (toolWindowId == EditorToolWindowId.PlayView && _playViewHideOnCloseConfigured)
+        if (target is null || !_hideOnCloseConfigured.Add(toolWindowId))
         {
             return;
         }
 
         target.Closing += OnToolWindowClosingHideInstead;
-
-        if (toolWindowId == EditorToolWindowId.Preferences)
-        {
-            _preferencesHideOnCloseConfigured = true;
-        }
-        else if (toolWindowId == EditorToolWindowId.ProjectSettings)
-        {
-            _projectSettingsHideOnCloseConfigured = true;
-        }
-        else if (toolWindowId == EditorToolWindowId.InputMap)
-        {
-            _inputMapHideOnCloseConfigured = true;
-        }
-        else if (toolWindowId == EditorToolWindowId.PlayView)
-        {
-            _playViewHideOnCloseConfigured = true;
-        }
     }
 
     private static void OnToolWindowClosingHideInstead(object? sender, CancelEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorToolWindowId.cs
@@ -9,5 +9,11 @@ public enum EditorToolWindowId
     PlayView,
     Preferences,
     ProjectSettings,
-    InputMap
+    InputMap,
+    DebuggerControl,
+    DebuggerDisassembly,
+    DebuggerRegisters,
+    DebuggerMemory,
+    DebuggerBreakpoints,
+    DebuggerWatchpoints
 }


### PR DESCRIPTION
### Motivation
- Provide the first dockable debugger UI in the AvalonDock-based editor shell so users can interact with the already-implemented MAME debugger backend without changing the backend protocol or AvalonDock.
- Keep panel state isolated in dedicated viewmodels under `Features/MameDebugger/ViewModels` instead of hoisting all state into `MainWindowViewModel`.
- Surface the panels via the existing Editor shell and menus so they can be opened/hidden, and refresh relevant views automatically on debugger events.

### Description
- Added six new dockable tool windows and IDs in `EditorToolWindowId` and the shell: `DebuggerControl`, `DebuggerDisassembly`, `DebuggerRegisters`, `DebuggerMemory`, `DebuggerBreakpoints`, and `DebuggerWatchpoints`, and placed their `LayoutAnchorable` entries into `EditorShellView.xaml` bound to the new views.
- Implemented dedicated viewmodels under `OasisEditor/Features/MameDebugger/ViewModels` and corresponding WPF views under `OasisEditor/Features/MameDebugger/Views` for each panel, plus a `MameDebuggerShellViewModel` that composes the panel viewmodels and reacts to `IMameDebuggerService.DebuggerEventReceived` events.
- Integrated the debugger shell into `MainWindowViewModel`: created `_mameDebuggerShell`, exposed `DebuggerShell` in the main VM, added panel-open commands (e.g. `OpenDebuggerControlCommand`) and menu/window entries that call `ToolWindowOpenRequested` to show the panels, and wired event-driven UI refreshes so stopped/step events refresh status/disassembly/registers.
- Mappings to existing backend APIs: Control uses `GetStatusAsync`, `GetCpuListAsync`, `RunAsync`, `BreakAsync`, `StepAsync`; Disassembly uses `GetStatusAsync` + `DisassembleAsync` (around-PC and explicit address); Registers uses `GetStatusAsync` + `GetRegistersAsync`; Memory uses `ReadMemoryAsync` (CPU/address-space/start/length); Breakpoints uses `GetBreakpointsAsync`, `SetBreakpointAsync`, `EnableBreakpointAsync`, `DisableBreakpointAsync`, `ClearBreakpointAsync`; Watchpoints uses `GetWatchpointsAsync`, `SetWatchpointAsync`, `EnableWatchpointAsync`, `DisableWatchpointAsync`, `ClearWatchpointAsync`.
- Kept the existing temporary Emulation menu commands (status, CPU list, run/break/step, breakpoint/watchpoint list, test breakpoint, disassembly preview) and added a grouped "Open Debugger Panels" submenu and Window menu entries to open each panel.
- Added conservative UI behaviors: manual Refresh buttons on panels; CPU/address fields where applicable; panels are defensive when debugger unavailable and log errors to Output instead of crashing.

### Testing
- New unit tests added: `OasisEditor.Tests/MameDebuggerPanelViewModelTests.cs` provide viewmodel-level coverage using a fake `IMameDebuggerService` (no live MAME required). These tests are committed but were not executed in this environment.
- Automated build/test attempt: `dotnet build` and `dotnet test` were attempted but could not run here because the `dotnet` CLI is unavailable (failure: `/bin/bash: line 1: dotnet: command not found`).
- Quick checks performed: repository static checks and `git diff --check` were run locally in the rollout and returned no issues; changes were committed.

Notes / Manual acceptance checklist
- Start the editor in debugger launch mode, open the panels from the Window menu or the new Emulation -> "Open Debugger Panels" submenu, break execution, and verify: status and current PC are shown in Debugger Control, Disassembly refreshes around PC or from a supplied address, Registers refresh lists registers, Memory read shows a hex dump, and Breakpoints/Watchpoints can list/add/enable/disable/clear using the underlying Phase 3 service API endpoints.
- Known limitations: no source-level debugging, stack traces, or symbol loading; register edits and memory writes are intentionally omitted in this first UI pass; clearing breakpoints/watchpoints uses the backend clear-by-id API and is implemented conservatively (clears selected items or iterates the list).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f3a5735f08327a6882469ce635bbe)