### PR TITLE
Add Panel2D element context menu

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/AddPanel2DElement.ContextMenu.Investigation.md
+++ b/WindowsNetProjects/OasisEditor/Docs/AddPanel2DElement.ContextMenu.Investigation.md
@@ -40,25 +40,41 @@ Start by inspecting these files/classes and update this section with concrete fi
   - How MFME-imported components map into real Oasis elements.
   - Useful defaults for Lamp, Reel, 7 Segment Display, and Segment Alpha.
 - Existing undo/redo command infrastructure.
-  - TODO: record concrete files/classes here.
+  - `OasisEditor/Commands/CommandService.cs` executes commands, validates document ownership for `IDocumentCommand`, records commands in `CommandHistory`, and drives undo/redo. It respects `IExecutionTrackedCommand.WasExecuted` so no-op commands are not recorded.
+  - `OasisEditor/Commands/CommandHistory.cs` stores the linear undo/redo stack. Redo re-executes the same command instance, which means command instances must retain identity/state needed for stable redo.
+  - `OasisEditor/CanvasMutationCommands.cs` contains the current Panel2D mutation commands, including `AddPanelElementMutationCommand`, `DeleteElementMutationCommand`, and update/reorder/visibility/lock commands.
+  - `CanvasMutationCommands.CreateAddRectangleCommand` and `CreateAddImageCommand` wrap a `PanelElementFile` in `AddPanelElementMutationCommand`; this command converts the storage element to a `PanelElementModel`, inserts it, raises a structure change, and marks the document dirty.
 - Old Rectangle/Image add test methods.
-  - TODO: record concrete files/classes here.
+  - `OasisEditor/PanelToolPlacementController.cs` still contains the old rectangle/image placement flow. It uses `PanelElementFactory.CreateRectangleElement`/`CreateImageElement` and `CanvasMutationCommands.CreateAddRectangleCommand`/`CreateAddImageCommand`. This remains a useful reference for factory + command wiring only.
+  - `OasisEditor.Tests/Panel2DRoundTripTests.cs` has coverage around rectangle add and hierarchy refresh, plus existing undo/redo mutation tests.
 - Existing tests around Panel2D document mutation.
-  - TODO: record concrete files/classes here.
+  - `OasisEditor.Tests/ImportMfmeExtractCommandTests.cs` verifies import add mutations, history tracking, and stable undo/redo identity for imported elements.
+  - `OasisEditor.Tests/Panel2DRoundTripTests.cs` covers storage round trips, hierarchy provider behaviour, and many mutation commands. The new add service/command tests can live in a focused new test file without UI automation.
 
 ## Investigation checklist
 
 Before implementation, answer these questions in this document:
 
