### PR TITLE
Add Face document skeleton (.face) with model, storage, tab support and placeholder editor

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -1,0 +1,114 @@
+using OasisEditor.Automation;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceDocumentRoundTripTests
+{
+    [Fact]
+    public void Serialize_AndOpen_RoundTripsFaceDocument()
+    {
+        const string path = "C:/Repo/Assets/sample.face";
+        var source = new FaceDocumentModel
+        {
+            Id = "face-1",
+            Title = "Front Face",
+            Summary = "Physical face summary",
+            Layers =
+            [
+                new FaceLayerModel
+                {
+                    Id = "lamps",
+                    Name = "Lamp Windows",
+                    IsVisible = true
+                }
+            ],
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "lamp-window-17",
+                    Name = "Lamp 17 Window",
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    IsVisible = true,
+                    IsLocked = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(17),
+                    LinkedPanel2DElementId = "panel-lamp-17"
+                }
+            ]
+        };
+
+        var sourceJson = FaceDocumentStorage.Serialize(source);
+        var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData(path, sourceJson);
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateFromFile(path, openData.Summary, openData.PanelTitle),
+            faceDocumentJson: openData.FaceDocumentJson);
+
+        var savedContent = DocumentWorkspaceViewModel.BuildDocumentContent(document);
+
+        Assert.True(FaceDocumentStorage.TryRead(savedContent, out var savedDocument));
+        Assert.Equal(FaceDocumentStorage.CurrentSchemaVersion, savedDocument.SchemaVersion);
+        Assert.Equal("face-1", savedDocument.Id);
+        Assert.Equal("Front Face", savedDocument.Title);
+        Assert.Equal("Physical face summary", savedDocument.Summary);
+        var layer = Assert.Single(savedDocument.Layers!);
+        Assert.Equal("lamps", layer.Id);
+        Assert.Equal("Lamp Windows", layer.Name);
+        var element = Assert.Single(savedDocument.Elements!);
+        Assert.Equal("lamp-window-17", element.ObjectId);
+        Assert.Equal("lampWindow", element.Kind);
+        Assert.Equal("lamp:17", element.LinkedMachineObjectReference);
+        Assert.Equal("panel-lamp-17", element.LinkedPanel2DElementId);
+        Assert.True(element.IsLocked);
+    }
+
+    [Fact]
+    public void CreateFromFile_WithFaceExtension_DetectsFaceDocumentType()
+    {
+        var document = EditorDocument.CreateFromFile("C:/Repo/Assets/front.face", "summary");
+
+        Assert.Equal(EditorDocumentType.Face, document.DocumentType);
+    }
+
+    [Fact]
+    public void CreateFaceStubDocument_ProvidesFaceDocumentWithStorage()
+    {
+        var service = new FaceDocumentCreationService();
+
+        var document = service.CreateFaceStubDocument("Face 1", 1);
+
+        Assert.Equal(EditorDocumentType.Face, document.Document.DocumentType);
+        Assert.NotNull(document.FaceDocumentJson);
+        Assert.True(FaceDocumentStorage.TryRead(document.FaceDocumentJson, out var faceDocument));
+        Assert.Equal("Face 1", faceDocument.Title);
+    }
+
+    [Fact]
+    public void SaveDocument_WritesFaceDocumentContent()
+    {
+        var service = new DocumentSaveService();
+        var tempPath = Path.Combine(Path.GetTempPath(), $"oasis-save-{Guid.NewGuid():N}.face");
+
+        try
+        {
+            var current = new DocumentTabViewModel(
+                EditorDocument.CreateFaceStub("Face Save").MarkDirty(),
+                faceDocumentJson: FaceDocumentStorage.Serialize(FaceDocumentStorage.CreateEmpty("Face Save")));
+
+            var saved = service.SaveDocument(current, tempPath);
+
+            Assert.False(saved.IsDirty);
+            Assert.Equal(EditorDocumentType.Face, saved.Document.DocumentType);
+            Assert.True(File.Exists(tempPath));
+            Assert.True(FaceDocumentStorage.TryRead(File.ReadAllText(tempPath), out var faceDocument));
+            Assert.Equal("Face Save", faceDocument.Title);
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -53,7 +53,9 @@ public sealed class DocumentSaveService : IDocumentSaveService
             current.Document.SaveAs(savePath, current.ContentSummary).MarkClean(),
             current.PanelLayoutJson,
             current.DocumentId,
-            current.CommandService)
+            current.CommandService,
+            current.RuntimeState,
+            current.FaceDocumentJson)
         {
             PanelZoom = current.PanelZoom,
             PanelPanX = current.PanelPanX,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/ProjectAndPanelCreationServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/ProjectAndPanelCreationServices.cs
@@ -25,6 +25,11 @@ public interface IPanel2DDocumentCreationService
     DocumentTabViewModel CreatePanel2DStubDocument(string title, int panelIndex);
 }
 
