### PR TITLE
Cycle selection through overlapping Panel2D elements (front-to-back)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DHitTestServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DHitTestServiceTests.cs
@@ -33,6 +33,19 @@ public sealed class Panel2DHitTestServiceTests
     }
 
     [Fact]
+    public void HitAllAtPoint_ReturnsHitsFromFrontToBack()
+    {
+        var bottom = new PanelElementModel { ObjectId = "bottom", Kind = PanelElementKind.Background, X = 0, Y = 0, Width = 30, Height = 30, IsVisible = true };
+        var middle = new PanelElementModel { ObjectId = "middle", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 20, Height = 20, IsVisible = true };
+        var top = new PanelElementModel { ObjectId = "top", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true };
+        var elements = new[] { bottom, middle, top };
+
+        var hits = Panel2DHitTestService.HitAllAtPoint(elements, new Point(5, 5));
+
+        Assert.Equal(new[] { "top", "middle", "bottom" }, hits.Select(hit => hit.ObjectId));
+    }
+
+    [Fact]
     public void HitTopmostIntersectingRect_ReturnsTopmostIntersectingElement()
     {
         var bottom = new PanelElementModel { ObjectId = "bottom", Kind = PanelElementKind.Lamp, X = 10, Y = 10, Width = 10, Height = 10, IsVisible = true };

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DSelectionServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DSelectionServiceTests.cs
@@ -21,6 +21,39 @@ public sealed class Panel2DSelectionServiceTests
     }
 
     [Fact]
+    public void SelectFromPoint_WithCurrentSelectionCyclesThroughOverlappingHitsFrontToBack()
+    {
+        var elements = new[]
+        {
+            new PanelElementModel { ObjectId = "background", Name = "background", Kind = PanelElementKind.Background, X = 0, Y = 0, Width = 100, Height = 100, IsVisible = true },
+            new PanelElementModel { ObjectId = "lamp1", Name = "lamp1", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true },
+            new PanelElementModel { ObjectId = "lamp2", Name = "lamp2", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true }
+        };
+        var current = new PanelSelectionInfo("lamp2", "Lamp", 0, 0, 10, 10);
+
+        var selection = Panel2DSelectionService.SelectFromPoint(elements, new Point(5, 5), current);
+
+        Assert.NotNull(selection);
+        Assert.Equal("lamp1", selection!.Value.ObjectId);
+    }
+
+    [Fact]
+    public void SelectFromPoint_WithRearCurrentSelectionWrapsToFrontmostHit()
+    {
+        var elements = new[]
+        {
+            new PanelElementModel { ObjectId = "background", Name = "background", Kind = PanelElementKind.Background, X = 0, Y = 0, Width = 100, Height = 100, IsVisible = true },
+            new PanelElementModel { ObjectId = "lamp", Name = "lamp", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true }
+        };
+        var current = new PanelSelectionInfo("background", "Background", 0, 0, 100, 100);
+
+        var selection = Panel2DSelectionService.SelectFromPoint(elements, new Point(5, 5), current);
+
+        Assert.NotNull(selection);
+        Assert.Equal("lamp", selection!.Value.ObjectId);
+    }
+
+    [Fact]
     public void SelectFromRect_ReturnsNullWhenNoIntersection()
     {
         var elements = new[]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DHitTestService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DHitTestService.cs
@@ -28,6 +28,31 @@ internal static class Panel2DHitTestService
         return null;
     }
 
+    public static IReadOnlyList<PanelElementModel> HitAllAtPoint(IReadOnlyList<PanelElementModel> elements, Point documentPoint)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+
+        var hits = new List<PanelElementModel>();
+        for (var i = elements.Count - 1; i >= 0; i--)
+        {
+            var element = elements[i];
+            if (!element.IsVisible || element.IsLocked)
+            {
+                continue;
+            }
+
+            if (documentPoint.X >= element.X
+                && documentPoint.X <= element.X + element.Width
+                && documentPoint.Y >= element.Y
+                && documentPoint.Y <= element.Y + element.Height)
+            {
+                hits.Add(element);
+            }
+        }
+
+        return hits;
+    }
+
     public static PanelElementModel? HitTopmostIntersectingRect(
         IReadOnlyList<PanelElementModel> elements,
         double minX,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DSelectionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DSelectionService.cs
@@ -8,8 +8,34 @@ internal static class Panel2DSelectionService
         IReadOnlyList<PanelElementModel> elements,
         Point documentPoint)
     {
-        var hit = Panel2DHitTestService.HitTopmostAtPoint(elements, documentPoint);
-        return hit is null ? null : ToSelectionInfo(hit);
+        return SelectFromPoint(elements, documentPoint, currentSelection: null);
+    }
+
+    public static PanelSelectionInfo? SelectFromPoint(
+        IReadOnlyList<PanelElementModel> elements,
+        Point documentPoint,
+        PanelSelectionInfo? currentSelection)
+    {
+        var hits = Panel2DHitTestService.HitAllAtPoint(elements, documentPoint);
+        if (hits.Count == 0)
+        {
+            return null;
+        }
+
+        if (currentSelection is not { } selected)
+        {
+            return ToSelectionInfo(hits[0]);
+        }
+
+        for (var i = 0; i < hits.Count; i++)
+        {
+            if (IsSelectionMatch(hits[i], selected))
+            {
+                return ToSelectionInfo(hits[(i + 1) % hits.Count]);
+            }
+        }
+
+        return ToSelectionInfo(hits[0]);
     }
 
     public static PanelSelectionInfo? SelectFromRect(
@@ -32,5 +58,25 @@ internal static class Panel2DSelectionService
             element.Y,
             element.Width,
             element.Height);
