### PR TITLE
Add VFD 96×8 dot-matrix Panel2D element (vfddotmatrix0..767)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -112,6 +112,24 @@ public sealed class MameStdoutParserTests
         Assert.Equal(0, duty.CellId);
         Assert.Equal(1d, duty.Brightness);
     }
+
+    [Fact]
+    public void ProcessLine_WhenVfdDotMatrixLine_AppliesDotState()
+    {
+        var lampAdapter = new RecordingLampAdapter();
+        var reelAdapter = new RecordingReelAdapter();
+        var segmentAdapter = new RecordingSegmentAdapter();
+        var dotMatrixAdapter = new RecordingVfdDotMatrixAdapter();
+        var parser = new MameStdoutParser(new MameLampStateParser(), lampAdapter, new MameReelStateParser(), reelAdapter, new MameSegmentStateParser(), segmentAdapter, vfdDotMatrixRuntimeAdapter: dotMatrixAdapter);
+
+        parser.ProcessLine("vfddotmatrix767 = 1");
+
+        var call = Assert.Single(dotMatrixAdapter.Calls);
+        Assert.Equal(767, call.DotIndex);
+        Assert.Equal(1, call.Value);
+        Assert.Empty(segmentAdapter.Calls);
+    }
+
     private sealed class RecordingLampAdapter : IMameLampRuntimeAdapter
     {
         public List<(int LampId, int Value)> Calls { get; } = [];
@@ -122,6 +140,12 @@ public sealed class MameStdoutParserTests
     {
         public List<(int ReelId, int Value)> Calls { get; } = [];
         public void ApplyReelState(int reelId, int reelValue) => Calls.Add((reelId, reelValue));
+    }
+
+    private sealed class RecordingVfdDotMatrixAdapter : IMameVfdDotMatrixRuntimeAdapter
+    {
+        public List<(int DotIndex, int Value)> Calls { get; } = [];
+        public void ApplyDotState(int dotIndex, int dotValue) => Calls.Add((dotIndex, dotValue));
     }
 
     private sealed class RecordingSegmentAdapter : IMameSegmentRuntimeAdapter

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDotMatrixStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameVfdDotMatrixStateParserTests.cs
@@ -1,0 +1,33 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameVfdDotMatrixStateParserTests
+{
+    [Theory]
+    [InlineData("vfddotmatrix0 = 1", 0, 1)]
+    [InlineData("vfddotmatrix767 = 0", 767, 0)]
+    [InlineData("vfddotmatrix767 = -1", 767, 0)]
+    public void TryParse_DotMatrixLine_ParsesRangeAndNormalizesOnState(string line, int expectedIndex, int expectedValue)
+    {
+        var parser = new MameVfdDotMatrixStateParser();
+
+        var ok = parser.TryParse(line, out var dotIndex, out var dotValue);
+
+        Assert.True(ok);
+        Assert.Equal(expectedIndex, dotIndex);
+        Assert.Equal(expectedValue, dotValue);
+    }
+
+    [Theory]
+    [InlineData("vfddotmatrix768 = 1")]
+    [InlineData("vfddotmatrix-1 = 1")]
+    [InlineData("vfd0 = 1")]
+    public void TryParse_InvalidDotMatrixLine_ReturnsFalse(string line)
+    {
+        var parser = new MameVfdDotMatrixStateParser();
+
+        Assert.False(parser.TryParse(line, out _, out _));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -396,6 +396,7 @@ public sealed class Panel2DRoundTripTests
     [InlineData("reel", "reel")]
     [InlineData("sevenSegment", "sevenSegment")]
     [InlineData("alpha", "alpha")]
+    [InlineData("vfdDotMatrix", "vfdDotMatrix")]
     public void ParseElementKind_WithNativeKinds_ReturnsExpectedKind(string serializedKind, string expectedRoundTripKind)
     {
         var parsedKind = Panel2DDocumentStorage.ParseElementKind(serializedKind);
@@ -411,6 +412,7 @@ public sealed class Panel2DRoundTripTests
     [InlineData("reel", "Reel ")]
     [InlineData("sevenSegment", "7 Segment ")]
     [InlineData("alpha", "Alpha ")]
+    [InlineData("vfdDotMatrix", "VFD Dot Matrix ")]
     public void CreateDefaultElementName_WithNativeKinds_UsesNativePrefix(string kind, string expectedPrefix)
     {
         var name = Panel2DDocumentStorage.CreateDefaultElementName(kind, "abcdef123456");
@@ -595,6 +597,7 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal("Reels (1)", groups.Single(g => g.NodeKey == "group:reel").DisplayName);
         Assert.Equal("Seven Segments (1)", groups.Single(g => g.NodeKey == "group:sevenSegment").DisplayName);
         Assert.Equal("Alphas (1)", groups.Single(g => g.NodeKey == "group:alpha").DisplayName);
+        Assert.Equal("VFD Dot Matrices (0)", groups.Single(g => g.NodeKey == "group:vfdDotMatrix").DisplayName);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -21,6 +21,7 @@ internal static class CanvasMutationCommands
             PanelElementKind.Reel => "Add reel",
             PanelElementKind.SevenSegment => "Add 7 segment display",
             PanelElementKind.Alpha => "Add segment alpha",
+            PanelElementKind.VfdDotMatrix => "Add VFD dot matrix",
             _ => "Add panel element"
         };
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -245,7 +245,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 () => OpenDocuments,
                 DispatchToUiThread,
                 () => SelectedFruitMachinePlatform),
-            platformProvider: () => SelectedFruitMachinePlatform);
+            platformProvider: () => SelectedFruitMachinePlatform,
+            vfdDotMatrixStateParser: new MameVfdDotMatrixStateParser(),
+            vfdDotMatrixRuntimeAdapter: new MameVfdDotMatrixRuntimeAdapter(
+                () => OpenDocuments,
+                DispatchToUiThread));
         _mameProcessRunner = new MameProcessRunner(
             stdoutLogger: line => ProcessMameStdoutLine(line, mameStdoutParser),
             stdinLogger: line =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
@@ -54,6 +54,11 @@ public interface IMameSegmentRuntimeAdapter
     void ApplyVfdBrightness(int cellId, double normalizedBrightness);
 }
 
+public interface IMameVfdDotMatrixRuntimeAdapter
+{
+    void ApplyDotState(int dotIndex, int dotValue);
+}
+
 public sealed record MameProcessLaunchRequest(
     string MameExecutablePath,
     string MameRomName,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
@@ -8,10 +8,12 @@ public sealed class MameStdoutParser : IMameStdoutParser
     private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
     private readonly IMameSegmentStateParser _segmentStateParser;
     private readonly IMameSegmentRuntimeAdapter _segmentRuntimeAdapter;
+    private readonly IMameVfdDotMatrixStateParser _vfdDotMatrixStateParser;
+    private readonly IMameVfdDotMatrixRuntimeAdapter? _vfdDotMatrixRuntimeAdapter;
     private readonly MameVfdDutyParser _vfdDutyParser;
     private readonly Func<FruitMachinePlatformType> _platformProvider;
 
-    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Func<FruitMachinePlatformType>? platformProvider = null)
+    public MameStdoutParser(IMameLampStateParser lampStateParser, IMameLampRuntimeAdapter lampRuntimeAdapter, IMameReelStateParser reelStateParser, IMameReelRuntimeAdapter reelRuntimeAdapter, IMameSegmentStateParser segmentStateParser, IMameSegmentRuntimeAdapter segmentRuntimeAdapter, Func<FruitMachinePlatformType>? platformProvider = null, IMameVfdDotMatrixStateParser? vfdDotMatrixStateParser = null, IMameVfdDotMatrixRuntimeAdapter? vfdDotMatrixRuntimeAdapter = null)
     {
         _lampStateParser = lampStateParser ?? throw new ArgumentNullException(nameof(lampStateParser));
         _lampRuntimeAdapter = lampRuntimeAdapter ?? throw new ArgumentNullException(nameof(lampRuntimeAdapter));
@@ -19,6 +21,8 @@ public sealed class MameStdoutParser : IMameStdoutParser
         _reelRuntimeAdapter = reelRuntimeAdapter ?? throw new ArgumentNullException(nameof(reelRuntimeAdapter));
         _segmentStateParser = segmentStateParser ?? throw new ArgumentNullException(nameof(segmentStateParser));
         _segmentRuntimeAdapter = segmentRuntimeAdapter ?? throw new ArgumentNullException(nameof(segmentRuntimeAdapter));
+        _vfdDotMatrixStateParser = vfdDotMatrixStateParser ?? new MameVfdDotMatrixStateParser();
+        _vfdDotMatrixRuntimeAdapter = vfdDotMatrixRuntimeAdapter;
         _vfdDutyParser = new MameVfdDutyParser();
         _platformProvider = platformProvider ?? (() => FruitMachinePlatformType.MPU4);
     }
@@ -45,6 +49,12 @@ public sealed class MameStdoutParser : IMameStdoutParser
         if (_segmentStateParser.TryParse(line, out var cellId, out var segmentMask, out var outputType))
         {
             _segmentRuntimeAdapter.ApplySegmentState(cellId, segmentMask, outputType);
+            return;
+        }
+
+        if (_vfdDotMatrixRuntimeAdapter is not null && _vfdDotMatrixStateParser.TryParse(line, out var dotIndex, out var dotValue))
+        {
+            _vfdDotMatrixRuntimeAdapter.ApplyDotState(dotIndex, dotValue);
             return;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixRuntimeAdapter.cs
@@ -1,0 +1,68 @@
+namespace OasisEditor;
+
+public sealed class MameVfdDotMatrixRuntimeAdapter : IMameVfdDotMatrixRuntimeAdapter
+{
+    private const int DotCount = MameVfdDotMatrixStateParser.DotCount;
+    private readonly object _pendingSync = new();
+    private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
+    private readonly Action<Action> _uiDispatch;
+    private readonly Dictionary<int, int> _pendingDots = new();
+    private readonly int[] _latestDots = new int[DotCount];
+    private bool _uiUpdateScheduled;
+
+    public MameVfdDotMatrixRuntimeAdapter(Func<IEnumerable<DocumentTabViewModel>> documentProvider, Action<Action> uiDispatch)
+    {
+        _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
+        _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
+    }
+
+    public void ApplyDotState(int dotIndex, int dotValue)
+    {
+        if (dotIndex is < 0 or >= DotCount)
+        {
+            return;
+        }
+
+        lock (_pendingSync)
+        {
+            _pendingDots[dotIndex] = dotValue == 1 ? 1 : 0;
+            if (_uiUpdateScheduled) return;
+            _uiUpdateScheduled = true;
+        }
+
+        _uiDispatch(ApplyPendingOnUiThread);
+    }
+
+    private void ApplyPendingOnUiThread()
+    {
+        Dictionary<int, int> snapshot;
+        lock (_pendingSync)
+        {
+            snapshot = new(_pendingDots);
+            _pendingDots.Clear();
+            _uiUpdateScheduled = false;
+        }
+
+        foreach (var (dotIndex, dotValue) in snapshot)
+        {
+            _latestDots[dotIndex] = dotValue == 1 ? 1 : 0;
+        }
+
+        foreach (var document in _documentProvider())
+        {
+            var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var element in document.GetPanelElements().Where(e => e.Kind == PanelElementKind.VfdDotMatrix && !string.IsNullOrWhiteSpace(e.ObjectId)))
+            {
+                if (document.RuntimeState.SetVfdDotMatrixDotsIfChanged(element.ObjectId, _latestDots))
+                {
+                    changedObjectIds.Add(element.ObjectId);
+                }
+            }
+
+            if (changedObjectIds.Count > 0)
+            {
+                document.NotifyPanelVisualPreviewChanged(changedObjectIds);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameVfdDotMatrixStateParser.cs
@@ -1,0 +1,40 @@
+namespace OasisEditor;
+using System.Text.RegularExpressions;
+
+public interface IMameVfdDotMatrixStateParser
+{
+    bool TryParse(string line, out int dotIndex, out int dotValue);
+}
+
+public sealed class MameVfdDotMatrixStateParser : IMameVfdDotMatrixStateParser
+{
+    public const int DotCount = 96 * 8;
+
+    private static readonly Regex DotLineRegex = new(
+        @"^vfddotmatrix\s*(\d+)\s*=\s*(-?\d+)\s*$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public bool TryParse(string line, out int dotIndex, out int dotValue)
+    {
+        dotIndex = 0;
+        dotValue = 0;
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        var match = DotLineRegex.Match(line.Trim());
+        if (!match.Success
+            || !int.TryParse(match.Groups[1].Value, out dotIndex)
+            || !int.TryParse(match.Groups[2].Value, out var rawValue)
+            || dotIndex is < 0 or >= DotCount)
+        {
+            dotIndex = 0;
+            dotValue = 0;
+            return false;
+        }
+
+        dotValue = rawValue == 1 ? 1 : 0;
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -54,6 +54,11 @@ internal static class Panel2DDocumentStorage
         {
             return PanelElementKind.Alpha;
         }
+
+        if (string.Equals(kind, "vfdDotMatrix", StringComparison.OrdinalIgnoreCase))
+        {
+            return PanelElementKind.VfdDotMatrix;
+        }
         if (string.Equals(kind, "label", StringComparison.OrdinalIgnoreCase))
         {
             return PanelElementKind.Label;
@@ -75,6 +80,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "reel",
             PanelElementKind.SevenSegment => "sevenSegment",
             PanelElementKind.Alpha => "alpha",
+            PanelElementKind.VfdDotMatrix => "vfdDotMatrix",
             PanelElementKind.Label => "label",
             _ => string.Empty
         };
@@ -259,7 +265,7 @@ internal static class Panel2DDocumentStorage
         foreach (var element in elements)
         {
             var kind = ParseElementKind(element.Kind);
-            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.Label)
+            if (kind is PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix or PanelElementKind.Label)
             {
                 return CurrentSchemaVersion;
             }
@@ -558,6 +564,7 @@ internal static class Panel2DDocumentStorage
             PanelElementKind.Reel => "Reel",
             PanelElementKind.SevenSegment => "7 Segment",
             PanelElementKind.Alpha => "Alpha",
+            PanelElementKind.VfdDotMatrix => "VFD Dot Matrix",
             PanelElementKind.Label => "Label",
             _ => "Rectangle"
         };
@@ -737,6 +744,7 @@ internal enum PanelElementKind
     Reel,
     SevenSegment,
     Alpha,
+    VfdDotMatrix,
     Label
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -39,6 +39,8 @@ internal static class PanelElementFactory
     public const double NewSevenSegmentHeight = 120;
     public const double NewSegmentAlphaWidth = 220;
     public const double NewSegmentAlphaHeight = 60;
+    public const double NewVfdDotMatrixWidth = 480;
+    public const double NewVfdDotMatrixHeight = 80;
 
 
     public static string? ProjectDirectoryPath
@@ -91,6 +93,7 @@ internal static class PanelElementFactory
             AddablePanelElementKind.Reel => CreateReelElement(panelPoint),
             AddablePanelElementKind.SevenSegmentDisplay => CreateSevenSegmentDisplayElement(panelPoint),
             AddablePanelElementKind.SegmentAlpha => CreateSegmentAlphaElement(panelPoint),
+            AddablePanelElementKind.VfdDotMatrix => CreateVfdDotMatrixElement(panelPoint),
             _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported addable Panel2D element kind.")
         };
     }
@@ -142,6 +145,15 @@ internal static class PanelElementFactory
         };
     }
 
+    private static PanelElementFile CreateVfdDotMatrixElement(Point panelPoint)
+    {
+        var objectId = Guid.NewGuid().ToString("N");
+        return CreateBaseElement(PanelElementKind.VfdDotMatrix, objectId, "VFD Dot Matrix", panelPoint, NewVfdDotMatrixWidth, NewVfdDotMatrixHeight) with
+        {
+            OnColorHex = "#FFB000"
+        };
+    }
+
     private static PanelElementFile CreateBaseElement(PanelElementKind kind, string objectId, string name, Point panelPoint, double width, double height)
     {
         return new PanelElementFile
@@ -173,6 +185,7 @@ internal static class PanelElementFactory
             PanelElementKind.Reel => CreateReelVisual(element),
             PanelElementKind.SevenSegment => CreateSevenSegmentVisual(element),
             PanelElementKind.Alpha => CreateAlphaVisual(element),
+            PanelElementKind.VfdDotMatrix => CreateVfdDotMatrixVisual(element),
             PanelElementKind.Label => CreateLabelVisual(element),
             _ => null
         };
@@ -434,6 +447,32 @@ internal static class PanelElementFactory
                 UnlitBrush = TryCreateBrush(element.OffColorHex, new SolidColorBrush(Color.FromArgb(32, 0, 255, 255))),
                 ShowDecimalPoint = element.ShowDecimalPoint ?? true,
                 ShowCommaTail = element.ShowCommaTail ?? false
+            }
+        };
+    }
+
+
+    private static Border CreateVfdDotMatrixVisual(PanelElementFile element)
+    {
+        var width = element.Width <= 0 ? NewVfdDotMatrixWidth : element.Width;
+        var height = element.Height <= 0 ? NewVfdDotMatrixHeight : element.Height;
+
+        return new Border
+        {
+            Uid = element.ObjectId,
+            Width = width,
+            Height = height,
+            BorderThickness = new Thickness(1),
+            BorderBrush = Brushes.SlateGray,
+            Background = TryCreateBrush("#0A0700", Brushes.Black),
+            Padding = new Thickness(4),
+            Child = new TextBlock
+            {
+                Text = "VFD Dot Matrix 96×8",
+                Foreground = TryCreateBrush(element.OnColorHex, Brushes.Orange),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontSize = 12
             }
         };
     }