+public interface IFaceDocumentCreationService
+{
+    DocumentTabViewModel CreateFaceStubDocument(string title, int faceIndex);
+}
+
 public sealed class Panel2DDocumentCreationService : IPanel2DDocumentCreationService
 {
     public DocumentTabViewModel CreatePanel2DStubDocument(string title, int panelIndex)
@@ -36,5 +41,19 @@ public sealed class Panel2DDocumentCreationService : IPanel2DDocumentCreationSer
         return new DocumentTabViewModel(
             EditorDocument.CreatePanel2DStub(resolvedTitle),
             panelLayoutJson: Panel2DDocumentStorage.SerializeLayout([]));
+    }
+}
+
+public sealed class FaceDocumentCreationService : IFaceDocumentCreationService
+{
+    public DocumentTabViewModel CreateFaceStubDocument(string title, int faceIndex)
+    {
+        var resolvedTitle = string.IsNullOrWhiteSpace(title)
+            ? $"Face {faceIndex}"
+            : title.Trim();
+
+        return new DocumentTabViewModel(
+            EditorDocument.CreateFaceStub(resolvedTitle),
+            faceDocumentJson: FaceDocumentStorage.Serialize(FaceDocumentStorage.CreateEmpty(resolvedTitle)));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -6,7 +6,8 @@ public enum EditorDocumentType
     ProjectOverview,
     Panel2D,
     Cabinet3D,
-    Machine
+    Machine,
+    Face
 }
 
 public sealed class EditorDocument
@@ -70,6 +71,15 @@ public sealed class EditorDocument
             "Machine stub:\n- Reference panel and cabinet docs\n- Configure runtime metadata\n- Set default generated output targets");
     }
 
