### PR TITLE
Remove Skia component outlines

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -46,9 +46,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var backgroundColor = ScaleBrightness(onColor, 0.04d);
 
         using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
         context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
 
         var marginX = bounds.Width * 0.05f;
         var marginY = bounds.Height * 0.1f;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -23,7 +23,6 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         var reelPosition = context.RuntimeState.GetEffectiveReelPosition(element.ObjectId);
         var wrappedOffset = ComputeWrappedOffset(reelPosition, stops);
 
-        using var borderPaint = new SKPaint { Color = new SKColor(45, 45, 45), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
         using var clipPath = new SKPath();
         clipPath.AddRect(bounds);
 
@@ -42,7 +41,6 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         }
 
         context.Canvas.Restore();
-        context.Canvas.DrawRect(bounds, borderPaint);
     }
 
     internal static double ComputeWrappedOffset(double position, int stops)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -84,9 +84,7 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
         var bounds = SKRect.Create(0f, 0f, cacheKey.Width, cacheKey.Height);
         var backgroundColor = ScaleBrightness(cacheKey.OnColor, 0.04d);
         using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
         canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
         var marginX = bounds.Width * 0.1f;
         var marginY = bounds.Height * 0.1f;
         var contentBounds = SKRect.Create(bounds.Left + marginX, bounds.Top + marginY, Math.Max(1f, bounds.Width - (marginX * 2f)), Math.Max(1f, bounds.Height - (marginY * 2f)));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/VfdDotMatrixElementRenderer.cs
@@ -26,9 +26,7 @@ internal sealed class VfdDotMatrixElementRenderer : IPanelElementRenderer
         var dots = context.RuntimeState.GetVfdDotMatrixDots(element.ObjectId, DotCount);
 
         using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var borderPaint = new SKPaint { Color = new SKColor(71, 85, 105), Style = SKPaintStyle.Stroke, StrokeWidth = 1f, IsAntialias = true };
         context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, borderPaint);
 
         var marginX = bounds.Width * 0.025f;
         var marginY = bounds.Height * 0.12f;


### PR DESCRIPTION
### Motivation
- The edit and play views draw thin stroke outlines around several panel components which are not wanted right now and will be replaced by a more fully featured outline system later. 
- Lamp and Background visuals intentionally do not have these outlines, but segment-style components and reels were drawing them and need to stop.

### Description
- Removed the stroke outline paint and stroke drawing around the rounded background from `SevenSegmentElementRenderer` while keeping the filled background and segment drawing. 
- Removed the stroke outline paint and stroke drawing around the rounded background from `AlphaElementRenderer` while keeping the filled background and per-cell rendering. 
- Removed the stroke outline paint and stroke drawing around the rounded background from `VfdDotMatrixElementRenderer` while keeping the filled background and dot rendering. 
- Removed the rectangular stroke drawn around the reel `bounds` in `ReelElementRenderer` and left the strip/placeholder drawing and clipping intact.

### Testing
- Ran `git diff --check` and there were no whitespace or patch errors reported. 
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln --no-restore` but `dotnet` is not available in the environment so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21ce2da134832788e9d7922b0c4506)