-- [ ] What is the canonical in-memory collection for elements on a Panel2D?
-- [ ] What IDs/properties are required for a new element to be valid?
-- [ ] What command type, service, or pattern is used for undoable Panel2D edits?
-- [ ] How does redo preserve identity and state?
-- [ ] How is the selected element set after an edit?
-- [ ] How do hierarchy and inspector views learn about model changes?
-- [ ] How does the Skia editor convert mouse coordinates to Panel2D coordinates?
-- [ ] Which defaults make each new element visible immediately?
-- [ ] Which tests can cover the model/command path without brittle UI automation?
+- [x] What is the canonical in-memory collection for elements on a Panel2D?
+  - `DocumentTabViewModel` owns a `Panel2DDocumentModel`; its immutable-style `Elements` list is exposed through `GetPanelElements()` and replaced through `SetPanelElements(...)`. `SetPanelElements` also rebuilds runtime lookup caches, updates `PanelLayoutJson`, raises `PropertyChanged`, and optionally raises `PanelChanged`.
+- [x] What IDs/properties are required for a new element to be valid?
+  - New elements need a non-empty `ObjectId`, a user-visible `Name`, a real `PanelElementKind`, `X`, `Y`, `Width`, `Height`, and should remain `IsVisible` by default. Storage uses `PanelElementFile.Kind` string values produced by `Panel2DDocumentStorage.SerializeElementKind(...)`.
+  - Element-specific useful defaults are needed for visible rendering: lamps need dimensions and colors; reels need dimensions and a placeholder-visible state if no band image exists; seven-segment and alpha displays need dimensions and on colors, with alpha using a known `SegmentDisplayType` such as `led16seg`.
+- [x] What command type, service, or pattern is used for undoable Panel2D edits?
+  - Panel2D edits are `OasisEditor.Commands.ICommand` instances, normally document-scoped via `IDocumentCommand`, executed through `DocumentTabViewModel.CommandService`. The existing add command is `CanvasMutationCommands.AddPanelElementMutationCommand`; it already raises `PanelChangeEvent` with canvas/hierarchy/inspector/persistence flags and marks dirty.
+- [x] How does redo preserve identity and state?
+  - `CommandHistory` stores the same command object; redo calls `Execute()` on that object. `AddPanelElementMutationCommand` stores the original `PanelElementFile` and previous insert index, so redo reconverts the same stored file with the same `ObjectId`/properties and restores it at the same index.
+- [x] How is the selected element set after an edit?
+  - Selection is held in `DocumentTabViewModel.HierarchySelectedPanelSelection`. Skia selection clicks call `Panel2DSelectionNotificationService.NotifySelection(...)`, which routes through `MainWindowViewModel.UpdateDocumentPanelSelection(...)` when a shell view model is available, otherwise sets `HierarchySelectedPanelSelection` directly.
+- [x] How do hierarchy and inspector views learn about model changes?
+  - `DocumentTabViewModel.SetPanelElements(...)` raises `PanelChanged` when passed a `PanelChangeEvent`. Existing structure changes set `AffectsCanvas`, `AffectsHierarchy`, `AffectsInspectorRows`, and `AffectsPersistence` to `true`, which is the correct event shape for an add. `PanelLayoutJson` property changes also notify persistence/projection observers.
+- [x] How does the Skia editor convert mouse coordinates to Panel2D coordinates?
+  - `SkiaPanel2DEditView` constructs `PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY)` and uses `ScreenToDocument(Point)` for selection, drag selection, move, and resize computations. The context menu should reuse that transform with `eventArgs.GetPosition(EditSkiaSurface)`.
+- [x] Which defaults make each new element visible immediately?
+  - Renderer findings: `LampElementRenderer` draws a solid rectangle when no `DisplayText` or asset exists, using `OnColorHex`/`OffColorHex` and current lamp intensity; because default runtime intensity is normally 0, a visible dark/off color is required. `ReelElementRenderer` draws a labelled placeholder when no asset exists. `SevenSegmentElementRenderer` draws a lit default mask when runtime masks are absent, using `OnColorHex`. `AlphaElementRenderer` similarly draws default lit cells when a loadable display definition is available; `SegmentDisplayDefinitionLoader` supports `led16seg`.
+  - First-pass defaults: Lamp 80x40 with red/off-red colors and text font defaults; Reel 120x180 with display number 1, stops 24, visible scale 3/24; 7 Segment 80x120 with red on color; Segment Alpha 220x60 with `SegmentDisplayType = led16seg`, amber on color, and reversed false. Positions should use the clicked document coordinate as top-left, per the requested behaviour.
+- [x] Which tests can cover the model/command path without brittle UI automation?
+  - Add focused unit tests for a new creation path and command wrapper: create every supported addable type, assert required defaults and requested top-left position, execute through `DocumentTabViewModel.CommandService`, assert history count, selection, `PanelChanged` flags, undo removal, and redo restoration of the same identity/properties/position. UI context-menu automation is not necessary for this pass.
 
 ## Proposed implementation shape
 
@@ -120,10 +136,14 @@ At least one real element type must be covered by add + undo + redo. Cover all f
 
 Record final code touch points here once implemented:
 