+    public static EditorDocument CreateFaceStub(string title)
+    {
+        return CreateUntitledWithType(
+            title,
+            EditorDocumentType.Face,
+            "Not saved yet (.face)",
+            "Face document placeholder:\n- Physical presentation model\n- Lamp windows and future glass artwork\n- Links to machine/runtime objects");
+    }
+
     private static EditorDocument CreateUntitledWithType(
         string title,
         EditorDocumentType documentType,
@@ -113,6 +123,10 @@ public sealed class EditorDocument
         else if (normalizedExtension == ".machine")
         {
             documentType = EditorDocumentType.Machine;
+        }
+        else if (normalizedExtension == ".face")
+        {
+            documentType = EditorDocumentType.Face;
         }
         else
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -1,0 +1,36 @@
+namespace OasisEditor;
+
+public sealed class FaceDocumentModel
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+    public string Title { get; init; } = string.Empty;
+    public string? Summary { get; init; }
+    public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
+    public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
+}
+
+public sealed class FaceLayerModel
+{
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+    public string Name { get; init; } = string.Empty;
+    public bool IsVisible { get; init; } = true;
+    public bool IsLocked { get; init; }
+}
+
+public abstract class FaceElementModel
+{
+    public string ObjectId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public bool IsVisible { get; init; } = true;
+    public bool IsLocked { get; init; }
+    public MachineObjectReference? LinkedMachineObjectReference { get; init; }
+    public string? LinkedPanel2DElementId { get; init; }
+}
+
+public sealed class FaceLampWindowElement : FaceElementModel
+{
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OasisEditor;
+
+public static class FaceDocumentStorage
+{
+    public const int CurrentSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions s_readOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static readonly JsonSerializerOptions s_writeOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static FaceDocumentFile CreateEmpty(string title)
+    {
+        var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Face" : title.Trim();
+        return new FaceDocumentFile
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            Id = Guid.NewGuid().ToString("N"),
+            Title = resolvedTitle,
+            Summary = "Face document placeholder.",
+            SavedAtUtc = DateTime.UtcNow,
+            Layers =
+            [
+                new FaceLayerFile
+                {
+                    Id = "layer-lamp-windows",
+                    Name = "Lamp Windows",
+                    IsVisible = true
+                }
+            ],
+            Elements = []
+        };
+    }
+
+    public static string Serialize(FaceDocumentModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        return Serialize(ToFile(model));
+    }
+
+    public static string Serialize(FaceDocumentFile file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        var normalized = file with
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            SavedAtUtc = DateTime.UtcNow
+        };
+        return JsonSerializer.Serialize(normalized, s_writeOptions);
+    }
+
+    public static bool TryRead(string? json, out FaceDocumentFile file)
+    {
+        file = new FaceDocumentFile();
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<FaceDocumentFile>(json, s_readOptions);
+            if (parsed is null)
+            {
+                return false;
+            }
+
+            file = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    public static bool TryReadValidated(string? json, out FaceDocumentFile file, out string errorMessage)
+    {
+        file = new FaceDocumentFile();
+        errorMessage = string.Empty;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            errorMessage = "Face document is empty.";
+            return false;
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<FaceDocumentFile>(json, s_readOptions);
+            if (parsed is null)
+            {
+                errorMessage = "Face document could not be parsed.";
+                return false;
+            }
+
+            if (parsed.SchemaVersion > CurrentSchemaVersion)
+            {
+                errorMessage = $"Unsupported face schema version '{parsed.SchemaVersion}'. This editor supports up to version {CurrentSchemaVersion}.";
+                return false;
+            }
+
+            file = parsed;
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            errorMessage = $"Malformed JSON: {ex.Message}";
+            return false;
+        }
+    }
+
+    public static FaceDocumentModel ToModel(FaceDocumentFile file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+        return new FaceDocumentModel
+        {
+            Id = string.IsNullOrWhiteSpace(file.Id) ? Guid.NewGuid().ToString("N") : file.Id.Trim(),
+            Title = file.Title ?? string.Empty,
+            Summary = file.Summary,
+            Layers = (file.Layers ?? [])
+                .Select(layer => new FaceLayerModel
+                {
+                    Id = string.IsNullOrWhiteSpace(layer.Id) ? Guid.NewGuid().ToString("N") : layer.Id.Trim(),
+                    Name = layer.Name ?? string.Empty,
+                    IsVisible = layer.IsVisible,
+                    IsLocked = layer.IsLocked
+                })
+                .ToArray(),
+            Elements = (file.Elements ?? [])
+                .Select(ToModel)
+                .ToArray()
+        };
+    }
+
+    public static FaceDocumentFile ToFile(FaceDocumentModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        return new FaceDocumentFile
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            Id = string.IsNullOrWhiteSpace(model.Id) ? Guid.NewGuid().ToString("N") : model.Id.Trim(),
+            Title = model.Title,
+            Summary = model.Summary,
+            SavedAtUtc = DateTime.UtcNow,
+            Layers = model.Layers.Select(layer => new FaceLayerFile
+            {
+                Id = layer.Id,
+                Name = layer.Name,
+                IsVisible = layer.IsVisible,
+                IsLocked = layer.IsLocked
+            }).ToArray(),
+            Elements = model.Elements.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceElementModel ToModel(FaceElementFile file)
+    {
+        MachineObjectReference? reference = null;
+        if (MachineObjectReference.TryParse(file.LinkedMachineObjectReference, out var parsedReference))
+        {
+            reference = parsedReference;
+        }
+
+        return new FaceLampWindowElement
+        {
+            ObjectId = file.ObjectId ?? string.Empty,
+            Name = file.Name ?? string.Empty,
+            X = file.X,
+            Y = file.Y,
+            Width = file.Width,
+            Height = file.Height,
+            IsVisible = file.IsVisible,
+            IsLocked = file.IsLocked,
+            LinkedMachineObjectReference = reference,
+            LinkedPanel2DElementId = file.LinkedPanel2DElementId
+        };
+    }
+
+    private static FaceElementFile ToFile(FaceElementModel model)
+    {
+        return new FaceElementFile
+        {
+            ObjectId = model.ObjectId,
+            Name = model.Name,
+            Kind = model is FaceLampWindowElement ? "lampWindow" : "unknown",
+            X = model.X,
+            Y = model.Y,
+            Width = model.Width,
+            Height = model.Height,
+            IsVisible = model.IsVisible,
+            IsLocked = model.IsLocked,
+            LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
+            LinkedPanel2DElementId = model.LinkedPanel2DElementId
+        };
+    }
+}
+
+public sealed record FaceDocumentFile
+{
+    public int SchemaVersion { get; init; } = FaceDocumentStorage.CurrentSchemaVersion;
+    public string? Id { get; init; }
+    public string? Title { get; init; }
+    public string? Summary { get; init; }
+    public DateTime SavedAtUtc { get; init; }
+    public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
+    public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];
+}
+
+public sealed record FaceLayerFile
+{
+    public string? Id { get; init; }
+    public string? Name { get; init; }
+    public bool IsVisible { get; init; } = true;
+    public bool IsLocked { get; init; }
+}
+
+public sealed record FaceElementFile
+{
+    public string? ObjectId { get; init; }
+    public string? Name { get; init; }
+    public string? Kind { get; init; } = "lampWindow";
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public bool IsVisible { get; init; } = true;
+    public bool IsLocked { get; init; }
+    public string? LinkedMachineObjectReference { get; init; }
+    public string? LinkedPanel2DElementId { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -51,6 +51,8 @@
             <MenuItem Header="_File">
                 <MenuItem Header="New _Panel2D Stub"
                           Command="{Binding OpenPanel2DStubCommand}" />
+                <MenuItem Header="New _Face Stub"
+                          Command="{Binding OpenFaceStubCommand}" />
                 <MenuItem Header="New _Cabinet3D Stub"
                           Command="{Binding OpenCabinet3DStubCommand}" />
                 <MenuItem Header="New _Machine Stub"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -105,6 +105,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
         OpenPanel2DStubCommand = new RelayCommand(OpenPanel2DStubDocument, CanOpenUntitledDocument);
+        OpenFaceStubCommand = new RelayCommand(OpenFaceStubDocument, CanOpenUntitledDocument);
         OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
@@ -389,6 +390,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public ICommand OpenUntitledDocumentCommand { get; }
     public ICommand OpenPanel2DStubCommand { get; }
+    public ICommand OpenFaceStubCommand { get; }
     public ICommand OpenCabinet3DStubCommand { get; }
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
@@ -961,6 +963,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _documentWorkspace.OpenPanel2DStubDocument();
     }
 
+    private void OpenFaceStubDocument()
+    {
+        _documentWorkspace.OpenFaceStubDocument();
+    }
+
     private void OpenCabinet3DStubDocument()
     {
         _documentWorkspace.OpenCabinet3DStubDocument();
@@ -991,7 +998,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var dialog = new OpenFileDialog
         {
             Title = "Open Document",
-            Filter = "Editor Documents|*.panel2d;*.cabinet3d;*.machine|All Files|*.*",
+            Filter = "Editor Documents|*.panel2d;*.face;*.cabinet3d;*.machine|All Files|*.*",
             InitialDirectory = LoadedProject.ProjectDirectory,
             CheckFileExists = true
         };
@@ -1155,6 +1162,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         var extension = Path.GetExtension(path);
         return string.Equals(extension, ".panel2d", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(extension, ".face", StringComparison.OrdinalIgnoreCase)
             || string.Equals(extension, ".cabinet3d", StringComparison.OrdinalIgnoreCase)
             || string.Equals(extension, ".machine", StringComparison.OrdinalIgnoreCase);
     }
@@ -1168,7 +1176,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             path,
             openData.Summary,
             openData.PanelLayoutJson,
-            openData.PanelTitle);
+            openData.PanelTitle,
+            openData.FaceDocumentJson);
         if (!openedNewTab)
         {
             AddOutputEntry($"Switched to already open document tab for {path}", OutputLogStatus.Info);
@@ -1242,9 +1251,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var defaultName = selectedDocument?.Document.Title ?? "Document";
         var (defaultExtension, filter) = selectedDocument?.Document.DocumentType switch
         {
-            EditorDocumentType.Cabinet3D => (".cabinet3d", "Cabinet 3D|*.cabinet3d|Panel 2D|*.panel2d|Machine|*.machine|All Files|*.*"),
-            EditorDocumentType.Machine => (".machine", "Machine|*.machine|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|All Files|*.*"),
-            _ => (".panel2d", "Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*")
+            EditorDocumentType.Face => (".face", "Face|*.face|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*"),
+            EditorDocumentType.Cabinet3D => (".cabinet3d", "Cabinet 3D|*.cabinet3d|Face|*.face|Panel 2D|*.panel2d|Machine|*.machine|All Files|*.*"),
+            EditorDocumentType.Machine => (".machine", "Machine|*.machine|Face|*.face|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|All Files|*.*"),
+            _ => (".panel2d", "Panel 2D|*.panel2d|Face|*.face|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*")
         };
 
         var dialog = new SaveFileDialog
@@ -3101,6 +3111,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             openPanelRelayCommand.RaiseCanExecuteChanged();
         }
 
