### PR TITLE
Improve tree view row hit areas

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -69,18 +69,100 @@
                 <TreeView.ItemContainerStyle>
                     <Style TargetType="{x:Type TreeViewItem}">
                         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="BorderBrush" Value="Transparent" />
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                         <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
-                        <Style.Triggers>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsSelected" Value="True" />
-                                    <Condition Property="Selector.IsSelectionActive" Value="False" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
-                                <Setter Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
-                            </MultiTrigger>
-                        </Style.Triggers>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                                    <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType={x:Type TreeView}}}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="18" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+
+                                        <Border x:Name="RowHighlight"
+                                                Grid.ColumnSpan="2"
+                                                Margin="1"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                CornerRadius="2"
+                                                SnapsToDevicePixels="True" />
+
+                                        <ToggleButton x:Name="Expander"
+                                                      Grid.Column="0"
+                                                      Width="18"
+                                                      Height="22"
+                                                      Focusable="False"
+                                                      IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}">
+                                            <ToggleButton.Template>
+                                                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                                                    <Border Background="Transparent">
+                                                        <Path x:Name="Arrow"
+                                                              Width="5"
+                                                              Height="8"
+                                                              HorizontalAlignment="Center"
+                                                              VerticalAlignment="Center"
+                                                              Data="M 0 0 L 0 8 L 5 4 Z"
+                                                              Fill="{DynamicResource TextSecondaryBrush}" />
+                                                    </Border>
+                                                    <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsChecked" Value="True">
+                                                            <Setter TargetName="Arrow" Property="Width" Value="8" />
+                                                            <Setter TargetName="Arrow" Property="Height" Value="5" />
+                                                            <Setter TargetName="Arrow" Property="Data" Value="M 0 0 L 8 0 L 4 5 Z" />
+                                                        </Trigger>
+                                                    </ControlTemplate.Triggers>
+                                                </ControlTemplate>
+                                            </ToggleButton.Template>
+                                        </ToggleButton>
+
+                                        <ContentPresenter x:Name="PART_Header"
+                                                          Grid.Column="1"
+                                                          Margin="0,3,6,3"
+                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          ContentSource="Header"
+                                                          RecognizesAccessKey="True" />
+
+                                        <ItemsPresenter x:Name="ItemsHost"
+                                                        Grid.Row="1"
+                                                        Grid.Column="1" />
+                                    </Grid>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="HasItems" Value="False">
+                                            <Setter TargetName="Expander" Property="Visibility" Value="Hidden" />
+                                        </Trigger>
+                                        <Trigger Property="IsExpanded" Value="False">
+                                            <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed" />
+                                        </Trigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource ControlHoverBrush}" />
+                                            <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource SelectionBrush}" />
+                                            <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
+                                        </Trigger>
+                                        <MultiTrigger>
+                                            <MultiTrigger.Conditions>
+                                                <Condition Property="IsSelected" Value="True" />
+                                                <Condition Property="Selector.IsSelectionActive" Value="False" />
+                                            </MultiTrigger.Conditions>
+                                            <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
+                                            <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                                        </MultiTrigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
                     </Style>
                 </TreeView.ItemContainerStyle>
                 <TreeView.Resources>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -41,6 +41,8 @@
                       ItemsSource="{Binding AssetDirectoryTree}"
                       PreviewMouseRightButtonDown="OnDirectoryTreePreviewMouseRightButtonDown"
                       SelectedItemChanged="OnDirectoryTreeSelectedItemChanged"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                       Background="{DynamicResource PanelBackgroundBrush}"
                       Foreground="{DynamicResource TextPrimaryBrush}"
                       BorderBrush="{DynamicResource BorderSubtleBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -20,6 +20,8 @@
                   PreviewMouseLeftButtonDown="OnTreeViewPreviewMouseLeftButtonDown"
                   PreviewMouseRightButtonDown="OnTreeViewPreviewMouseRightButtonDown"
                   Visibility="{Binding HasHierarchyItems, Converter={StaticResource BoolToVisibility}}"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                   Foreground="{DynamicResource TextPrimaryBrush}"
                   Background="{DynamicResource PanelBackgroundBrush}"
                   BorderBrush="{DynamicResource BorderSubtleBrush}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -77,19 +77,101 @@
             <TreeView.Resources>
                 <Style TargetType="{x:Type TreeViewItem}">
                     <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="1" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                     <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                                <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType={x:Type TreeView}}}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="18" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <Border x:Name="RowHighlight"