-- TODO
+- `OasisEditor/PanelElementFactory.cs` — add a real-element creation method/enum with centralized defaults.
+- `OasisEditor/CanvasMutationCommands.cs` — expose a generic real-element add command and update add command selection behaviour.
+- `OasisEditor/Views/SkiaPanel2DEditView.xaml.cs` — add thin right-click context menu wiring that converts pointer coordinates and executes add commands.
+- `OasisEditor.Tests/AddPanel2DElementCommandTests.cs` — new focused factory/command undo/redo tests.
+- `Docs/AddPanel2DElement.ContextMenu.Investigation.md` and `Docs/AddPanel2DElement.ContextMenu.Verification.md` — record findings/results.
 
 ## Open questions
 
 Record any decisions needed from John here:
 
-- TODO
+- None for this first pass. Default sizes/colors are intentionally centralized in `PanelElementFactory` so they can be tuned later.

--- a/WindowsNetProjects/OasisEditor/Docs/AddPanel2DElement.ContextMenu.Verification.md
+++ b/WindowsNetProjects/OasisEditor/Docs/AddPanel2DElement.ContextMenu.Verification.md
@@ -8,22 +8,23 @@ Verify that users can create real Panel2D elements directly from the editor via 
 
 ### Branch
 
-TODO
+`work`
 
 ### Commit
 
-TODO
+`b816f3a` (implementation commit; later commits may update this verification document)
 
 ### Build command(s)
 
 ```text
-TODO
+dotnet test OasisEditor.sln
 ```
 
 ### Result
 
 - [ ] Build succeeded
-- [ ] Build warnings reviewed
+- [x] Build could not run in this container because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
+- [x] Build warnings reviewed: no compiler warnings were available because the SDK is unavailable; `git diff --check` passed with no whitespace errors.
 
 ## Automated tests
 
@@ -32,18 +33,24 @@ TODO
 List new tests added for this feature.
 
 ```text
-TODO
+OasisEditor.Tests/AddPanel2DElementCommandTests.cs
+- CreateAddableElement_ReturnsValidVisibleElementAtRequestedPosition
+- CreateAddableElement_UsesVisibleDefaultsForEachRealElementType
+- AddPanelElementCommand_AddsSelectsUndoesAndRedoesSameElement
 ```
 
 ### Existing tests run
 
 ```text
-TODO
+dotnet test OasisEditor.sln
+git diff --check
 ```
 
 ### Result
 
 - [ ] All relevant tests passed
+- [x] Automated tests could not run in this container because `dotnet` is not installed.
+- [x] `git diff --check` passed.
 
 ## Manual verification checklist
 
@@ -120,12 +127,21 @@ For at least one instance of each supported type:
 Record final implementation files.
 
 ```text
-TODO
+Docs/AddPanel2DElement.ContextMenu.Investigation.md
+Docs/AddPanel2DElement.ContextMenu.Verification.md
+OasisEditor/CanvasMutationCommands.cs
+OasisEditor/PanelElementFactory.cs
+OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+OasisEditor.Tests/AddPanel2DElementCommandTests.cs
 ```
 
 ## Notes
 
 Capture any compromises, known limitations, or follow-up work.