+        if (OpenFaceStubCommand is RelayCommand openFaceRelayCommand)
+        {
+            openFaceRelayCommand.RaiseCanExecuteChanged();
+        }
+
         if (OpenCabinet3DStubCommand is RelayCommand openCabinetRelayCommand)
         {
             openCabinetRelayCommand.RaiseCanExecuteChanged();
@@ -3286,7 +3301,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
 }
 
-internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null);
+internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null, string? FaceDocumentJson = null);
 
 
 internal static class EditorProjectInputDefinitionExtensions

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -9,7 +9,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private readonly CommandService _commandService;
     private EditorDocument _document;
     private string? _panelLayoutJson;
+    private string? _faceDocumentJson;
     private Panel2DDocumentModel _panelDocumentModel;
+    private FaceDocumentModel _faceDocumentModel;
     private Dictionary<string, PanelElementModel> _lampElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _reelElementsByObjectId = new(StringComparer.Ordinal);
     private Dictionary<string, PanelElementModel> _alphaElementsByObjectId = new(StringComparer.Ordinal);
@@ -32,12 +34,14 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         string? panelLayoutJson = null,
         Guid? documentId = null,
         CommandService? commandService = null,
-        MachineRuntimeState? runtimeState = null)
+        MachineRuntimeState? runtimeState = null,
+        string? faceDocumentJson = null)
     {
         _document = document;
         DocumentId = documentId ?? Guid.NewGuid();
         _commandService = commandService ?? new CommandService(new CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
+        _faceDocumentJson = faceDocumentJson;
         _runtimeState = runtimeState ?? new MachineRuntimeState();
         _panelDocumentModel = new Panel2DDocumentModel
         {
@@ -45,6 +49,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 .Select(Panel2DDocumentStorage.ToModel)
                 .ToArray()
         };
+        _faceDocumentModel = FaceDocumentStorage.TryRead(faceDocumentJson, out var faceDocumentFile)
+            ? FaceDocumentStorage.ToModel(faceDocumentFile)
+            : new FaceDocumentModel();
         RebuildLampCaches();
     }
 
@@ -59,6 +66,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         EditorDocumentType.Panel2D => "Panel 2D",
         EditorDocumentType.Cabinet3D => "Cabinet 3D",
         EditorDocumentType.Machine => "Machine",
+        EditorDocumentType.Face => "Face",
         _ => "Document Type"
     };
     public string FilePath => Document.FilePath;
