### PR TITLE
Add VFD 96x8 dot-matrix element (vfddotmatrix0..767)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -118,13 +118,36 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.Equal(4, masks[15]);
     }
 
+
+    [Fact]
+    public void ApplyVfdDotMatrixDotState_UpdatesDotMatrixElements()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplyVfdDotMatrixDotState(0, true);
+        adapter.ApplyVfdDotMatrixDotState(1, false);
+        adapter.ApplyVfdDotMatrixDotState(767, true);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var dots = document.RuntimeState.GetVfdDotMatrixDots("vfd-dot-0", MameVfdDotMatrixStateParser.DotCount);
+        Assert.Equal(MameVfdDotMatrixStateParser.DotCount, dots.Length);
+        Assert.True(dots[0]);
+        Assert.False(dots[1]);
+        Assert.True(dots[767]);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");
         var tab = new DocumentTabViewModel(panelDocument);
         tab.SetPanelElements([
             new PanelElementModel { ObjectId = "alpha-0", Kind = PanelElementKind.Alpha, DisplayNumber = 0 },
-            new PanelElementModel { ObjectId = "seven-3", Kind = PanelElementKind.SevenSegment, DisplayNumber = 3 }
+            new PanelElementModel { ObjectId = "seven-3", Kind = PanelElementKind.SevenSegment, DisplayNumber = 3 },
+            new PanelElementModel { ObjectId = "vfd-dot-0", Kind = PanelElementKind.VfdDotMatrix }
         ]);
         return tab;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -112,6 +112,23 @@ public sealed class MameStdoutParserTests
         Assert.Equal(0, duty.CellId);
         Assert.Equal(1d, duty.Brightness);
     }