@@ -726,5 +765,6 @@ internal enum AddablePanelElementKind
     Lamp,
     Reel,
     SevenSegmentDisplay,
-    SegmentAlpha
+    SegmentAlpha,
+    VfdDotMatrix
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelRuntimeState.cs
@@ -7,6 +7,7 @@ public sealed class PanelRuntimeState
     private readonly Dictionary<string, double> _temporaryReelOffsetByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, int[]> _segmentMasksByObjectId = new(StringComparer.Ordinal);
     private readonly Dictionary<string, double[]> _segmentBrightnessByObjectId = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int[]> _vfdDotMatrixDotsByObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
 
@@ -17,6 +18,7 @@ public sealed class PanelRuntimeState
     public IReadOnlyDictionary<string, double> TemporaryReelOffsetByObjectId => _temporaryReelOffsetByObjectId;
     public IReadOnlyDictionary<string, int[]> SegmentMasksByObjectId => _segmentMasksByObjectId;
     public IReadOnlyDictionary<string, double[]> SegmentBrightnessByObjectId => _segmentBrightnessByObjectId;
+    public IReadOnlyDictionary<string, int[]> VfdDotMatrixDotsByObjectId => _vfdDotMatrixDotsByObjectId;
 
     public bool SetLampIntensityIfChanged(string objectId, double intensity)
     {
@@ -146,6 +148,7 @@ public sealed class PanelRuntimeState
         _temporaryReelOffsetByObjectId.Clear();
         _segmentMasksByObjectId.Clear();
         _segmentBrightnessByObjectId.Clear();
+        _vfdDotMatrixDotsByObjectId.Clear();
     }
 
     public bool SetSegmentCellMasksIfChanged(string objectId, int[] masks)
