### PR TITLE
Add Panel2D region face generation MVP

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -1,0 +1,119 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceGenerationServiceTests
+{
+    [Fact]
+    public void GenerateFromPanelRegion_ConvertsContainedLampsWithRelativeCoordinatesAndReferences()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Title = "Panel",
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-17",
+                    Name = "Start Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 110,
+                    Y = 220,
+                    Width = 30,
+                    Height = 40,
+                    DisplayNumber = 17,
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "reel-1",
+                    Name = "Ignored Reel",
+                    Kind = PanelElementKind.Reel,
+                    X = 120,
+                    Y = 225,
+                    Width = 20,
+                    Height = 20,
+                    DisplayNumber = 1,
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-outside",
+                    Name = "Outside Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    DisplayNumber = 99,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var service = new FaceGenerationService();
+        var result = service.GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 200, 150)),
+            "Generated Face",
+            "panel-doc-1");
+
+        Assert.Equal(1, result.ConvertedLampCount);
+        Assert.Equal("Generated Face", result.Document.Title);
+        Assert.Equal("panel-doc-1", result.Document.SourcePanel2DDocumentId);
+        Assert.NotNull(result.Document.SourceRegion);
+
+        var element = Assert.IsType<FaceLampWindowElement>(Assert.Single(result.Document.Elements));
+        Assert.Equal("face-lamp-17", element.ObjectId);
+        Assert.Equal("Start Lamp", element.Name);
+        Assert.Equal(10d, element.X);
+        Assert.Equal(20d, element.Y);
+        Assert.Equal(30d, element.Width);
+        Assert.Equal(40d, element.Height);
+        Assert.Equal("lamp:17", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("lamp-17", element.LinkedPanel2DElementId);
+    }
+
+    [Fact]
+    public void GenerateFromPanelRegion_RoundTripsGeneratedSourceAndElementLinks()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-5",
+                    Name = "Hold Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 25,
+                    Y = 35,
+                    Width = 15,
+                    Height = 20,
+                    DisplayNumber = 5,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var generated = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(20, 30, 100, 100)),
+            "Round Trip Face",
+            "source-panel").Document;
+
+        var json = FaceDocumentStorage.Serialize(generated);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var model = FaceDocumentStorage.ToModel(file);
+
+        Assert.Equal("source-panel", model.SourcePanel2DDocumentId);
+        Assert.Equal(20d, model.SourceRegion!.X);
+        Assert.Equal(30d, model.SourceRegion!.Y);
+        var element = Assert.Single(model.Elements);
+        Assert.Equal("lamp:5", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("lamp-5", element.LinkedPanel2DElementId);
+        Assert.Equal(5d, element.X);
+        Assert.Equal(5d, element.Y);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -5,6 +5,8 @@ public sealed class FaceDocumentModel
     public string Id { get; init; } = Guid.NewGuid().ToString("N");
     public string Title { get; init; } = string.Empty;
     public string? Summary { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionModel? SourceRegion { get; init; }
     public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
     public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -128,6 +128,8 @@ public static class FaceDocumentStorage
             Id = string.IsNullOrWhiteSpace(file.Id) ? Guid.NewGuid().ToString("N") : file.Id.Trim(),
             Title = file.Title ?? string.Empty,
             Summary = file.Summary,
+            SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
+            SourceRegion = ToModel(file.SourceRegion),
             Layers = (file.Layers ?? [])
                 .Select(layer => new FaceLayerModel
                 {
@@ -152,6 +154,8 @@ public static class FaceDocumentStorage
             Id = string.IsNullOrWhiteSpace(model.Id) ? Guid.NewGuid().ToString("N") : model.Id.Trim(),
             Title = model.Title,
             Summary = model.Summary,
+            SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
+            SourceRegion = ToFile(model.SourceRegion),
             SavedAtUtc = DateTime.UtcNow,
             Layers = model.Layers.Select(layer => new FaceLayerFile
             {
@@ -161,6 +165,42 @@ public static class FaceDocumentStorage
                 IsLocked = layer.IsLocked
             }).ToArray(),
             Elements = model.Elements.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceSourceRegionModel? ToModel(FaceSourceRegionFile? file)
+    {
+        if (file is null)
+        {
+            return null;
+        }
+
+        var model = new FaceSourceRegionModel
+        {
+            Kind = file.Kind,
+            X = file.X,
+            Y = file.Y,
+            Width = file.Width,
+            Height = file.Height
+        };
+
+        return model.IsValid ? model : null;
+    }
+
+    private static FaceSourceRegionFile? ToFile(FaceSourceRegionModel? model)
+    {
+        if (model is null)
+        {
+            return null;
+        }
+
+        return new FaceSourceRegionFile
+        {
+            Kind = model.Kind,
+            X = model.X,
+            Y = model.Y,
+            Width = model.Width,
+            Height = model.Height
         };
     }
 
@@ -212,9 +252,20 @@ public sealed record FaceDocumentFile
     public string? Id { get; init; }
     public string? Title { get; init; }
     public string? Summary { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionFile? SourceRegion { get; init; }
     public DateTime SavedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
     public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];
+}
+
+public sealed record FaceSourceRegionFile
+{
+    public FaceSourceRegionKind Kind { get; init; } = FaceSourceRegionKind.Rect;
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
 }
 
 public sealed record FaceLayerFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -1,0 +1,154 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+public enum FaceSourceRegionKind
+{
+    Rect
+}
+
+public sealed class FaceSourceRegionModel
+{
+    public FaceSourceRegionKind Kind { get; init; } = FaceSourceRegionKind.Rect;
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+
+    public static FaceSourceRegionModel FromRect(Rect rect)
+    {
+        var normalized = Normalize(rect);
+        return new FaceSourceRegionModel
+        {
+            Kind = FaceSourceRegionKind.Rect,
+            X = normalized.X,
+            Y = normalized.Y,
+            Width = normalized.Width,
+            Height = normalized.Height
+        };
+    }
+
+    public Rect ToRect() => new(X, Y, Width, Height);
+
+    public bool IsValid => Kind == FaceSourceRegionKind.Rect
+        && PanelElementValidation.IsFinite(X)
+        && PanelElementValidation.IsFinite(Y)
+        && PanelElementValidation.IsFinite(Width)
+        && PanelElementValidation.IsFinite(Height)
+        && Width > 0
+        && Height > 0;
+
+    private static Rect Normalize(Rect rect)
+    {
+        var left = Math.Min(rect.Left, rect.Right);
+        var top = Math.Min(rect.Top, rect.Bottom);
+        var right = Math.Max(rect.Left, rect.Right);
+        var bottom = Math.Max(rect.Top, rect.Bottom);
+        return new Rect(left, top, right - left, bottom - top);
+    }
+}
+
+internal sealed class FaceGenerationResult
+{
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount)
+    {
+        Document = document;
+        ConvertedLampCount = convertedLampCount;
+    }
+
+    public FaceDocumentModel Document { get; }
+    public int ConvertedLampCount { get; }
+}
+
+internal sealed class FaceGenerationService
+{
+    private readonly IMachineObjectReferenceResolver _machineObjectReferenceResolver;
+
+    public FaceGenerationService(IMachineObjectReferenceResolver? machineObjectReferenceResolver = null)
+    {
+        _machineObjectReferenceResolver = machineObjectReferenceResolver ?? MachineObjectReferenceResolver.Instance;
+    }
+
+    public FaceGenerationResult GenerateFromPanelRegion(
+        Panel2DDocumentModel sourcePanel,
+        FaceSourceRegionModel sourceRegion,
+        string title,
+        string? sourcePanel2DDocumentId = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePanel);
+        ArgumentNullException.ThrowIfNull(sourceRegion);
+
+        if (!sourceRegion.IsValid)
+        {
+            throw new ArgumentException("Face source region must be a non-empty finite rectangle.", nameof(sourceRegion));
+        }
+
+        var region = sourceRegion.ToRect();
+        var lampWindows = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region))
+            .Select(element => CreateLampWindow(element, region))
+            .ToArray();
+
+        var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim();
+        var document = new FaceDocumentModel
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Title = resolvedTitle,
+            Summary = $"Generated from Panel2D source region ({Format(region.X)}, {Format(region.Y)}, {Format(region.Width)}, {Format(region.Height)}).",
+            SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(sourcePanel2DDocumentId) ? null : sourcePanel2DDocumentId.Trim(),
+            SourceRegion = sourceRegion,
+            Layers =
+            [
+                new FaceLayerModel
+                {
+                    Id = "layer-lamp-windows",
+                    Name = "Lamp Windows",
+                    IsVisible = true
+                }
+            ],
+            Elements = lampWindows
+        };
+
+        return new FaceGenerationResult(document, lampWindows.Length);
+    }
+
+    private FaceLampWindowElement CreateLampWindow(PanelElementModel sourceElement, Rect region)
+    {
+        _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
+
+        return new FaceLampWindowElement
+        {
+            ObjectId = CreateGeneratedElementId(sourceElement),
+            Name = sourceElement.Name ?? string.Empty,
+            X = Math.Round(sourceElement.X - region.X, 2),
+            Y = Math.Round(sourceElement.Y - region.Y, 2),
+            Width = Math.Round(sourceElement.Width, 2),
+            Height = Math.Round(sourceElement.Height, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId
+        };
+    }
+
+    private static string CreateGeneratedElementId(PanelElementModel sourceElement)
+    {
+        return string.IsNullOrWhiteSpace(sourceElement.ObjectId)
+            ? Guid.NewGuid().ToString("N")
+            : $"face-{sourceElement.ObjectId.Trim()}";
+    }
+
+    private static bool IsContainedBy(PanelElementModel element, Rect region)
+    {
+        var left = element.X;
+        var top = element.Y;
+        var right = element.X + element.Width;
+        var bottom = element.Y + element.Height;
+        return left >= region.Left
+            && top >= region.Top
+            && right <= region.Right
+            && bottom <= region.Bottom;
+    }
+
+    private static string Format(double value) => Math.Round(value, 2).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/GenerateFaceFromRegionDialog.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/GenerateFaceFromRegionDialog.xaml
@@ -1,0 +1,45 @@
+<Window x:Class="OasisEditor.GenerateFaceFromRegionDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Generate Face From Region"
+        Height="260"
+        Width="360"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource EditorBackgroundBrush}"
+        Foreground="{DynamicResource TextPrimaryBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="90" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Margin="0,0,0,12"
+                   Text="Enter a rectangular Panel2D source region. Contained lamp elements will become Face lamp windows with coordinates relative to this region." />
+
+        <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Text="X" />
+        <TextBox x:Name="XTextBox" Grid.Row="1" Grid.Column="1" Margin="0,2" Text="0" />
+        <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Y" />
+        <TextBox x:Name="YTextBox" Grid.Row="2" Grid.Column="1" Margin="0,2" Text="0" />
+        <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Text="Width" />
+        <TextBox x:Name="WidthTextBox" Grid.Row="3" Grid.Column="1" Margin="0,2" Text="800" />
+        <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Text="Height" />
+        <TextBox x:Name="HeightTextBox" Grid.Row="4" Grid.Column="1" Margin="0,2" Text="600" />
+
+        <TextBlock x:Name="ErrorTextBlock" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,8,0,0" Foreground="#FFFF6B6B" TextWrapping="Wrap" />
+
+        <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Cancel" Width="80" Margin="0,0,8,0" IsCancel="True" />
+            <Button Content="Generate" Width="90" IsDefault="True" Click="OnGenerateClicked" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/GenerateFaceFromRegionDialog.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/GenerateFaceFromRegionDialog.xaml.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using System.Windows;
+
+namespace OasisEditor;
+
+public partial class GenerateFaceFromRegionDialog : Window
+{
+    public GenerateFaceFromRegionDialog()
+    {
+        InitializeComponent();
+    }
+
+    public Rect SourceRegion { get; private set; }
+
+    private void OnGenerateClicked(object sender, RoutedEventArgs e)
+    {
+        if (!TryReadDouble(XTextBox.Text, out var x)
+            || !TryReadDouble(YTextBox.Text, out var y)
+            || !TryReadDouble(WidthTextBox.Text, out var width)
+            || !TryReadDouble(HeightTextBox.Text, out var height)
+            || width <= 0
+            || height <= 0)
+        {
+            ErrorTextBlock.Text = "Enter finite numeric X, Y, Width, and Height values. Width and Height must be greater than zero.";
+            return;
+        }
+
+        SourceRegion = new Rect(x, y, width, height);
+        DialogResult = true;
+    }
+
+    private static bool TryReadDouble(string? value, out double result)
+    {
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result)
+            && !double.IsNaN(result)
+            && !double.IsInfinity(result);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -53,6 +53,8 @@
                           Command="{Binding OpenPanel2DStubCommand}" />
                 <MenuItem Header="New _Face Stub"
                           Command="{Binding OpenFaceStubCommand}" />
+                <MenuItem Header="Generate Face From _Region..."
+                          Command="{Binding GenerateFaceFromRegionCommand}" />
                 <MenuItem Header="New _Cabinet3D Stub"
                           Command="{Binding OpenCabinet3DStubCommand}" />
                 <MenuItem Header="New _Machine Stub"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -106,6 +106,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenUntitledDocumentCommand = new RelayCommand(OpenUntitledDocument, CanOpenUntitledDocument);
         OpenPanel2DStubCommand = new RelayCommand(OpenPanel2DStubDocument, CanOpenUntitledDocument);
         OpenFaceStubCommand = new RelayCommand(OpenFaceStubDocument, CanOpenUntitledDocument);
+        GenerateFaceFromRegionCommand = new RelayCommand(GenerateFaceFromRegion, CanGenerateFaceFromRegion);
         OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
@@ -391,6 +392,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenUntitledDocumentCommand { get; }
     public ICommand OpenPanel2DStubCommand { get; }
     public ICommand OpenFaceStubCommand { get; }
+    public ICommand GenerateFaceFromRegionCommand { get; }
     public ICommand OpenCabinet3DStubCommand { get; }
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
@@ -966,6 +968,31 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private void OpenFaceStubDocument()
     {
         _documentWorkspace.OpenFaceStubDocument();
+    }
+
+    private bool CanGenerateFaceFromRegion()
+    {
+        return _documentWorkspace.CanGenerateFaceFromSelectedPanel2DRegion();
+    }
+
+    private void GenerateFaceFromRegion()
+    {
+        if (!CanGenerateFaceFromRegion())
+        {
+            return;
+        }
+
+        var dialog = new GenerateFaceFromRegionDialog
+        {
+            Owner = _ownerWindow
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        _documentWorkspace.GenerateFaceFromSelectedPanel2DRegion(dialog.SourceRegion);
     }
 
     private void OpenCabinet3DStubDocument()
@@ -3114,6 +3141,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (OpenFaceStubCommand is RelayCommand openFaceRelayCommand)
         {
             openFaceRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (GenerateFaceFromRegionCommand is RelayCommand generateFaceRelayCommand)
+        {
+            generateFaceRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (OpenCabinet3DStubCommand is RelayCommand openCabinetRelayCommand)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -166,6 +166,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             Id = _faceDocumentModel.Id,
             Title = _faceDocumentModel.Title,
             Summary = _faceDocumentModel.Summary,
+            SourcePanel2DDocumentId = _faceDocumentModel.SourcePanel2DDocumentId,
+            SourceRegion = _faceDocumentModel.SourceRegion,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()
         };
@@ -176,6 +178,11 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         {
             PanelChanged?.Invoke(change);
         }
+    }
+
+    internal Panel2DDocumentModel GetPanelDocument()
+    {
+        return _panelDocumentModel;
     }
 
     internal IReadOnlyList<PanelElementModel> GetPanelElements()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Windows;
 using EditorCommands = OasisEditor.Commands;
 
 namespace OasisEditor;
@@ -21,6 +22,7 @@ public sealed class DocumentWorkspaceViewModel
     private readonly MachineRuntimeStateStore _runtimeStateStore;
     private readonly Automation.IPanel2DDocumentCreationService _panel2dCreationService;
     private readonly Automation.IFaceDocumentCreationService _faceCreationService;
+    private readonly FaceGenerationService _faceGenerationService = new();
 
     private int _untitledDocumentCounter = 1;
     private int _panelDocumentCounter = 1;
@@ -90,6 +92,43 @@ public sealed class DocumentWorkspaceViewModel
     {
         var selectedDocument = _getSelectedDocument();
         return selectedDocument is not null;
+    }
+
+
+    public bool CanGenerateFaceFromSelectedPanel2DRegion()
+    {
+        return _getLoadedProject() is not null
+            && _getSelectedDocument() is { Document.DocumentType: EditorDocumentType.Panel2D };
+    }
+
+    public DocumentTabViewModel? GenerateFaceFromSelectedPanel2DRegion(Rect sourceRect)
+    {
+        var sourceDocument = _getSelectedDocument();
+        if (_getLoadedProject() is null || sourceDocument is null || sourceDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        {
+            return null;
+        }
+
+        var sourceRegion = FaceSourceRegionModel.FromRect(sourceRect);
+        if (!sourceRegion.IsValid)
+        {
+            return null;
+        }
+
+        var title = $"{sourceDocument.Title} Face";
+        var result = _faceGenerationService.GenerateFromPanelRegion(
+            sourceDocument.GetPanelDocument(),
+            sourceRegion,
+            title,
+            sourceDocument.DocumentId.ToString("N"));
+
+        var faceJson = FaceDocumentStorage.Serialize(result.Document);
+        var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
+        var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
+        ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
+        _setStatusMessage($"Generated face document from Panel2D region with {result.ConvertedLampCount} lamp window(s).");
+        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ConvertedLampCount} lamp window(s).", OutputLogStatus.Info);
+        return document;
     }
 
     public void OpenUntitledDocument()


### PR DESCRIPTION
### Motivation
- Provide a Phase 4 MVP to generate Face elements from a rectangular region of an existing Panel2D, converting lamps into Face lamp windows while preserving machine references and source linkage.

### Description
- Added `FaceSourceRegionModel` and `FaceGenerationService` to generate a `FaceDocumentModel` from a Panel2D source rectangle, converting only contained `PanelElementKind.Lamp` elements into `FaceLampWindowElement` with relative coordinates, `LinkedMachineObjectReference`, and `LinkedPanel2DElementId` preserved (`OasisEditor/FaceGenerationService.cs`).
- Extended the Face model and persistence to include `SourcePanel2DDocumentId` and `SourceRegion` so generated provenance persists through save/load (`OasisEditor/FaceDocumentModel.cs`, `OasisEditor/FaceDocumentStorage.cs`).
- Added a modal dialog `GenerateFaceFromRegionDialog` for entering a numeric source rectangle and validation (`OasisEditor/GenerateFaceFromRegionDialog.xaml(.cs)`).
- Wired a new menu action and command `Generate Face From Region...` that is enabled only when a Panel2D document is active, and implemented workspace flow to create and open the generated Face document tab (`OasisEditor/MainWindow.xaml`, `OasisEditor/MainWindowViewModel.cs`, `OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs`).
- Preserved Face source metadata when replacing Face elements in the editor (`OasisEditor/ViewModels/DocumentTabViewModel.cs`).
- Added unit tests validating lamp conversion, relative coordinates, machine reference/link preservation, and save/load round-trip (`OasisEditor.Tests/FaceGenerationServiceTests.cs`).

### Testing
- Ran repository checks: `git diff --check` and committed the changes successfully (commit created).
- Added automated tests: `OasisEditor.Tests/FaceGenerationServiceTests.cs` covering conversion and round-trip persistence; running `dotnet test OasisEditor.sln` could not be executed in this environment because the `dotnet` runtime is not available (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24f670e44c8327bff0cc6c834a613e)