### PR TITLE
Preview panel element movement while dragging

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
@@ -1,0 +1,91 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PanelElementPreviewMutationServiceTests
+{
+    [Fact]
+    public void TryApplyPreview_UpdatesElementAndInspectorWithoutRecordingUndoHistoryOrDirtyingDocument()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Name = "Lamp 1",
+            Kind = PanelElementKind.Lamp,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var updated = PanelElementModelCloner.Clone(document.GetPanelElements().Single(), x: 25, y: 45);
+        var applied = PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", updated);
+
+        Assert.True(applied);
+        var element = document.GetPanelElements().Single();
+        Assert.Equal(25, element.X);
+        Assert.Equal(45, element.Y);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+
+        var panelChange = Assert.Single(events);
+        Assert.Equal("lamp-1", panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Geometry));
+        Assert.True(panelChange.AffectsCanvas);
+        Assert.True(panelChange.AffectsInspectorRows);
+        Assert.False(panelChange.AffectsHierarchy);
+        Assert.False(panelChange.AffectsPersistence);
+    }
+
+    [Fact]
+    public void PreviewedUpdateElementCommand_RecordsSingleUndoableActionFromOriginalToPreviewedPosition()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "reel-1",
+            Name = "Reel 1",
+            Kind = PanelElementKind.Reel,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var original = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        var previewed = PanelElementModelCloner.Clone(original, x: 35, y: 55);
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "reel-1", previewed));
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "reel-1",
+            previewed,
+            original,
+            "Move element");
+
+        document.CommandService.Execute(command);
+
+        Assert.Single(document.CommandService.History.Entries);
+        Assert.True(document.IsDirty);
+        Assert.Equal(35, document.GetPanelElements().Single().X);
+        Assert.Equal(55, document.GetPanelElements().Single().Y);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Equal(10, document.GetPanelElements().Single().X);
+        Assert.Equal(20, document.GetPanelElements().Single().Y);
+
+        Assert.True(document.CommandService.TryRedo());
+        Assert.Equal(35, document.GetPanelElements().Single().X);
+        Assert.Equal(55, document.GetPanelElements().Single().Y);
+    }
+
+    private static DocumentTabViewModel CreateDocument(params PanelElementModel[] elements)
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(elements);
+        return document;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -118,6 +118,17 @@ internal static class CanvasMutationCommands
         return new UpdateElementMutationCommand(documentId, document, objectId, updatedElement, description);
     }
 
+    public static Commands.ICommand CreateUpdateElementCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        string objectId,
+        PanelElementModel updatedElement,
+        PanelElementModel originalElement,
+        string description)
+    {
+        return new UpdateElementMutationCommand(documentId, document, objectId, updatedElement, description, originalElement);
+    }
+
     private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
@@ -727,6 +738,7 @@ internal static class CanvasMutationCommands
         private readonly string _objectId;
         private readonly PanelElementModel _updatedElement;
         private readonly string _description;
+        private readonly PanelElementModel? _previewOriginalElement;
         private PanelElementModel? _previousElement;
 
         public UpdateElementMutationCommand(
@@ -734,12 +746,16 @@ internal static class CanvasMutationCommands
             DocumentTabViewModel document,
             string objectId,
             PanelElementModel updatedElement,
-            string description)
+            string description,
+            PanelElementModel? previewOriginalElement = null)
         {
             _documentId = documentId;
             _document = document;
             _objectId = objectId;
             _updatedElement = updatedElement;
+            _previewOriginalElement = previewOriginalElement is null
+                ? null
+                : PanelElementModelCloner.Clone(previewOriginalElement);
             _description = string.IsNullOrWhiteSpace(description)
                 ? "Update element"
                 : description;
@@ -769,9 +785,25 @@ internal static class CanvasMutationCommands
             var existing = elements[index];
             if (!string.Equals(_updatedElement.ObjectId, _objectId, StringComparison.Ordinal)
                 || _updatedElement.Kind != existing.Kind
-                || !PanelElementValidation.IsValidForInspectorUpdate(_updatedElement)
-                || PanelElementModelComparer.AreEquivalent(existing, _updatedElement))
+                || !PanelElementValidation.IsValidForInspectorUpdate(_updatedElement))
             {
+                return;
+            }
+
+            if (PanelElementModelComparer.AreEquivalent(existing, _updatedElement))
+            {
+                if (_previewOriginalElement is null
+                    || !string.Equals(_previewOriginalElement.ObjectId, _objectId, StringComparison.Ordinal)
+                    || _previewOriginalElement.Kind != existing.Kind
+                    || !PanelElementValidation.IsValidForInspectorUpdate(_previewOriginalElement)
+                    || PanelElementModelComparer.AreEquivalent(_previewOriginalElement, _updatedElement))
+                {
+                    return;
+                }
+
+                _previousElement = PanelElementModelCloner.Clone(_previewOriginalElement);
+                _document.MarkDirty();
+                WasExecuted = true;
                 return;
             }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
