### PR TITLE
Add Face Artwork MVP

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -25,6 +25,40 @@ public sealed class FaceDocumentRoundTripTests
             ],
             Elements =
             [
+                new FaceArtworkElement
+                {
+                    ObjectId = "artwork-1",
+                    Name = "Glass Artwork",
+                    X = 0,
+                    Y = 0,
+                    Width = 320,
+                    Height = 240,
+                    IsVisible = true,
+                    AssetPath = "Assets/Panel2D/glass.png",
+                    SourcePanel2DDocumentId = "panel-doc-1",
+                    SourceRegion = new FaceSourceRegionModel
+                    {
+                        X = 100,
+                        Y = 200,
+                        Width = 320,
+                        Height = 240
+                    },
+                    Provenance = new FaceArtworkProvenanceModel
+                    {
+                        Generator = "Generate Face From Region",
+                        GeneratedAtUtc = new DateTime(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc),
+                        SourcePanel2DElementId = "background-1",
+                        SourcePanel2DElementKind = "background",
+                        SourceAssetPath = "Assets/Panel2D/glass.png",
+                        SourceElementBounds = new FaceSourceRegionModel
+                        {
+                            X = 0,
+                            Y = 0,
+                            Width = 640,
+                            Height = 480
+                        }
+                    }
+                },
                 new FaceLampWindowElement
                 {
                     ObjectId = "lamp-window-17",
@@ -57,7 +91,16 @@ public sealed class FaceDocumentRoundTripTests
         var layer = Assert.Single(savedDocument.Layers!);
         Assert.Equal("lamps", layer.Id);
         Assert.Equal("Lamp Windows", layer.Name);
-        var element = Assert.Single(savedDocument.Elements!);
+        Assert.Equal(2, savedDocument.Elements!.Count);
+        var artwork = savedDocument.Elements![0];
+        Assert.Equal("artwork-1", artwork.ObjectId);
+        Assert.Equal("artwork", artwork.Kind);
+        Assert.Equal("Assets/Panel2D/glass.png", artwork.AssetPath);
+        Assert.Equal("panel-doc-1", artwork.SourcePanel2DDocumentId);
+        Assert.Equal(100d, artwork.SourceRegion!.X);
+        Assert.Equal("background-1", artwork.ArtworkProvenance!.SourcePanel2DElementId);
+
+        var element = savedDocument.Elements![1];
         Assert.Equal("lamp-window-17", element.ObjectId);
         Assert.Equal("lampWindow", element.Kind);
         Assert.Equal("lamp:17", element.LinkedMachineObjectReference);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceEditViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceEditViewModelTests.cs
@@ -98,6 +98,42 @@ public sealed class FaceEditViewModelTests
         Assert.Contains("lamp:1", child.DisplayName);
     }
 
+    [Fact]
+    public void FaceHierarchyProvider_BuildsArtworkAndLampWindowGroupsWhenArtworkExists()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));
+        document.SetFaceElements(
+            [
+                new FaceArtworkElement
+                {
+                    ObjectId = "face-artwork-1",
+                    Name = "Glass Artwork",
+                    X = 0,
+                    Y = 0,
+                    Width = 200,
+                    Height = 100
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-lamp-1",
+                    Name = "Lamp Window",
+                    X = 10,
+                    Y = 20,
+                    Width = 80,
+                    Height = 40
+                }
+            ]);
+
+        var provider = new FaceHierarchyProvider();
+        var roots = provider.Build(document);
+
+        Assert.Equal(2, roots.Count);
+        Assert.Equal("Artwork (1)", roots[0].DisplayName);
+        Assert.Equal("face-artwork-1", Assert.Single(roots[0].Children).PanelSelection?.ObjectId);
+        Assert.Equal("Lamp Windows (1)", roots[1].DisplayName);
+        Assert.Equal("face-lamp-1", Assert.Single(roots[1].Children).PanelSelection?.ObjectId);
+    }
+
     private static InspectorViewModel CreateInspectorViewModel(
         DocumentTabViewModel selectedDocument,
         ActiveDocumentContextService context,

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -15,6 +15,18 @@ public sealed class FaceGenerationServiceTests
             [
                 new PanelElementModel
                 {
+                    ObjectId = "background-1",
+                    Name = "Glass",
+                    Kind = PanelElementKind.Background,
+                    X = 0,
+                    Y = 0,
+                    Width = 400,
+                    Height = 300,
+                    AssetPath = "Assets/Panel2D/glass.png",
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
                     ObjectId = "lamp-17",
                     Name = "Start Lamp",
                     Kind = PanelElementKind.Lamp,
@@ -60,11 +72,21 @@ public sealed class FaceGenerationServiceTests
             "panel-doc-1");
 
         Assert.Equal(1, result.ConvertedLampCount);
+        Assert.Equal(1, result.ArtworkElementCount);
         Assert.Equal("Generated Face", result.Document.Title);
         Assert.Equal("panel-doc-1", result.Document.SourcePanel2DDocumentId);
         Assert.NotNull(result.Document.SourceRegion);
 
-        var element = Assert.IsType<FaceLampWindowElement>(Assert.Single(result.Document.Elements));
+        var artwork = Assert.IsType<FaceArtworkElement>(result.Document.Elements[0]);
+        Assert.Equal("face-artwork-background-1", artwork.ObjectId);
+        Assert.Equal("Assets/Panel2D/glass.png", artwork.AssetPath);
+        Assert.Equal("panel-doc-1", artwork.SourcePanel2DDocumentId);
+        Assert.Equal(100d, artwork.SourceRegion!.X);
+        Assert.Equal(200d, artwork.SourceRegion.Y);
+        Assert.Equal("background-1", artwork.Provenance!.SourcePanel2DElementId);
+        Assert.Equal("background", artwork.Provenance.SourcePanel2DElementKind);
+
+        var element = Assert.IsType<FaceLampWindowElement>(result.Document.Elements[1]);
         Assert.Equal("face-lamp-17", element.ObjectId);
         Assert.Equal("Start Lamp", element.Name);
         Assert.Equal(10d, element.X);
@@ -82,6 +104,18 @@ public sealed class FaceGenerationServiceTests
         {
             Elements =
             [
+                new PanelElementModel
+                {
+                    ObjectId = "background-1",
+                    Name = "Glass",
+                    Kind = PanelElementKind.Background,
+                    X = 0,
+                    Y = 0,
+                    Width = 200,
+                    Height = 200,
+                    AssetPath = "Assets/Panel2D/glass.png",
+                    IsVisible = true
+                },
                 new PanelElementModel
                 {
                     ObjectId = "lamp-5",
@@ -110,7 +144,12 @@ public sealed class FaceGenerationServiceTests
         Assert.Equal("source-panel", model.SourcePanel2DDocumentId);
         Assert.Equal(20d, model.SourceRegion!.X);
         Assert.Equal(30d, model.SourceRegion!.Y);
-        var element = Assert.Single(model.Elements);
+        var artwork = Assert.IsType<FaceArtworkElement>(model.Elements[0]);
+        Assert.Equal("source-panel", artwork.SourcePanel2DDocumentId);
+        Assert.Equal(20d, artwork.SourceRegion!.X);
+        Assert.Equal("Assets/Panel2D/glass.png", artwork.Provenance!.SourceAssetPath);
+
+        var element = Assert.IsType<FaceLampWindowElement>(model.Elements[1]);
         Assert.Equal("lamp:5", element.LinkedMachineObjectReference?.ToString());
         Assert.Equal("lamp-5", element.LinkedPanel2DElementId);
         Assert.Equal(5d, element.X);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -33,6 +33,24 @@ public abstract class FaceElementModel
     public string? LinkedPanel2DElementId { get; init; }
 }
 
+public sealed class FaceArtworkElement : FaceElementModel
+{
+    public string? AssetPath { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionModel? SourceRegion { get; init; }
+    public FaceArtworkProvenanceModel? Provenance { get; init; }
+}
+
+public sealed class FaceArtworkProvenanceModel
+{
+    public string Generator { get; init; } = string.Empty;
+    public DateTime GeneratedAtUtc { get; init; }
+    public string? SourcePanel2DElementId { get; init; }
+    public string? SourcePanel2DElementKind { get; init; }
+    public string? SourceAssetPath { get; init; }
+    public FaceSourceRegionModel? SourceElementBounds { get; init; }
+}
+
 public sealed class FaceLampWindowElement : FaceElementModel
 {
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -34,6 +34,12 @@ public static class FaceDocumentStorage
             [
                 new FaceLayerFile
                 {
+                    Id = "layer-artwork",
+                    Name = "Artwork",
+                    IsVisible = true
+                },
+                new FaceLayerFile
+                {
                     Id = "layer-lamp-windows",
                     Name = "Lamp Windows",
                     IsVisible = true
@@ -212,7 +218,25 @@ public static class FaceDocumentStorage
             reference = parsedReference;
         }
 
-        return new FaceLampWindowElement
+        return string.Equals(file.Kind, "artwork", StringComparison.OrdinalIgnoreCase)
+            ? new FaceArtworkElement
+            {
+                ObjectId = file.ObjectId ?? string.Empty,
+                Name = file.Name ?? string.Empty,
+                X = file.X,
+                Y = file.Y,
+                Width = file.Width,
+                Height = file.Height,
+                IsVisible = file.IsVisible,
+                IsLocked = file.IsLocked,
+                LinkedMachineObjectReference = reference,
+                LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+                AssetPath = file.AssetPath,
+                SourcePanel2DDocumentId = file.SourcePanel2DDocumentId,
+                SourceRegion = ToModel(file.SourceRegion),
+                Provenance = ToModel(file.ArtworkProvenance)
+            }
+            : new FaceLampWindowElement
         {
             ObjectId = file.ObjectId ?? string.Empty,
             Name = file.Name ?? string.Empty,
@@ -227,13 +251,36 @@ public static class FaceDocumentStorage
         };
     }
 
+    private static FaceArtworkProvenanceModel? ToModel(FaceArtworkProvenanceFile? file)
+    {
+        if (file is null)
+        {
+            return null;
+        }
+
+        return new FaceArtworkProvenanceModel
+        {
+            Generator = file.Generator ?? string.Empty,
+            GeneratedAtUtc = file.GeneratedAtUtc,
+            SourcePanel2DElementId = file.SourcePanel2DElementId,
+            SourcePanel2DElementKind = file.SourcePanel2DElementKind,
+            SourceAssetPath = file.SourceAssetPath,
+            SourceElementBounds = ToModel(file.SourceElementBounds)
+        };
+    }
+
     private static FaceElementFile ToFile(FaceElementModel model)
     {
         return new FaceElementFile
         {
             ObjectId = model.ObjectId,
             Name = model.Name,
-            Kind = model is FaceLampWindowElement ? "lampWindow" : "unknown",
+            Kind = model switch
+            {
+                FaceArtworkElement => "artwork",
+                FaceLampWindowElement => "lampWindow",
+                _ => "unknown"
+            },
             X = model.X,
             Y = model.Y,
             Width = model.Width,
@@ -241,7 +288,29 @@ public static class FaceDocumentStorage
             IsVisible = model.IsVisible,
             IsLocked = model.IsLocked,
             LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
-            LinkedPanel2DElementId = model.LinkedPanel2DElementId
+            LinkedPanel2DElementId = model.LinkedPanel2DElementId,
+            AssetPath = model is FaceArtworkElement artwork ? artwork.AssetPath : null,
+            SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
+            SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
+            ArtworkProvenance = model is FaceArtworkElement artworkProvenance ? ToFile(artworkProvenance.Provenance) : null
+        };
+    }
+
+    private static FaceArtworkProvenanceFile? ToFile(FaceArtworkProvenanceModel? model)
+    {
+        if (model is null)
+        {
+            return null;
+        }
+
+        return new FaceArtworkProvenanceFile
+        {
+            Generator = model.Generator,
+            GeneratedAtUtc = model.GeneratedAtUtc,
+            SourcePanel2DElementId = model.SourcePanel2DElementId,
+            SourcePanel2DElementKind = model.SourcePanel2DElementKind,
+            SourceAssetPath = model.SourceAssetPath,
+            SourceElementBounds = ToFile(model.SourceElementBounds)
         };
     }
 }
@@ -289,4 +358,18 @@ public sealed record FaceElementFile
     public bool IsLocked { get; init; }
     public string? LinkedMachineObjectReference { get; init; }
     public string? LinkedPanel2DElementId { get; init; }
+    public string? AssetPath { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionFile? SourceRegion { get; init; }
+    public FaceArtworkProvenanceFile? ArtworkProvenance { get; init; }
+}
+
+public sealed record FaceArtworkProvenanceFile
+{
+    public string? Generator { get; init; }
+    public DateTime GeneratedAtUtc { get; init; }
+    public string? SourcePanel2DElementId { get; init; }
+    public string? SourcePanel2DElementKind { get; init; }
+    public string? SourceAssetPath { get; init; }
+    public FaceSourceRegionFile? SourceElementBounds { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -31,6 +31,23 @@ internal static class FaceElementModelUpdater
 
         return existing switch
         {
+            FaceArtworkElement artwork => new FaceArtworkElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                AssetPath = artwork.AssetPath,
+                SourcePanel2DDocumentId = artwork.SourcePanel2DDocumentId,
+                SourceRegion = artwork.SourceRegion,
+                Provenance = artwork.Provenance
+            },
             FaceLampWindowElement => new FaceLampWindowElement
             {
                 ObjectId = existing.ObjectId,
@@ -117,6 +134,11 @@ internal static class FaceSelectionService
 
     public static string GetKindToken(FaceElementModel element)
     {
-        return element is FaceLampWindowElement ? "lampWindow" : "unknown";
+        return element switch
+        {
+            FaceArtworkElement => "artwork",
+            FaceLampWindowElement => "lampWindow",
+            _ => "unknown"
+        };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -50,14 +50,16 @@ public sealed class FaceSourceRegionModel
 
 internal sealed class FaceGenerationResult
 {
-    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount)
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount)
     {
         Document = document;
         ConvertedLampCount = convertedLampCount;
+        ArtworkElementCount = artworkElementCount;
     }
 
     public FaceDocumentModel Document { get; }
     public int ConvertedLampCount { get; }
+    public int ArtworkElementCount { get; }
 }
 
 internal sealed class FaceGenerationService
@@ -84,6 +86,7 @@ internal sealed class FaceGenerationService
         }
 
         var region = sourceRegion.ToRect();
+        var artworkElements = CreateArtworkElements(sourcePanel, region, sourcePanel2DDocumentId);
         var lampWindows = sourcePanel.Elements
             .Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region))
             .Select(element => CreateLampWindow(element, region))
@@ -101,15 +104,88 @@ internal sealed class FaceGenerationService
             [
                 new FaceLayerModel
                 {
+                    Id = "layer-artwork",
+                    Name = "Artwork",
+                    IsVisible = true
+                },
+                new FaceLayerModel
+                {
                     Id = "layer-lamp-windows",
                     Name = "Lamp Windows",
                     IsVisible = true
                 }
             ],
-            Elements = lampWindows
+            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).ToArray()
         };
 
-        return new FaceGenerationResult(document, lampWindows.Length);
+        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length);
+    }
+
+    private static FaceArtworkElement[] CreateArtworkElements(
+        Panel2DDocumentModel sourcePanel,
+        Rect region,
+        string? sourcePanel2DDocumentId)
+    {
+        var backgroundArtwork = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Background && Intersects(element, region))
+            .Select(element => CreateArtworkElement(element, region, sourcePanel2DDocumentId))
+            .ToArray();
+
+        if (backgroundArtwork.Length > 0)
+        {
+            return backgroundArtwork;
+        }
+
+        return
+        [
+            new FaceArtworkElement
+            {
+                ObjectId = $"face-artwork-{Guid.NewGuid():N}",
+                Name = "Artwork Region",
+                X = 0,
+                Y = 0,
+                Width = Math.Round(region.Width, 2),
+                Height = Math.Round(region.Height, 2),
+                IsVisible = true,
+                SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
+                SourceRegion = FaceSourceRegionModel.FromRect(region),
+                Provenance = new FaceArtworkProvenanceModel
+                {
+                    Generator = "Generate Face From Region",
+                    GeneratedAtUtc = DateTime.UtcNow
+                }
+            }
+        ];
+    }
+
+    private static FaceArtworkElement CreateArtworkElement(PanelElementModel sourceElement, Rect region, string? sourcePanel2DDocumentId)
+    {
+        var sourceBounds = new Rect(sourceElement.X, sourceElement.Y, sourceElement.Width, sourceElement.Height);
+        var intersection = Rect.Intersect(sourceBounds, region);
+        return new FaceArtworkElement
+        {
+            ObjectId = CreateGeneratedArtworkElementId(sourceElement),
+            Name = string.IsNullOrWhiteSpace(sourceElement.Name) ? "Artwork" : sourceElement.Name.Trim(),
+            X = Math.Round(intersection.X - region.X, 2),
+            Y = Math.Round(intersection.Y - region.Y, 2),
+            Width = Math.Round(intersection.Width, 2),
+            Height = Math.Round(intersection.Height, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            AssetPath = sourceElement.AssetPath,
+            SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
+            SourceRegion = FaceSourceRegionModel.FromRect(intersection),
+            Provenance = new FaceArtworkProvenanceModel
+            {
+                Generator = "Generate Face From Region",
+                GeneratedAtUtc = DateTime.UtcNow,
+                SourcePanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+                SourcePanel2DElementKind = Panel2DDocumentStorage.SerializeElementKind(sourceElement.Kind),
+                SourceAssetPath = sourceElement.AssetPath,
+                SourceElementBounds = FaceSourceRegionModel.FromRect(sourceBounds)
+            }
+        };
     }
 
     private FaceLampWindowElement CreateLampWindow(PanelElementModel sourceElement, Rect region)
@@ -138,6 +214,13 @@ internal sealed class FaceGenerationService
             : $"face-{sourceElement.ObjectId.Trim()}";
     }
 
