### PR TITLE
Set launcher default project location to Documents\Oasis\Editor\Projects and add unit test

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LauncherWindowViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LauncherWindowViewModelTests.cs
@@ -1,0 +1,18 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class LauncherWindowViewModelTests
+{
+    [Fact]
+    public void GetDefaultProjectLocation_PlacesProjectsUnderOasisEditorProjectsInDocuments()
+    {
+        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        var expectedPath = Path.Combine(documentsPath, "Oasis", "Editor", "Projects");
+
+        var defaultProjectLocation = LauncherWindowViewModel.GetDefaultProjectLocation();
+
+        Assert.Equal(expectedPath, defaultProjectLocation);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
@@ -17,7 +17,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
     private readonly EditorPreferencesStore _preferencesStore;
     private readonly Window _launcherWindow;
     private string _projectName = string.Empty;
-    private string _projectLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+    private string _projectLocation = GetDefaultProjectLocation();
     private string _projectFilePath = string.Empty;
     private string _statusMessage = "Create or open a project to continue.";
     private string? _selectedRecentProject;
@@ -50,6 +50,15 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
     public ICommand OpenRecentProjectCommand { get; }
     public ICommand ExitCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
+
+    public static string GetDefaultProjectLocation()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "Oasis",
+            "Editor",
+            "Projects");
+    }
 
     public string ProjectName
     {


### PR DESCRIPTION
### Motivation
- The launcher previously defaulted new projects to the user Documents root, but the intended UX is to default to `Documents\Oasis\Editor\Projects` so projects are placed beneath the Oasis editor folder structure. 
- The project scaffolder already creates the project tree under a chosen root, so pointing the launcher at `Documents\Oasis\Editor\Projects` ensures the proper parent folders are created for new projects.

### Description
- Changed the launcher initial `ProjectLocation` to use a new static helper `GetDefaultProjectLocation()` instead of `Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)`. 
- Implemented `GetDefaultProjectLocation()` to return `Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Oasis", "Editor", "Projects")`.
- Added a unit test `LauncherWindowViewModelTests.GetDefaultProjectLocation_PlacesProjectsUnderOasisEditorProjectsInDocuments` that asserts the default path composition. 

### Testing
- Added the unit test `LauncherWindowViewModelTests.GetDefaultProjectLocation_PlacesProjectsUnderOasisEditorProjectsInDocuments` (test file: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/LauncherWindowViewModelTests.cs`) but it was not executed in this environment. 
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` but the `dotnet` CLI is not available in the current environment, so automated test execution did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21e42edb788327bf278d2990f996e5)