+
+- Manual UI verification was not performed in this non-interactive container.
+- Automated build/test verification is blocked by the missing .NET SDK in this container.
+- The UI layer only maps the captured right-click point to a document point and delegates element creation and undoable mutation to shared factory/command paths.
 
 ### Follow-up candidates
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AddPanel2DElementCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AddPanel2DElementCommandTests.cs
@@ -1,0 +1,122 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class AddPanel2DElementCommandTests
+{
+    public static IEnumerable<object[]> AddableElementCases =>
+    [
+        [AddablePanelElementKind.Lamp, PanelElementKind.Lamp, PanelElementFactory.NewLampWidth, PanelElementFactory.NewLampHeight],
+        [AddablePanelElementKind.Reel, PanelElementKind.Reel, PanelElementFactory.NewReelWidth, PanelElementFactory.NewReelHeight],
+        [AddablePanelElementKind.SevenSegmentDisplay, PanelElementKind.SevenSegment, PanelElementFactory.NewSevenSegmentWidth, PanelElementFactory.NewSevenSegmentHeight],
+        [AddablePanelElementKind.SegmentAlpha, PanelElementKind.Alpha, PanelElementFactory.NewSegmentAlphaWidth, PanelElementFactory.NewSegmentAlphaHeight]
+    ];
+
+    [Theory]
+    [MemberData(nameof(AddableElementCases))]
+    public void CreateAddableElement_ReturnsValidVisibleElementAtRequestedPosition(
+        object addableKindObject,
+        object expectedKindObject,
+        double expectedWidth,
+        double expectedHeight)
+    {
+        var addableKind = (AddablePanelElementKind)addableKindObject;
+        var expectedKind = (PanelElementKind)expectedKindObject;
+        var panelPoint = new Point(123.5, 45.25);
+
+        var element = PanelElementFactory.CreateAddableElement(addableKind, panelPoint);
+
+        Assert.False(string.IsNullOrWhiteSpace(element.ObjectId));
+        Assert.False(string.IsNullOrWhiteSpace(element.Name));
+        Assert.Equal(expectedKind, Panel2DDocumentStorage.ParseElementKind(element.Kind));
+        Assert.Equal(panelPoint.X, element.X);
+        Assert.Equal(panelPoint.Y, element.Y);
+        Assert.Equal(expectedWidth, element.Width);
+        Assert.Equal(expectedHeight, element.Height);
+        Assert.True(element.IsVisible.GetValueOrDefault());
+    }
+
+    [Fact]
+    public void CreateAddableElement_UsesVisibleDefaultsForEachRealElementType()
+    {
+        var lamp = PanelElementFactory.CreateAddableElement(AddablePanelElementKind.Lamp, new Point());
+        var reel = PanelElementFactory.CreateAddableElement(AddablePanelElementKind.Reel, new Point());
+        var sevenSegment = PanelElementFactory.CreateAddableElement(AddablePanelElementKind.SevenSegmentDisplay, new Point());
+        var alpha = PanelElementFactory.CreateAddableElement(AddablePanelElementKind.SegmentAlpha, new Point());
+
+        Assert.Equal("#FF3030", lamp.OnColorHex);
+        Assert.Equal("#2A0505", lamp.OffColorHex);
+        Assert.Equal("Tahoma", lamp.TextBoxFontName);
+        Assert.Equal(1, reel.DisplayNumber);
+        Assert.Equal(24, reel.Stops);
+        Assert.Equal(3d / 24d, reel.VisibleScale);
+        Assert.Equal("#FF4040", sevenSegment.OnColorHex);
+        Assert.Equal(1, sevenSegment.DisplayNumber);
+        Assert.Equal("led16seg", alpha.SegmentDisplayType);
+        Assert.Equal("#FFB000", alpha.OnColorHex);
+    }
+
+    [Theory]
+    [MemberData(nameof(AddableElementCases))]
+    public void AddPanelElementCommand_AddsSelectsUndoesAndRedoesSameElement(
+        object addableKindObject,
+        object expectedKindObject,
+        double expectedWidth,
+        double expectedHeight)
+    {
+        var addableKind = (AddablePanelElementKind)addableKindObject;
+        var expectedKind = (PanelElementKind)expectedKindObject;
+        var document = CreatePanelDocument();
+        var changedEvents = new List<PanelChangeEvent>();
+        document.PanelChanged += changedEvents.Add;
+        var panelPoint = new Point(321.5, 654.25);
+        var element = PanelElementFactory.CreateAddableElement(addableKind, panelPoint);
+        var command = CanvasMutationCommands.CreateAddPanelElementCommand(document.DocumentId, document, element);
+
+        document.CommandService.Execute(command);
+
+        var added = Assert.Single(document.GetPanelElements());
+        Assert.Equal(element.ObjectId, added.ObjectId);
+        Assert.Equal(expectedKind, added.Kind);
+        Assert.Equal(panelPoint.X, added.X);
+        Assert.Equal(panelPoint.Y, added.Y);
+        Assert.Equal(expectedWidth, added.Width);
+        Assert.Equal(expectedHeight, added.Height);
+        Assert.Equal(element.OnColorHex, added.OnColorHex);
+        Assert.Equal(element.SegmentDisplayType, added.SegmentDisplayType);
+        Assert.Single(document.CommandService.History.Entries);
+        Assert.NotNull(document.HierarchySelectedPanelSelection);
+        Assert.Equal(element.ObjectId, document.HierarchySelectedPanelSelection!.Value.ObjectId);
+        var addEvent = Assert.Single(changedEvents);
+        Assert.Equal(element.ObjectId, addEvent.ObjectId);
+        Assert.True(addEvent.AffectsCanvas);
+        Assert.True(addEvent.AffectsHierarchy);
+        Assert.True(addEvent.AffectsInspectorRows);
+        Assert.True(addEvent.AffectsPersistence);
+        Assert.True(addEvent.ChangedProperties.HasFlag(PanelChangeProperties.Structure));
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Empty(document.GetPanelElements());
+        Assert.Null(document.HierarchySelectedPanelSelection);
+
+        Assert.True(document.CommandService.TryRedo());
+        var redone = Assert.Single(document.GetPanelElements());
+        Assert.Equal(added.ObjectId, redone.ObjectId);
+        Assert.Equal(added.Kind, redone.Kind);
+        Assert.Equal(added.X, redone.X);
+        Assert.Equal(added.Y, redone.Y);
+        Assert.Equal(added.Width, redone.Width);
+        Assert.Equal(added.Height, redone.Height);
+        Assert.Equal(added.OnColorHex, redone.OnColorHex);
+        Assert.Equal(added.SegmentDisplayType, redone.SegmentDisplayType);
+        Assert.Equal(element.ObjectId, document.HierarchySelectedPanelSelection!.Value.ObjectId);
+    }
+
+    private static DocumentTabViewModel CreatePanelDocument(params PanelElementModel[] elements)
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(elements);
+        return document;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -12,6 +12,21 @@ internal static class CanvasMutationCommands
         return new AddPanelElementMutationCommand(documentId, document, element, "Add image");
     }
 