+    private static string CreateGeneratedArtworkElementId(PanelElementModel sourceElement)
+    {
+        return string.IsNullOrWhiteSpace(sourceElement.ObjectId)
+            ? $"face-artwork-{Guid.NewGuid():N}"
+            : $"face-artwork-{sourceElement.ObjectId.Trim()}";
+    }
+
     private static bool IsContainedBy(PanelElementModel element, Rect region)
     {
         var left = element.X;
@@ -148,6 +231,21 @@ internal sealed class FaceGenerationService
             && top >= region.Top
             && right <= region.Right
             && bottom <= region.Bottom;
+    }
+
+    private static bool Intersects(PanelElementModel element, Rect region)
+    {
+        if (element.Width <= 0 || element.Height <= 0)
+        {
+            return false;
+        }
+
+        return new Rect(element.X, element.Y, element.Width, element.Height).IntersectsWith(region);
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     private static string Format(double value) => Math.Round(value, 2).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -126,8 +126,8 @@ public sealed class DocumentWorkspaceViewModel
         var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
-        _setStatusMessage($"Generated face document from Panel2D region with {result.ConvertedLampCount} lamp window(s).");
-        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ConvertedLampCount} lamp window(s).", OutputLogStatus.Info);
+        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s) and {result.ConvertedLampCount} lamp window(s).");
+        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s) and {result.ConvertedLampCount} lamp window(s).", OutputLogStatus.Info);
         return document;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -25,11 +25,18 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
             .Select((element, index) => CreateElementItem(element, index, "Lamp Window", "lampWindow"))
             .ToArray();
 
