### PR TITLE
Fix MAME input debug logging noise

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelMameStdoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelMameStdoutTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MainWindowViewModelMameStdoutTests
+{
+    [Fact]
+    public void TryClassifyMameStdoutSegment_DebugDisabled_SuppressesPluginDiagnostics()
+    {
+        var logged = TryClassify("@Oasis plugin: ### command line received: set_input_value J9_2 1 1", debugOutputStdOut: false, out _);
+
+        Assert.False(logged);
+    }
+
+    [Fact]
+    public void TryClassifyMameStdoutSegment_DebugDisabled_StillLogsErrorsAsWarnings()
+    {
+        var logged = TryClassify("@ERROR failed to process command", debugOutputStdOut: false, out var status);
+
+        Assert.True(logged);
+        Assert.Equal(OutputLogStatus.Warning, status);
+    }
+
+    [Fact]
+    public void TryClassifyMameStdoutSegment_DebugEnabled_LogsPluginDiagnosticsAsInfo()
+    {
+        var logged = TryClassify("@Oasis plugin: ### command line received: set_input_value J9_2 1 1", debugOutputStdOut: true, out var status);
+
+        Assert.True(logged);
+        Assert.Equal(OutputLogStatus.Info, status);
+    }
+
+    private static bool TryClassify(string segment, bool debugOutputStdOut, out OutputLogStatus status)
+    {
+        var method = typeof(MainWindowViewModel).GetMethod("TryClassifyMameStdoutSegment", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        object?[] parameters = [segment, debugOutputStdOut, null];
+        var result = (bool)method!.Invoke(null, parameters)!;
+        status = Assert.IsType<OutputLogStatus>(parameters[2]);
+        return result;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterTests.cs
@@ -20,6 +20,20 @@ public sealed class PlayViewKeyboardInputRouterTests
     }
 
     [Fact]
+    public async Task TryHandleKeyDownAsync_NormalizedShortcut_SendsCommand()
+    {
+        var runner = new FakeMameProcessRunner();
+        var keyboardRouter = CreateRouter(runner, out _);
+
+        var sent = await keyboardRouter.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "SPACE", isFocused: true, isRepeat: false, CancellationToken.None);
+
+        Assert.True(sent);
+        Assert.True(keyboardRouter.CanResolveShortcut("SPACE"));
+        Assert.Single(runner.Commands);
+        Assert.Equal("set_input_value ORANGE1 4 1", runner.Commands[0]);
+    }
+
+    [Fact]
     public async Task TryHandleKeyUpAsync_FocusedKey_ReleasesInput()
     {
         var runner = new FakeMameProcessRunner();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterUnknownShortcutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewKeyboardInputRouterUnknownShortcutTests.cs
@@ -13,6 +13,7 @@ public sealed class PlayViewKeyboardInputRouterUnknownShortcutTests
         var sent = await router.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "F12", isFocused: true, isRepeat: false, CancellationToken.None);
 
         Assert.False(sent);
+        Assert.False(router.CanResolveShortcut("F12"));
         Assert.Empty(runner.Commands);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1272,7 +1272,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var handled = await router.TryHandleKeyDownAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, isRepeat, cancellationToken).ConfigureAwait(false);
-        if (!handled && canRoute && isFocused && !isRepeat && !string.IsNullOrWhiteSpace(keyboardShortcut))
+        if (!handled && canRoute && isFocused && !isRepeat && !router.CanResolveShortcut(keyboardShortcut))
         {
             AddOutputEntry($"Play View key input unresolved: '{keyboardShortcut}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
         }
@@ -1768,19 +1768,32 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         foreach (var segment in segments)
         {
-            if (DebugOutputStdOut)
+            if (TryClassifyMameStdoutSegment(segment, DebugOutputStdOut, out var status))
             {
-                AddOutputEntry($"[MAME-STDOUT] {segment}", OutputLogStatus.Info);
-            }
-            else if (segment.StartsWith("@ERROR", StringComparison.Ordinal) || segment.StartsWith("@Oasis plugin:", StringComparison.Ordinal))
-            {
-                var status = segment.StartsWith("@ERROR", StringComparison.Ordinal) ? OutputLogStatus.Warning : OutputLogStatus.Info;
                 AddOutputEntry($"[MAME-STDOUT] {segment}", status);
             }
 
             _mameDebuggerService.ProcessStdoutLine(segment);
             parser.ProcessLine(segment);
         }
+    }
+
+    private static bool TryClassifyMameStdoutSegment(string segment, bool debugOutputStdOut, out OutputLogStatus status)
+    {
+        if (debugOutputStdOut)
+        {
+            status = OutputLogStatus.Info;
+            return true;
+        }
+
+        if (segment.StartsWith("@ERROR", StringComparison.Ordinal))
+        {
+            status = OutputLogStatus.Warning;
+            return true;
+        }
+
+        status = OutputLogStatus.Info;
+        return false;
     }
 
     private void OpenProjectSettings()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
