### PR TITLE
Restore sreel parsing and add reel parser tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelStateParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelStateParserTests.cs
@@ -1,0 +1,52 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameReelStateParserTests
+{
+    [Theory]
+    [InlineData("sreel3 = 0", 3, 0)]
+    [InlineData("sreel3 = 64170", 3, 94)]
+    [InlineData("sreel3 = 65535", 3, 0)]
+    [InlineData("sreel3 = -1", 3, 0)]
+    public void TryParse_WhenSreelLine_ConvertsToLegacyReelPosition(string line, int expectedReelId, int expectedValue)
+    {
+        var parser = new MameReelStateParser();
+
+        var parsed = parser.TryParse(line, out var reelId, out var reelValue);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedReelId, reelId);
+        Assert.Equal(expectedValue, reelValue);
+    }
+
+    [Theory]
+    [InlineData("reel3 = 94", 3, 94)]
+    [InlineData("reel3 94", 3, 94)]
+    public void TryParse_WhenReelLine_UsesPositionDirectly(string line, int expectedReelId, int expectedValue)
+    {
+        var parser = new MameReelStateParser();
+
+        var parsed = parser.TryParse(line, out var reelId, out var reelValue);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedReelId, reelId);
+        Assert.Equal(expectedValue, reelValue);
+    }
+
+    [Theory]
+    [InlineData("reel3 = 96")]
+    [InlineData("reel3 = -1")]
+    [InlineData("unknown output")]
+    public void TryParse_WhenLineUnsupported_ReturnsFalse(string line)
+    {
+        var parser = new MameReelStateParser();
+
+        var parsed = parser.TryParse(line, out var reelId, out var reelValue);
+
+        Assert.False(parsed);
+        Assert.Equal(0, reelId);
+        Assert.Equal(0, reelValue);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameStdoutParserTests.cs
@@ -38,7 +38,7 @@ public sealed class MameStdoutParserTests
     }
 
     [Fact]
-    public void ProcessLine_WhenLegacySreelLine_IgnoresLine()
+    public void ProcessLine_WhenSreelLine_AppliesConvertedReelState()
     {
         var lampAdapter = new RecordingLampAdapter();
         var reelAdapter = new RecordingReelAdapter();
@@ -47,7 +47,10 @@ public sealed class MameStdoutParserTests
 
         parser.ProcessLine("sreel3 = 64170");
 
-        Assert.Empty(reelAdapter.Calls);
+        var call = Assert.Single(reelAdapter.Calls);
+        Assert.Equal(3, call.ReelId);
+        Assert.Equal(94, call.Value);
+        Assert.Empty(lampAdapter.Calls);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelStateParser.cs
@@ -11,9 +11,14 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
 {
     private const int MinReelPosition = 0;
     private const int MaxReelPosition = 95;
+    private const int SreelCycle = 65536;
+    private const int LegacyReelPositionsPerRevolution = 96;
 
     [GeneratedRegex(@"^reel\s*(\d+)(?:\s*=\s*|\s+)(-?\d+)\s*$", RegexOptions.IgnoreCase)]
     private static partial Regex ReelPattern();
+
+    [GeneratedRegex(@"^sreel\s*(\d+)\s*=\s*(-?\d+)\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex SreelPattern();
 
     public bool TryParse(string line, out int reelId, out int reelValue)
     {
@@ -25,7 +30,17 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
             return false;
         }
 
-        var match = ReelPattern().Match(line.Trim());
+        var trimmed = line.Trim();
+        var sreelMatch = SreelPattern().Match(trimmed);
+        if (sreelMatch.Success
+            && int.TryParse(sreelMatch.Groups[1].Value, out reelId)
+            && int.TryParse(sreelMatch.Groups[2].Value, out var sreelValue))
+        {
+            reelValue = ConvertSreelToLegacyReelPosition(sreelValue);
+            return true;
+        }
+
+        var match = ReelPattern().Match(trimmed);
         if (!match.Success
             || !int.TryParse(match.Groups[1].Value, out reelId)
             || !int.TryParse(match.Groups[2].Value, out reelValue))
@@ -43,5 +58,12 @@ public sealed partial class MameReelStateParser : IMameReelStateParser
         }
 
         return true;
+    }
+
+    private static int ConvertSreelToLegacyReelPosition(int sreelValue)
+    {
+        var wrapped = ((sreelValue % SreelCycle) + SreelCycle) % SreelCycle;
+        return (int)Math.Round((wrapped / (double)SreelCycle) * LegacyReelPositionsPerRevolution, MidpointRounding.AwayFromZero)
+            % LegacyReelPositionsPerRevolution;
     }
 }


### PR DESCRIPTION
### Motivation
- Recent changes removed support for legacy MAME `sreel` stdout lines, which prevented legacy 16‑bit reel position output from driving reel visuals; this restores that behavior while keeping the newer direct `reel` path and validation.

### Description
- Reintroduced `sreel` parsing to `MameReelStateParser` and added `ConvertSreelToLegacyReelPosition` to convert 16‑bit `sreel` values into 96‑step reel positions used by the renderer.
- Kept the direct `reel` parsing path (accepting `reel<id> = <pos>` or `reel<id> <pos>`) and its 0–95 validation guard in `MameReelStateParser`.
- Updated `MameStdoutParser` test expectations so `sreel3 = 64170` now produces a converted reel position again, and added a new focused parser test file `MameReelStateParserTests.cs` covering `sreel`, `reel`, and unsupported/invalid lines.

### Testing
- Added unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelStateParserTests.cs` and updated `MameStdoutParserTests.cs` to reflect the restored behavior.
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` but the test run could not be executed because `dotnet` is not installed in the environment, so automated tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21eb63a5e88327a2857fb3ebce4ce0)