@@ -76,6 +84,24 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Document)));
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDirty)));
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
+    }
+
+    public string? FaceDocumentJson
+    {
+        get => _faceDocumentJson;
+        set
+        {
+            if (string.Equals(_faceDocumentJson, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _faceDocumentJson = value;
+            _faceDocumentModel = FaceDocumentStorage.TryRead(value, out var faceDocumentFile)
+                ? FaceDocumentStorage.ToModel(faceDocumentFile)
+                : new FaceDocumentModel();
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
+        }
     }
 
     public string? PanelLayoutJson
@@ -98,6 +124,16 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             RebuildLampCaches();
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
         }
+    }
+
+    public FaceDocumentModel GetFaceDocument()
+    {
+        return _faceDocumentModel;
+    }
+
+    public string GetFaceDocumentJson()
+    {
+        return FaceDocumentStorage.Serialize(_faceDocumentModel);
     }
 
     internal IReadOnlyList<PanelElementModel> GetPanelElements()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -20,11 +20,13 @@ public sealed class DocumentWorkspaceViewModel
     private readonly Action<Guid> _onDocumentClosed;
     private readonly MachineRuntimeStateStore _runtimeStateStore;
     private readonly Automation.IPanel2DDocumentCreationService _panel2dCreationService;
+    private readonly Automation.IFaceDocumentCreationService _faceCreationService;
 
     private int _untitledDocumentCounter = 1;
     private int _panelDocumentCounter = 1;
     private int _cabinetDocumentCounter = 1;
     private int _machineDocumentCounter = 1;
