### PR TITLE
Bake MFME reel overlays into imported background assets

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportMfmeExtractCommandTests.cs
@@ -69,6 +69,62 @@ public sealed class ImportMfmeExtractCommandTests
         Assert.Contains(document.GetPanelElements(), element => element.ObjectId == "import-b");
     }
 
+
+    [Fact]
+    public void Execute_WithImportedReelsAndAlphaDisplays_MovesThemBeforeBackgroundSoBackgroundDrawsInFront()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "existing",
+                    Name = "Existing",
+                    Kind = PanelElementKind.Lamp,
+                    Width = 1,
+                    Height = 1
+                }
+            ]);
+
+        var command = new ImportMfmeExtractCommand(
+            document.DocumentId,
+            document,
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "background",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    Width = 4,
+                    Height = 4
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "reel",
+                    Name = "Reel",
+                    Kind = PanelElementKind.Reel,
+                    Width = 1,
+                    Height = 1
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "alpha",
+                    Name = "Alpha",
+                    Kind = PanelElementKind.Alpha,
+                    Width = 1,
+                    Height = 1
+                }
+            ]);
+
+        document.CommandService.Execute(command);
+
+        var elements = document.GetPanelElements();
+        Assert.Equal("reel", elements[0].ObjectId);
+        Assert.Equal("alpha", elements[1].ObjectId);
+        Assert.Equal("existing", elements[2].ObjectId);
+        Assert.Equal("background", elements[3].ObjectId);
+    }
+
     [Fact]
     public void Execute_WithNoElements_DoesNotMutateOrRecordHistory()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -243,8 +243,9 @@ public sealed class MfmeExtractReaderTests
 
             Assert.True(result.Succeeded);
             Assert.Empty(result.Errors);
-            Assert.Equal(5, result.Warnings.Count);
+            Assert.Equal(6, result.Warnings.Count);
             Assert.All(result.Warnings, warning => Assert.Equal("mfme.extract.asset.missing", warning.Code));
+            Assert.Contains(result.Warnings, warning => warning.Message.Contains("Alpha overlay", StringComparison.OrdinalIgnoreCase));
             Assert.Equal(7, result.Extract!.Components.Count);
         }
         finally

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -156,6 +156,7 @@ public sealed class MfmeExtractReaderTests
         File.WriteAllText(Path.Combine(extractDirectory, "lamps", "lamp-mask.png"), "placeholder");
         File.WriteAllText(Path.Combine(extractDirectory, "reels", "band.png"), "placeholder");
         File.WriteAllText(Path.Combine(extractDirectory, "reels", "overlay.png"), "placeholder");
+        File.WriteAllText(Path.Combine(extractDirectory, "reels", "alpha-overlay.bmp"), "placeholder");
         File.WriteAllText(manifestPath, CreateSupportedComponentsManifestJson());
 
         try
@@ -202,6 +203,8 @@ public sealed class MfmeExtractReaderTests
             Assert.Equal("ExtractComponentAlpha", alpha.SourceType);
             Assert.NotNull(alpha.SegmentOnColor);
             Assert.Equal(0.1f, alpha.SegmentOnColor?.R);
+            Assert.True(alpha.HasOverlay);
+            Assert.Equal("alpha-overlay.bmp", alpha.OverlayBmpImageFilename);
 
             var alphaNew = Assert.IsType<MfmeLegacyAlphaComponent>(components[5]);
             Assert.Equal("ExtractComponentAlphaNew", alphaNew.SourceType);
@@ -367,7 +370,9 @@ public sealed class MfmeExtractReaderTests
               "Position": { "X": 1, "Y": 2 },
               "Size": { "X": 3, "Y": 4 },
               "Reversed": true,
-              "OnColor": { "R": 0.1, "G": 0.2, "B": 0.3, "A": 1.0 }
+              "OnColor": { "R": 0.1, "G": 0.2, "B": 0.3, "A": 1.0 },
+              "HasOverlay": true,
+              "OverlayBmpImageFilename": "alpha-overlay.bmp"
             },
             {
               "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentAlphaNew, MfmeTools",

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
@@ -18,7 +18,7 @@ public sealed class MfmeImportAssetCopierTests
             Directory.CreateDirectory(Path.Combine(extractRoot, "background"));
             Directory.CreateDirectory(Path.Combine(extractRoot, "lamps"));
             Directory.CreateDirectory(Path.Combine(extractRoot, "reels"));
-            File.WriteAllText(Path.Combine(extractRoot, "background", "bg.png"), "bg");
+            CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 1, 1, _ => Color.FromArgb(255, 10, 20, 30));
             File.WriteAllText(Path.Combine(extractRoot, "lamps", "lamp.png"), "lamp");
             File.WriteAllText(Path.Combine(extractRoot, "reels", "band.png"), "band");
 
@@ -80,12 +80,15 @@ public sealed class MfmeImportAssetCopierTests
             Assert.Equal(3, result.CopiedAssetRelativePaths.Count);
             Assert.All(result.CopiedAssetRelativePaths, path => Assert.StartsWith("Assets/MfmeImport/My Layout/", path));
 
