### PR TITLE
Open recent projects on double-click

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml
@@ -109,7 +109,13 @@
                     <ListBox Grid.Row="4"
                              MinHeight="120"
                              ItemsSource="{Binding RecentProjects}"
-                             SelectedItem="{Binding SelectedRecentProject, Mode=TwoWay}" />
+                             SelectedItem="{Binding SelectedRecentProject, Mode=TwoWay}">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="{x:Type ListBoxItem}">
+                                <EventSetter Event="MouseDoubleClick" Handler="RecentProjectListBoxItem_MouseDoubleClick" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                    </ListBox>
                 </Grid>
             </GroupBox>
         </Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindow.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace OasisEditor;
 
@@ -12,6 +14,27 @@ public partial class LauncherWindow : Window
         InitializeComponent();
         ApplyDefaultSize();
         DataContext = new LauncherWindowViewModel(applicationThemeService, preferencesStore, this);
+    }
+
+    private void RecentProjectListBoxItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is not LauncherWindowViewModel viewModel || sender is not ListBoxItem item)
+        {
+            return;
+        }
+
+        if (item.DataContext is string projectFilePath)
+        {
+            viewModel.SelectedRecentProject = projectFilePath;
+        }
+
+        if (!viewModel.OpenRecentProjectCommand.CanExecute(null))
+        {
+            return;
+        }
+
+        viewModel.OpenRecentProjectCommand.Execute(null);
+        e.Handled = true;
     }
 
     private void ApplyDefaultSize()


### PR DESCRIPTION
### Motivation
- Let users open a recent project by double-clicking its entry in the Launcher recent projects list instead of requiring them to select a row and press the "Open Selected Recent" button.

### Description
- Added a `MouseDoubleClick` `EventSetter` to recent-project `ListBoxItem`s in `LauncherWindow.xaml` and implemented `RecentProjectListBoxItem_MouseDoubleClick` in `LauncherWindow.xaml.cs` which sets `SelectedRecentProject`, invokes the existing `OpenRecentProjectCommand`, and marks the event handled, and added the necessary `using` directives.

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted to run `dotnet test OasisEditor.sln` but `dotnet` is not available in this environment so the test suite was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a242ac45958832788cba8ac40789bd6)