+
+    [Fact]
+    public void ProcessLine_WhenVfdDotMatrixLine_AppliesDotMatrixState()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter);
+
+        parser.ProcessLine("vfddotmatrix767 = 1");
+
+        var dot = Assert.Single(segmentAdapter.DotMatrixCalls);
+        Assert.Equal(767, dot.DotIndex);
+        Assert.True(dot.IsOn);
+        Assert.Empty(segmentAdapter.Calls);
+    }
+
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
     {
         public List<(int LampId, int Value)> Calls { get; } = [];
@@ -128,7 +145,9 @@ public sealed class MameStdoutParserTests
     {
         public List<(int CellId, int Mask, MameSegmentOutputType OutputType)> Calls { get; } = [];
         public List<(int CellId, double Brightness)> BrightnessCalls { get; } = [];
+        public List<(int DotIndex, bool IsOn)> DotMatrixCalls { get; } = [];
         public void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType) => Calls.Add((cellId, segmentMask, outputType));
         public void ApplyVfdBrightness(int cellId, double normalizedBrightness) => BrightnessCalls.Add((cellId, normalizedBrightness));
+        public void ApplyVfdDotMatrixDotState(int dotIndex, bool isOn) => DotMatrixCalls.Add((dotIndex, isOn));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDotMatrixStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDotMatrixStateParserTests.cs
@@ -1,0 +1,30 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameVfdDotMatrixStateParserTests
+{
+    private readonly MameVfdDotMatrixStateParser _parser = new();
+
+    [Theory]
+    [InlineData("vfddotmatrix0 = 1", 0, true)]
+    [InlineData("vfddotmatrix767 = 1", 767, true)]
+    [InlineData("vfddotmatrix767 = 0", 767, false)]
+    [InlineData("vfddotmatrix767 = -1", 767, false)]
+    public void TryParse_ParsesSupportedDotRange(string line, int expectedIndex, bool expectedOn)
+    {
+        Assert.True(_parser.TryParse(line, out var dotIndex, out var isOn));
+        Assert.Equal(expectedIndex, dotIndex);
+        Assert.Equal(expectedOn, isOn);
+    }
+
+    [Theory]
+    [InlineData("vfddotmatrix768 = 1")]
+    [InlineData("vfddotmatrix-1 = 1")]
+    [InlineData("vfd0 = 1")]
+    public void TryParse_RejectsUnsupportedLines(string line)
+    {
+        Assert.False(_parser.TryParse(line, out _, out _));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -75,6 +75,29 @@ public sealed class Panel2DRoundTripTests
     }
 
     [Fact]
+    public void ToStorageElement_VfdDotMatrix_SerializesKindAndClearsOffColor()
+    {
+        var element = Panel2DDocumentStorage.ToStorageElement(new PanelElementModel
+        {
+            ObjectId = "dot-1",
+            Name = "Dot Matrix",
+            Kind = PanelElementKind.VfdDotMatrix,
+            X = 10,
+            Y = 20,
+            Width = 480,
+            Height = 80,
+            OnColorHex = "#FF4040",
+            OffColorHex = "#111111"
+        });
+
+        Assert.Equal("vfdDotMatrix", element.Kind);
+        Assert.Equal("#FF4040", element.OnColorHex);
+        Assert.Null(element.OffColorHex);
+        Assert.Equal("#FF4040", element.Native?.OnColorHex);
+        Assert.Null(element.Native?.OffColorHex);
+    }
+
+    [Fact]
     public void BuildOpenDocumentData_WithInvalidPanelJson_ReturnsClearErrorSummary()
     {
         const string path = "C:/Repo/Assets/bad.panel2d";

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -18,6 +18,7 @@ public sealed class PanelElementFactoryTests
     [InlineData((int)PanelElementKind.Reel)]
     [InlineData((int)PanelElementKind.SevenSegment)]
     [InlineData((int)PanelElementKind.Alpha)]
+    [InlineData((int)PanelElementKind.VfdDotMatrix)]
     public void CreateVisualFromElement_ForNativeKinds_PreservesElementKindForRoundTrip(int kindValue)
     {
         RunInSta(() =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -12,6 +12,11 @@ internal static class CanvasMutationCommands
         return new AddPanelElementMutationCommand(documentId, document, element, "Add image");
     }
 
+    public static Commands.ICommand CreateAddVfdDotMatrixCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
+    {
+        return new AddPanelElementMutationCommand(documentId, document, element, "Add VFD dot matrix");
+    }
+
     public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
     {
         return new DeleteElementMutationCommand(documentId, document, selection);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -109,6 +109,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
         ImportMfmeExtractCommand = new RelayCommand(ImportMfmeExtract, CanImportMfmeExtract);
+        AddVfdDotMatrixElementCommand = new RelayCommand(AddVfdDotMatrixElement, CanAddVfdDotMatrixElement);
         SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         OpenPreferencesCommand = new RelayCommand(OpenPreferences);
@@ -389,6 +390,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
     public ICommand ImportMfmeExtractCommand { get; }
+    public ICommand AddVfdDotMatrixElementCommand { get; }
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
@@ -1004,6 +1006,28 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Open document failed: {ex.Message}", OutputLogStatus.Error);
             MessageBox.Show(ex.Message, "Open Document Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
         }
+    }
+
+
+    private bool CanAddVfdDotMatrixElement()
+    {
+        return SelectedDocument?.Document.DocumentType == EditorDocumentType.Panel2D;
+    }
+
+    private void AddVfdDotMatrixElement()
+    {
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument?.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        var element = PanelElementFactory.CreateVfdDotMatrixElement(new Point(
+            Math.Max(PanelElementFactory.NewVfdDotMatrixWidth / 2d, -selectedDocument.PanelPanX + 40d + (PanelElementFactory.NewVfdDotMatrixWidth / 2d)),
+            Math.Max(PanelElementFactory.NewVfdDotMatrixHeight / 2d, -selectedDocument.PanelPanY + 40d + (PanelElementFactory.NewVfdDotMatrixHeight / 2d))));
+        ExecuteDocumentCanvasCommand(
+            selectedDocument.DocumentId,
+            CanvasMutationCommands.CreateAddVfdDotMatrixCommand(selectedDocument.DocumentId, selectedDocument, element));
     }
 
     private bool CanImportMfmeExtract()
@@ -3099,6 +3123,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (ImportMfmeExtractCommand is RelayCommand importMfmeRelayCommand)
         {
             importMfmeRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (AddVfdDotMatrixElementCommand is RelayCommand addVfdDotMatrixCommand)
+        {
+            addVfdDotMatrixCommand.RaiseCanExecuteChanged();
         }
 
         if (SaveSelectedDocumentCommand is RelayCommand saveRelayCommand)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -52,6 +52,7 @@ public interface IMameSegmentRuntimeAdapter
 {
     void ApplySegmentState(int cellId, int segmentMask, MameSegmentOutputType outputType);
     void ApplyVfdBrightness(int cellId, double normalizedBrightness);
+    void ApplyVfdDotMatrixDotState(int dotIndex, bool isOn);
 }
 
 public sealed record MameProcessLaunchRequest(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -8,9 +8,11 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Action<Action> _uiDispatch;
     private readonly Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> _pendingMasks = new();
     private readonly Dictionary<int, double> _pendingVfdBrightnessByDisplay = new();
+    private readonly Dictionary<int, bool> _pendingVfdDotMatrixDots = new();
     private readonly Dictionary<int, int> _latestVfdMasksByCell = new();
     private readonly Dictionary<int, int> _latestDigitMasksByCell = new();
     private readonly Dictionary<int, double> _latestVfdBrightnessByDisplay = new();
+    private readonly bool[] _latestVfdDotMatrixDots = new bool[MameVfdDotMatrixStateParser.DotCount];
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch, Func<FruitMachinePlatformType>? platformProvider = null)
@@ -44,16 +46,36 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         _uiDispatch(ApplyPendingOnUiThread);
     }
 
+    public void ApplyVfdDotMatrixDotState(int dotIndex, bool isOn)
+    {
+        if (dotIndex is < 0 or >= MameVfdDotMatrixStateParser.DotCount)
+        {
+            return;
+        }
+
+        lock (_pendingSync)
+        {
+            _pendingVfdDotMatrixDots[dotIndex] = isOn;
+            if (_uiUpdateScheduled) return;
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
     private void ApplyPendingOnUiThread()
     {
         Dictionary<int, (int Mask, MameSegmentOutputType OutputType)> snapshot;
         Dictionary<int, double> brightnessSnapshot;
+        Dictionary<int, bool> dotMatrixSnapshot;
         lock (_pendingSync)
         {
             snapshot = new(_pendingMasks);
             brightnessSnapshot = new(_pendingVfdBrightnessByDisplay);
+            dotMatrixSnapshot = new(_pendingVfdDotMatrixDots);
             _pendingMasks.Clear();
             _pendingVfdBrightnessByDisplay.Clear();
+            _pendingVfdDotMatrixDots.Clear();
             _uiUpdateScheduled = false;
         }
 
@@ -76,6 +98,22 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
             foreach (var (cellId, brightness) in brightnessSnapshot)
             {
                 _latestVfdBrightnessByDisplay[cellId] = brightness;
+            }
+
+            foreach (var (dotIndex, isOn) in dotMatrixSnapshot)
+            {
+                _latestVfdDotMatrixDots[dotIndex] = isOn;
+            }
+
+            if (dotMatrixSnapshot.Count > 0)
+            {
+                foreach (var element in document.GetPanelElements().Where(e => e.Kind == PanelElementKind.VfdDotMatrix && !string.IsNullOrWhiteSpace(e.ObjectId)))
+                {
+                    if (document.RuntimeState.SetVfdDotMatrixDotsIfChanged(element.ObjectId, _latestVfdDotMatrixDots))
+                    {
+                        changedObjectIds.Add(element.ObjectId);
+                    }
+                }
             }
 
             foreach (var element in document.GetPanelElements().Where(e => (e.Kind == PanelElementKind.Alpha || e.Kind == PanelElementKind.SevenSegment) && !string.IsNullOrWhiteSpace(e.ObjectId)))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -9,6 +9,7 @@ public sealed class MameStdoutParser : IMameStdoutParser
     private readonly IMameSegmentStateParser _segmentStateParser;
     private readonly IMameSegmentRuntimeAdapter _segmentRuntimeAdapter;
     private readonly MameVfdDutyParser _vfdDutyParser;
+    private readonly IMameVfdDotMatrixStateParser _vfdDotMatrixStateParser;
     private readonly Func<FruitMachinePlatformType> _platformProvider;
 
     public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Func<FruitMachinePlatformType>? platformProvider = null)
@@ -20,6 +21,7 @@ public sealed class MameStdoutParser : IMameStdoutParser
         _segmentStateParser = segmentStateParser ?? throw new ArgumentNullException(nameof(segmentStateParser));
         _segmentRuntimeAdapter = segmentRuntimeAdapter ?? throw new ArgumentNullException(nameof(segmentRuntimeAdapter));
         _vfdDutyParser = new MameVfdDutyParser();
+        _vfdDotMatrixStateParser = new MameVfdDotMatrixStateParser();
         _platformProvider = platformProvider ?? (() => FruitMachinePlatformType.MPU4);
     }
 
@@ -45,6 +47,12 @@ public sealed class MameStdoutParser : IMameStdoutParser
         if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask, out var outputType))
         {
             _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask, outputType);
+            return;
+        }
+
+        if (_vfdDotMatrixStateParser.TryParse(line, out var dotIndex, out var isDotOn))
+        {
+            _segmentRuntimeAdapter.ApplyVfdDotMatrixDotState(dotIndex, isDotOn);
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixStateParser.cs
@@ -1,0 +1,41 @@
+namespace OasisEditor;
+using System.Text.RegularExpressions;
+
+public interface IMameVfdDotMatrixStateParser
+{
+    bool TryParse(string line, out int dotIndex, out bool isOn);
+}
+
+public sealed class MameVfdDotMatrixStateParser : IMameVfdDotMatrixStateParser
+{
+    public const int Columns = 96;
+    public const int Rows = 8;
+    public const int DotCount = Columns * Rows;
+
+    private static readonly Regex DotLineRegex = new(
+        @"^vfddotmatrix\s*(\d+)\s*=\s*(-?\d+)\s*$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public bool TryParse(string line, out int dotIndex, out bool isOn)
+    {
+        dotIndex = 0;
+        isOn = false;
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var match = DotLineRegex.Match(line.Trim());
+        if (!match.Success
+            || !int.TryParse(match.Groups[1].Value, out dotIndex)
+            || dotIndex < 0
+            || dotIndex >= DotCount
+            || !int.TryParse(match.Groups[2].Value, out var rawValue))
+        {
+            return false;
+        }
+
+        isOn = rawValue == 1;
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -54,6 +54,13 @@ internal static class Panel2DDocumentStorage
         {
             return PanelElementKind.Alpha;
         }
+
+        if (string.Equals(kind, "vfddotmatrix", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(kind, "vfdDotMatrix", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.VfdDotMatrix;
+        }
+
         if (string.Equals(kind, "label", StringComparison.OrdinalIgnoreCase))
         {
             return PanelElementKind.Label;
@@ -75,6 +82,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "reel",
             PanelElementKind.SevenSegment => "sevenSegment",
             PanelElementKind.Alpha => "alpha",
+            PanelElementKind.VfdDotMatrix => "vfdDotMatrix",
             PanelElementKind.Label => "label",
             _ => string.Empty
         };
@@ -259,7 +267,7 @@ internal static class Panel2DDocumentStorage
         foreach (var element in elements)
         {
             var kind = ParseElementKind(element.Kind);
-            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.Label)
+            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix or PanelElementKind.Label)
             {
                 return CurrentSchemaVersion;
             }
@@ -444,7 +452,9 @@ internal static class Panel2DDocumentStorage
         var normalizedShowDecimalPoint = normalizedNative?.ShowDecimalPoint ?? element.ShowDecimalPoint ?? false;
         var normalizedShowCommaTail = normalizedNative?.ShowCommaTail ?? element.ShowCommaTail ?? false;
         var normalizedOnColorHex = NormalizeOptionalString(normalizedNative?.OnColorHex ?? normalizedNative?.DisplayColorHex ?? element.OnColorHex);
-        var normalizedOffColorHex = NormalizeOptionalString(normalizedNative?.OffColorHex ?? element.OffColorHex);
+        var normalizedOffColorHex = normalizedKind == PanelElementKind.VfdDotMatrix
+            ? null
+            : NormalizeOptionalString(normalizedNative?.OffColorHex ?? element.OffColorHex);
         var normalizedTextColorHex = NormalizeOptionalString(normalizedNative?.TextColorHex ?? element.TextColorHex);
         var normalizedDisplayText = NormalizeOptionalString(normalizedNative?.Text ?? element.DisplayText);
         var normalizedTextBoxFontName = normalizedKind == PanelElementKind.Lamp
@@ -558,6 +568,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "Reel",
             PanelElementKind.SevenSegment => "7 Segment",
             PanelElementKind.Alpha => "Alpha",
+            PanelElementKind.VfdDotMatrix => "VFD Dot Matrix",
             PanelElementKind.Label => "Label",
             _ => "Rectangle"
         };
@@ -737,6 +748,7 @@ internal enum PanelElementKind
     Reel,
     SevenSegment,
     Alpha,
+    VfdDotMatrix,
     Label
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -31,6 +31,8 @@ internal static class PanelElementFactory
     public const double NewRectangleHeight = 120;
     public const double NewImageWidth = 220;
     public const double NewImageHeight = 140;
+    public const double NewVfdDotMatrixWidth = 480;
+    public const double NewVfdDotMatrixHeight = 80;
 
     public static string? ProjectDirectoryPath
     {
@@ -72,6 +74,24 @@ internal static class PanelElementFactory
         };
     }
 
+    public static PanelElementFile CreateVfdDotMatrixElement(Point canvasPoint)
+    {
+        var x = Math.Max(0, canvasPoint.X - (NewVfdDotMatrixWidth / 2));
+        var y = Math.Max(0, canvasPoint.Y - (NewVfdDotMatrixHeight / 2));
+        var objectId = Guid.NewGuid().ToString("N");
+        return new PanelElementFile
+        {
+            ObjectId = objectId,
+            Name = Panel2DDocumentStorage.CreateDefaultElementName(PanelElementKind.VfdDotMatrix, objectId),
+            Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.VfdDotMatrix),
+            X = x,
+            Y = y,
+            Width = NewVfdDotMatrixWidth,
+            Height = NewVfdDotMatrixHeight,
+            OnColorHex = "#FF4040"
+        };
+    }
+
 
     public static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
     {
@@ -89,6 +109,7 @@ internal static class PanelElementFactory
             PanelElementKind.Reel => CreateReelVisual(element),
             PanelElementKind.SevenSegment => CreateSevenSegmentVisual(element),
             PanelElementKind.Alpha => CreateAlphaVisual(element),
+            PanelElementKind.VfdDotMatrix => CreateVfdDotMatrixVisual(element),
             PanelElementKind.Label => CreateLabelVisual(element),
             _ => null
         };
@@ -352,6 +373,14 @@ internal static class PanelElementFactory
                 ShowCommaTail = element.ShowCommaTail ?? false
             }
         };
+    }
+
+    private static Border CreateVfdDotMatrixVisual(PanelElementFile element)
+    {
+        return CreatePlaceholderComponentVisual(
+            element,
+            "VFD Dot Matrix 96 x 8",
+            element.OnColorHex ?? "#220909");
     }
 
     private static Border CreateLabelVisual(PanelElementFile element)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -7,6 +7,7 @@ public sealed class PanelRuntimeState
     private readonly Dictionary<string, double> _temporaryReelOffsetByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, double[]> _segmentBrightnessByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, bool[]> _vfdDotMatrixDotsByObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
 
@@ -17,6 +18,7 @@ public sealed class PanelRuntimeState
     public IReadOnlyDictionary<string, double> TemporaryReelOffsetByObjectId => _temporaryReelOffsetByObjectId;
     public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
     public IReadOnlyDictionary<string, double[]> SegmentBrightnessByObjectId => _segmentBrightnessByObjectId;
+    public IReadOnlyDictionary<string, bool[]> VfdDotMatrixDotsByObjectId => _vfdDotMatrixDotsByObjectId;
 
     public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
@@ -146,6 +148,7 @@ public sealed class PanelRuntimeState
         _temporaryReelOffsetByObjectId.Clear();
         _segmentMasksByObjectId.Clear();
         _segmentBrightnessByObjectId.Clear();
+        _vfdDotMatrixDotsByObjectId.Clear();
     }
 
     public bool SetSegmentCellMasksIfChanged(string objectId, int[] masks)