-            Assert.Equal("Assets/MfmeImport/My Layout/Background/bg.png", result.Elements[0].AssetPath);
-            Assert.Equal("Assets/MfmeImport/My Layout/Lamps/lamp.png", result.Elements[1].AssetPath);
-            Assert.Equal("Assets/MfmeImport/My Layout/Reels/band.png", result.Elements[2].AssetPath);
-            Assert.Equal("Lithograph", result.Elements[1].TextBoxFontName);
-            Assert.Equal("Bold", result.Elements[1].TextBoxFontStyle);
-            Assert.Equal("12", result.Elements[1].TextBoxFontSize);
+            var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
+            var lamp = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Lamp);
+            var reel = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Reel);
+            Assert.Equal("Assets/MfmeImport/My Layout/Background/bg.png", background.AssetPath);
+            Assert.Equal("Assets/MfmeImport/My Layout/Lamps/lamp.png", lamp.AssetPath);
+            Assert.Equal("Assets/MfmeImport/My Layout/Reels/band.png", reel.AssetPath);
+            Assert.Equal("Lithograph", lamp.TextBoxFontName);
+            Assert.Equal("Bold", lamp.TextBoxFontStyle);
+            Assert.Equal("12", lamp.TextBoxFontSize);
         }
         finally
         {
@@ -316,6 +319,7 @@ public sealed class MfmeImportAssetCopierTests
 
             Assert.True(result.Succeeded);
             Assert.Empty(result.Errors);
+            Assert.Equal(PanelElementKind.Reel, result.Elements[0].Kind);
 
             var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
             var backgroundPath = Path.Combine(projectRoot, "Assets", background.AssetPath!["Assets/".Length..]);
@@ -341,6 +345,93 @@ public sealed class MfmeImportAssetCopierTests
             Assert.Equal(0, opaqueOverlayPixel.R);
             Assert.Equal(0, opaqueOverlayPixel.G);
             Assert.Equal(200, opaqueOverlayPixel.B);
+        }
+        finally
+        {
+            Directory.Delete(extractRoot, recursive: true);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+
+    [Fact]
+    public void CopyAssets_WithReelAndAlphaWithoutOverlay_ClearsBackgroundRectsAndSendsDisplaysBehindBackground()
+    {
+        var extractRoot = CreateTempDirectory();
+        var projectRoot = CreateTempDirectory();
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(extractRoot, "background"));
+            Directory.CreateDirectory(Path.Combine(extractRoot, "reels"));
+            CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 5, 4, _ => Color.FromArgb(255, 10, 20, 30));
+            CreatePng(Path.Combine(extractRoot, "reels", "band.png"), 1, 1, _ => Color.FromArgb(255, 1, 2, 3));
+
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractRoot,
+                ProjectRootPath = projectRoot,
+                ProjectAssetsPath = Path.Combine(projectRoot, "Assets"),
+                CopyAssets = true
+            };
+
+            var extract = new MfmeLegacyExtractData
+            {
+                ExtractRootPath = extractRoot,
+                ManifestPath = Path.Combine(extractRoot, "layout.json"),
+                LayoutName = "layout",
+                Components = []
+            };
+
+            var elements = new[]
+            {
+                new PanelElementModel
+                {
+                    ObjectId = "bg",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    Width = 5,
+                    Height = 4,
+                    AssetPath = "background/bg.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "reel",
+                    Name = "Reel",
+                    Kind = PanelElementKind.Reel,
+                    X = 1,
+                    Y = 1,
+                    Width = 1,
+                    Height = 1,
+                    AssetPath = "reels/band.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "alpha",
+                    Name = "Alpha",
+                    Kind = PanelElementKind.Alpha,
+                    X = 3,
+                    Y = 2,
+                    Width = 1,
+                    Height = 1
+                }
+            };
+
+            var copier = new MfmeImportAssetCopier();
+            var result = copier.CopyAssets(context, extract, elements);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(PanelElementKind.Reel, result.Elements[0].Kind);
+            Assert.Equal(PanelElementKind.Alpha, result.Elements[1].Kind);
+            Assert.Equal(PanelElementKind.Background, result.Elements[2].Kind);
+
+            var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
+            var backgroundPath = Path.Combine(projectRoot, "Assets", background.AssetPath!["Assets/".Length..]);
+            var pixels = ReadBgra32(backgroundPath, out var stride);
+
+            Assert.Equal(0, GetPixel(pixels, stride, 1, 1).A);
+            Assert.Equal(0, GetPixel(pixels, stride, 3, 2).A);
+            Assert.Equal(255, GetPixel(pixels, stride, 0, 0).A);
         }
         finally
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
@@ -251,7 +251,7 @@ public sealed class MfmeImportAssetCopierTests
 
 
     [Fact]
-    public void CopyAssets_WithReelOverlay_BakesOverlayPixelsAndAlphaIntoBackground()
+    public void CopyAssets_WithReelBmpOverlay_BakesOverlayPixelsAndAlphaIntoBackground()
     {
         var extractRoot = CreateTempDirectory();
         var projectRoot = CreateTempDirectory();
@@ -262,7 +262,7 @@ public sealed class MfmeImportAssetCopierTests
             Directory.CreateDirectory(Path.Combine(extractRoot, "reels"));
             CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 4, 4, _ => Color.FromArgb(255, 10, 20, 30));
             CreatePng(Path.Combine(extractRoot, "reels", "band.png"), 1, 1, _ => Color.FromArgb(255, 1, 2, 3));
-            CreatePng(Path.Combine(extractRoot, "reels", "overlay.png"), 2, 2, index => index switch
+            CreateTopDownBgra32Bmp(Path.Combine(extractRoot, "reels", "overlay.bmp"), 2, 2, index => index switch
             {
                 0 => Color.FromArgb(128, 200, 0, 0),
                 1 => Color.FromArgb(0, 0, 200, 0),
@@ -307,7 +307,7 @@ public sealed class MfmeImportAssetCopierTests
                     Width = 2,
                     Height = 2,
                     AssetPath = "reels/band.png",
-                    SecondaryAssetPath = "reels/overlay.png"
+                    SecondaryAssetPath = "reels/overlay.bmp"
                 }
             };
 
@@ -374,6 +374,41 @@ public sealed class MfmeImportAssetCopierTests
         encoder.Frames.Add(BitmapFrame.Create(bitmap));
         using var stream = File.Create(path);
         encoder.Save(stream);
+    }
+
+    private static void CreateTopDownBgra32Bmp(string path, int width, int height, Func<int, Color> colorFactory)
+    {
+        var pixelDataOffset = 14 + 40;
+        var stride = width * 4;
+        var fileSize = pixelDataOffset + (stride * height);
+
+        using var stream = File.Create(path);
+        using var writer = new BinaryWriter(stream);
+        writer.Write((byte)'B');
+        writer.Write((byte)'M');
+        writer.Write(fileSize);
+        writer.Write(0);
+        writer.Write(pixelDataOffset);
+        writer.Write(40);
+        writer.Write(width);
+        writer.Write(-height);
+        writer.Write((ushort)1);
+        writer.Write((ushort)32);
+        writer.Write(0);
+        writer.Write(stride * height);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);
+        writer.Write(0);
+
+        for (var index = 0; index < width * height; index++)
+        {
+            var color = colorFactory(index);
+            writer.Write(color.B);
+            writer.Write(color.G);
+            writer.Write(color.R);
+            writer.Write(color.A);
+        }
     }
 
     private static byte[] ReadBgra32(string path, out int stride)

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
@@ -1,3 +1,5 @@
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using OasisEditor.Features.MfmeImport;
 using Xunit;
 
@@ -247,10 +249,147 @@ public sealed class MfmeImportAssetCopierTests
         }
     }
 
