### PR TITLE
Launcher: center and size to 80% of screen on startup

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml
@@ -4,6 +4,7 @@
         Title="Oasis Launcher"
         Height="460"
         Width="680"
+        WindowStartupLocation="CenterScreen"
         MinHeight="420"
         MinWidth="620"
         Background="{DynamicResource EditorBackgroundBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml.cs
@@ -1,12 +1,24 @@
+using System;
 using System.Windows;
 
 namespace OasisEditor;
 
 public partial class LauncherWindow : Window
 {
+    private const double DefaultScreenCoverage = 0.8;
+
     public LauncherWindow(IApplicationThemeService applicationThemeService, EditorPreferencesStore preferencesStore)
     {
         InitializeComponent();
+        ApplyDefaultSize();
         DataContext = new LauncherWindowViewModel(applicationThemeService, preferencesStore, this);
+    }
+
+    private void ApplyDefaultSize()
+    {
+        var workArea = SystemParameters.WorkArea;
+
+        Width = Math.Max(MinWidth, workArea.Width * DefaultScreenCoverage);
+        Height = Math.Max(MinHeight, workArea.Height * DefaultScreenCoverage);
     }
 }


### PR DESCRIPTION
### Motivation
- The launcher opens at a small fixed default size; users should see the launcher at roughly 80% of the available screen work area and centered for a better first-run experience.

### Description
- Added `WindowStartupLocation="CenterScreen"` to `LauncherWindow.xaml` to center the launcher on open.
- Added a `DefaultScreenCoverage = 0.8` constant and `ApplyDefaultSize()` in `LauncherWindow.xaml.cs` to compute size from `SystemParameters.WorkArea` and set `Width`/`Height` while respecting `MinWidth`/`MinHeight`, and invoked it from the constructor.
- Minor `using System;` import added; changed files: `WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml` and `WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml.cs`.

### Testing
- No automated tests were run in this environment because the WPF/.NET toolchain is unavailable here per the project `AGENT.md` guidance.
- Please run `dotnet build` and `dotnet test` locally and verify the build succeeds and unit tests pass, and confirm the launcher opens centered and sized to approximately 80% of the screen work area while still honoring minimum dimensions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21e2300ecc8327a020736625af7871)