### PR TITLE
Show pan cursor while middle dragging

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -191,6 +191,7 @@ public partial class PlayView : UserControl
         _isSkiaPanning = true;
         _skiaPanStart = eventArgs.GetPosition(PlaySkiaSurface);
         _skiaPanOrigin = _skiaPan;
+        PlaySkiaSurface.Cursor = Cursors.SizeAll;
         PlaySkiaSurface.CaptureMouse();
         eventArgs.Handled = true;
     }
@@ -205,23 +206,16 @@ public partial class PlayView : UserControl
             return;
         }
 
-        if (TryResolveSkiaReelElement(current, out _))
+        if (_isSkiaPanning)
         {
-            PlaySkiaSurface.Cursor = Cursors.ScrollNS;
-        }
-        else
-        {
-            var isClickable = TryResolveSkiaVisualElementId(current, out _);
-            PlaySkiaSurface.Cursor = isClickable ? Cursors.Hand : Cursors.Arrow;
-        }
-
-        if (!_isSkiaPanning)
-        {
+            PlaySkiaSurface.Cursor = Cursors.SizeAll;
+            var delta = current - _skiaPanStart;
+            _skiaPan = _skiaPanOrigin + (Vector)delta;
+            RequestRender();
             return;
         }
-        var delta = current - _skiaPanStart;
-        _skiaPan = _skiaPanOrigin + (Vector)delta;
-        RequestRender();
+
+        UpdatePlaySkiaHoverCursor(current);
     }
 
     private async void OnPlaySkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
@@ -251,6 +245,7 @@ public partial class PlayView : UserControl
 
         _isSkiaPanning = false;
         PlaySkiaSurface.ReleaseMouseCapture();
+        UpdatePlaySkiaHoverCursor(eventArgs.GetPosition(PlaySkiaSurface));
         eventArgs.Handled = true;
     }
 
@@ -363,7 +358,12 @@ public partial class PlayView : UserControl
 
     private void OnPlaySkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
     {
-        _isSkiaPanning = false;
+        if (_isSkiaPanning)
+        {
+            _isSkiaPanning = false;
+            UpdatePlaySkiaHoverCursor(eventArgs.GetPosition(PlaySkiaSurface));
+        }
+
         if (_activeReelDragElement is not null)
         {
             EndReelDrag(releaseMouseCapture: false);
@@ -388,6 +388,18 @@ public partial class PlayView : UserControl
         }
 
         await ViewModel.ReleaseAllPlayViewInputsAsync("Play View close", CancellationToken.None);
+    }
+
+    private void UpdatePlaySkiaHoverCursor(Point current)
+    {
+        if (TryResolveSkiaReelElement(current, out _))
+        {
+            PlaySkiaSurface.Cursor = Cursors.ScrollNS;
+            return;
+        }
+
+        var isClickable = TryResolveSkiaVisualElementId(current, out _);
+        PlaySkiaSurface.Cursor = isClickable ? Cursors.Hand : Cursors.Arrow;
     }
 
     private void BeginReelDrag(PanelElementModel reelElement, Point current)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml
@@ -17,7 +17,8 @@
                           MouseDown="OnEditSkiaSurfaceMouseDown"
                           MouseMove="OnEditSkiaSurfaceMouseMove"
                           MouseUp="OnEditSkiaSurfaceMouseUp"
-                          MouseWheel="OnEditSkiaSurfaceMouseWheel" />
+                          MouseWheel="OnEditSkiaSurfaceMouseWheel"
+                          LostMouseCapture="OnEditSkiaSurfaceLostMouseCapture" />
         </Border>
     </Grid>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -303,6 +303,7 @@ public partial class SkiaPanel2DEditView : UserControl
         _isPanning = true;
         _panStart = eventArgs.GetPosition(EditSkiaSurface);
         _panOrigin = new Vector(Document.PanelPanX, Document.PanelPanY);
+        EditSkiaSurface.Cursor = Cursors.SizeAll;
         EditSkiaSurface.CaptureMouse();
         eventArgs.Handled = true;
     }
@@ -335,6 +336,7 @@ public partial class SkiaPanel2DEditView : UserControl
             return;
         }
 
+        EditSkiaSurface.Cursor = Cursors.SizeAll;
         var delta = eventArgs.GetPosition(EditSkiaSurface) - _panStart;
         Document.PanelPanX = _panOrigin.X + delta.X;
         Document.PanelPanY = _panOrigin.Y + delta.Y;
@@ -384,8 +386,7 @@ public partial class SkiaPanel2DEditView : UserControl
             return;
         }
 
-        _isPanning = false;
-        EditSkiaSurface.ReleaseMouseCapture();
+        EndPan();
         eventArgs.Handled = true;
     }
 
@@ -404,6 +405,25 @@ public partial class SkiaPanel2DEditView : UserControl
         Document.PanelPanY = transform.PanY;
         RequestRender();
         eventArgs.Handled = true;
+    }
+
+    private void OnEditSkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    {
+        if (_isPanning)
+        {
+            EndPan(releaseMouseCapture: false);
+        }
+    }
+
+    private void EndPan(bool releaseMouseCapture = true)
+    {
+        _isPanning = false;
+        if (releaseMouseCapture && EditSkiaSurface.IsMouseCaptured)
+        {
+            EditSkiaSurface.ReleaseMouseCapture();
+        }
+
+        EditSkiaSurface.Cursor = Cursors.Arrow;
     }
 
 


### PR DESCRIPTION
### Motivation
- Provide visual feedback that middle-button dragging is performing a pan by switching the cursor to the four-way pan icon in both the Play view and Panel2D edit view.

### Description
- In `PlayView.xaml.cs` start panning with `PlaySkiaSurface.Cursor = Cursors.SizeAll`, preserve `SizeAll` while `_isSkiaPanning`, and restore the appropriate hover cursor after pan via a new `UpdatePlaySkiaHoverCursor` helper.
- In `SkiaPanel2DEditView.xaml` add a `LostMouseCapture` handler on the `EditSkiaSurface` element and in `SkiaPanel2DEditView.xaml.cs` set `EditSkiaSurface.Cursor = Cursors.SizeAll` when middle panning starts and while panning.
- Add a centralized `EndPan` method in the edit view to release capture and reset the cursor to `Cursors.Arrow`, and call it from mouse-up and lost-capture paths.
- Files changed: `Views/PlayView.xaml.cs`, `Views/SkiaPanel2DEditView.xaml`, and `Views/SkiaPanel2DEditView.xaml.cs`.

### Testing
- Ran `git diff --check` which reported no whitespace/diff issues.
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln --no-restore` but the `dotnet` SDK/runtime is not available in the environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21c8d8cd4c8327996156febe98e160)