+    private int _faceDocumentCounter = 1;
 
     public DocumentWorkspaceViewModel(
         Func<EditorProject?> getLoadedProject,
@@ -47,7 +49,8 @@ public sealed class DocumentWorkspaceViewModel
             addOutputEntry,
             new MachineRuntimeStateStore(),
             new Automation.Panel2DDocumentCreationService(),
-            onDocumentClosed)
+            onDocumentClosed,
+            new Automation.FaceDocumentCreationService())
     {
     }
 
@@ -62,7 +65,8 @@ public sealed class DocumentWorkspaceViewModel
         Action<string, OutputLogStatus> addOutputEntry,
         MachineRuntimeStateStore runtimeStateStore,
         Automation.IPanel2DDocumentCreationService panel2dCreationService,
-        Action<Guid>? onDocumentClosed = null)
+        Action<Guid>? onDocumentClosed = null,
+        Automation.IFaceDocumentCreationService? faceCreationService = null)
     {
         _getLoadedProject = getLoadedProject;
         _setLoadedProject = setLoadedProject;
@@ -75,6 +79,7 @@ public sealed class DocumentWorkspaceViewModel
         _onDocumentClosed = onDocumentClosed ?? (_ => { });
         _runtimeStateStore = runtimeStateStore;
         _panel2dCreationService = panel2dCreationService;
+        _faceCreationService = faceCreationService ?? new Automation.FaceDocumentCreationService();
     }
 
     public bool CanOpenUntitledDocument() => _getLoadedProject() is not null;
@@ -112,6 +117,19 @@ public sealed class DocumentWorkspaceViewModel
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Opened panel document stub: {document.Title}");
         _addOutputEntry($"Opened panel document stub: {document.Title}", OutputLogStatus.Info);
+    }
+
+    public void OpenFaceStubDocument()
+    {
+        if (_getLoadedProject() is null)
+        {
+            return;
+        }
+
+        var document = _faceCreationService.CreateFaceStubDocument($"Face {_faceDocumentCounter++}", _faceDocumentCounter - 1);
+        ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
+        _setStatusMessage($"Opened face document stub: {document.Title}");
+        _addOutputEntry($"Opened face document stub: {document.Title}", OutputLogStatus.Info);
     }
 
     public void OpenCabinet3DStubDocument()
@@ -153,7 +171,7 @@ public sealed class DocumentWorkspaceViewModel
         _addOutputEntry($"Closed document tab: {selectedDocument.Title}", OutputLogStatus.Info);
     }
 
-    public bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson, string? panelTitle = null)
+    public bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson, string? panelTitle = null, string? faceDocumentJson = null)
     {
         var existing = _openDocuments.FirstOrDefault(tab => string.Equals(tab.FilePath, path, StringComparison.OrdinalIgnoreCase));
         if (existing is not null)
@@ -162,7 +180,7 @@ public sealed class DocumentWorkspaceViewModel
             return false;
         }
 
-        var document = CreateDocumentTab(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson);
+        var document = CreateDocumentTab(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson, faceDocumentJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         return true;
     }
@@ -254,7 +272,8 @@ public sealed class DocumentWorkspaceViewModel
             selectedDocument.PanelLayoutJson,
             selectedDocument.DocumentId,
             selectedDocument.CommandService,
-            selectedDocument.RuntimeState)
+            selectedDocument.RuntimeState,
+            selectedDocument.FaceDocumentJson)
         {
             PanelZoom = selectedDocument.PanelZoom,
             PanelPanX = selectedDocument.PanelPanX,
@@ -267,14 +286,15 @@ public sealed class DocumentWorkspaceViewModel
         return updated;
     }
 