@@ -208,5 +211,39 @@ public sealed class PanelRuntimeState
         return _segmentMasksByObjectId.TryGetValue(objectId.Trim(), out var value)
             ? value.ToArray()
             : new int[cellCount];
+    }
+    public bool SetVfdDotMatrixDotsIfChanged(string objectId, bool[] dots)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || dots is null)
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        if (_vfdDotMatrixDotsByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && previous.SequenceEqual(dots))
+        {
+            return false;
+        }
+
+        _vfdDotMatrixDotsByObjectId[normalizedObjectId] = dots.ToArray();
+        return true;
+    }
+
+    public bool[] GetVfdDotMatrixDots(string objectId, int dotCount)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || dotCount <= 0)
+        {
+            return Array.Empty<bool>();
+        }
+
+        if (!_vfdDotMatrixDotsByObjectId.TryGetValue(objectId.Trim(), out var value))
+        {
+            return new bool[dotCount];
+        }
+
+        var dots = new bool[dotCount];
+        Array.Copy(value, dots, Math.Min(value.Length, dots.Length));
+        return dots;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRenderer.cs
@@ -32,12 +32,14 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
         var alphaElapsed = TimeSpan.Zero;
         var sevenElapsed = TimeSpan.Zero;
         var reelElapsed = TimeSpan.Zero;