@@ -208,5 +211,36 @@ public sealed class PanelRuntimeState
         return _segmentMasksByObjectId.TryGetValue(objectId.Trim(), out var value)
             ? value.ToArray()
             : new int[cellCount];
+    }
+
+    public bool SetVfdDotMatrixDotsIfChanged(string objectId, int[] dots)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || dots is null)
+        {
+            return false;
+        }
+
+        var normalizedObjectId = objectId.Trim();
+        var normalizedDots = dots.Select(value => value == 1 ? 1 : 0).ToArray();
+        if (_vfdDotMatrixDotsByObjectId.TryGetValue(normalizedObjectId, out var previous)
+            && previous.SequenceEqual(normalizedDots))
+        {
+            return false;
+        }
+
+        _vfdDotMatrixDotsByObjectId[normalizedObjectId] = normalizedDots;
+        return true;
+    }
+
+    public int[] GetVfdDotMatrixDots(string objectId, int dotCount)
+    {
+        if (string.IsNullOrWhiteSpace(objectId) || dotCount <= 0)
+        {
+            return Array.Empty<int>();
+        }
+
+        return _vfdDotMatrixDotsByObjectId.TryGetValue(objectId.Trim(), out var value)
+            ? value.ToArray()
+            : new int[dotCount];
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
@@ -1,0 +1,72 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class VfdDotMatrixElementRenderer : IPanelElementRenderer
+{
+    internal const int Columns = 96;
+    internal const int Rows = 8;
+    internal const int CellCount = 16;
+    internal const int CellWidth = 6;
+    internal const int DotCount = Columns * Rows;
+
+    public PanelElementKind Kind => PanelElementKind.VfdDotMatrix;
+
+    public void Render(in PanelElementRenderContext context, PanelElementModel element)
+    {
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 176, 0));
+        var offColor = ScaleBrightness(onColor, 0.10d);
+        var backgroundColor = ScaleBrightness(onColor, 0.04d);
+        var dots = context.RuntimeState.GetVfdDotMatrixDots(element.ObjectId, DotCount);
+
+        using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
+
+        var marginX = bounds.Width * 0.025f;
+        var marginY = bounds.Height * 0.12f;
+        var contentBounds = SKRect.Create(
+            bounds.Left + marginX,
+            bounds.Top + marginY,
+            Math.Max(1f, bounds.Width - (marginX * 2f)),
+            Math.Max(1f, bounds.Height - (marginY * 2f)));
+
+        var pitchX = contentBounds.Width / Columns;
+        var pitchY = contentBounds.Height / Rows;
+        var dotDiameter = Math.Max(0.5f, Math.Min(pitchX, pitchY) * 0.72f);
+        var radius = dotDiameter * 0.5f;
+
+        using var onPaint = new SKPaint { Color = onColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var offPaint = new SKPaint { Color = offColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+
+        for (var y = 0; y < Rows; y++)
+        {
+            var centerY = contentBounds.Top + (y * pitchY) + (pitchY * 0.5f);
+            for (var x = 0; x < Columns; x++)
+            {
+                var index = (y * Columns) + x;
+                var centerX = contentBounds.Left + (x * pitchX) + (pitchX * 0.5f);
+                context.Canvas.DrawCircle(centerX, centerY, radius, IsDotOn(dots, index) ? onPaint : offPaint);
+            }
+        }
+    }
+
+    internal static bool IsDotOn(IReadOnlyList<int> dots, int index)
+    {
+        return index >= 0 && index < dots.Count && dots[index] == 1;
+    }
+
+    private static SKColor ScaleBrightness(SKColor color, double factor)
+    {
+        var clamped = Math.Clamp(factor, 0d, 1d);
+        byte Scale(byte value) => (byte)Math.Clamp(Math.Round(value * clamped), 0d, 255d);
+        return new SKColor(Scale(color.Red), Scale(color.Green), Scale(color.Blue), 255);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -14,6 +14,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private Dictionary<string, PanelElementModel> _reelElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _alphaElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _sevenSegmentElementsByObjectId = new(StringComparer.Ordinal);
+    private Dictionary<string, PanelElementModel> _vfdDotMatrixElementsByObjectId = new(StringComparer.Ordinal);
     private HashSet<string> _visualStateObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
@@ -145,7 +146,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     {
         var changedObjectIds = _panelDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
-                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel || element.Kind == PanelElementKind.Alpha || element.Kind == PanelElementKind.SevenSegment))
+                && (element.Kind == PanelElementKind.Lamp || element.Kind == PanelElementKind.Reel || element.Kind == PanelElementKind.Alpha || element.Kind == PanelElementKind.SevenSegment || element.Kind == PanelElementKind.VfdDotMatrix))
             .Select(element => element.ObjectId)
             .ToArray();
         NotifyPanelVisualPreviewChanged(changedObjectIds);
@@ -177,7 +178,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                     ? new ReelVisualState(_runtimeState.GetReelPosition(objectId))
                     : _sevenSegmentElementsByObjectId.ContainsKey(objectId)
                         ? new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 1))