-    private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null)
+    private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null, string? faceDocumentJson = null)
     {
         var documentId = Guid.NewGuid();
         return new DocumentTabViewModel(
             document,
             panelLayoutJson,
             documentId,
-            runtimeState: _runtimeStateStore.GetOrCreate(documentId));
+            runtimeState: _runtimeStateStore.GetOrCreate(documentId),
+            faceDocumentJson: faceDocumentJson);
     }
 
     internal static OpenDocumentData BuildOpenDocumentData(string path, string content)
@@ -298,6 +318,26 @@ public sealed class DocumentWorkspaceViewModel
                 Path.GetFileName(path));
         }
 
+
+        if (string.Equals(Path.GetExtension(path), ".face", StringComparison.OrdinalIgnoreCase))
+        {
+            if (FaceDocumentStorage.TryReadValidated(content, out var faceDocument, out var errorMessage))
+            {
+                var summary = string.IsNullOrWhiteSpace(faceDocument.Summary)
+                    ? "Face document opened."
+                    : faceDocument.Summary.Trim();
+                var title = string.IsNullOrWhiteSpace(faceDocument.Title)
+                    ? Path.GetFileName(path)
+                    : faceDocument.Title.Trim();
+                return new OpenDocumentData(summary, null, title, FaceDocumentStorage.Serialize(faceDocument));
+            }
+
+            return new OpenDocumentData(
+                $"Failed to open face document: {errorMessage}",
+                null,
+                Path.GetFileName(path));
+        }
+
         var preview = content.Length > 300 ? $"{content[..300]}..." : content;
         if (string.IsNullOrWhiteSpace(preview))
         {
@@ -315,6 +355,21 @@ public sealed class DocumentWorkspaceViewModel
                 .Select(Panel2DDocumentStorage.ToStorageElement)
                 .ToArray();
             return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
+        }
+
+
+        if (document.Document.DocumentType == EditorDocumentType.Face)
+        {
+            var faceDocument = document.GetFaceDocument();
+            var persistedFaceDocument = new FaceDocumentModel
+            {
+                Id = faceDocument.Id,
+                Title = document.Document.Title,
+                Summary = document.ContentSummary,
+                Layers = faceDocument.Layers,
+                Elements = faceDocument.Elements
+            };
+            return FaceDocumentStorage.Serialize(persistedFaceDocument);
         }
 
         var persisted = new

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
@@ -42,6 +42,36 @@
                 </Grid>
             </Border>
 
+            <Border Padding="16"
+                    CornerRadius="4"
+                    Background="{DynamicResource EditorBackgroundBrush}"
+                    BorderBrush="{DynamicResource BorderSubtleBrush}"
+                    BorderThickness="1">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Face}">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <StackPanel>
+                    <TextBlock FontSize="18"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextPrimaryBrush}"
+                               Text="Face Editor Placeholder" />
+                    <TextBlock Margin="0,8,0,0"
+                               Foreground="{DynamicResource TextSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Text="Face documents can be created, opened, and saved. Face Edit View, Face Play View, and 3D preview are intentionally not implemented in Phase 2." />
+                    <TextBlock Margin="0,12,0,0"
+                               TextWrapping="Wrap"
+                               Text="{Binding ContentSummary}" />
+                </StackPanel>
+            </Border>
+
             <Border Padding="10"
                     CornerRadius="4"
                     Background="{DynamicResource SelectionBrush}"
@@ -52,6 +82,9 @@
                         <Setter Property="Visibility" Value="Visible" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Panel2D}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Document.DocumentType}" Value="{x:Static local:EditorDocumentType.Face}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                             </DataTrigger>
                         </Style.Triggers>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
@@ -33,6 +33,10 @@
                         Content="New Panel2D" />
                 <Button Padding="10,4"
                         Margin="0,0,8,0"
+                        Command="{Binding OpenFaceStubCommand}"
+                        Content="New Face" />
+                <Button Padding="10,4"
+                        Margin="0,0,8,0"
                         Command="{Binding OpenCabinet3DStubCommand}"
                         Content="New Cabinet3D" />
                 <Button Padding="10,4"
@@ -125,6 +129,28 @@
                                 </Grid>
                             </Border>
 