+        var vfdDotMatrixElapsed = TimeSpan.Zero;
         var backgroundCount = 0;
         var lampCount = 0;
         var textLampCount = 0;
         var alphaCount = 0;
         var sevenCount = 0;
         var reelCount = 0;
+        var vfdDotMatrixCount = 0;
 
         foreach (var element in elements)
         {
@@ -80,6 +82,10 @@ internal sealed class Panel2DRenderer : IPanel2DRenderer
                 case PanelElementKind.Reel:
                     reelCount++;
                     reelElapsed += sw.Elapsed;
+                    break;
+                case PanelElementKind.VfdDotMatrix:
+                    vfdDotMatrixCount++;
+                    vfdDotMatrixElapsed += sw.Elapsed;
                     break;
             }
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
@@ -1,0 +1,74 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class VfdDotMatrixElementRenderer : IPanelElementRenderer
+{
+    internal const int CellCount = 16;
+    internal const int CellWidth = 6;
+    internal const int Columns = CellCount * CellWidth;
+    internal const int Rows = 8;
+    internal const int DotCount = Columns * Rows;
+
+    public PanelElementKind Kind => PanelElementKind.VfdDotMatrix;
+
+    public void Render(in PanelElementRenderContext context, PanelElementModel element)
+    {
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
+        var offColor = ScaleBrightness(onColor, 0.10d);
+        var backgroundColor = ScaleBrightness(onColor, 0.04d);
+        var dots = context.RuntimeState.GetVfdDotMatrixDots(element.ObjectId, DotCount);
+
+        using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
+
+        var marginX = bounds.Width * 0.05f;
+        var marginY = bounds.Height * 0.1f;
+        var contentBounds = SKRect.Create(
+            bounds.Left + marginX,
+            bounds.Top + marginY,
+            Math.Max(1f, bounds.Width - (marginX * 2f)),
+            Math.Max(1f, bounds.Height - (marginY * 2f)));
+
+        var dotPitch = Math.Min(contentBounds.Width / Columns, contentBounds.Height / Rows);
+        if (dotPitch <= 0f)
+        {
+            return;
+        }
+
+        var matrixWidth = dotPitch * Columns;
+        var matrixHeight = dotPitch * Rows;
+        var originX = contentBounds.Left + ((contentBounds.Width - matrixWidth) * 0.5f);
+        var originY = contentBounds.Top + ((contentBounds.Height - matrixHeight) * 0.5f);
+        var dotSize = Math.Max(0.5f, dotPitch * 0.72f);
+        var dotInset = (dotPitch - dotSize) * 0.5f;
+
+        using var dotPaint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        for (var y = 0; y < Rows; y++)
+        {
+            for (var x = 0; x < Columns; x++)
+            {
+                var index = (y * Columns) + x;
+                dotPaint.Color = index < dots.Length && dots[index] ? onColor : offColor;
+                context.Canvas.DrawOval(
+                    SKRect.Create(originX + (x * dotPitch) + dotInset, originY + (y * dotPitch) + dotInset, dotSize, dotSize),
+                    dotPaint);
+            }
+        }
+    }
+
+    private static SKColor ScaleBrightness(SKColor color, double factor)
+    {
+        var clamped = Math.Clamp(factor, 0d, 1d);
+        byte Scale(byte value) => (byte)Math.Clamp(Math.Round(value * clamped), 0d, 255d);
+        return new SKColor(Scale(color.Red), Scale(color.Green), Scale(color.Blue), 255);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -14,6 +14,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private Dictionary<string, PanelElementModel> _reelElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _alphaElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _sevenSegmentElementsByObjectId = new(StringComparer.Ordinal);
+    private Dictionary<string, PanelElementModel> _vfdDotMatrixElementsByObjectId = new(StringComparer.Ordinal);
     private HashSet<string> _visualStateObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
@@ -145,7 +146,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     {
         var changedObjectIds = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel || element.Kind == PanelElementKind.Alpha || element.Kind == PanelElementKind.SevenSegment))
+                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel || element.Kind == PanelElementKind.Alpha || element.Kind == PanelElementKind.SevenSegment || element.Kind == PanelElementKind.VfdDotMatrix))
             .Select(element => element.ObjectId)
             .ToArray();
         NotifyPanelVisualPreviewChanged(changedObjectIds);