+    }
+
+    private static bool IsSelectionMatch(PanelElementModel element, PanelSelectionInfo selection)
+    {
+        if (!string.IsNullOrWhiteSpace(element.ObjectId)
+            && !string.IsNullOrWhiteSpace(selection.ObjectId))
+        {
+            return string.Equals(element.ObjectId, selection.ObjectId, StringComparison.Ordinal);
+        }
+
+        return element.Kind == Panel2DDocumentStorage.ParseElementKind(selection.Kind)
+            && AreClose(element.X, selection.X)
+            && AreClose(element.Y, selection.Y)
+            && AreClose(element.Width, selection.Width)
+            && AreClose(element.Height, selection.Height);
+    }
+
+    private static bool AreClose(double left, double right)
+    {
+        return Math.Abs(left - right) < 0.01d;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -356,7 +356,14 @@ public partial class SkiaPanel2DEditView : UserControl
                 }
                 else if (_isMovingSelection)
                 {
-                    HandleMoveSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                    if (HasDraggedSelection(document, _leftMouseDownStart, _dragSelectionCurrent))
+                    {
+                        HandleMoveSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                    }
+                    else
+                    {
+                        HandleSelectionClick(_leftMouseDownStart);
+                    }
                 }
                 else if (_isResizingSelection)
                 {
@@ -486,8 +493,19 @@ public partial class SkiaPanel2DEditView : UserControl
 
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var documentPoint = viewport.ScreenToDocument(screenPoint);
-        var selection = Panel2DSelectionService.SelectFromPoint(document.GetPanelElements(), documentPoint);
+        var selection = Panel2DSelectionService.SelectFromPoint(
+            document.GetPanelElements(),
+            documentPoint,
+            document.HierarchySelectedPanelSelection);
         NotifySelection(document, selection);
+    }
+
+    private static bool HasDraggedSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
+    {
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var start = viewport.ScreenToDocument(startScreenPoint);
+        var end = viewport.ScreenToDocument(endScreenPoint);
+        return Panel2DViewportInteractionService.HasDocumentDelta(start, end);
     }
 
     private void NotifySelection(DocumentTabViewModel document, PanelSelectionInfo? selection)


### PR DESCRIPTION
### Motivation
- Improve Panel2D edit selection so clicking while a background or lower element is selected will pick the element in front instead of forcing the user to click empty space first.  
- Allow repeated clicks to cycle through all overlaid elements from front to back and then wrap back to the frontmost element.  
- Treat a click on the currently-selected element without a move delta as an intent to re-select (i.e., cycle) rather than always start a move operation.

### Description
- Added `HitAllAtPoint` to `Panel2DHitTestService` to return all visible/unlocked elements under a point in front-to-back order.  
- Updated `Panel2DSelectionService` to accept an optional `currentSelection` and to cycle the selection through the list returned by `HitAllAtPoint`, with object-id matching and a kind/bounds fallback used to detect the current selection.  
- Modified `SkiaPanel2DEditView` so a mouse-up over the selected element only performs a move when there is a document delta otherwise it delegates to the selection click flow that triggers cycling.  
- Added unit tests covering front-to-back hit ordering and overlapped selection cycling and wrapped the new logic into the existing test suite (`Panel2DHitTestServiceTests` and `Panel2DSelectionServiceTests`).

### Testing
- Ran `git diff --check` to verify there are no whitespace errors and it passed.  
- Added unit tests for `HitAllAtPoint` and selection cycling; `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` was intended but could not be executed in this environment because `dotnet` is not installed.  
- Changes were committed locally with the message "Cycle Panel2D overlapped selection" and test files were added to the test project for CI to run in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21d2879dc8832799df29a51df03795)