+                            <Border x:Name="FacePlaceholderContainer"
+                                    Padding="16"
+                                    CornerRadius="4"
+                                    Background="{DynamicResource EditorBackgroundBrush}"
+                                    BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                    BorderThickness="1"
+                                    Visibility="Collapsed">
+                                <StackPanel>
+                                    <TextBlock FontSize="18"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextPrimaryBrush}"
+                                               Text="Face Editor Placeholder" />
+                                    <TextBlock Margin="0,8,0,0"
+                                               Foreground="{DynamicResource TextSecondaryBrush}"
+                                               TextWrapping="Wrap"
+                                               Text="Face documents now round-trip through the editor. Face Edit View, Face Play View, and 3D preview are intentionally not implemented in this phase." />
+                                    <TextBlock Margin="0,12,0,0"
+                                               TextWrapping="Wrap"
+                                               Text="{Binding ContentSummary}" />
+                                </StackPanel>
+                            </Border>
+
                             <Border x:Name="DefaultSummaryContainer"
                                     Padding="10"
                                     CornerRadius="4"
@@ -140,6 +166,15 @@
                         <DataTrigger Binding="{Binding Document.DocumentType}"
                                      Value="{x:Static local:EditorDocumentType.Panel2D}">
                             <Setter TargetName="PanelCanvasContainer"
+                                    Property="Visibility"
+                                    Value="Visible" />
+                            <Setter TargetName="DefaultSummaryContainer"
+                                    Property="Visibility"
+                                    Value="Collapsed" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Document.DocumentType}"
+                                     Value="{x:Static local:EditorDocumentType.Face}">
+                            <Setter TargetName="FacePlaceholderContainer"
                                     Property="Visibility"
                                     Value="Visible" />
                             <Setter TargetName="DefaultSummaryContainer"


### PR DESCRIPTION
### Motivation

- Introduce Phase 2 Face document type so Face documents can be created, opened, saved and round-tripped through the editor without yet implementing Face views or runtime ownership changes.
- Provide a small, evolvable Face model and storage format to enable future work linking Face elements to machine/runtime objects while preserving existing Panel2D workflows.

### Description

- Add `Face` document type and `.face` extension detection in `EditorDocument` and UI save/open flows to allow the editor to recognize Face files (new `EditorDocumentType.Face`).
- Add a minimal Face model `FaceDocumentModel` with `Layers` and `Elements`, and an initial element type `FaceLampWindowElement` supporting geometry, visibility/lock, `LinkedMachineObjectReference` and `LinkedPanel2DElementId` (`FaceDocumentModel.cs`).
- Add JSON storage and schema handling via `FaceDocumentStorage` including `CreateEmpty`, `Serialize`, `TryReadValidated`, and model ↔ file conversion (`FaceDocumentStorage.cs`).
- Wire Face JSON into tab and workspace state: `DocumentTabViewModel` now accepts and exposes `FaceDocumentJson`/`FaceDocumentModel`; `DocumentWorkspaceViewModel` can open/create/serialize Face documents and preserves Face JSON when saving/replacing tabs (`DocumentTabViewModel.cs`, `DocumentWorkspaceViewModel.cs`).
- Add a Face document creation service `FaceDocumentCreationService` and interface `IFaceDocumentCreationService` and expose a `New Face` button in the document host UI; the editor shows a placeholder Face editor surface only (no edit/play/3D implementations) (`Automation/ProjectAndPanelCreationServices.cs`, `Views/PanelCanvasView.xaml`, `Views/DocumentEditorView.xaml`).
- Persist Face JSON when saving via the existing `DocumentSaveService` so Face documents round-trip through file open/save (`Automation/MfmeImportAndDocumentSaveServices.cs`).
- Add unit tests `FaceDocumentRoundTripTests` to verify storage serialization/deserialization, `.face` type detection, stub creation, and save behavior (`OasisEditor.Tests/FaceDocumentRoundTripTests.cs`).

### Testing

- Ran quick repository checks and XAML parse smoke tests: `git diff --check` and parsing `DocumentEditorView.xaml` and `PanelCanvasView.xaml` via a small `python3` XML parse script; these checks succeeded.
- Added automated unit tests in `FaceDocumentRoundTripTests` to cover Face storage round-trip, creation, and save behavior; tests were added to the test project but `dotnet test` was not executed in this environment because `dotnet` is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24826e64e48327a8c72667a6cb3904)