@@ -177,7 +178,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                     ? new ReelVisualState(_runtimeState.GetReelPosition(objectId))
                     : _sevenSegmentElementsByObjectId.ContainsKey(objectId)
                         ? new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 1))
-                        : new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 16));
+                        : _vfdDotMatrixElementsByObjectId.ContainsKey(objectId)
+                            ? new VfdDotMatrixVisualState(_runtimeState.GetVfdDotMatrixDots(objectId, MameVfdDotMatrixStateParser.DotCount))
+                            : new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 16));
             if (!_lastVisualStateByObjectId.TryGetValue(objectId, out var previous)
                 || !Equals(previous, nextState))
             {
@@ -335,10 +338,14 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         _sevenSegmentElementsByObjectId = _panelDocumentModel.Elements
             .Where(element => element.Kind == PanelElementKind.SevenSegment && !string.IsNullOrWhiteSpace(element.ObjectId))
             .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+        _vfdDotMatrixElementsByObjectId = _panelDocumentModel.Elements
+            .Where(element => element.Kind == PanelElementKind.VfdDotMatrix && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
         _visualStateObjectIds = _lampElementsByObjectId.Keys
             .Concat(_reelElementsByObjectId.Keys)
             .Concat(_alphaElementsByObjectId.Keys)
             .Concat(_sevenSegmentElementsByObjectId.Keys)
+            .Concat(_vfdDotMatrixElementsByObjectId.Keys)
             .ToHashSet(StringComparer.Ordinal);
     }
 }
