### PR TITLE
Face Edit View MVP: Skia-based editor, face element model, inspector & hierarchy support

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceEditViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceEditViewModelTests.cs
@@ -1,0 +1,120 @@
+using System.Linq;
+using EditorCommands = OasisEditor.Commands;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceEditViewModelTests
+{
+    [Fact]
+    public void AddLampWindowCommand_AddsSelectsAndPersistsFaceElement()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));
+        var element = new FaceLampWindowElement
+        {
+            ObjectId = "face-lamp-1",
+            Name = "Start Lamp Window",
+            X = 10,
+            Y = 20,
+            Width = 80,
+            Height = 40,
+            LinkedMachineObjectReference = MachineObjectReference.Lamp(17)
+        };
+
+        var command = FaceMutationCommands.CreateAddLampWindowCommand(document.DocumentId, document, element);
+        command.Execute();
+
+        var added = Assert.Single(document.GetFaceElements());
+        Assert.Equal("face-lamp-1", added.ObjectId);
+        Assert.Equal("lamp:17", added.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("face-lamp-1", document.HierarchySelectedPanelSelection?.ObjectId);
+        Assert.True(document.IsDirty);
+
+        var savedJson = document.GetFaceDocumentJson();
+        Assert.True(FaceDocumentStorage.TryRead(savedJson, out var saved));
+        var savedElement = Assert.Single(saved.Elements!);
+        Assert.Equal("lampWindow", savedElement.Kind);
+        Assert.Equal("lamp:17", savedElement.LinkedMachineObjectReference);
+    }
+
+    [Fact]
+    public void InspectorRows_SelectedFaceLampWindow_EditMachineReferencePersists()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));
+        selectedDocument.SetFaceElements(
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-lamp-1",
+                    Name = "Lamp Window",
+                    X = 10,
+                    Y = 20,
+                    Width = 80,
+                    Height = 40
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("face-lamp-1", "lampWindow", 10, 20, 80, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        Assert.Contains("Selected face lamp window", viewModel.InspectorSummary);
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Machine Reference");
+        var row = Assert.IsType<InspectorTextPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Machine Reference"));
+        row.Value = "lamp:42";
+        row.Commit();
+
+        var updated = Assert.Single(selectedDocument.GetFaceElements());
+        Assert.Equal("lamp:42", updated.LinkedMachineObjectReference?.ToString());
+        Assert.True(FaceDocumentStorage.TryRead(selectedDocument.GetFaceDocumentJson(), out var saved));
+        Assert.Equal("lamp:42", Assert.Single(saved.Elements!).LinkedMachineObjectReference);
+    }
+
+    [Fact]
+    public void FaceHierarchyProvider_BuildsLampWindowGroup()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));
+        document.SetFaceElements(
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-lamp-1",
+                    Name = "Lamp Window",
+                    X = 10,
+                    Y = 20,
+                    Width = 80,
+                    Height = 40,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(1)
+                }
+            ]);
+
+        var provider = new FaceHierarchyProvider();
+        var root = Assert.Single(provider.Build(document));
+        Assert.Equal("Lamp Windows (1)", root.DisplayName);
+        var child = Assert.Single(root.Children);
+        Assert.Equal("face-lamp-1", child.PanelSelection?.ObjectId);
+        Assert.Contains("lamp:1", child.DisplayName);
+    }
+
+    private static InspectorViewModel CreateInspectorViewModel(
+        DocumentTabViewModel selectedDocument,
+        ActiveDocumentContextService context,
+        Func<Guid, EditorCommands.ICommand, bool>? executeCanvasCommand = null)
+    {
+        return new InspectorViewModel(
+            selectedAssetAccessor: () => null,
+            selectedDocumentAccessor: () => selectedDocument,
+            loadedProjectAccessor: () => null,
+            activeDocumentContext: context,
+            executeCanvasCommand: executeCanvasCommand ?? ((_, _) => true),
+            applySummary: (document, summary) => document);
+    }
+
+    private static bool ExecuteImmediately(Guid _, EditorCommands.ICommand command)
+    {
+        command.Execute();
+        return command is not EditorCommands.IExecutionTrackedCommand tracked || tracked.WasExecuted;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -1,0 +1,122 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+internal static class FaceElementFactory
+{
+    public static FaceLampWindowElement CreateLampWindow(Point documentPoint)
+    {
+        return new FaceLampWindowElement
+        {
+            ObjectId = Guid.NewGuid().ToString("N"),
+            Name = "Lamp Window",
+            X = Math.Round(documentPoint.X, 2),
+            Y = Math.Round(documentPoint.Y, 2),
+            Width = 80,
+            Height = 40,
+            IsVisible = true
+        };
+    }
+}
+
+internal static class FaceElementModelUpdater
+{
+    public static FaceElementModel Apply(FaceElementModel existing, FaceElementModelUpdate update)
+    {
+        var linkedMachineObjectReference = existing.LinkedMachineObjectReference;
+        if (update.HasLinkedMachineObjectReference)
+        {
+            linkedMachineObjectReference = update.LinkedMachineObjectReference;
+        }
+
+        return existing switch
+        {
+            FaceLampWindowElement => new FaceLampWindowElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId
+            },
+            _ => existing
+        };
+    }
+}
+
+internal sealed class FaceElementModelUpdate
+{
+    public string? Name { get; init; }
+    public double? X { get; init; }
+    public double? Y { get; init; }
+    public double? Width { get; init; }
+    public double? Height { get; init; }
+    public bool? IsVisible { get; init; }
+    public bool? IsLocked { get; init; }
+    public bool HasLinkedMachineObjectReference { get; init; }
+    public MachineObjectReference? LinkedMachineObjectReference { get; init; }
+    public bool HasLinkedPanel2DElementId { get; init; }
+    public string? LinkedPanel2DElementId { get; init; }
+}
+
+internal static class FaceElementValidation
+{
+    public static bool IsValidForInspectorUpdate(FaceElementModel element)
+    {
+        return PanelElementValidation.IsFinite(element.X)
+            && PanelElementValidation.IsFinite(element.Y)
+            && PanelElementValidation.IsFinite(element.Width)
+            && PanelElementValidation.IsFinite(element.Height)
+            && element.Width > 0
+            && element.Height > 0;
+    }
+}
+
+internal static class FaceSelectionService
+{
+    public static PanelSelectionInfo? SelectFromPoint(
+        IReadOnlyList<FaceElementModel> elements,
+        Point documentPoint,
+        PanelSelectionInfo? currentSelection = null)
+    {
+        foreach (var element in elements.Reverse())
+        {
+            if (!element.IsVisible || element.IsLocked)
+            {
+                continue;
+            }
+
+            if (documentPoint.X < element.X || documentPoint.Y < element.Y
+                || documentPoint.X > element.X + element.Width
+                || documentPoint.Y > element.Y + element.Height)
+            {
+                continue;
+            }
+
+            return ToSelectionInfo(element);
+        }
+
+        return null;
+    }
+
+    public static PanelSelectionInfo ToSelectionInfo(FaceElementModel element)
+    {
+        return new PanelSelectionInfo(
+            element.ObjectId,
+            GetKindToken(element),
+            element.X,
+            element.Y,
+            element.Width,
+            element.Height);
+    }
+
+    public static string GetKindToken(FaceElementModel element)
+    {
+        return element is FaceLampWindowElement ? "lampWindow" : "unknown";
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -1,0 +1,144 @@
+namespace OasisEditor;
+
+internal static class FaceMutationCommands
+{
+    public static Commands.ICommand CreateAddLampWindowCommand(Guid documentId, DocumentTabViewModel document, FaceLampWindowElement element)
+    {
+        return new AddFaceElementMutationCommand(documentId, document, element);
+    }
+
+    public static Commands.ICommand CreateUpdateElementCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        string objectId,
+        FaceElementModel updatedElement,
+        string description)
+    {
+        return new UpdateFaceElementMutationCommand(documentId, document, objectId, updatedElement, description);
+    }
+
+    private static PanelChangeEvent CreateChange(DocumentTabViewModel document, string? objectId, PanelChangeProperties properties, bool structure = false)
+    {
+        return new PanelChangeEvent(
+            document.DocumentId,
+            objectId,
+            properties,
+            AffectsCanvas: true,
+            AffectsHierarchy: structure || properties.HasFlag(PanelChangeProperties.Name) || properties.HasFlag(PanelChangeProperties.Visibility) || properties.HasFlag(PanelChangeProperties.LockState),
+            AffectsInspectorRows: true,
+            AffectsPersistence: true);
+    }
+
+    private sealed class AddFaceElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly FaceLampWindowElement _element;
+        private int? _insertIndex;
+
+        public AddFaceElementMutationCommand(Guid documentId, DocumentTabViewModel document, FaceLampWindowElement element)
+        {
+            _documentId = documentId;
+            _document = document;
+            _element = element;
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => "Add face lamp window";
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetFaceElements().ToList();
+            var index = Math.Clamp(_insertIndex ?? elements.Count, 0, elements.Count);
+            elements.Insert(index, _element);
+            _insertIndex = index;
+            _document.SetFaceElements(elements, CreateChange(_document, _element.ObjectId, PanelChangeProperties.Structure, structure: true));
+            _document.HierarchySelectedPanelSelection = FaceSelectionService.ToSelectionInfo(_element);
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            var elements = _document.GetFaceElements().ToList();
+            var index = elements.FindIndex(element => string.Equals(element.ObjectId, _element.ObjectId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return;
+            }
+
+            elements.RemoveAt(index);
+            _document.SetFaceElements(elements, CreateChange(_document, _element.ObjectId, PanelChangeProperties.Structure, structure: true));
+            if (_document.HierarchySelectedPanelSelection is PanelSelectionInfo selection
+                && string.Equals(selection.ObjectId, _element.ObjectId, StringComparison.Ordinal))
+            {
+                _document.HierarchySelectedPanelSelection = null;
+            }
+
+            _document.MarkDirty();
+        }
+    }
+
+    private sealed class UpdateFaceElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly string _objectId;
+        private readonly FaceElementModel _updatedElement;
+        private readonly string _description;
+        private FaceElementModel? _originalElement;
+
+        public UpdateFaceElementMutationCommand(Guid documentId, DocumentTabViewModel document, string objectId, FaceElementModel updatedElement, string description)
+        {
+            _documentId = documentId;
+            _document = document;
+            _objectId = objectId;
+            _updatedElement = updatedElement;
+            _description = description;
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => _description;
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetFaceElements().ToList();
+            var index = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return;
+            }
+
+            _originalElement ??= elements[index];
+            elements[index] = _updatedElement;
+            _document.SetFaceElements(elements, CreateChange(_document, _objectId, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.LockState | PanelChangeProperties.Metadata));
+            _document.HierarchySelectedPanelSelection = FaceSelectionService.ToSelectionInfo(_updatedElement);
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_originalElement is null)
+            {
+                return;
+            }
+
+            var elements = _document.GetFaceElements().ToList();
+            var index = elements.FindIndex(element => string.Equals(element.ObjectId, _objectId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return;
+            }
+
+            elements[index] = _originalElement;
+            _document.SetFaceElements(elements, CreateChange(_document, _objectId, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.LockState | PanelChangeProperties.Metadata));
+            _document.HierarchySelectedPanelSelection = FaceSelectionService.ToSelectionInfo(_originalElement);
+            _document.MarkDirty();
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -184,7 +184,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             ApplyInspectorSummary);
         _hierarchy = new HierarchyViewModel(
             () => SelectedDocument,
-            [new Panel2DHierarchyProvider()]);
+            [new Panel2DHierarchyProvider(), new FaceHierarchyProvider()]);
         _hierarchyPanelCommands = new HierarchyPanelCommandService(
             () => SelectedDocument,
             ExecuteDocumentCanvasCommand,
@@ -857,7 +857,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public void SelectHierarchyItem(HierarchyItemViewModel? hierarchyItem)
     {
-        if (SelectedDocument is null || SelectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        if (SelectedDocument is null || SelectedDocument.Document.DocumentType is not (EditorDocumentType.Panel2D or EditorDocumentType.Face))
         {
             return;
         }
@@ -873,7 +873,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public void SelectHierarchyItemForContextMenu(HierarchyItemViewModel? hierarchyItem)
     {
-        if (SelectedDocument is null || SelectedDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        if (SelectedDocument is null || SelectedDocument.Document.DocumentType is not (EditorDocumentType.Panel2D or EditorDocumentType.Face))
         {
             return;
         }
@@ -3241,6 +3241,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         if (e.PropertyName is nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
         {
+            if (SelectedDocument is not null)
+            {
+                _activeDocumentContext.SetPanelSelection(SelectedDocument.DocumentId, SelectedDocument.HierarchySelectedPanelSelection);
+            }
+
             _hierarchy.SyncSelection(SelectedDocument?.HierarchySelectedPanelSelection);
             OnPropertyChanged(nameof(HierarchyItems));
             NotifyInspectorChanged();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -20,6 +20,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private HashSet<string> _visualStateObjectIds = new(StringComparer.Ordinal);
     private PanelSelectionInfo? _hierarchySelectedPanelSelection;
     private double _panelZoom = 1.0;
+    private double _faceZoom = 1.0;
+    private double _facePanX;
+    private double _facePanY;
     private double _panelPanX;
     private double _panelPanY;
     private Dictionary<string, object>? _lastVisualStateByObjectId;
@@ -134,6 +137,45 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public string GetFaceDocumentJson()
     {
         return FaceDocumentStorage.Serialize(_faceDocumentModel);
+    }
+
+    internal IReadOnlyList<FaceElementModel> GetFaceElements()
+    {
+        return _faceDocumentModel.Elements;
+    }
+
+    internal bool TryGetFaceElement(PanelSelectionInfo selection, out FaceElementModel element)
+    {
+        var match = _faceDocumentModel.Elements.FirstOrDefault(candidate =>
+            !string.IsNullOrWhiteSpace(selection.ObjectId)
+            && string.Equals(candidate.ObjectId, selection.ObjectId, StringComparison.Ordinal));
+        if (match is null)
+        {
+            element = new FaceLampWindowElement();
+            return false;
+        }
+
+        element = match;
+        return true;
+    }
+
+    internal void SetFaceElements(IReadOnlyList<FaceElementModel> elements, PanelChangeEvent? faceChange = null)
+    {
+        _faceDocumentModel = new FaceDocumentModel
+        {
+            Id = _faceDocumentModel.Id,
+            Title = _faceDocumentModel.Title,
+            Summary = _faceDocumentModel.Summary,
+            Layers = _faceDocumentModel.Layers,
+            Elements = elements.ToArray()
+        };
+        _faceDocumentJson = GetFaceDocumentJson();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
+
+        if (faceChange is PanelChangeEvent change)
+        {
+            PanelChanged?.Invoke(change);
+        }
     }
 
     internal IReadOnlyList<PanelElementModel> GetPanelElements()
@@ -343,6 +385,51 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
             _panelPanY = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelPanY)));
+        }
+    }
+
+    public double FaceZoom
+    {
+        get => _faceZoom;
+        set
+        {
+            if (Math.Abs(_faceZoom - value) < 0.0001)
+            {
+                return;
+            }
+
+            _faceZoom = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceZoom)));
+        }
+    }
+
+    public double FacePanX
+    {
+        get => _facePanX;
+        set
+        {
+            if (Math.Abs(_facePanX - value) < 0.0001)
+            {
+                return;
+            }
+
+            _facePanX = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FacePanX)));
+        }
+    }
+
+    public double FacePanY
+    {
+        get => _facePanY;
+        set
+        {
+            if (Math.Abs(_facePanY - value) < 0.0001)
+            {
+                return;
+            }
+
+            _facePanY = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FacePanY)));
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -1,0 +1,56 @@
+namespace OasisEditor;
+
+public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
+{
+    public bool CanBuild(DocumentTabViewModel? document)
+    {
+        return document?.Document.DocumentType == EditorDocumentType.Face;
+    }
+
+    public IReadOnlyList<HierarchyItemViewModel> Build(DocumentTabViewModel? document)
+    {
+        if (!CanBuild(document))
+        {
+            return [];
+        }
+
+        var faceDocument = document!;
+        var lampWindows = faceDocument.GetFaceElements()
+            .OfType<FaceLampWindowElement>()
+            .Select((element, index) =>
+            {
+                var x = Math.Round(element.X);
+                var y = Math.Round(element.Y);
+                var width = Math.Round(element.Width);
+                var height = Math.Round(element.Height);
+                var displayName = string.IsNullOrWhiteSpace(element.Name)
+                    ? $"Lamp Window {index + 1} ({width}×{height} at {x}, {y})"
+                    : element.Name.Trim();
+                if (element.IsLocked)
+                {
+                    displayName += " [Locked]";
+                }
+
+                if (!element.IsVisible)
+                {
+                    displayName += " [Hidden]";
+                }
+
+                if (element.LinkedMachineObjectReference is MachineObjectReference reference && !reference.IsEmpty)
+                {
+                    displayName += $" [{reference}]";
+                }
+
+                return new HierarchyItemViewModel(
+                    displayName,
+                    $"lampWindow:{element.ObjectId}",
+                    panelSelection: FaceSelectionService.ToSelectionInfo(element));
+            })
+            .ToArray();
+
+        return
+        [
+            new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows)
+        ];
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -23,6 +23,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private DateTime _suppressPropertyRowRefreshUntilUtc;
     private string? _lastInspectorSelectionObjectId;
     private PanelElementKind? _lastInspectorSelectionKind;
+    private string? _lastInspectorFaceSelectionKind;
     private bool _hadInspectorSelection;
 
     public InspectorViewModel(
@@ -54,10 +55,18 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             var selectedDocument = _selectedDocumentAccessor();
             if (selectedDocument is not null
-                && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection
-                && selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
+                && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection)
             {
-                return NicifyElementKind(selectedElement.Kind);
+                if (selectedDocument.Document.DocumentType == EditorDocumentType.Face
+                    && selectedDocument.TryGetFaceElement(panelSelection, out var selectedFaceElement))
+                {
+                    return NicifyFaceElementKind(selectedFaceElement);
+                }
+
+                if (selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
+                {
+                    return NicifyElementKind(selectedElement.Kind);
+                }
             }
 
             var selectedAsset = _selectedAssetAccessor();
@@ -142,6 +151,12 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             {
                 if (_activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection)
                 {
+                    if (selectedDocument.Document.DocumentType == EditorDocumentType.Face
+                        && selectedDocument.TryGetFaceElement(panelSelection, out var selectedFaceElement))
+                    {
+                        return BuildSelectedFaceElementSummary(selectedFaceElement);
+                    }
+
                     if (selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
                     {
                         return BuildSelectedElementSummary(selectedElement);
@@ -197,6 +212,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             var selectedDocument = _selectedDocumentAccessor();
             return selectedDocument is not null
+                && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
                 && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection
                 && selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement)
                 && selectedElement.Kind == PanelElementKind.Lamp;
@@ -250,6 +266,19 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (selectedDocument.Document.DocumentType == EditorDocumentType.Face)
+        {
+            if (!selectedDocument.TryGetFaceElement(panelSelection, out var selectedFaceElement))
+            {
+                RebuildPropertyRows();
+                return;
+            }
+
+            RefreshFacePropertyRowValues(selectedFaceElement);
+            OnPropertyChanged(nameof(InspectorSummary));
+            return;
+        }
+
         if (!selectedDocument.TryGetPanelElement(panelSelection, out var selectedElement))
         {
             RebuildPropertyRows();
@@ -266,15 +295,26 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         var selectedDocument = _selectedDocumentAccessor();
         var selection = _activeDocumentContext.ActivePanelSelection;
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Face
+            && selection is PanelSelectionInfo faceSelection
+            && selectedDocument.TryGetFaceElement(faceSelection, out var selectedFaceElement))
+        {
+            RebuildFacePropertyRows(selectedDocument, selectedFaceElement);
+            return;
+        }
+
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
         {
             _hadInspectorSelection = false;
             _lastInspectorSelectionObjectId = null;
             _lastInspectorSelectionKind = null;
+            _lastInspectorFaceSelectionKind = null;
             OnPropertyChanged(nameof(InspectorPropertyRows));
             return;
         }
 
+        _lastInspectorFaceSelectionKind = null;
         _propertyRows.Add(new InspectorTextPropertyViewModel(
             "Name",
             "Common",
@@ -327,6 +367,20 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     {
         var selectedDocument = _selectedDocumentAccessor();
         var selection = _activeDocumentContext.ActivePanelSelection;
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Face
+            && selection is PanelSelectionInfo faceSelection
+            && selectedDocument.TryGetFaceElement(faceSelection, out var selectedFaceElement))
+        {
+            if (!_hadInspectorSelection)
+            {
+                return true;
+            }
+
+            return !string.Equals(_lastInspectorSelectionObjectId, selectedFaceElement.ObjectId, StringComparison.Ordinal)
+                || !string.Equals(_lastInspectorFaceSelectionKind, FaceSelectionService.GetKindToken(selectedFaceElement), StringComparison.Ordinal);
+        }
+
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
         {
             return _hadInspectorSelection || _propertyRows.Count > 0;
@@ -490,6 +544,65 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
     }
 
+    private void RebuildFacePropertyRows(DocumentTabViewModel selectedDocument, FaceElementModel selectedElement)
+    {
+        _propertyRows.Add(new InspectorTextPropertyViewModel(
+            "Name",
+            "Common",
+            selectedElement.Name,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update name", new FaceElementModelUpdate { Name = value })));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "X",
+            "Transform",
+            selectedElement.X,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update X", new FaceElementModelUpdate { X = value })));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Y",
+            "Transform",
+            selectedElement.Y,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update Y", new FaceElementModelUpdate { Y = value })));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Width",
+            "Transform",
+            selectedElement.Width,
+            commit: value => value > 0
+                ? TryApplyFaceUpdate(selectedElement.ObjectId, "Update width", new FaceElementModelUpdate { Width = value })
+                : "Width must be greater than zero."));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel(
+            "Height",
+            "Transform",
+            selectedElement.Height,
+            commit: value => value > 0
+                ? TryApplyFaceUpdate(selectedElement.ObjectId, "Update height", new FaceElementModelUpdate { Height = value })
+                : "Height must be greater than zero."));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel(
+            "Locked",
+            "Common",
+            selectedElement.IsLocked,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update lock state", new FaceElementModelUpdate { IsLocked = value })));
+        _propertyRows.Add(new InspectorBoolPropertyViewModel(
+            "Visible",
+            "Common",
+            selectedElement.IsVisible,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update visibility", new FaceElementModelUpdate { IsVisible = value })));
+        _propertyRows.Add(new InspectorTextPropertyViewModel(
+            "Machine Reference",
+            "References",
+            selectedElement.LinkedMachineObjectReference?.ToString() ?? string.Empty,
+            commit: value => TryApplyFaceMachineReferenceUpdate(selectedElement.ObjectId, value)));
+        _propertyRows.Add(new InspectorTextPropertyViewModel(
+            "Linked Panel2D Element",
+            "References",
+            selectedElement.LinkedPanel2DElementId ?? string.Empty,
+            commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update linked Panel2D element", new FaceElementModelUpdate { HasLinkedPanel2DElementId = true, LinkedPanel2DElementId = NormalizeOptionalText(value) })));
+
+        _hadInspectorSelection = true;
+        _lastInspectorSelectionObjectId = selectedElement.ObjectId;
+        _lastInspectorSelectionKind = null;
+        _lastInspectorFaceSelectionKind = FaceSelectionService.GetKindToken(selectedElement);
+        OnPropertyChanged(nameof(InspectorPropertyRows));
+    }
+
     private void RefreshPropertyRowValues(PanelElementModel selectedElement)
     {
         foreach (var row in _propertyRows)
@@ -581,6 +694,43 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         }
     }
 
+    private void RefreshFacePropertyRowValues(FaceElementModel selectedElement)
+    {
+        foreach (var row in _propertyRows)
+        {
+            switch (row.DisplayName)
+            {
+                case "Name" when row is InspectorTextPropertyViewModel textRow:
+                    textRow.SetCommittedValue(selectedElement.Name);
+                    break;
+                case "X" when row is InspectorDoublePropertyViewModel doubleRow:
+                    doubleRow.SetCommittedValue(selectedElement.X);
+                    break;
+                case "Y" when row is InspectorDoublePropertyViewModel yRow:
+                    yRow.SetCommittedValue(selectedElement.Y);
+                    break;
+                case "Width" when row is InspectorDoublePropertyViewModel widthRow:
+                    widthRow.SetCommittedValue(selectedElement.Width);
+                    break;
+                case "Height" when row is InspectorDoublePropertyViewModel heightRow:
+                    heightRow.SetCommittedValue(selectedElement.Height);
+                    break;
+                case "Locked" when row is InspectorBoolPropertyViewModel lockedRow:
+                    lockedRow.SetCommittedValue(selectedElement.IsLocked);
+                    break;
+                case "Visible" when row is InspectorBoolPropertyViewModel visibleRow:
+                    visibleRow.SetCommittedValue(selectedElement.IsVisible);
+                    break;
+                case "Machine Reference" when row is InspectorTextPropertyViewModel referenceRow:
+                    referenceRow.SetCommittedValue(selectedElement.LinkedMachineObjectReference?.ToString() ?? string.Empty);
+                    break;
+                case "Linked Panel2D Element" when row is InspectorTextPropertyViewModel panelRow:
+                    panelRow.SetCommittedValue(selectedElement.LinkedPanel2DElementId ?? string.Empty);
+                    break;
+            }
+        }
+    }
+
     private string? TryApplyColorUpdate(string objectId, string description, PanelElementModelUpdate update)
     {
         return TryApplyUpdate(objectId, description, update, suppressInspectorRefresh: true);
@@ -639,6 +789,66 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     }
 
 
+    private string? TryApplyFaceMachineReferenceUpdate(string objectId, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return TryApplyFaceUpdate(objectId, "Update machine reference", new FaceElementModelUpdate
+            {
+                HasLinkedMachineObjectReference = true,
+                LinkedMachineObjectReference = null
+            });
+        }
+
+        if (!MachineObjectReference.TryParse(value, out var reference))
+        {
+            return "Use a machine reference such as lamp:17, reel:2, alpha:0, sevenSegment:12, or input:start.";
+        }
+
+        return TryApplyFaceUpdate(objectId, "Update machine reference", new FaceElementModelUpdate
+        {
+            HasLinkedMachineObjectReference = true,
+            LinkedMachineObjectReference = reference
+        });
+    }
+
+    private string? TryApplyFaceUpdate(string objectId, string description, FaceElementModelUpdate update)
+    {
+        var selectedDocument = _selectedDocumentAccessor();
+        if (selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Face)
+        {
+            return "No active face document.";
+        }
+
+        var existing = selectedDocument.GetFaceElements()
+            .FirstOrDefault(element => string.Equals(element.ObjectId, objectId, StringComparison.Ordinal));
+        if (existing is null)
+        {
+            return "Selected face element no longer exists.";
+        }
+
+        var updated = FaceElementModelUpdater.Apply(existing, update);
+        if (!FaceElementValidation.IsValidForInspectorUpdate(updated))
+        {
+            return "Invalid face element dimensions.";
+        }
+
+        var command = FaceMutationCommands.CreateUpdateElementCommand(
+            selectedDocument.DocumentId,
+            selectedDocument,
+            objectId,
+            updated,
+            description);
+
+        var executed = _executeCanvasCommand(selectedDocument.DocumentId, command);
+        if (!executed)
+        {
+            return "Unable to apply update.";
+        }
+
+        return null;
+    }
+
     private bool ShouldSuppressPropertyRowRefresh()
     {
         return DateTime.UtcNow < _suppressPropertyRowRefreshUntilUtc;
@@ -664,6 +874,11 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         var titleCased = char.ToUpperInvariant(serializedKind[0]) + serializedKind[1..];
         return Regex.Replace(titleCased, "([a-z0-9])([A-Z])", "$1 $2");
+    }
+
+    private static string NicifyFaceElementKind(FaceElementModel element)
+    {
+        return element is FaceLampWindowElement ? "Face Lamp Window" : "Face Element";
     }
 
     private bool CanApplyInspectorSummary()
@@ -723,6 +938,17 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         selectedDocument.RuntimeState.LampTestObjectId = targetObjectId;
         Debug.WriteLine($"[LampTest] SetLampTestActive={isActive} document={selectedDocument.DocumentId}");
         selectedDocument.NotifyPanelVisualPreviewChanged();
+    }
+
+    private static string BuildSelectedFaceElementSummary(FaceElementModel selectedElement)
+    {
+        var displayName = string.IsNullOrWhiteSpace(selectedElement.Name)
+            ? "Lamp Window"
+            : selectedElement.Name.Trim();
+        var reference = selectedElement.LinkedMachineObjectReference is MachineObjectReference machineReference && !machineReference.IsEmpty
+            ? $" Machine reference: {machineReference}."
+            : string.Empty;
+        return $"Selected face lamp window '{displayName}' at ({selectedElement.X:0.##}, {selectedElement.Y:0.##}) sized {selectedElement.Width:0.##} x {selectedElement.Height:0.##}.{reference}";
     }
 
     private static string BuildSelectedElementSummary(PanelElementModel selectedElement)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/DocumentEditorView.xaml
@@ -57,19 +57,33 @@
                         </Style.Triggers>
                     </Style>
                 </Border.Style>
-                <StackPanel>
-                    <TextBlock FontSize="18"
-                               FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextPrimaryBrush}"
-                               Text="Face Editor Placeholder" />
-                    <TextBlock Margin="0,8,0,0"
-                               Foreground="{DynamicResource TextSecondaryBrush}"
-                               TextWrapping="Wrap"
-                               Text="Face documents can be created, opened, and saved. Face Edit View, Face Play View, and 3D preview are intentionally not implemented in Phase 2." />
-                    <TextBlock Margin="0,12,0,0"
-                               TextWrapping="Wrap"
-                               Text="{Binding ContentSummary}" />
-                </StackPanel>
+                <Grid MinHeight="280"
+                      ClipToBounds="True"
+                      Background="{DynamicResource PanelBackgroundBrush}">
+                    <views:SkiaFaceEditView />
+
+                    <Border Margin="12"
+                            Padding="12"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            IsHitTestVisible="False"
+                            CornerRadius="4"
+                            Background="{DynamicResource ToolBarBackgroundBrush}"
+                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                            BorderThickness="1">
+                        <StackPanel>
+                            <TextBlock FontWeight="SemiBold"
+                                       Text="Face Edit View"
+                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                            <TextBlock Margin="0,6,0,0"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Text="Right-click to add a lamp window. Left-click to select." />
+                            <TextBlock Margin="0,4,0,0"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Text="Drag with middle mouse to pan. Use mouse wheel to zoom." />
+                        </StackPanel>
+                    </Border>
+                </Grid>
             </Border>
 
             <Border Padding="10"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PanelCanvasView.xaml
@@ -130,25 +130,39 @@
                             </Border>
 
                             <Border x:Name="FacePlaceholderContainer"
-                                    Padding="16"
+                                    Padding="12"
                                     CornerRadius="4"
                                     Background="{DynamicResource EditorBackgroundBrush}"
                                     BorderBrush="{DynamicResource BorderSubtleBrush}"
                                     BorderThickness="1"
                                     Visibility="Collapsed">
-                                <StackPanel>
-                                    <TextBlock FontSize="18"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource TextPrimaryBrush}"
-                                               Text="Face Editor Placeholder" />
-                                    <TextBlock Margin="0,8,0,0"
-                                               Foreground="{DynamicResource TextSecondaryBrush}"
-                                               TextWrapping="Wrap"
-                                               Text="Face documents now round-trip through the editor. Face Edit View, Face Play View, and 3D preview are intentionally not implemented in this phase." />
-                                    <TextBlock Margin="0,12,0,0"
-                                               TextWrapping="Wrap"
-                                               Text="{Binding ContentSummary}" />
-                                </StackPanel>
+                                <Grid MinHeight="280"
+                                      ClipToBounds="True"
+                                      Background="{DynamicResource PanelBackgroundBrush}">
+                                    <views:SkiaFaceEditView />
+
+                                    <Border Margin="12"
+                                            Padding="12"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Top"
+                                            IsHitTestVisible="False"
+                                            CornerRadius="4"
+                                            Background="{DynamicResource ToolBarBackgroundBrush}"
+                                            BorderBrush="{DynamicResource BorderSubtleBrush}"
+                                            BorderThickness="1">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="SemiBold"
+                                                       Text="Face Edit View"
+                                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                                            <TextBlock Margin="0,6,0,0"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                                       Text="Right-click to add a lamp window. Left-click to select." />
+                                            <TextBlock Margin="0,4,0,0"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                                       Text="Drag with middle mouse to pan. Use mouse wheel to zoom." />
+                                        </StackPanel>
+                                    </Border>
+                                </Grid>
                             </Border>
 
                             <Border x:Name="DefaultSummaryContainer"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="OasisEditor.Views.SkiaFaceEditView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sk="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF"
+             mc:Ignorable="d"
+             d:DesignHeight="450"
+             d:DesignWidth="700">
+    <Grid>
+        <Border Padding="8"
+                Background="{DynamicResource EditorBackgroundBrush}"
+                BorderBrush="{DynamicResource BorderSubtleBrush}"
+                BorderThickness="1">
+            <sk:SKElement x:Name="FaceSkiaSurface"
+                          PaintSurface="OnFaceSkiaSurfacePaintSurface"
+                          MouseDown="OnFaceSkiaSurfaceMouseDown"
+                          MouseMove="OnFaceSkiaSurfaceMouseMove"
+                          MouseUp="OnFaceSkiaSurfaceMouseUp"
+                          MouseWheel="OnFaceSkiaSurfaceMouseWheel"
+                          LostMouseCapture="OnFaceSkiaSurfaceLostMouseCapture" />
+        </Border>
+    </Grid>
+</UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -1,0 +1,326 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Threading;
+using SkiaSharp;
+using SkiaSharp.Views.Desktop;
+
+namespace OasisEditor.Views;
+
+public partial class SkiaFaceEditView : UserControl
+{
+    private const double TargetFrameMillis = 16.0;
+    private DocumentTabViewModel? _subscribedDocument;
+    private bool _isPanning;
+    private bool _isRenderQueued;
+    private bool _isRenderDirty;
+    private Point _panStart;
+    private Vector _panOrigin;
+    private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
+    private readonly DispatcherTimer _renderThrottleTimer;
+
+    public SkiaFaceEditView()
+    {
+        InitializeComponent();
+        _renderThrottleTimer = new DispatcherTimer(DispatcherPriority.Render, Dispatcher);
+        _renderThrottleTimer.Tick += OnRenderThrottleTick;
+        DataContextChanged += OnDataContextChanged;
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private DocumentTabViewModel? Document => DataContext as DocumentTabViewModel;
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        UpdateDocumentSubscription(Document);
+        RequestRender();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        _renderThrottleTimer.Stop();
+        UpdateDocumentSubscription(null);
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        UpdateDocumentSubscription(e.NewValue as DocumentTabViewModel);
+        RequestRender();
+    }
+
+    private void UpdateDocumentSubscription(DocumentTabViewModel? next)
+    {
+        if (_subscribedDocument is not null)
+        {
+            _subscribedDocument.PanelChanged -= OnDocumentChanged;
+            _subscribedDocument.PropertyChanged -= OnDocumentPropertyChanged;
+        }
+
+        _subscribedDocument = next;
+        if (_subscribedDocument is null)
+        {
+            return;
+        }
+
+        _subscribedDocument.PanelChanged += OnDocumentChanged;
+        _subscribedDocument.PropertyChanged += OnDocumentPropertyChanged;
+    }
+
+    private void OnDocumentChanged(PanelChangeEvent _)
+    {
+        RequestRender();
+    }
+
+    private void OnDocumentPropertyChanged(object? sender, PropertyChangedEventArgs eventArgs)
+    {
+        if (eventArgs.PropertyName is nameof(DocumentTabViewModel.FaceZoom)
+            or nameof(DocumentTabViewModel.FacePanX)
+            or nameof(DocumentTabViewModel.FacePanY)
+            or nameof(DocumentTabViewModel.HierarchySelectedPanelSelection))
+        {
+            RequestRender();
+        }
+    }
+
+    private void RequestRender()
+    {
+        _isRenderDirty = true;
+        if (_isRenderQueued || _renderThrottleTimer.IsEnabled)
+        {
+            return;
+        }
+
+        var elapsedMillis = _renderStopwatch.Elapsed.TotalMilliseconds;
+        if (elapsedMillis < TargetFrameMillis)
+        {
+            _renderThrottleTimer.Interval = TimeSpan.FromMilliseconds(Math.Max(1.0, TargetFrameMillis - elapsedMillis));
+            _renderThrottleTimer.Start();
+            return;
+        }
+
+        QueueRenderNow();
+    }
+
+    private void OnRenderThrottleTick(object? sender, EventArgs e)
+    {
+        _renderThrottleTimer.Stop();
+        if (_isRenderDirty)
+        {
+            QueueRenderNow();
+        }
+    }
+
+    private void QueueRenderNow()
+    {
+        _isRenderQueued = true;
+        Dispatcher.BeginInvoke(() =>
+        {
+            _isRenderQueued = false;
+            _renderStopwatch.Restart();
+            FaceSkiaSurface.InvalidateVisual();
+        }, DispatcherPriority.Render);
+    }
+
+    private void OnFaceSkiaSurfacePaintSurface(object? sender, SKPaintSurfaceEventArgs eventArgs)
+    {
+        _isRenderDirty = false;
+        var canvas = eventArgs.Surface.Canvas;
+        canvas.Clear(new SKColor(0x1E, 0x1E, 0x1E));
+
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Face)
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        canvas.Save();
+        canvas.Translate((float)viewport.PanX, (float)viewport.PanY);
+        canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
+        DrawFaceElements(canvas, document, viewport);
+        canvas.Restore();
+    }
+
+    private static void DrawFaceElements(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
+    {
+        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xC1, 0x07, 0x66), IsAntialias = true };
+        using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0xFF, 0xD5, 0x4F), StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
+        using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+        foreach (var element in document.GetFaceElements())
+        {
+            var rect = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
+            if (element.IsVisible)
+            {
+                canvas.DrawRect(rect, fillPaint);
+                canvas.DrawRect(rect, strokePaint);
+            }
+            else
+            {
+                canvas.DrawRect(rect, hiddenPaint);
+            }
+        }
+
+        if (document.HierarchySelectedPanelSelection is PanelSelectionInfo selection
+            && document.TryGetFaceElement(selection, out var selectedElement))
+        {
+            using var selectionPaint = new SKPaint
+            {
+                Style = SKPaintStyle.Stroke,
+                Color = new SKColor(0x4F, 0xC3, 0xF7),
+                StrokeWidth = (float)(2d / viewport.NormalizedZoom),
+                IsAntialias = true
+            };
+            canvas.DrawRect(
+                (float)selectedElement.X,
+                (float)selectedElement.Y,
+                (float)Math.Max(0d, selectedElement.Width),
+                (float)Math.Max(0d, selectedElement.Height),
+                selectionPaint);
+        }
+    }
+
+    private void OnFaceSkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)
+    {
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Face)
+        {
+            return;
+        }
+
+        if (eventArgs.ChangedButton == MouseButton.Right)
+        {
+            ShowAddElementContextMenu(eventArgs.GetPosition(FaceSkiaSurface));
+            eventArgs.Handled = true;
+            return;
+        }
+
+        if (eventArgs.ChangedButton == MouseButton.Left)
+        {
+            HandleSelectionClick(eventArgs.GetPosition(FaceSkiaSurface));
+            eventArgs.Handled = true;
+            return;
+        }
+
+        if (eventArgs.ChangedButton != MouseButton.Middle)
+        {
+            return;
+        }
+
+        _isPanning = true;
+        _panStart = eventArgs.GetPosition(FaceSkiaSurface);
+        _panOrigin = new Vector(document.FacePanX, document.FacePanY);
+        FaceSkiaSurface.Cursor = Cursors.SizeAll;
+        FaceSkiaSurface.CaptureMouse();
+        eventArgs.Handled = true;
+    }
+
+    private void OnFaceSkiaSurfaceMouseMove(object sender, MouseEventArgs eventArgs)
+    {
+        var document = Document;
+        if (!_isPanning || document is null)
+        {
+            return;
+        }
+
+        FaceSkiaSurface.Cursor = Cursors.SizeAll;
+        var delta = eventArgs.GetPosition(FaceSkiaSurface) - _panStart;
+        document.FacePanX = _panOrigin.X + delta.X;
+        document.FacePanY = _panOrigin.Y + delta.Y;
+        RequestRender();
+    }
+
+    private void OnFaceSkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
+    {
+        if (eventArgs.ChangedButton != MouseButton.Middle)
+        {
+            return;
+        }
+
+        EndPan();
+        eventArgs.Handled = true;
+    }
+
+    private void OnFaceSkiaSurfaceMouseWheel(object sender, MouseWheelEventArgs eventArgs)
+    {
+        var document = Document;
+        if (document is null)
+        {
+            return;
+        }
+
+        var transform = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY)
+            .WithZoomAt(eventArgs.GetPosition(FaceSkiaSurface), eventArgs.Delta);
+
+        document.FaceZoom = transform.Zoom;
+        document.FacePanX = transform.PanX;
+        document.FacePanY = transform.PanY;
+        RequestRender();
+        eventArgs.Handled = true;
+    }
+
+    private void OnFaceSkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    {
+        if (_isPanning)
+        {
+            EndPan(releaseMouseCapture: false);
+        }
+    }
+
+    private void ShowAddElementContextMenu(Point screenPoint)
+    {
+        var contextMenu = new ContextMenu
+        {
+            PlacementTarget = FaceSkiaSurface,
+            Placement = PlacementMode.MousePoint
+        };
+
+        var menuItem = new MenuItem { Header = "Add Lamp Window" };
+        menuItem.Click += (_, _) => AddLampWindowAt(screenPoint);
+        contextMenu.Items.Add(menuItem);
+        contextMenu.IsOpen = true;
+    }
+
+    private void AddLampWindowAt(Point screenPoint)
+    {
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Face)
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var element = FaceElementFactory.CreateLampWindow(viewport.ScreenToDocument(screenPoint));
+        var command = FaceMutationCommands.CreateAddLampWindowCommand(document.DocumentId, document, element);
+        document.CommandService.Execute(command);
+        RequestRender();
+    }
+
+    private void HandleSelectionClick(Point screenPoint)
+    {
+        var document = Document;
+        if (document is null)
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var selection = FaceSelectionService.SelectFromPoint(document.GetFaceElements(), viewport.ScreenToDocument(screenPoint), document.HierarchySelectedPanelSelection);
+        Panel2DSelectionNotificationService.NotifySelection(this, document, selection);
+        RequestRender();
+    }
+
+    private void EndPan(bool releaseMouseCapture = true)
+    {
+        _isPanning = false;
+        if (releaseMouseCapture && FaceSkiaSurface.IsMouseCaptured)
+        {
+            FaceSkiaSurface.ReleaseMouseCapture();
+        }
+
+        FaceSkiaSurface.Cursor = Cursors.Arrow;
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement Phase 3 (Face Edit View MVP) by replacing the Face placeholder with an interactive 2D Face Edit surface while reusing existing Skia viewport math and interaction patterns.
- Provide a minimal Face element model (lamp window), allow creating/visiting/persisting Face elements, and expose editing of MachineObjectReference values without touching Panel2D runtime behavior.

### Description
- Added a Skia-based Face edit surface (`Views/SkiaFaceEditView.xaml(.cs)`) implementing pan/zoom, left-click selection, right-click "Add Lamp Window", and rectangle rendering for `FaceLampWindowElement`.
- Extended `DocumentTabViewModel` with Face document accessors and per-document Face viewport state (`GetFaceElements`, `TryGetFaceElement`, `SetFaceElements`, `FaceZoom`, `FacePanX`, `FacePanY`) so Face documents open in a real editable view.
- Introduced Face element services and model utilities (`FaceElementServices.cs`) for factory, update, validation, and selection logic, and mutation commands (`FaceMutationCommands.cs`) that integrate with the existing document command/history system.
- Wired Face into the UI/hierarchy/inspector: added `FaceHierarchyProvider`, updated `MainWindowViewModel` to include Face hierarchy provider, replaced placeholder XAML to host `SkiaFaceEditView`, and extended `InspectorViewModel` to show/edit Face element rows including `Machine Reference` and `Linked Panel2D Element` with command-backed persistence.
- Added unit tests (`OasisEditor.Tests/FaceEditViewModelTests.cs`) that cover creating a Face lamp window, inspector editing of `MachineObjectReference`, persistence round-trip, and Face hierarchy generation.

### Testing
- Ran lightweight repository checks (`git diff --check`) which reported no whitespace errors and succeeded.
- Attempted to run a full build (`dotnet build OasisEditor.sln`) but `dotnet`/SDK is not available in this environment so no compile or test runner was executed here.
- Added automated unit tests under `OasisEditor.Tests/FaceEditViewModelTests.cs`; these tests are included in the repo but were not run due to the missing .NET SDK in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24897b3d1483279206c9f64cfbc8f6)