@@ -1,0 +1,57 @@
+namespace OasisEditor;
+
+internal static class PanelElementPreviewMutationService
+{
+    public static bool TryApplyPreview(DocumentTabViewModel document, string objectId, PanelElementModel updatedElement)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (string.IsNullOrWhiteSpace(objectId))
+        {
+            return false;
+        }
+
+        var elements = document.GetPanelElements().ToList();
+        var index = elements.FindIndex(element => string.Equals(element.ObjectId, objectId, StringComparison.Ordinal));
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var existing = elements[index];
+        if (!string.Equals(updatedElement.ObjectId, objectId, StringComparison.Ordinal)
+            || updatedElement.Kind != existing.Kind
+            || !PanelElementValidation.IsValidForInspectorUpdate(updatedElement)
+            || PanelElementModelComparer.AreEquivalent(existing, updatedElement))
+        {
+            return false;
+        }
+
+        elements[index] = PanelElementModelCloner.Clone(updatedElement);
+        document.SetPanelElements(
+            elements,
+            new PanelChangeEvent(
+                document.DocumentId,
+                objectId,
+                GetChangedProperties(existing, updatedElement),
+                AffectsCanvas: true,
+                AffectsHierarchy: false,
+                AffectsInspectorRows: true,
+                AffectsPersistence: false));
+        return true;
+    }
+
+    private static PanelChangeProperties GetChangedProperties(PanelElementModel before, PanelElementModel after)
+    {
+        var changed = PanelChangeProperties.None;
+
+        if (before.X != after.X || before.Y != after.Y || before.Width != after.Width || before.Height != after.Height)
+        {
+            changed |= PanelChangeProperties.Geometry;
+        }
+
+        return changed is PanelChangeProperties.None
+            ? PanelChangeProperties.Metadata
+            : changed;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -315,6 +315,7 @@ public partial class SkiaPanel2DEditView : UserControl
             _dragSelectionCurrent = eventArgs.GetPosition(EditSkiaSurface);
             if (_isMovingSelection)
             {
+                UpdateMoveSelectionPreview(_dragSelectionCurrent);
                 return;
             }
 
@@ -581,8 +582,27 @@ public partial class SkiaPanel2DEditView : UserControl
             document,
             _moveSourceElement.ObjectId,
             updated,
+            _moveSourceElement,
             "Move element");
         document.CommandService.Execute(moveCommand);
+    }
+
+    private void UpdateMoveSelectionPreview(Point currentScreenPoint)
+    {
+        var document = Document;
+        if (document is null || _moveSourceElement is null || string.IsNullOrWhiteSpace(_moveSourceElement.ObjectId))
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var start = viewport.ScreenToDocument(_leftMouseDownStart);
+        var current = viewport.ScreenToDocument(currentScreenPoint);
+        var updated = Panel2DMoveComputationService.ComputeMovedElement(_moveSourceElement, start, current);
+        if (PanelElementPreviewMutationService.TryApplyPreview(document, _moveSourceElement.ObjectId, updated))
+        {
+            RequestRender();
+        }
     }
 
     private static bool TryGetSelectedElement(DocumentTabViewModel document, out PanelElementModel selectedElement)


### PR DESCRIPTION
### Motivation

- Improve UX by showing the selected Panel2D element moving live while the user drags so the Inspector X/Y update in real time and the canvas shows the element at the current drag position.
- Ensure releasing the mouse still produces a single undoable action in history despite live preview updates during the drag.

### Description

- Apply live previews during drag by updating the preview on each mouse move when a selection is being moved and requesting a re-render (changes in `Views/SkiaPanel2DEditView.xaml.cs`).
- Add `PanelElementPreviewMutationService` to apply preview updates to the `DocumentTabViewModel` without recording undo history or marking the document as persisted (`PanelElementPreviewMutationService.cs`).
- Add an overload to `CanvasMutationCommands.CreateUpdateElementCommand` and extend `UpdateElementMutationCommand` to accept an optional original/preview source element so committing a previewed move records a single undoable `Move element` operation (`CanvasMutationCommands.cs`).
- Add unit tests exercising the preview behavior and verifying undo/redo from a previewed move in `OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs`.

### Testing

- Ran `git diff --cached --check` (no issues).
- Added unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs`, but could not execute `dotnet test` in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21d5d6cf788327b3490a4f4bdc8c7e)