+    public static Commands.ICommand CreateAddPanelElementCommand(Guid documentId, DocumentTabViewModel document, PanelElementFile element)
+    {
+        var kind = Panel2DDocumentStorage.ParseElementKind(element.Kind);
+        var description = kind switch
+        {
+            PanelElementKind.Lamp => "Add lamp",
+            PanelElementKind.Reel => "Add reel",
+            PanelElementKind.SevenSegment => "Add 7 segment display",
+            PanelElementKind.Alpha => "Add segment alpha",
+            _ => "Add panel element"
+        };
+
+        return new AddPanelElementMutationCommand(documentId, document, element, description);
+    }
+
     public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
     {
         return new DeleteElementMutationCommand(documentId, document, selection);
@@ -137,6 +152,7 @@ internal static class CanvasMutationCommands
             elements.Insert(index, elementModel);
             _insertIndex = index;
             _document.SetPanelElements(elements, CreateStructureChange(_document, elementModel.ObjectId));
+            _document.HierarchySelectedPanelSelection = PanelSelectionContract.ToSelectionInfo(Panel2DDocumentStorage.ToStorageElement(elementModel));
             _document.MarkDirty();
             WasExecuted = true;
         }
@@ -177,9 +193,20 @@ internal static class CanvasMutationCommands
             if (removed)
             {
                 _document.SetPanelElements(elements, CreateStructureChange(_document));
+                if (_document.HierarchySelectedPanelSelection is PanelSelectionInfo selection
+                    && IsSelectionForElement(selection, _element))
+                {
+                    _document.HierarchySelectedPanelSelection = null;
+                }
+
                 _document.MarkDirty();
             }
         }
+    }
+
+    private static bool IsSelectionForElement(PanelSelectionInfo selection, PanelElementFile element)
+    {
+        return PanelSelectionContract.IsMatch(element, selection);
     }
 
     private sealed class DeleteElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -31,6 +31,15 @@ internal static class PanelElementFactory
     public const double NewRectangleHeight = 120;
     public const double NewImageWidth = 220;
     public const double NewImageHeight = 140;