-                        : new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 16));
+                        : _vfdDotMatrixElementsByObjectId.ContainsKey(objectId)
+                            ? new VfdDotMatrixVisualState(_runtimeState.GetVfdDotMatrixDots(objectId, MameVfdDotMatrixStateParser.DotCount))
+                            : new SegmentVisualState(_runtimeState.GetSegmentCellMasks(objectId, 16));
             if (!_lastVisualStateByObjectId.TryGetValue(objectId, out var previous)
                 || !Equals(previous, nextState))
             {
@@ -335,10 +338,14 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         _sevenSegmentElementsByObjectId = _panelDocumentModel.Elements
             .Where(element => element.Kind == PanelElementKind.SevenSegment && !string.IsNullOrWhiteSpace(element.ObjectId))
             .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
+        _vfdDotMatrixElementsByObjectId = _panelDocumentModel.Elements
+            .Where(element => element.Kind == PanelElementKind.VfdDotMatrix && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, element => element, StringComparer.Ordinal);
         _visualStateObjectIds = _lampElementsByObjectId.Keys
             .Concat(_reelElementsByObjectId.Keys)
             .Concat(_alphaElementsByObjectId.Keys)
             .Concat(_sevenSegmentElementsByObjectId.Keys)
+            .Concat(_vfdDotMatrixElementsByObjectId.Keys)
             .ToHashSet(StringComparer.Ordinal);
     }
 }