-        return
-        [
-            new HierarchyItemViewModel($"Artwork ({artwork.Length})", "group:artwork", isGroup: true, children: artwork),
-            new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows)
-        ];
+        var groups = new List<HierarchyItemViewModel>();
+        if (artwork.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Artwork ({artwork.Length})", "group:artwork", isGroup: true, children: artwork));
+        }
+
+        if (lampWindows.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows));
+        }
+
+        return groups;
     }
 
     private static HierarchyItemViewModel CreateElementItem(FaceElementModel element, int index, string kindName, string token)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -15,42 +15,50 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
         }
 
         var faceDocument = document!;
+        var artwork = faceDocument.GetFaceElements()
+            .OfType<FaceArtworkElement>()
+            .Select((element, index) => CreateElementItem(element, index, "Artwork", "artwork"))
+            .ToArray();
+
         var lampWindows = faceDocument.GetFaceElements()
             .OfType<FaceLampWindowElement>()
-            .Select((element, index) =>
-            {
-                var x = Math.Round(element.X);
-                var y = Math.Round(element.Y);
-                var width = Math.Round(element.Width);
-                var height = Math.Round(element.Height);
-                var displayName = string.IsNullOrWhiteSpace(element.Name)
-                    ? $"Lamp Window {index + 1} ({width}×{height} at {x}, {y})"
-                    : element.Name.Trim();
-                if (element.IsLocked)
-                {
-                    displayName += " [Locked]";
-                }
-
-                if (!element.IsVisible)
-                {
-                    displayName += " [Hidden]";
-                }
-
-                if (element.LinkedMachineObjectReference is MachineObjectReference reference && !reference.IsEmpty)
-                {
-                    displayName += $" [{reference}]";
-                }
-
-                return new HierarchyItemViewModel(
-                    displayName,
-                    $"lampWindow:{element.ObjectId}",
-                    panelSelection: FaceSelectionService.ToSelectionInfo(element));
-            })
+            .Select((element, index) => CreateElementItem(element, index, "Lamp Window", "lampWindow"))
             .ToArray();
 
         return
         [
+            new HierarchyItemViewModel($"Artwork ({artwork.Length})", "group:artwork", isGroup: true, children: artwork),
             new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows)
         ];