+    public const double NewLampWidth = 80;
+    public const double NewLampHeight = 40;
+    public const double NewReelWidth = 120;
+    public const double NewReelHeight = 180;
+    public const double NewSevenSegmentWidth = 80;
+    public const double NewSevenSegmentHeight = 120;
+    public const double NewSegmentAlphaWidth = 220;
+    public const double NewSegmentAlphaHeight = 60;
+
 
     public static string? ProjectDirectoryPath
     {
@@ -72,6 +81,81 @@ internal static class PanelElementFactory
         };
     }
 
+
+
+    public static PanelElementFile CreateAddableElement(AddablePanelElementKind kind, Point panelPoint)
+    {
+        return kind switch
+        {
+            AddablePanelElementKind.Lamp => CreateLampElement(panelPoint),
+            AddablePanelElementKind.Reel => CreateReelElement(panelPoint),
+            AddablePanelElementKind.SevenSegmentDisplay => CreateSevenSegmentDisplayElement(panelPoint),
+            AddablePanelElementKind.SegmentAlpha => CreateSegmentAlphaElement(panelPoint),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported addable Panel2D element kind.")
+        };
+    }
+
+    private static PanelElementFile CreateLampElement(Point panelPoint)
+    {
+        var objectId = Guid.NewGuid().ToString("N");
+        return CreateBaseElement(PanelElementKind.Lamp, objectId, "Lamp", panelPoint, NewLampWidth, NewLampHeight) with
+        {
+            OnColorHex = "#FF3030",
+            OffColorHex = "#2A0505",
+            TextColorHex = "#FFFFFF",
+            TextBoxFontName = "Tahoma",
+            TextBoxFontStyle = "Regular",
+            TextBoxFontSize = "8"
+        };
+    }
+
+    private static PanelElementFile CreateReelElement(Point panelPoint)
+    {
+        var objectId = Guid.NewGuid().ToString("N");
+        return CreateBaseElement(PanelElementKind.Reel, objectId, "Reel 1", panelPoint, NewReelWidth, NewReelHeight) with
+        {
+            DisplayNumber = 1,
+            Stops = 24,
+            VisibleScale = 3d / 24d,
+            IsReversed = false
+        };
+    }
+
+    private static PanelElementFile CreateSevenSegmentDisplayElement(Point panelPoint)
+    {
+        var objectId = Guid.NewGuid().ToString("N");
+        return CreateBaseElement(PanelElementKind.SevenSegment, objectId, "7 Segment Display", panelPoint, NewSevenSegmentWidth, NewSevenSegmentHeight) with
+        {
+            DisplayNumber = 1,
+            OnColorHex = "#FF4040"
+        };
+    }
+
+    private static PanelElementFile CreateSegmentAlphaElement(Point panelPoint)
+    {
+        var objectId = Guid.NewGuid().ToString("N");
+        return CreateBaseElement(PanelElementKind.Alpha, objectId, "Segment Alpha", panelPoint, NewSegmentAlphaWidth, NewSegmentAlphaHeight) with
+        {
+            SegmentDisplayType = "led16seg",
+            OnColorHex = "#FFB000",
+            IsReversed = false
+        };
+    }
+
+    private static PanelElementFile CreateBaseElement(PanelElementKind kind, string objectId, string name, Point panelPoint, double width, double height)
+    {
+        return new PanelElementFile
+        {
+            ObjectId = objectId,
+            Name = name,
+            Kind = Panel2DDocumentStorage.SerializeElementKind(kind),
+            X = Math.Max(0, panelPoint.X),
+            Y = Math.Max(0, panelPoint.Y),
+            Width = width,
+            Height = height,
+            IsVisible = true
+        };
+    }
 
     public static FrameworkElement? CreateVisualFromElement(PanelElementFile element)
     {
@@ -635,4 +719,12 @@ internal static class PanelElementFactory
         bitmap.Freeze();
         return bitmap;
     }