+                                            Grid.ColumnSpan="2"
+                                            Margin="1"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="2"
+                                            SnapsToDevicePixels="True" />
+
+                                    <ToggleButton x:Name="Expander"
+                                                  Grid.Column="0"
+                                                  Width="18"
+                                                  Height="22"
+                                                  Focusable="False"
+                                                  IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}">
+                                        <ToggleButton.Template>
+                                            <ControlTemplate TargetType="{x:Type ToggleButton}">
+                                                <Border Background="Transparent">
+                                                    <Path x:Name="Arrow"
+                                                          Width="5"
+                                                          Height="8"
+                                                          HorizontalAlignment="Center"
+                                                          VerticalAlignment="Center"
+                                                          Data="M 0 0 L 0 8 L 5 4 Z"
+                                                          Fill="{DynamicResource TextSecondaryBrush}" />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsChecked" Value="True">
+                                                        <Setter TargetName="Arrow" Property="Width" Value="8" />
+                                                        <Setter TargetName="Arrow" Property="Height" Value="5" />
+                                                        <Setter TargetName="Arrow" Property="Data" Value="M 0 0 L 8 0 L 4 5 Z" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </ToggleButton.Template>
+                                    </ToggleButton>
+
+                                    <ContentPresenter x:Name="PART_Header"
+                                                      Grid.Column="1"
+                                                      Margin="0,3,6,3"
+                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      ContentSource="Header"
+                                                      RecognizesAccessKey="True" />
+
+                                    <ItemsPresenter x:Name="ItemsHost"
+                                                    Grid.Row="1"
+                                                    Grid.Column="1" />
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="HasItems" Value="False">
+                                        <Setter TargetName="Expander" Property="Visibility" Value="Hidden" />
+                                    </Trigger>
+                                    <Trigger Property="IsExpanded" Value="False">
+                                        <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource ControlHoverBrush}" />
+                                        <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                                    </Trigger>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource SelectionBrush}" />
+                                        <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
+                                    </Trigger>
+                                    <MultiTrigger>
+                                        <MultiTrigger.Conditions>
+                                            <Condition Property="IsSelected" Value="True" />
+                                            <Condition Property="Selector.IsSelectionActive" Value="False" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
+                                        <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+                                    </MultiTrigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
                     <EventSetter Event="Selected" Handler="OnTreeViewItemSelected" />
-                    <Style.Triggers>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="True" />
-                                <Condition Property="Selector.IsSelectionActive" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
-                            <Setter Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
-                        </MultiTrigger>
-                    </Style.Triggers>
                 </Style>
                 <HierarchicalDataTemplate DataType="{x:Type local:HierarchyItemViewModel}"
                                           ItemsSource="{Binding Children}">


### PR DESCRIPTION
### Motivation

- Tree items were only selectable when clicking the text area and did not show the desired faint hover/outline across the full pane width.
- Make selection and hover visuals consistent with the assets pane right-side content so rows are selectable across the entire pane and show a fainter hover outline.

### Description

- Replaced the default `TreeViewItem` styling in `WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml` with a full-row `ControlTemplate` that binds `MinWidth` to the enclosing `TreeView` and provides a `RowHighlight` border for hover/selected visuals.
- Applied the same full-row `TreeViewItem` template to `WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml` so the asset directory tree has matching hit targets and hover/selection states.
- Added transparent default `Background`/`BorderBrush`, `HorizontalContentAlignment="Stretch"`, and preserved expand/collapse `ToggleButton` behavior and nested `ItemsPresenter` rendering.
- Implemented `Trigger`s for `IsMouseOver`, `IsSelected`, and inactive selection (`Selector.IsSelectionActive == False`) to use existing theme brushes (`ControlHoverBrush`, `SelectionBrush`, `InactiveSelectionBrush`, etc.).

### Testing

- Ran an XML parse check with `python3` using `xml.etree.ElementTree.parse` on the modified XAML files which succeeded.
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Attempted to run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` but `dotnet` was not available in the execution environment so the solution build was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a242d41baa48327bb372217bfdda20d)