+    }
+
+    private static HierarchyItemViewModel CreateElementItem(FaceElementModel element, int index, string kindName, string token)
+    {
+        var x = Math.Round(element.X);
+        var y = Math.Round(element.Y);
+        var width = Math.Round(element.Width);
+        var height = Math.Round(element.Height);
+        var displayName = string.IsNullOrWhiteSpace(element.Name)
+            ? $"{kindName} {index + 1} ({width}×{height} at {x}, {y})"
+            : element.Name.Trim();
+        if (element.IsLocked)
+        {
+            displayName += " [Locked]";
+        }
+
+        if (!element.IsVisible)
+        {
+            displayName += " [Hidden]";
+        }
+
+        if (element.LinkedMachineObjectReference is MachineObjectReference reference && !reference.IsEmpty)
+        {
+            displayName += $" [{reference}]";
+        }
+
+        return new HierarchyItemViewModel(
+            displayName,
+            $"{token}:{element.ObjectId}",
+            panelSelection: FaceSelectionService.ToSelectionInfo(element));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -596,6 +596,22 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             selectedElement.LinkedPanel2DElementId ?? string.Empty,
             commit: value => TryApplyFaceUpdate(selectedElement.ObjectId, "Update linked Panel2D element", new FaceElementModelUpdate { HasLinkedPanel2DElementId = true, LinkedPanel2DElementId = NormalizeOptionalText(value) })));
 