@@ -346,6 +353,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 internal readonly record struct LampVisualState(bool IsLampTestOn, double Intensity);
 internal readonly record struct ReelVisualState(double Position);
 internal readonly record struct SegmentVisualState(int[] CellMasks);
+internal readonly record struct VfdDotMatrixVisualState(int[] Dots);
 
 public sealed record PanelVisualStateChangedEvent(
     Guid DocumentId,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -379,7 +379,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 commit: value => TryApplyColorUpdate(selectedElement.ObjectId, "Update background color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) })));
         }
 
-        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha)
+        if (selectedElement.Kind is PanelElementKind.Lamp or PanelElementKind.SevenSegment or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix)
         {
             _propertyRows.Add(new InspectorColorPropertyViewModel(
                 "On Color",
@@ -748,6 +748,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             PanelElementKind.Alpha => selectedElement.IsReversed == true
                 ? $"{geometrySummary} Alpha mode: reversed."
                 : geometrySummary,
+            PanelElementKind.VfdDotMatrix => $"{geometrySummary} VFD dot matrix: 96 x 8 dots, 16 cells.",
             _ => geometrySummary
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -23,6 +23,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
             BuildGroup("Reels", elements, PanelElementKind.Reel, "Reel"),
             BuildGroup("Seven Segments", elements, PanelElementKind.SevenSegment, "7 Segment"),
             BuildGroup("Alphas", elements, PanelElementKind.Alpha, "Alpha"),
+            BuildGroup("VFD Dot Matrices", elements, PanelElementKind.VfdDotMatrix, "VFD Dot Matrix"),
             BuildGroup("Labels", elements, PanelElementKind.Label, "Label"),
             BuildGroup("Images", elements, PanelElementKind.Image, "Image"),
             BuildGroup("Rectangles", elements, PanelElementKind.Rectangle, "Rectangle"),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -35,7 +35,7 @@ public partial class PlayView : UserControl
     private const double TargetFrameMillis = 16.0;
     private const double LegacyReelPositionsPerRevolution = 96d;
     private const double ReelDragSpeedScale = 3d;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "PlayView");
+    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer()], "PlayView");
 
     public PlayView()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -33,7 +33,7 @@ public partial class SkiaPanel2DEditView : UserControl
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
-    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer()], "EditView");
+    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer()], "EditView");
 
     public SkiaPanel2DEditView()
     {
@@ -427,6 +427,7 @@ public partial class SkiaPanel2DEditView : UserControl
         AddAddElementMenuItem(contextMenu, "Add Reel", AddablePanelElementKind.Reel, panelPoint);
         AddAddElementMenuItem(contextMenu, "Add 7 Segment Display", AddablePanelElementKind.SevenSegmentDisplay, panelPoint);
         AddAddElementMenuItem(contextMenu, "Add Segment Alpha", AddablePanelElementKind.SegmentAlpha, panelPoint);
+        AddAddElementMenuItem(contextMenu, "Add VFD Dot Matrix", AddablePanelElementKind.VfdDotMatrix, panelPoint);
 
         contextMenu.IsOpen = true;
     }


