### PR TITLE
Add temporary reel0 stdout diagnostics

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -1768,6 +1769,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         foreach (var segment in segments)
         {
+            if (IsReel0StdoutLine(segment))
+            {
+                AddOutputEntry($"[MAME-REEL0-DIAGNOSTIC] {segment}", OutputLogStatus.Info);
+            }
+
             if (DebugOutputStdOut)
             {
                 AddOutputEntry($"[MAME-STDOUT] {segment}", OutputLogStatus.Info);
@@ -1781,6 +1787,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameDebuggerService.ProcessStdoutLine(segment);
             parser.ProcessLine(segment);
         }
+    }
+
+    private static bool IsReel0StdoutLine(string line)
+    {
+        return Regex.IsMatch(line.Trim(), @"^reel\s*0(?:\s*=\s*|\s+)-?\d+\s*$", RegexOptions.IgnoreCase);
     }
 
     private void OpenProjectSettings()


### PR DESCRIPTION
### Motivation
- Add a quick, temporary diagnostic so any MAME stdout lines that report `reel0` position are echoed to the editor Output pane to help debug why reels are not spinning.

### Description
- Import `System.Text.RegularExpressions`, add a helper `IsReel0StdoutLine(string)` that matches only `reel0` position lines, and log matched segments with `AddOutputEntry("[MAME-REEL0-DIAGNOSTIC] ...", OutputLogStatus.Info)` in `ProcessMameStdoutLine` in `MainWindowViewModel.cs`.

### Testing
- Ran `git diff --check` which passed, and attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln --no-restore` but `dotnet` is not available in this environment so build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a23db9f01a08327a8f1f47d10a6df1d)