### PR TITLE
Add Epoch MAME input port mapping

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputPortResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameInputPortResolverTests.cs
@@ -30,6 +30,25 @@ public sealed class MameInputPortResolverTests
         Assert.Equal("4", target.Mask);
     }
 
+    [Theory]
+    [InlineData("0", "IN0", "1")]
+    [InlineData("17", "COINS", "2")]
+    [InlineData("24", "STAKE", "1")]
+    [InlineData("48", "CAB1", "1")]
+    [InlineData("57", "CAB2", "2")]
+    [InlineData("64", "DSW1", "1")]
+    [InlineData("73", "DSW2", "2")]
+    public void TryResolve_EpochButton_ResolvesTagAndMask(string buttonNumber, string expectedTag, string expectedMask)
+    {
+        var input = new InputDefinitionModel { Id = "1", Kind = InputDefinitionKind.Button, ButtonNumber = buttonNumber };
+
+        var ok = _resolver.TryResolve(FruitMachinePlatformType.Epoch, input, out var target);
+
+        Assert.True(ok);
+        Assert.Equal(expectedTag, target.Tag);
+        Assert.Equal(expectedMask, target.Mask);
+    }
+
     [Fact]
     public void TryResolve_UnsupportedPlatform_ReturnsFalse()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameInputPortResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameInputPortResolver.cs
@@ -46,6 +46,7 @@ public sealed class MameInputPortResolver : IMameInputPortResolver
         {
             FruitMachinePlatformType.MPU4 => ["ORANGE1", "ORANGE2", "BLACK1", "BLACK2", "AUX1", "AUX2", "DIL1", "DIL2"],
             FruitMachinePlatformType.Impact => ["???", "???", "J10_0", "J10_1", "J10_2", "J9_0", "J9_1", "J9_2", "COIN_SENSE", "COINS"],
+            FruitMachinePlatformType.Epoch => ["IN0", "IN1", "COINS", "STAKE", "REELS", "AUX", "CAB1", "CAB2", "DSW1", "DSW2"],
             FruitMachinePlatformType.Scorpion4 => BuildScorpion4(),
             _ => []
         };


### PR DESCRIPTION
### Motivation
- Support MFME/MAME input mapping for the Maygay Epoch platform so input definitions from MFME can be resolved to MAME input tags.
- Provide unit coverage for the new mapping so the resolver behavior for representative Epoch button numbers is verified.

### Description
- Added an Epoch tag sequence in `MameInputPortResolver.TryResolveTag` mapping MFME port groups to `IN0`, `IN1`, `COINS`, `STAKE`, `REELS`, `AUX`, `CAB1`, `CAB2`, `DSW1`, and `DSW2`.
- Added a parameterized unit test `TryResolve_EpochButton_ResolvesTagAndMask` to `MameInputPortResolverTests` that verifies tag and mask resolution for sample button numbers (e.g. `"0" -> IN0/1`, `"17" -> COINS/2`, `"24" -> STAKE/1`, `"48" -> CAB1/1`, `"57" -> CAB2/2`, `"64" -> DSW1/1`, `"73" -> DSW2/2`).
- Left existing mask calculation (`GetMask`) and other platform mappings unchanged.

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` but the `dotnet` command is not available in this environment, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2061e35d988327906fa8b1e3950d6d)