@@ -346,6 +353,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
 internal readonly record struct ReelVisualState(double Position);
 internal readonly record struct SegmentVisualState(int[] CellMasks);
+internal readonly record struct VfdDotMatrixVisualState(bool[] Dots);
 
 public sealed record PanelVisualStateChangedEvent(
     Guid DocumentId,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -343,6 +343,11 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     private void AddTypeSpecificRows(PanelElementModel selectedElement)
     {
+        if (selectedElement.Kind is PanelElementKind.VfdDotMatrix)
+        {
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Display", "Type-specific", "VFD Dot Matrix (96 x 8)"));
+        }
+
         if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment)
         {
             _propertyRows.Add(new InspectorIntPropertyViewModel(
@@ -379,7 +384,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update background color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) })));
         }
 
-        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
+        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix)
         {
             _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "On Color",
@@ -516,6 +521,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                     break;
                 case "Visible" when row is InspectorBoolPropertyViewModel visibleRow:
                     visibleRow.SetCommittedValue(selectedElement.IsVisible);
+                    break;
+                case "Display" when row is InspectorInfoPropertyViewModel displayInfoRow:
+                    displayInfoRow.SetCommittedValue(selectedElement.Kind == PanelElementKind.VfdDotMatrix ? "VFD Dot Matrix (96 x 8)" : string.Empty);
                     break;
                 case "Display Number" when row is InspectorIntPropertyViewModel displayRow:
                     displayRow.SetCommittedValue(selectedElement.DisplayNumber);
@@ -748,6 +756,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             PanelElementKind.Alpha => selectedElement.IsReversed == true
                 ? $"{geometrySummary} Alpha mode: reversed."
                 : geometrySummary,
+            PanelElementKind.VfdDotMatrix => $"{geometrySummary} VFD dot matrix: 96 x 8 dots.",
             _ => geometrySummary
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -23,6 +23,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
             BuildGroup("Reels", elements, PanelElementKind.Reel, "Reel"),
             BuildGroup("Seven Segments", elements, PanelElementKind.SevenSegment, "7 Segment"),
             BuildGroup("Alphas", elements, PanelElementKind.Alpha, "Alpha"),
+            BuildGroup("VFD Dot Matrices", elements, PanelElementKind.VfdDotMatrix, "VFD Dot Matrix"),
             BuildGroup("Labels", elements, PanelElementKind.Label, "Label"),
             BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
             BuildGroup("Rectangles", elements, PanelElementKind.Rectangle, "Rectangle"),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
@@ -47,6 +47,10 @@
                         Margin="0,0,8,0"
                         Command="{Binding SaveSelectedDocumentCommand}"
                         Content="Save" />
+                <Button Padding="10,4"
+                        Margin="0,0,8,0"
+                        Command="{Binding AddVfdDotMatrixElementCommand}"
+                        Content="Add VFD Dot Matrix" />
                 <ToggleButton x:Name="RectangleToolToggle"
                               Padding="10,4"
                               Margin="0,0,8,0"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -35,7 +35,7 @@ public partial class PlayView : UserControl
     private const double TargetFrameMillis = 16.0;
     private const double LegacyReelPositionsPerRevolution = 96d;
     private const double ReelDragSpeedScale = 3d;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
+    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer()], "PlayView");
 
     public PlayView()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -32,7 +32,7 @@ public partial class SkiaPanel2DEditView : UserControl
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
-    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "EditView");
+    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer()], "EditView");
 
     public SkiaPanel2DEditView()
     {


### PR DESCRIPTION
### Motivation

- Provide a native OasisEditor element to represent MAME `vfddotmatrix0..vfddotmatrix767` outputs as a fixed `96 x 8` VFD dot-matrix (16 cells × 6×8 each). 
- Follow existing alpha/segment element conventions for naming, rendering, inspector surface, serialization, and runtime binding so the new element integrates with the editor and MAME runtime plumbing.

### Description

- Added a new element kind `PanelElementKind.VfdDotMatrix` and storage name `"vfdDotMatrix"` with serialization/deserialization and default naming via `Panel2DDocumentStorage` and `CreateDefaultElementName`.
- Implemented MAME parsing and routing: `MameVfdDotMatrixStateParser` parses `vfddotmatrix{index} = {value}` (index 0..767) and `MameStdoutParser` forwards parsed dot events to the runtime adapter via `IMameSegmentRuntimeAdapter.ApplyVfdDotMatrixDotState`.
- Extended the runtime adapter (`MameSegmentRuntimeAdapter`) to coalesce incoming dot updates and apply them on the UI thread, and added `PanelRuntimeState` storage APIs `SetVfdDotMatrixDotsIfChanged` / `GetVfdDotMatrixDots` to hold per-element 768-dot state.
- Added a Skia renderer `VfdDotMatrixElementRenderer` that draws a uniform `96` columns × `8` rows grid, uses row-major mapping (`index = y * 96 + x`), renders lit dots when value == `1` using element `OnColor`, and derives `OffColor` and background by darkening `OnColor` consistent with the existing alpha/segment style.
- Created WPF placeholder visuals and factory support: `PanelElementFactory.CreateVfdDotMatrixElement` (defaults), `CreateVfdDotMatrixVisual`, registration in `PanelElementFactory.CreateVisualFromElement`, and registered the renderer in edit/play `Panel2DRenderer` paths.
- Exposed a single `OnColor` property in the Inspector for this element and added a dedicated inspector summary/rows identifying the element as a VFD dot matrix while not exposing separate off/background colors.
- Added a quick-add UI flow: `AddVfdDotMatrixElementCommand` on `MainWindowViewModel` and a toolbar button `Add VFD Dot Matrix` in `PanelCanvasView.xaml` that inserts a default element into the active Panel2D.
- Minor storage behavior: for `vfdDotMatrix` the persisted/off color is normalized so only `OnColor` is user-configured, matching the requirement that `OffColor` and background are derived.

### Testing

- Added unit tests: `MameVfdDotMatrixStateParserTests` (parser range/value checks), an updated `MameStdoutParserTests` test exercising `vfddotmatrix` lines, and an updated `MameSegmentRuntimeAdapterTests` test to verify the runtime adapter applies dot updates to `PanelRuntimeState` correctly, plus round-trip and factory tests adjusted to include the new element kind.
- Ran repository checks: `git diff --check` passed with no reported whitespace/errors.
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore`, but `dotnet` is not installed in the execution environment so tests were not executed here (tests were added and compile/run should succeed in a proper .NET/WPF dev environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2085498df08327936e19cd68cf2ab2)