+        if (selectedElement is FaceArtworkElement artwork)
+        {
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Asset Path", "Artwork", artwork.AssetPath ?? string.Empty));
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Panel2D Document", "Artwork", artwork.SourcePanel2DDocumentId ?? string.Empty));
+            if (artwork.SourceRegion is not null)
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Region", "Artwork", FormatSourceRegion(artwork.SourceRegion)));
+            }
+
+            if (artwork.Provenance is not null)
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Artwork Generator", "Provenance", artwork.Provenance.Generator));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Asset", "Provenance", artwork.Provenance.SourceAssetPath ?? string.Empty));
+            }
+        }
+
         _hadInspectorSelection = true;
         _lastInspectorSelectionObjectId = selectedElement.ObjectId;
         _lastInspectorSelectionKind = null;
@@ -878,7 +894,17 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     private static string NicifyFaceElementKind(FaceElementModel element)
     {
-        return element is FaceLampWindowElement ? "Face Lamp Window" : "Face Element";
+        return element switch
+        {
+            FaceArtworkElement => "Face Artwork",
+            FaceLampWindowElement => "Face Lamp Window",
+            _ => "Face Element"
+        };
+    }
+
+    private static string FormatSourceRegion(FaceSourceRegionModel region)
+    {
+        return $"{region.Kind}: {Math.Round(region.X, 2)}, {Math.Round(region.Y, 2)}, {Math.Round(region.Width, 2)}×{Math.Round(region.Height, 2)}";
     }
 
     private bool CanApplyInspectorSummary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -13,6 +15,7 @@ namespace OasisEditor.Views;
 public partial class SkiaFaceEditView : UserControl
 {
     private const double TargetFrameMillis = 16.0;
+    private static readonly ConcurrentDictionary<string, SKImage?> CachedArtworkImages = new(StringComparer.OrdinalIgnoreCase);
     private DocumentTabViewModel? _subscribedDocument;
     private bool _isPanning;
     private bool _isRenderQueued;
@@ -150,7 +153,13 @@ public partial class SkiaFaceEditView : UserControl
         using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xC1, 0x07, 0x66), IsAntialias = true };
         using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0xFF, 0xD5, 0x4F), StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
         using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
