### PR TITLE
Show project name in editor window title

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelWindowTitleTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelWindowTitleTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MainWindowViewModelWindowTitleTests
+{
+    [Fact]
+    public void WindowTitle_WithLoadedProject_IncludesProjectName()
+    {
+        var vm = CreateUninitializedViewModel();
+        SetPrivateField(vm, "_loadedProject", new EditorProject
+        {
+            Name = "Andy Capp",
+            ProjectFilePath = "C:/temp/Andy Capp.oasisproj",
+            ProjectDirectory = "C:/temp",
+            AssetsDirectory = "C:/temp/Assets",
+            MachinesDirectory = "C:/temp/Machines",
+            GeneratedDirectory = "C:/temp/Generated"
+        });
+
+        Assert.Equal("Andy Capp - Oasis Editor", vm.WindowTitle);
+    }
+
+    [Fact]
+    public void WindowTitle_WithoutLoadedProject_UsesEditorTitle()
+    {
+        var vm = CreateUninitializedViewModel();
+
+        Assert.Equal("Oasis Editor", vm.WindowTitle);
+    }
+
+    private static MainWindowViewModel CreateUninitializedViewModel()
+    {
+        return (MainWindowViewModel)System.Runtime.CompilerServices.RuntimeHelpers
+            .GetUninitializedObject(typeof(MainWindowViewModel));
+    }
+
+    private static void SetPrivateField<T>(MainWindowViewModel vm, string name, T value)
+    {
+        var field = typeof(MainWindowViewModel).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(vm, value);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Oasis Editor"
+        Title="{Binding WindowTitle, FallbackValue=Oasis Editor}"
         Height="780"
         Width="1200"
         MinHeight="620"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -707,11 +707,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             {
                 OnPropertyChanged(nameof(HasLoadedProject));
                 OnPropertyChanged(nameof(InputDefinitions));
+                OnPropertyChanged(nameof(WindowTitle));
                 NotifyInspectorChanged();
                 NotifyDocumentCommands();
             }
         }
     }
+
+    public string WindowTitle => FormatWindowTitle(LoadedProject?.Name);
 
     public bool HasLoadedProject => LoadedProject is not null;
     public MameEmulationState EmulationState
@@ -3271,6 +3274,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    internal static string FormatWindowTitle(string? projectName)
+    {
+        var trimmedProjectName = projectName?.Trim();
+        return string.IsNullOrWhiteSpace(trimmedProjectName)
+            ? "Oasis Editor"
+            : $"{trimmedProjectName} - Oasis Editor";
     }
 
 }


### PR DESCRIPTION
### Motivation
- The editor window was always showing the fixed title `Oasis Editor` instead of including the opened project's name in the window title (should be `<Project Name> - Oasis Editor`).

### Description
- Bind the main window `Title` to a view-model property by changing `MainWindow.xaml` to `Title="{Binding WindowTitle, FallbackValue=Oasis Editor}"` so the fallback remains `Oasis Editor`.
- Add `WindowTitle` to `MainWindowViewModel` and raise `OnPropertyChanged(nameof(WindowTitle))` when `LoadedProject` changes so the UI updates when a project is loaded.
- Add `FormatWindowTitle(string? projectName)` helper in `MainWindowViewModel` to format the title as either `Oasis Editor` or `<Project Name> - Oasis Editor`.
- Add unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MainWindowViewModelWindowTitleTests.cs` to verify both loaded-project and fallback title formatting.

### Testing
- Ran `git diff --check` to validate changes and it reported no problems.
- Attempted `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln --no-restore` but it could not be executed in this environment because `dotnet` is not installed, so the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2432e6e19883278e51611a2c11ce4d)