+}
+
+internal enum AddablePanelElementKind
+{
+    Lamp,
+    Reel,
+    SevenSegmentDisplay,
+    SegmentAlpha
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Threading;
 using OasisEditor.Rendering;
@@ -240,6 +241,13 @@ public partial class SkiaPanel2DEditView : UserControl
 
     private void OnEditSkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)
     {
+        if (eventArgs.ChangedButton == MouseButton.Right)
+        {
+            ShowAddElementContextMenu(eventArgs.GetPosition(EditSkiaSurface));
+            eventArgs.Handled = true;
+            return;
+        }
+
         if (eventArgs.ChangedButton == MouseButton.Left)
         {
             var document = Document;
@@ -396,6 +404,55 @@ public partial class SkiaPanel2DEditView : UserControl
         Document.PanelPanY = transform.PanY;
         RequestRender();
         eventArgs.Handled = true;
+    }
+
+
+    private void ShowAddElementContextMenu(Point screenPoint)
+    {
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var panelPoint = viewport.ScreenToDocument(screenPoint);
+        var contextMenu = new ContextMenu
+        {
+            PlacementTarget = EditSkiaSurface,
+            Placement = PlacementMode.MousePoint
+        };
+
+        AddAddElementMenuItem(contextMenu, "Add Lamp", AddablePanelElementKind.Lamp, panelPoint);
+        AddAddElementMenuItem(contextMenu, "Add Reel", AddablePanelElementKind.Reel, panelPoint);
+        AddAddElementMenuItem(contextMenu, "Add 7 Segment Display", AddablePanelElementKind.SevenSegmentDisplay, panelPoint);
+        AddAddElementMenuItem(contextMenu, "Add Segment Alpha", AddablePanelElementKind.SegmentAlpha, panelPoint);
+
+        contextMenu.IsOpen = true;
+    }
+
+    private void AddAddElementMenuItem(ContextMenu contextMenu, string header, AddablePanelElementKind kind, Point panelPoint)
+    {
+        var menuItem = new MenuItem
+        {
+            Header = header
+        };
+        menuItem.Click += (_, _) => AddElementAt(kind, panelPoint);
+        contextMenu.Items.Add(menuItem);
+    }
+
+    private void AddElementAt(AddablePanelElementKind kind, Point panelPoint)
+    {
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return;
+        }
+
+        var element = PanelElementFactory.CreateAddableElement(kind, panelPoint);
+        var command = CanvasMutationCommands.CreateAddPanelElementCommand(document.DocumentId, document, element);
+        document.CommandService.Execute(command);
+        RequestRender();
     }
 
     private void HandleSelectionClick(Point screenPoint)


### PR DESCRIPTION
### Motivation
- Provide a first-pass right-click add menu on the Panel2D edit surface so real Oasis elements (Lamp, Reel, 7 Segment, Segment Alpha) can be created at the clicked document coordinate.  
- Keep the UI thin by delegating element construction to a centralized factory and all document mutations to the existing undo/redo command infrastructure.  
- Ensure add operations participate in the normal history, selection, hierarchy and inspector update paths without duplicating MFME import logic.

### Description
- Added centralized addable element support in `PanelElementFactory` with new defaults and creation helpers: `CreateAddableElement(...)` and typed helpers for `Lamp`, `Reel`, `SevenSegment`, and `SegmentAlpha`, plus constants for default sizes (`NewLampWidth`, `NewReelHeight`, etc.).  
- Reused the existing mutation command by introducing `CanvasMutationCommands.CreateAddPanelElementCommand(...)` and updated the add command execution to set `HierarchySelectedPanelSelection` after execution and to clear it on undo when appropriate.  
- Wired a thin UI context menu in `Views/SkiaPanel2DEditView.xaml.cs` to capture right-clicks, convert to Panel2D coordinates via `PanelViewportTransform.ScreenToDocument(...)`, show the add-menu, and execute the add command.  
- Added focused model/command tests in `OasisEditor.Tests/AddPanel2DElementCommandTests.cs` and updated investigation/verification docs to record findings and environment test results.

### Testing
- New unit tests added: `OasisEditor.Tests/AddPanel2DElementCommandTests.cs` covering creation defaults and add + undo + redo identity/position/property preservation.  
- Attempted to run the test suite (`dotnet test OasisEditor.sln`) but the container lacks the .NET SDK so automated tests could not be executed here.  
- Performed static checks: `git diff --check` passed with no whitespace errors, and the verification document records the build/test limitation and the new tests/files added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a208ac4b750832783657596042f6789)