-        foreach (var element in document.GetFaceElements())
+
+        foreach (var element in document.GetFaceElements().OfType<FaceArtworkElement>())
+        {
+            DrawArtworkElement(canvas, element, viewport, hiddenPaint);
+        }
+
+        foreach (var element in document.GetFaceElements().Where(element => element is not FaceArtworkElement))
         {
             var rect = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
             if (element.IsVisible)
@@ -181,6 +190,117 @@ public partial class SkiaFaceEditView : UserControl
                 (float)Math.Max(0d, selectedElement.Height),
                 selectionPaint);
         }
+    }
+
+    private static void DrawArtworkElement(SKCanvas canvas, FaceArtworkElement element, PanelViewportTransform viewport, SKPaint hiddenPaint)
+    {
+        var destination = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
+        if (destination.Width <= 0f || destination.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            canvas.DrawRect(destination, hiddenPaint);
+            return;
+        }
+
+        if (TryGetArtworkImage(element.AssetPath, out var image))
+        {
+            var source = ResolveArtworkSourceRect(element, image);
+            canvas.DrawImage(image, source, destination);
+            return;
+        }
+
+        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0x33, 0x33, 0x33), IsAntialias = true };
+        using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x66, 0x66, 0x66), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+        canvas.DrawRect(destination, fillPaint);
+        canvas.DrawRect(destination, strokePaint);
+    }
+
+    private static SKRect ResolveArtworkSourceRect(FaceArtworkElement element, SKImage image)
+    {
+        var sourceRegion = element.SourceRegion;
+        var sourceBounds = element.Provenance?.SourceElementBounds;
+        if (sourceRegion is null || sourceBounds is null || sourceBounds.Width <= 0d || sourceBounds.Height <= 0d)
+        {
+            return SKRect.Create(0f, 0f, image.Width, image.Height);
+        }
+
+        var scaleX = image.Width / sourceBounds.Width;
+        var scaleY = image.Height / sourceBounds.Height;
+        var x = (sourceRegion.X - sourceBounds.X) * scaleX;
+        var y = (sourceRegion.Y - sourceBounds.Y) * scaleY;
+        var width = sourceRegion.Width * scaleX;
+        var height = sourceRegion.Height * scaleY;
+        var left = (float)Math.Clamp(x, 0d, image.Width);
+        var top = (float)Math.Clamp(y, 0d, image.Height);
+        var right = (float)Math.Clamp(x + width, left, image.Width);
+        var bottom = (float)Math.Clamp(y + height, top, image.Height);
+        return new SKRect(left, top, right, bottom);
+    }
+
+    private static bool TryGetArtworkImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        if (!TryResolveAssetPath(assetPath, out var resolvedPath))
+        {
+            return false;
+        }
+
+        var cached = CachedArtworkImages.GetOrAdd(resolvedPath, LoadArtworkImage);
+        if (cached is null)
+        {
+            return false;
+        }
+
+        image = cached;
+        return true;
+    }
+
+    private static SKImage? LoadArtworkImage(string resolvedPath)
+    {
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            return null;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        return bitmap is null ? null : SKImage.FromBitmap(bitmap);
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
+        {
+            return false;
+        }
+
+        var relativePath = candidate
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+        return true;
     }
 
     private void OnFaceSkiaSurfaceMouseDown(object sender, MouseButtonEventArgs eventArgs)