@@ -31,14 +31,14 @@ public sealed class PlayViewKeyboardInputRouter
         }
     }
 
+    public bool CanResolveShortcut(string keyboardShortcut)
+    {
+        return TryGetInputForShortcut(keyboardShortcut, out _);
+    }
+
     public Task<bool> TryHandleKeyDownAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, bool isRepeat, CancellationToken cancellationToken)
     {
-        if (!isFocused || isRepeat || string.IsNullOrWhiteSpace(keyboardShortcut))
-        {
-            return Task.FromResult(false);
-        }
-
-        if (!_shortcutToInputId.TryGetValue(keyboardShortcut, out var inputId) || !_inputById.TryGetValue(inputId, out var input))
+        if (!isFocused || isRepeat || !TryGetInputForShortcut(keyboardShortcut, out var input))
         {
             return Task.FromResult(false);
         }
@@ -48,17 +48,27 @@ public sealed class PlayViewKeyboardInputRouter
 
     public Task<bool> TryHandleKeyUpAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
     {
-        if (!isFocused || string.IsNullOrWhiteSpace(keyboardShortcut))
-        {
-            return Task.FromResult(false);
-        }
-
-        if (!_shortcutToInputId.TryGetValue(keyboardShortcut, out var inputId) || !_inputById.TryGetValue(inputId, out var input))
+        if (!isFocused || !TryGetInputForShortcut(keyboardShortcut, out var input))
         {
             return Task.FromResult(false);
         }
 
         return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+    }
+
+    private bool TryGetInputForShortcut(string keyboardShortcut, out InputDefinitionModel input)
+    {
+        input = null!;
+
+        var normalizedShortcut = MfmeShortcutKeyMapper.NormalizeShortcutForRouting(keyboardShortcut);
+        if (string.IsNullOrWhiteSpace(normalizedShortcut)
+            || !_shortcutToInputId.TryGetValue(normalizedShortcut, out var inputId)
+            || !_inputById.TryGetValue(inputId, out input))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public Task<int> ReleaseAllActiveAsync(FruitMachinePlatformType platform, CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation
- Suppress noisy MAME stdout messages emitted by the Oasis plugin when the user has not enabled the MAME "Debug output stdout" preference while still surfacing real `@ERROR` lines as warnings.
- Avoid spurious "Play View key input unresolved" warnings for keys that are mapped (or normalize to a mapped shortcut) but do not result in a new command (for example when a key is already active).

### Description
- Change MAME stdout handling in `MainWindowViewModel` to use a helper `TryClassifyMameStdoutSegment` so plugin echo lines are logged only when `DebugOutputStdOut` is enabled, while lines starting with `@ERROR` are always classified as `Warning` and logged. (`MainWindowViewModel.cs`)
- Add normalized shortcut lookup and exposure of `CanResolveShortcut` in `PlayViewKeyboardInputRouter` and factor shortcut lookup into `TryGetInputForShortcut`, so Play View routing uses a normalized mapping and callers can detect whether a key is resolvable without producing a press/release. (`PlayViewKeyboardInputRouter.cs`)
- Update unresolved-key warning logic in `MainWindowViewModel` to only warn when the router cannot resolve the shortcut, preventing false positives when a mapped key simply did not send a command. (`MainWindowViewModel.cs`)
- Add unit tests covering stdout classification and shortcut resolution/normalization: `MainWindowViewModelMameStdoutTests`, a new normalized-shortcut test in `PlayViewKeyboardInputRouterTests`, and an added assertion in `PlayViewKeyboardInputRouterUnknownShortcutTests`. (`OasisEditor.Tests`)

### Testing
- Ran `git diff --check` to validate whitespace/patch issues; the check passed.
- Attempted to run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` but the `dotnet` CLI is not installed in the environment so unit tests could not be executed here.
- New unit tests were added to cover the changed behavior but were not executed in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24282f8eb48327b7f1f3d570fec5e9)