### PR DESCRIPTION
### Motivation

- Add native support for a 96×8 VFD dot-matrix display (16 cells of 6×8 dots) driven by MAME `vfddotmatrix0`..`vfddotmatrix767` outputs and expose it as a distinct OasisEditor Panel2D element separate from segment/alpha displays.

### Description

- Introduced a new element kind `VfdDotMatrix` with storage token `vfdDotMatrix` and default naming/size support in `Panel2DDocumentStorage` and `PanelElementFactory`.
- Implemented a Skia renderer `VfdDotMatrixElementRenderer` that renders a uniform 96 columns × 8 rows grid, maps dots row-major (index = y*96 + x), renders dots with `OnColor` when value == `1` and derived off/background colors when value != `1`, and uses the same brightness-scaling style applied to segment/alpha elements.
- Added MAME parsing and runtime plumbing: `MameVfdDotMatrixStateParser` (parses `vfddotmatrix{index} = value`, normalizes `1`→on and `0`/`-1`→off), `IMameVfdDotMatrixRuntimeAdapter` + `MameVfdDotMatrixRuntimeAdapter` to coalesce updates and push dot arrays into `PanelRuntimeState`, and `PanelRuntimeState` storage+accessors for per-element dot arrays.
- Registered the new renderer with the Skia renderers used by the edit/play views, added UI factory support and placeholder WPF visual, added `Add VFD Dot Matrix` to the Panel2D right-click context menu, integrated the element into the hierarchy and inspector (exposes standard fields and `On Color` only, with a VFD-specific inspector summary), and added `AddablePanelElementKind.VfdDotMatrix`.
- Added test coverage and parser/stdout routing checks: new `MameVfdDotMatrixStateParserTests`, extended `MameStdoutParserTests` to verify vfddotmatrix routing, and updated panel storage/hierarchy round-trip tests to include the new kind.

### Testing

- Added unit tests: `MameVfdDotMatrixStateParserTests` and extended `MameStdoutParserTests` and `Panel2DRoundTripTests` to cover parsing, stdout routing, and storage/hierarchy behavior; these tests are included in the solution.
- Performed repository sanity checks (`git diff --check`) with no whitespace errors detected.
- Attempted to run the automated test suite (`dotnet test`), but the `dotnet` SDK is not available in this environment so tests could not be executed here; the test additions are ready for CI/local execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a208e39e88c832787e15fbec2f62859)