### PR TITLE
Update MAME ROM default URL test to use service DefaultDownloadRootUrl

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs
@@ -7,13 +7,18 @@ namespace OasisEditor.Tests;
 public sealed class MameRomDownloadServiceTests
 {
     [Fact]
-    public void BuildDownloadUrl_UsesArchiveOrgPattern()
+    public void BuildDownloadUrl_UsesDefaultDownloadRootUrl()
     {
         var sut = new MameRomDownloadService();
 
         var url = sut.BuildDownloadUrl("mpu4");
 
-        Assert.Equal("https://archive.org/download/MAME215RomsOnlyMerged/mpu4.zip", url);
+        var defaultRootUrl = MameRomDownloadService.DefaultDownloadRootUrl;
+        var expectedRootUrl = defaultRootUrl.EndsWith("/", StringComparison.Ordinal)
+            ? defaultRootUrl
+            : defaultRootUrl + "/";
+
+        Assert.Equal($"{expectedRootUrl}mpu4.zip", url);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- A unit test duplicated a hardcoded archive.org base URL which diverged from the service's `MameRomDownloadService.DefaultDownloadRootUrl`, causing a test failure when the default was changed; the test should reference the live default so it stays correct.

### Description
- Renamed the test `BuildDownloadUrl_UsesArchiveOrgPattern` to `BuildDownloadUrl_UsesDefaultDownloadRootUrl` in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameRomDownloadServiceTests.cs`.
- Rewrote the test assertion to derive the expected URL from `MameRomDownloadService.DefaultDownloadRootUrl` and normalize a trailing slash before comparison.
- No production code behavior was modified; only the test file was updated to avoid brittle, duplicated constants.

### Testing
- Ran `git diff --check` to validate the patch formatting and it succeeded.
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore`, but `dotnet` is not installed in this environment so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21c597db68832794c8f2153d10b4c7)