+
+    [Fact]
+    public void CopyAssets_WithReelOverlay_BakesOverlayPixelsAndAlphaIntoBackground()
+    {
+        var extractRoot = CreateTempDirectory();
+        var projectRoot = CreateTempDirectory();
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(extractRoot, "background"));
+            Directory.CreateDirectory(Path.Combine(extractRoot, "reels"));
+            CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 4, 4, _ => Color.FromArgb(255, 10, 20, 30));
+            CreatePng(Path.Combine(extractRoot, "reels", "band.png"), 1, 1, _ => Color.FromArgb(255, 1, 2, 3));
+            CreatePng(Path.Combine(extractRoot, "reels", "overlay.png"), 2, 2, index => index switch
+            {
+                0 => Color.FromArgb(128, 200, 0, 0),
+                1 => Color.FromArgb(0, 0, 200, 0),
+                2 => Color.FromArgb(255, 0, 0, 200),
+                _ => Color.FromArgb(64, 200, 200, 0)
+            });
+
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractRoot,
+                ProjectRootPath = projectRoot,
+                ProjectAssetsPath = Path.Combine(projectRoot, "Assets"),
+                CopyAssets = true
+            };
+
+            var extract = new MfmeLegacyExtractData
+            {
+                ExtractRootPath = extractRoot,
+                ManifestPath = Path.Combine(extractRoot, "layout.json"),
+                LayoutName = "layout",
+                Components = []
+            };
+
+            var elements = new[]
+            {
+                new PanelElementModel
+                {
+                    ObjectId = "bg",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    Width = 4,
+                    Height = 4,
+                    AssetPath = "background/bg.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "reel",
+                    Name = "Reel",
+                    Kind = PanelElementKind.Reel,
+                    X = 1,
+                    Y = 1,
+                    Width = 2,
+                    Height = 2,
+                    AssetPath = "reels/band.png",
+                    SecondaryAssetPath = "reels/overlay.png"
+                }
+            };
+
+            var copier = new MfmeImportAssetCopier();
+            var result = copier.CopyAssets(context, extract, elements);
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+
+            var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
+            var backgroundPath = Path.Combine(projectRoot, "Assets", background.AssetPath!["Assets/".Length..]);
+            var pixels = ReadBgra32(backgroundPath, out var stride);
+
+            var untouched = GetPixel(pixels, stride, 0, 0);
+            Assert.Equal(255, untouched.A);
+            Assert.Equal(10, untouched.R);
+            Assert.Equal(20, untouched.G);
+            Assert.Equal(30, untouched.B);
+
+            var halfAlphaOverlayPixel = GetPixel(pixels, stride, 1, 1);
+            Assert.Equal(128, halfAlphaOverlayPixel.A);
+            Assert.Equal(200, halfAlphaOverlayPixel.R);
+            Assert.Equal(0, halfAlphaOverlayPixel.G);
+            Assert.Equal(0, halfAlphaOverlayPixel.B);
+
+            var transparentOverlayPixel = GetPixel(pixels, stride, 2, 1);
+            Assert.Equal(0, transparentOverlayPixel.A);
+
+            var opaqueOverlayPixel = GetPixel(pixels, stride, 1, 2);
+            Assert.Equal(255, opaqueOverlayPixel.A);
+            Assert.Equal(0, opaqueOverlayPixel.R);
+            Assert.Equal(0, opaqueOverlayPixel.G);
+            Assert.Equal(200, opaqueOverlayPixel.B);
+        }
+        finally
+        {
+            Directory.Delete(extractRoot, recursive: true);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"oasis-mfme-copy-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+
+    private static void CreatePng(string path, int width, int height, Func<int, Color> colorFactory)
+    {
+        var pixels = new byte[width * height * 4];
+        for (var index = 0; index < width * height; index++)
+        {
+            var color = colorFactory(index);
+            pixels[(index * 4) + 0] = color.B;
+            pixels[(index * 4) + 1] = color.G;
+            pixels[(index * 4) + 2] = color.R;
+            pixels[(index * 4) + 3] = color.A;
+        }
+
+        var bitmap = BitmapSource.Create(width, height, 96, 96, PixelFormats.Bgra32, null, pixels, width * 4);
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        using var stream = File.Create(path);
+        encoder.Save(stream);
+    }
+
+    private static byte[] ReadBgra32(string path, out int stride)
+    {
+        using var stream = File.OpenRead(path);
+        var decoder = new PngBitmapDecoder(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+        var converted = new FormatConvertedBitmap(decoder.Frames[0], PixelFormats.Bgra32, null, 0);
+        stride = converted.PixelWidth * 4;
+        var pixels = new byte[stride * converted.PixelHeight];
+        converted.CopyPixels(pixels, stride, 0);
+        return pixels;
+    }
+
+    private static Color GetPixel(byte[] pixels, int stride, int x, int y)
+    {
+        var offset = (y * stride) + (x * 4);
+        return Color.FromArgb(pixels[offset + 3], pixels[offset + 2], pixels[offset + 1], pixels[offset + 0]);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -51,7 +51,9 @@ public sealed class MfmeToOasisComponentMapperTests
                     new MfmeLegacyPoint(1, 2),
                     new MfmeLegacyPoint(3, 4),
                     Reversed: false,
-                    SegmentOnColor: new MfmeLegacyColor(0f, 0f, 1f, 1f)),
+                    SegmentOnColor: new MfmeLegacyColor(0f, 0f, 1f, 1f),
+                    HasOverlay: true,
+                    OverlayBmpImageFilename: "alpha-overlay.bmp"),
                 new MfmeLegacyButtonComponent(
                     new MfmeLegacyPoint(120, 220),
                     new MfmeLegacyPoint(44, 22),
@@ -133,6 +135,7 @@ public sealed class MfmeToOasisComponentMapperTests
         Assert.Equal(PanelElementKind.Alpha, alpha.Kind);
         Assert.Equal("Alpha", alpha.Name);
         Assert.False(alpha.IsReversed);
+        Assert.Equal("reels/alpha-overlay.bmp", alpha.SecondaryAssetPath);
         Assert.Equal("#FF0000FF", alpha.OnColorHex);
 
         var label = result.Elements[6];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -55,6 +55,7 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
 
         var insertIndex = Math.Clamp(_insertIndex, 0, currentElements.Count);
         currentElements.InsertRange(insertIndex, _importedElements.Select(static element => CloneElement(element)));
+        SendImportedReelsAndAlphaDisplaysToBack(currentElements, importedIds);
         _document.SetPanelElements(currentElements, new PanelChangeEvent(_document.DocumentId, null, PanelChangeProperties.Structure, AffectsCanvas: true, AffectsHierarchy: true, AffectsInspectorRows: true, AffectsPersistence: true));
         _document.MarkDirty();
         WasExecuted = true;
@@ -99,6 +100,25 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
         return imported;
     }
 
+    private static void SendImportedReelsAndAlphaDisplaysToBack(List<PanelElementModel> elements, ISet<string> importedIds)
+    {
+        var importedDisplays = elements
+            .Where(element => importedIds.Contains(element.ObjectId) && IsImportedBackgroundCutoutDisplay(element))
+            .ToArray();
+        if (importedDisplays.Length == 0)
+        {
+            return;
+        }
+
+        elements.RemoveAll(element => importedIds.Contains(element.ObjectId) && IsImportedBackgroundCutoutDisplay(element));
+        elements.InsertRange(0, importedDisplays);
+    }
+
+    private static bool IsImportedBackgroundCutoutDisplay(PanelElementModel element)
+    {
+        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix;
+    }
+
     private static string BuildUniqueObjectId(IReadOnlySet<string> existingIds)
     {
         string candidate;
@@ -124,6 +144,9 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
             AssetPath = source.AssetPath,
             SecondaryAssetPath = source.SecondaryAssetPath,
             DisplayNumber = source.DisplayNumber,
+            SegmentDisplayType = source.SegmentDisplayType,
+            ShowDecimalPoint = source.ShowDecimalPoint,
+            ShowCommaTail = source.ShowCommaTail,
             OnColorHex = source.OnColorHex,
             OffColorHex = source.OffColorHex,
             TextColorHex = source.TextColorHex,
@@ -134,6 +157,9 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
             IsReversed = source.IsReversed,
             Stops = source.Stops,
             VisibleScale = source.VisibleScale,
+            BandOffset = source.BandOffset,
+            IsLocked = source.IsLocked,
+            IsVisible = source.IsVisible,
             ImportSource = source.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -7,7 +7,7 @@ namespace OasisEditor.Features.MfmeImport;
 
 internal static class MfmeBackgroundOverlayPostProcessor
 {
-    public static bool TryBakeReelOverlays(
+    public static bool TryBakeDisplayOverlays(
         string backgroundPath,
         PanelElementModel background,
         IEnumerable<PanelElementModel> elements,
@@ -21,13 +21,11 @@ internal static class MfmeBackgroundOverlayPostProcessor
 
         try
         {
-            var overlays = elements
-                .Where(element => element.Kind == PanelElementKind.Reel && !string.IsNullOrWhiteSpace(element.SecondaryAssetPath))
-                .Select(element => new OverlayPlacement(element, TryResolveProjectAssetPath(element.SecondaryAssetPath, projectAssetsRoot)))
-                .Where(placement => placement.FullPath is not null && File.Exists(placement.FullPath))
+            var displayElements = elements
+                .Where(IsBackgroundCutoutDisplay)
                 .ToArray();
 
-            if (overlays.Length == 0)
+            if (displayElements.Length == 0)
             {
                 return true;
             }
@@ -38,10 +36,17 @@ internal static class MfmeBackgroundOverlayPostProcessor
                 return true;
             }
 
-            foreach (var overlay in overlays)
+            foreach (var displayElement in displayElements)
             {
-                var overlayImage = LoadBgra32(overlay.FullPath!);
-                CopyOverlayIntoBackground(backgroundImage, background, overlay.Element, overlayImage);
+                if (TryResolveProjectAssetPath(displayElement.SecondaryAssetPath, projectAssetsRoot) is { } overlayPath && File.Exists(overlayPath))
+                {
+                    var overlayImage = LoadBgra32(overlayPath);
+                    CopyOverlayIntoBackground(backgroundImage, background, displayElement, overlayImage);
+                }
+                else
+                {
+                    ClearBackgroundRect(backgroundImage, background, displayElement);
+                }
             }
 
             var outputPath = ResolveOutputPath(backgroundPath);
@@ -62,9 +67,14 @@ internal static class MfmeBackgroundOverlayPostProcessor
         }
     }
 
+    private static bool IsBackgroundCutoutDisplay(PanelElementModel element)
+    {
+        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix;
+    }
+
     private static void CopyOverlayIntoBackground(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement, PixelBuffer overlayImage)
     {
-        var destinationRect = GetOverlayDestinationRect(backgroundImage, background, overlayElement);
+        var destinationRect = GetElementDestinationRect(backgroundImage, background, overlayElement);
         if (destinationRect.Width <= 0 || destinationRect.Height <= 0)
         {
             return;
@@ -93,7 +103,40 @@ internal static class MfmeBackgroundOverlayPostProcessor
         }
     }
 
-    private static PixelRect GetOverlayDestinationRect(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement)
+    private static void ClearBackgroundRect(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel displayElement)
+    {
+        var destinationRect = GetElementDestinationRect(backgroundImage, background, displayElement);
+        if (destinationRect.Width <= 0 || destinationRect.Height <= 0)
+        {
+            return;
+        }
+
+        for (var y = 0; y < destinationRect.Height; y++)
+        {
+            var destinationY = destinationRect.Y + y;
+            if (destinationY < 0 || destinationY >= backgroundImage.Height)
+            {
+                continue;
+            }
+
+            for (var x = 0; x < destinationRect.Width; x++)
+            {
+                var destinationX = destinationRect.X + x;
+                if (destinationX < 0 || destinationX >= backgroundImage.Width)
+                {
+                    continue;
+                }
+
+                var destinationOffset = (destinationY * backgroundImage.Stride) + (destinationX * 4);
+                backgroundImage.Pixels[destinationOffset + 0] = 0;
+                backgroundImage.Pixels[destinationOffset + 1] = 0;
+                backgroundImage.Pixels[destinationOffset + 2] = 0;
+                backgroundImage.Pixels[destinationOffset + 3] = 0;
+            }
+        }
+    }
+
+    private static PixelRect GetElementDestinationRect(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement)
     {
         if (background.Width <= 0 || background.Height <= 0 || overlayElement.Width <= 0 || overlayElement.Height <= 0)
         {
@@ -333,8 +376,6 @@ internal static class MfmeBackgroundOverlayPostProcessor
         using var stream = File.Create(destinationPath);
         encoder.Save(stream);
     }
-
-    private sealed record OverlayPlacement(PanelElementModel Element, string? FullPath);
 
     private readonly record struct PixelRect(int X, int Y, int Width, int Height);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.IO;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -121,6 +122,11 @@ internal static class MfmeBackgroundOverlayPostProcessor
 
     private static PixelBuffer LoadBgra32(string path)
     {
+        if (TryLoadUncompressedBgra32Bmp(path, out var bmp))
+        {
+            return bmp;
+        }
+
         using var stream = File.OpenRead(path);
         var decoder = BitmapDecoder.Create(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
         var frame = decoder.Frames[0];
@@ -135,6 +141,69 @@ internal static class MfmeBackgroundOverlayPostProcessor
         }
 
         return new PixelBuffer(converted.PixelWidth, converted.PixelHeight, stride, pixels);
+    }
+
+    private static bool TryLoadUncompressedBgra32Bmp(string path, out PixelBuffer image)
+    {
+        image = default!;
+
+        if (!string.Equals(Path.GetExtension(path), ".bmp", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var bytes = File.ReadAllBytes(path);
+        if (bytes.Length < 54 || bytes[0] != (byte)'B' || bytes[1] != (byte)'M')
+        {
+            return false;
+        }
+
+        var pixelDataOffset = ReadInt32LittleEndian(bytes, 10);
+        var dibHeaderSize = ReadInt32LittleEndian(bytes, 14);
+        if (dibHeaderSize < 40 || bytes.Length < 14 + dibHeaderSize)
+        {
+            return false;
+        }
+
+        var width = ReadInt32LittleEndian(bytes, 18);
+        var signedHeight = ReadInt32LittleEndian(bytes, 22);
+        var planes = ReadUInt16LittleEndian(bytes, 26);
+        var bitsPerPixel = ReadUInt16LittleEndian(bytes, 28);
+        var compression = ReadInt32LittleEndian(bytes, 30);
+        if (width <= 0 || signedHeight == 0 || signedHeight == int.MinValue || planes != 1 || bitsPerPixel != 32 || compression != 0 || pixelDataOffset < 0)
+        {
+            return false;
+        }
+
+        var height = Math.Abs(signedHeight);
+        var stride = checked(width * 4);
+        var pixelByteCount = (long)stride * height;
+        var requiredLength = pixelDataOffset + pixelByteCount;
+        if (pixelByteCount > int.MaxValue || requiredLength > bytes.Length)
+        {
+            return false;
+        }
+
+        var pixels = new byte[stride * height];
+        var sourceTopDown = signedHeight < 0;
+        for (var y = 0; y < height; y++)
+        {
+            var sourceY = sourceTopDown ? y : height - 1 - y;
+            Buffer.BlockCopy(bytes, pixelDataOffset + (sourceY * stride), pixels, y * stride, stride);
+        }
+
+        image = new PixelBuffer(width, height, stride, pixels);
+        return true;
+    }
+
+    private static int ReadInt32LittleEndian(byte[] bytes, int offset)
+    {
+        return BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset, sizeof(int)));
+    }
+
+    private static ushort ReadUInt16LittleEndian(byte[] bytes, int offset)
+    {
+        return BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(offset, sizeof(ushort)));
     }
 
     private static bool IsPalettized(PixelFormat format)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -1,0 +1,279 @@
+using System.IO;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace OasisEditor.Features.MfmeImport;
+
+internal static class MfmeBackgroundOverlayPostProcessor
+{
+    public static bool TryBakeReelOverlays(
+        string backgroundPath,
+        PanelElementModel background,
+        IEnumerable<PanelElementModel> elements,
+        string projectAssetsRoot,
+        ICollection<string> copied,
+        out string? updatedBackgroundPath,
+        out string? error)
+    {
+        updatedBackgroundPath = null;
+        error = null;
+
+        try
+        {
+            var overlays = elements
+                .Where(element => element.Kind == PanelElementKind.Reel && !string.IsNullOrWhiteSpace(element.SecondaryAssetPath))
+                .Select(element => new OverlayPlacement(element, TryResolveProjectAssetPath(element.SecondaryAssetPath, projectAssetsRoot)))
+                .Where(placement => placement.FullPath is not null && File.Exists(placement.FullPath))
+                .ToArray();
+
+            if (overlays.Length == 0)
+            {
+                return true;
+            }
+
+            var backgroundImage = LoadBgra32(backgroundPath);
+            if (backgroundImage.Width <= 0 || backgroundImage.Height <= 0)
+            {
+                return true;
+            }
+
+            foreach (var overlay in overlays)
+            {
+                var overlayImage = LoadBgra32(overlay.FullPath!);
+                CopyOverlayIntoBackground(backgroundImage, background, overlay.Element, overlayImage);
+            }
+
+            var outputPath = ResolveOutputPath(backgroundPath);
+            SavePng(backgroundImage, outputPath);
+
+            if (!string.Equals(outputPath, backgroundPath, StringComparison.OrdinalIgnoreCase))
+            {
+                updatedBackgroundPath = ToProjectRelativeAssetPath(outputPath, projectAssetsRoot);
+                copied.Add(updatedBackgroundPath);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static void CopyOverlayIntoBackground(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement, PixelBuffer overlayImage)
+    {
+        var destinationRect = GetOverlayDestinationRect(backgroundImage, background, overlayElement);
+        if (destinationRect.Width <= 0 || destinationRect.Height <= 0)
+        {
+            return;
+        }
+
+        for (var y = 0; y < destinationRect.Height; y++)
+        {
+            var destinationY = destinationRect.Y + y;
+            if (destinationY < 0 || destinationY >= backgroundImage.Height)
+            {
+                continue;
+            }
+
+            var sourceY = ScaleCoordinate(y, destinationRect.Height, overlayImage.Height);
+            for (var x = 0; x < destinationRect.Width; x++)
+            {
+                var destinationX = destinationRect.X + x;
+                if (destinationX < 0 || destinationX >= backgroundImage.Width)
+                {
+                    continue;
+                }
+
+                var sourceX = ScaleCoordinate(x, destinationRect.Width, overlayImage.Width);
+                CopySourcePixelToDestination(backgroundImage, destinationX, destinationY, overlayImage, sourceX, sourceY);
+            }
+        }
+    }
+
+    private static PixelRect GetOverlayDestinationRect(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement)
+    {
+        if (background.Width <= 0 || background.Height <= 0 || overlayElement.Width <= 0 || overlayElement.Height <= 0)
+        {
+            return new PixelRect(0, 0, 0, 0);
+        }
+
+        var scaleX = backgroundImage.Width / background.Width;
+        var scaleY = backgroundImage.Height / background.Height;
+        var x = (int)Math.Round((overlayElement.X - background.X) * scaleX);
+        var y = (int)Math.Round((overlayElement.Y - background.Y) * scaleY);
+        var width = Math.Max(1, (int)Math.Round(overlayElement.Width * scaleX));
+        var height = Math.Max(1, (int)Math.Round(overlayElement.Height * scaleY));
+        return new PixelRect(x, y, width, height);
+    }
+
+    private static void CopySourcePixelToDestination(PixelBuffer destination, int destinationX, int destinationY, PixelBuffer source, int sourceX, int sourceY)
+    {
+        var destinationOffset = (destinationY * destination.Stride) + (destinationX * 4);
+        var sourceOffset = (sourceY * source.Stride) + (sourceX * 4);
+
+        destination.Pixels[destinationOffset + 0] = source.Pixels[sourceOffset + 0];
+        destination.Pixels[destinationOffset + 1] = source.Pixels[sourceOffset + 1];
+        destination.Pixels[destinationOffset + 2] = source.Pixels[sourceOffset + 2];
+        destination.Pixels[destinationOffset + 3] = source.Pixels[sourceOffset + 3];
+    }
+
+    private static PixelBuffer LoadBgra32(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var decoder = BitmapDecoder.Create(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+        var frame = decoder.Frames[0];
+        var converted = new FormatConvertedBitmap(frame, PixelFormats.Bgra32, frame.Palette, 0);
+        var stride = converted.PixelWidth * 4;
+        var pixels = new byte[stride * converted.PixelHeight];
+        converted.CopyPixels(pixels, stride, 0);
+
+        if (IsPalettized(frame.Format) && frame.Palette is not null)
+        {
+            ReapplyIndexedAlpha(frame, pixels, stride);
+        }
+
+        return new PixelBuffer(converted.PixelWidth, converted.PixelHeight, stride, pixels);
+    }
+
+    private static bool IsPalettized(PixelFormat format)
+    {
+        return format == PixelFormats.Indexed1
+            || format == PixelFormats.Indexed2
+            || format == PixelFormats.Indexed4
+            || format == PixelFormats.Indexed8;
+    }
+
+    private static void ReapplyIndexedAlpha(BitmapSource frame, byte[] pixels, int stride)
+    {
+        var palette = frame.Palette.Colors;
+        if (palette.Count == 0)
+        {
+            return;
+        }
+
+        var bitsPerPixel = frame.Format.BitsPerPixel;
+        if (bitsPerPixel is not (1 or 2 or 4 or 8))
+        {
+            return;
+        }
+
+        var indexedStride = (frame.PixelWidth * bitsPerPixel + 7) / 8;
+        var indices = new byte[indexedStride * frame.PixelHeight];
+        frame.CopyPixels(indices, indexedStride, 0);
+
+        for (var y = 0; y < frame.PixelHeight; y++)
+        {
+            for (var x = 0; x < frame.PixelWidth; x++)
+            {
+                var paletteIndex = ReadPaletteIndex(indices, indexedStride, bitsPerPixel, x, y);
+                if (paletteIndex < 0 || paletteIndex >= palette.Count)
+                {
+                    continue;
+                }
+
+                var color = palette[paletteIndex];
+                pixels[(y * stride) + (x * 4) + 3] = color.A;
+            }
+        }
+    }
+
+    private static int ReadPaletteIndex(byte[] indices, int stride, int bitsPerPixel, int x, int y)
+    {
+        if (bitsPerPixel == 8)
+        {
+            return indices[(y * stride) + x];
+        }
+
+        var bitIndex = x * bitsPerPixel;
+        var byteIndex = (y * stride) + (bitIndex / 8);
+        var bitOffset = bitIndex % 8;
+        var shift = 8 - bitsPerPixel - bitOffset;
+        var mask = (1 << bitsPerPixel) - 1;
+        return (indices[byteIndex] >> shift) & mask;
+    }
+
+    private static int ScaleCoordinate(int value, int sourceSize, int destinationSize)
+    {
+        if (sourceSize <= 1 || destinationSize <= 1)
+        {
+            return 0;
+        }
+
+        return (int)Math.Round((double)value * (destinationSize - 1) / (sourceSize - 1));
+    }
+
+    private static string ResolveOutputPath(string backgroundPath)
+    {
+        if (string.Equals(Path.GetExtension(backgroundPath), ".png", StringComparison.OrdinalIgnoreCase))
+        {
+            return backgroundPath;
+        }
+
+        var directory = Path.GetDirectoryName(backgroundPath) ?? string.Empty;
+        var baseName = Path.GetFileNameWithoutExtension(backgroundPath);
+        var candidate = Path.Combine(directory, $"{baseName}.png");
+        var suffix = 2;
+
+        while (File.Exists(candidate))
+        {
+            candidate = Path.Combine(directory, $"{baseName}_{suffix}.png");
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static string? TryResolveProjectAssetPath(string? projectRelativePath, string projectAssetsRoot)
+    {
+        if (string.IsNullOrWhiteSpace(projectRelativePath) || !projectRelativePath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var relativePath = projectRelativePath["Assets/".Length..].Replace('/', Path.DirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(Path.Combine(projectAssetsRoot, relativePath));
+        return IsPathUnderRoot(fullPath, projectAssetsRoot) ? fullPath : null;
+    }
+
+    private static string ToProjectRelativeAssetPath(string fullPath, string projectAssetsRoot)
+    {
+        var relativePath = Path.GetRelativePath(projectAssetsRoot, fullPath).Replace('\\', '/');
+        return $"Assets/{relativePath}";
+    }
+
+    private static bool IsPathUnderRoot(string path, string root)
+    {
+        return path.StartsWith(root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(path, root, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void SavePng(PixelBuffer image, string destinationPath)
+    {
+        var directory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var bitmap = BitmapSource.Create(image.Width, image.Height, 96, 96, PixelFormats.Bgra32, null, image.Pixels, image.Stride);
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+
+        using var stream = File.Create(destinationPath);
+        encoder.Save(stream);
+    }
+
+    private sealed record OverlayPlacement(PanelElementModel Element, string? FullPath);
+
+    private readonly record struct PixelRect(int X, int Y, int Width, int Height);
+
+    private sealed class PixelBuffer(int width, int height, int stride, byte[] pixels)
+    {
+        public int Width { get; } = width;
+        public int Height { get; } = height;
+        public int Stride { get; } = stride;
+        public byte[] Pixels { get; } = pixels;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -146,6 +146,18 @@ internal static class MfmeExtractManifestParser
                         warnings);
                 }
                 break;
+            case MfmeLegacyAlphaComponent alpha:
+                if (alpha.HasOverlay)
+                {
+                    AddMissingImageWarningIfNeeded(
+                        extractDirectory,
+                        "reels",
+                        alpha.OverlayBmpImageFilename,
+                        "Alpha overlay",
+                        componentIndex,
+                        warnings);
+                }
+                break;
         }
     }
 
@@ -263,13 +275,18 @@ internal static class MfmeExtractManifestParser
             case "extractcomponentalpha":
             case "extractcomponentalphanew":
             case "extractcomponentmatrixalpha":
-                parsedComponent = new MfmeLegacyAlphaComponent(
-                    sourceType,
-                    position,
-                    size,
-                    ReadBool(component, "Reversed"),
-                    ReadColor(component, "OnColor") ?? ReadColor(component, "SegmentOnColor"));
-                return true;
+                {
+                    var overlayBmpImageFilename = ReadString(component, "OverlayBmpImageFilename") ?? ReadString(component, "BmpImageFilename");
+                    parsedComponent = new MfmeLegacyAlphaComponent(
+                        sourceType,
+                        position,
+                        size,
+                        ReadBool(component, "Reversed"),
+                        ReadColor(component, "OnColor") ?? ReadColor(component, "SegmentOnColor"),
+                        ReadBool(component, "HasOverlay") || !string.IsNullOrWhiteSpace(overlayBmpImageFilename),
+                        overlayBmpImageFilename);
+                    return true;
+                }
 
             case "extractcomponentlabel":
                 parsedComponent = new MfmeLegacyLabelComponent(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
@@ -50,6 +50,11 @@ internal sealed class MfmeImportAssetCopier
             .Select(element => MapElementAssets(element, extract.ExtractRootPath, destinationRoot, projectAssetsRoot, pathMap, copied, warnings, errors))
             .ToArray();
 
+        if (errors.Count == 0)
+        {
+            mappedElements = BakeOverlayImagesIntoBackgrounds(mappedElements, projectAssetsRoot, copied, errors);
+        }
+
         if (errors.Count > 0)
         {
             return CreateError(elements, warnings, errors);
@@ -138,6 +143,88 @@ internal sealed class MfmeImportAssetCopier
             VisibleScale = element.VisibleScale,
             ImportSource = element.ImportSource
         };
+    }
+
+    private static PanelElementModel[] BakeOverlayImagesIntoBackgrounds(
+        PanelElementModel[] elements,
+        string projectAssetsRoot,
+        ICollection<string> copied,
+        ICollection<string> errors)
+    {
+        if (!elements.Any(element => element.Kind == PanelElementKind.Reel && !string.IsNullOrWhiteSpace(element.SecondaryAssetPath)))
+        {
+            return elements;
+        }
+
+        var updatedElements = elements;
+        for (var index = 0; index < updatedElements.Length; index++)
+        {
+            var background = updatedElements[index];
+            if (background.Kind != PanelElementKind.Background || string.IsNullOrWhiteSpace(background.AssetPath))
+            {
+                continue;
+            }
+
+            var backgroundPath = TryResolveProjectAssetPath(background.AssetPath, projectAssetsRoot);
+            if (backgroundPath is null || !File.Exists(backgroundPath))
+            {
+                continue;
+            }
+
+            if (!MfmeBackgroundOverlayPostProcessor.TryBakeReelOverlays(backgroundPath, background, updatedElements, projectAssetsRoot, copied, out var updatedBackgroundPath, out var processingError))
+            {
+                errors.Add($"Failed to bake MFME overlay images into background asset '{background.AssetPath}': {processingError}");
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(updatedBackgroundPath))
+            {
+                updatedElements = (PanelElementModel[])updatedElements.Clone();
+                updatedElements[index] = CloneWithAssetPath(background, updatedBackgroundPath);
+            }
+        }
+
+        return updatedElements;
+    }
+
+    private static PanelElementModel CloneWithAssetPath(PanelElementModel element, string? assetPath)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = element.ObjectId,
+            Name = element.Name,
+            Kind = element.Kind,
+            X = element.X,
+            Y = element.Y,
+            Width = element.Width,
+            Height = element.Height,
+            AssetPath = assetPath,
+            SecondaryAssetPath = element.SecondaryAssetPath,
+            DisplayNumber = element.DisplayNumber,
+            OnColorHex = element.OnColorHex,
+            OffColorHex = element.OffColorHex,
+            TextColorHex = element.TextColorHex,
+            DisplayText = element.DisplayText,
+            TextBoxFontName = element.TextBoxFontName,
+            TextBoxFontStyle = element.TextBoxFontStyle,
+            TextBoxFontSize = element.TextBoxFontSize,
+            IsReversed = element.IsReversed,
+            Stops = element.Stops,
+            VisibleScale = element.VisibleScale,
+            ImportSource = element.ImportSource
+        };
+    }
+
+    private static string? TryResolveProjectAssetPath(string? projectRelativePath, string projectAssetsRoot)
+    {
+        if (string.IsNullOrWhiteSpace(projectRelativePath) || !projectRelativePath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var relativePath = projectRelativePath["Assets/".Length..].Replace('/', Path.DirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(Path.Combine(projectAssetsRoot, relativePath));
+        return IsPathUnderRoot(fullPath, projectAssetsRoot) ? fullPath : null;
     }
 
     private static string? CopyOneAsset(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
@@ -25,7 +25,7 @@ internal sealed class MfmeImportAssetCopier
         {
             return new MfmeAssetCopyResult
             {
-                Elements = elements,
+                Elements = SendReelsAndAlphaDisplaysToBack(elements.ToArray()),
                 CopiedAssetRelativePaths = [],
                 Warnings = [],
                 Errors = []
@@ -52,13 +52,15 @@ internal sealed class MfmeImportAssetCopier
 
         if (errors.Count == 0)
         {
-            mappedElements = BakeOverlayImagesIntoBackgrounds(mappedElements, projectAssetsRoot, copied, errors);
+            mappedElements = BakeDisplayOverlaysIntoBackgrounds(mappedElements, projectAssetsRoot, copied, errors);
         }
 
         if (errors.Count > 0)
         {
             return CreateError(elements, warnings, errors);
         }
+
+        mappedElements = SendReelsAndAlphaDisplaysToBack(mappedElements);
 
         return new MfmeAssetCopyResult
         {
@@ -131,6 +133,9 @@ internal sealed class MfmeImportAssetCopier
             AssetPath = primary,
             SecondaryAssetPath = secondary,
             DisplayNumber = element.DisplayNumber,
+            SegmentDisplayType = element.SegmentDisplayType,
+            ShowDecimalPoint = element.ShowDecimalPoint,
+            ShowCommaTail = element.ShowCommaTail,
             OnColorHex = element.OnColorHex,
             OffColorHex = element.OffColorHex,
             TextColorHex = element.TextColorHex,
@@ -141,17 +146,20 @@ internal sealed class MfmeImportAssetCopier
             IsReversed = element.IsReversed,
             Stops = element.Stops,
             VisibleScale = element.VisibleScale,
+            BandOffset = element.BandOffset,
+            IsLocked = element.IsLocked,
+            IsVisible = element.IsVisible,
             ImportSource = element.ImportSource
         };
     }
 
-    private static PanelElementModel[] BakeOverlayImagesIntoBackgrounds(
+    private static PanelElementModel[] BakeDisplayOverlaysIntoBackgrounds(
         PanelElementModel[] elements,
         string projectAssetsRoot,
         ICollection<string> copied,
         ICollection<string> errors)
     {
-        if (!elements.Any(element => element.Kind == PanelElementKind.Reel && !string.IsNullOrWhiteSpace(element.SecondaryAssetPath)))
+        if (!elements.Any(IsBackgroundCutoutDisplay))
         {
             return elements;
         }
@@ -171,9 +179,9 @@ internal sealed class MfmeImportAssetCopier
                 continue;
             }
 
-            if (!MfmeBackgroundOverlayPostProcessor.TryBakeReelOverlays(backgroundPath, background, updatedElements, projectAssetsRoot, copied, out var updatedBackgroundPath, out var processingError))
+            if (!MfmeBackgroundOverlayPostProcessor.TryBakeDisplayOverlays(backgroundPath, background, updatedElements, projectAssetsRoot, copied, out var updatedBackgroundPath, out var processingError))
             {
-                errors.Add($"Failed to bake MFME overlay images into background asset '{background.AssetPath}': {processingError}");
+                errors.Add($"Failed to bake MFME display overlay/cutout into background asset '{background.AssetPath}': {processingError}");
                 continue;
             }
 
@@ -185,6 +193,24 @@ internal sealed class MfmeImportAssetCopier
         }
 
         return updatedElements;
+    }
+
+    private static PanelElementModel[] SendReelsAndAlphaDisplaysToBack(PanelElementModel[] elements)
+    {
+        if (!elements.Any(IsBackgroundCutoutDisplay))
+        {
+            return elements;
+        }
+
+        return elements
+            .Where(IsBackgroundCutoutDisplay)
+            .Concat(elements.Where(element => !IsBackgroundCutoutDisplay(element)))
+            .ToArray();
+    }
+
+    private static bool IsBackgroundCutoutDisplay(PanelElementModel element)
+    {
+        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix;
     }
 
     private static PanelElementModel CloneWithAssetPath(PanelElementModel element, string? assetPath)
@@ -201,6 +227,9 @@ internal sealed class MfmeImportAssetCopier
             AssetPath = assetPath,
             SecondaryAssetPath = element.SecondaryAssetPath,
             DisplayNumber = element.DisplayNumber,
+            SegmentDisplayType = element.SegmentDisplayType,
+            ShowDecimalPoint = element.ShowDecimalPoint,
+            ShowCommaTail = element.ShowCommaTail,
             OnColorHex = element.OnColorHex,
             OffColorHex = element.OffColorHex,
             TextColorHex = element.TextColorHex,
@@ -211,6 +240,9 @@ internal sealed class MfmeImportAssetCopier
             IsReversed = element.IsReversed,
             Stops = element.Stops,
             VisibleScale = element.VisibleScale,
+            BandOffset = element.BandOffset,
+            IsLocked = element.IsLocked,
+            IsVisible = element.IsVisible,
             ImportSource = element.ImportSource
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -99,7 +99,9 @@ internal sealed record MfmeLegacyAlphaComponent(
     MfmeLegacyPoint Position,
     MfmeLegacyPoint Size,
     bool Reversed,
-    MfmeLegacyColor? SegmentOnColor)
+    MfmeLegacyColor? SegmentOnColor,
+    bool HasOverlay = false,
+    string? OverlayBmpImageFilename = null)
     : MfmeLegacyComponentBase(
         AlphaSourceType,
         Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -296,6 +296,9 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             IsReversed = component.Reversed,
+            SecondaryAssetPath = component.HasOverlay
+                ? BuildExtractRelativePath("reels", component.OverlayBmpImageFilename)
+                : null,
             OnColorHex = ToHex(component.SegmentOnColor),
             ImportSource = CreateImportSource(component.SourceType)
         };


### PR DESCRIPTION
### Motivation
- When importing an MFME extract that provides a background image, reel overlay images (from the MFME reel component) must be composited into the background so the final background contains overlay pixels at the correct panel-space location.  
- Overlay alpha must be preserved and transferred into the resulting background image so downstream rendering and masking behave correctly.  
- The asset-copy flow should update background asset paths when a new PNG output is produced by the bake step so the panel uses the baked image.

### Description
- Added `MfmeBackgroundOverlayPostProcessor` which locates reel overlay assets, maps each overlay into the background at the reel element bounds, and copies RGBA pixels so overlay alpha is preserved; palettized image alpha is re-applied when loading indexed BMPs. (`OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs`).  
- Wired baking into the asset copy flow: `MfmeImportAssetCopier.CopyAssets` now calls `BakeOverlayImagesIntoBackgrounds` after assets are copied and updates background element `AssetPath` when the post-processor writes a PNG replacement. (`OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs`).  
- Implemented helper functions to resolve project-relative asset paths, compute destination rects in pixel-space, scale overlay pixels, handle palette alpha, and save PNG output while ensuring no path-escaping.  
- Added an automated unit test `CopyAssets_WithReelOverlay_BakesOverlayPixelsAndAlphaIntoBackground` to `OasisEditor.Tests/MfmeImportAssetCopierTests.cs` which constructs small PNG fixtures, runs the copy flow, and asserts that untouched background pixels remain unchanged while overlay pixels (transparent, half-alpha, opaque) are transferred as expected.

### Testing
- No automated tests were executed in this environment because the repository guidance forbids building/running the Windows/.NET/WPF toolchain here; a local test run is required.  
- A new unit test was added: `CopyAssets_WithReelOverlay_BakesOverlayPixelsAndAlphaIntoBackground` in `OasisEditor.Tests/MfmeImportAssetCopierTests.cs` which validates RGB and alpha copy behavior for overlay pixels.  
- Please run the test suite locally with `dotnet test` (or `dotnet test OasisEditor.Tests`) to verify the new test and the full test suite pass; the new test is expected to pass and should be included in CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a243671fba8832796f7888d4f97f84f)