### PR DESCRIPTION
### Motivation

- Implement Phase 5 (Face Artwork MVP): capture and persist glass/artwork as first-class Face elements so Face documents can record source provenance for later regeneration workflows.  
- Keep runtime/Play View, lamp illumination, 3D preview, and Unity integration out of scope and focus on edit-time representation and serialization.  
- Preserve links back to originating Panel2D content (document id, source region, source element id/kind, and source asset) so artwork can be re-generated or cropped later.

### Description

- Add `FaceArtworkElement` and `FaceArtworkProvenanceModel` to the Face document model and update `FaceDocumentStorage` to serialize/deserialize artwork fields (`AssetPath`, `SourcePanel2DDocumentId`, `SourceRegion`, `ArtworkProvenance`) and include a default "Artwork" layer.  
- Extend `FaceGenerationService.GenerateFromPanelRegion` to emit artwork elements by converting intersecting `PanelElementKind.Background` entries (or creating a placeholder artwork element when none intersect), and preserve provenance such as `SourcePanel2DElementId`, `SourcePanel2DElementKind`, `SourceAssetPath`, and `SourceElementBounds`.  
- Render artwork in the Face Edit View (`SkiaFaceEditView`) below lamp windows and support loading/caching artwork assets plus cropping the source image using stored provenance when available.  
- Update element services, selection/kind tokens, hierarchy provider, and inspector to expose artwork in the UI (`FaceElementServices`, `FaceSelectionService`, `FaceHierarchyProvider`, `InspectorViewModel`).  
- Update document workspace status/output wording to include counts for artwork elements and lamp windows, and add/adjust unit tests to cover round-trip serialization and generation behaviors (`FaceDocumentRoundTripTests`, `FaceGenerationServiceTests`).

### Testing

- Ran `git diff --check` to validate the working tree; it succeeded.  
- Updated unit tests `FaceGenerationServiceTests` and `FaceDocumentRoundTripTests` to validate artwork generation, provenance preservation, and save/load round-trips, but `dotnet test OasisEditor.sln` was not executed in this environment because the `dotnet` SDK is unavailable.  
- All code changes were committed; please run `dotnet test OasisEditor.sln` in a development environment to execute the updated tests (expected to validate generation and round-trip behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a25008ddc948327ba89ca4423b25a92)