### PR TITLE
Update Face system architecture roadmap and runtime rules

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -45,6 +45,22 @@ Face Document
 
 `Assembly` can remain an internal concept, but the primary user-facing document should be `Face`, `Machine Face`, or similar.
 
+## Current Implementation State
+
+The Face system is no longer only a pre-implementation proposal. The project now has implemented foundations for:
+
+- `MachineRuntimeState` as the shared runtime-state container used by Panel2D and Face rendering/play workflows;
+- machine-object reference types and resolution services;
+- persisted Face documents and Face document storage;
+- Face document creation/open/save support;
+- Face element models, including lamp, reel, display, button, mask/cutout, and artwork elements;
+- a 2D Face Edit View with document-space rendering and editing workflows;
+- Face generation from Panel2D regions/selections;
+- Face artwork import/rendering support;
+- a 2D Face Play View path that renders Face documents against runtime state.
+
+This plan should now be read as an architecture record plus forward roadmap. Phases 0 through 6 are complete at MVP level unless a later section explicitly calls out hardening or follow-up work.
+
 ## Core Design Rule
 
 Do not duplicate runtime objects.
@@ -106,9 +122,9 @@ Project
 
 ## Runtime State Direction
 
-Before deep Face implementation, Codex should verify that runtime state is sufficiently renderer-independent.
+Runtime state is now represented by `MachineRuntimeState` and should remain renderer-independent.
 
-Desired architecture:
+Current architecture:
 
 ```text
 MAME Runtime
@@ -131,33 +147,26 @@ Seven Segment Display B = masks
 Button 5 = Down
 ```
 
-If the current `PanelRuntimeState` is too Panel2D-specific, Codex should introduce a light abstraction/rename/refactor path toward:
+Do not move emulator state ownership into Panel2D, Face Edit View, Face Play View, or any renderer. Views and renderers should consume `MachineRuntimeState` snapshots/values through explicit runtime-object references.
 
-```text
-MachineRuntimeState
-```
-
-or equivalent.
-
-Do not perform a giant runtime rewrite unless necessary. Make the smallest clean change that allows Face views to consume the same runtime state as Panel2D views.
+Future runtime-state changes should remain small and behavior-preserving unless a separate implementation plan explicitly approves a larger rewrite.
 
 ## Runtime Object References
 
-Codex should inspect existing IDs used by:
+The project now has a small machine-object reference layer for runtime-facing identities.
+
+Reference coverage should include:
 
 - lamps;
 - reels;
 - alpha displays;
 - seven-segment displays;
 - inputs/buttons;
-- Panel2D elements;
 - imported MFME components.
 
-If IDs are already stable enough, use them.
+Panel2D element IDs may be stored as editor/source provenance, but they are not the runtime identity contract for Face Play View.
 
-If not, introduce a small reference layer.
-
-Suggested types:
+Reference types include:
 
 ```text
 MachineObjectReference
@@ -171,9 +180,9 @@ A Face document should store references to these logical/runtime objects.
 
 ## Face Document Model
 
-Initial Face document can be simple.
+Face documents should remain small, versionable, and evolvable.
 
-Suggested high-level model:
+High-level model:
 
 ```text
 FaceDocument
@@ -184,7 +193,7 @@ FaceDocument
     Elements[]
 ```
 
-Suggested layer concepts:
+Layer concepts:
 
 ```text
 GlassArtworkLayer
@@ -195,7 +204,7 @@ DisplayWindowLayer
 ButtonLayer
 ```
 
-Suggested element concepts:
+Element concepts:
 
 ```text
 FaceArtworkElement
@@ -206,7 +215,7 @@ FaceButtonElement
 FaceMaskCutoutElement
 ```
 
-Initial fields:
+Core fields:
 
 ```text
 ObjectId
@@ -224,7 +233,9 @@ IsVisible
 IsLocked
 ```
 
-Keep the initial schema small and evolvable.
+`LinkedMachineObjectId` / typed machine-object references are the runtime identity path. `LinkedPanel2DElementId` is retained only as a provenance/source-authoring field for import, generation, and editor workflows.
+
+Keep the schema small and evolvable.
 
 ## Face File Extension
 
@@ -296,13 +307,16 @@ Face Play View should be:
 
 Initial Face Play View may be 2D layered or pseudo-3D. It does not need Unity immediately.
 
-Important rule:
+Important rules:
 
 ```text
 Face Play View does not own emulator state.
+Face Play View runtime behavior must resolve through MachineObjectReference and MachineRuntimeState.
+Face Play View must not depend on LinkedPanel2DElementId for runtime behavior.
+LinkedPanel2DElementId exists only for provenance, generation, and editor workflows.
 ```
 
-It observes the same runtime state and uses the same input command services as Panel2D Play View.
+Face Play View observes the same runtime state and uses the same input command services as Panel2D Play View.
 
 Mouse/keyboard routing should reuse the existing input system:
 
@@ -369,19 +383,17 @@ Do not implement Unity integration in the first Face phase.
 
 ## Recommended Phase Sequence
 
-### Phase 0 - Inventory / Readiness Check
+### Phase 0 - Inventory / Readiness Check - Complete
 
-Before implementing Face, inspect and document:
+Completed by the Face system inventory/readiness document.
 
-- current document type system;
-- project/document storage system;
-- Panel2D document model;
-- current runtime state model;
-- input definition/model system;
-- Panel2D Edit/Play View architecture;
-- Skia renderer abstractions;
-- document save/load behavior;
-- inspector/document routing.
+Outcome:
+
+- documented the current document type system;
+- documented project/document storage behavior;
+- documented Panel2D model and rendering architecture;
+- documented runtime state and input-routing readiness;
+- identified the minimal refactor path toward shared runtime state and machine-object references.
 
 Deliverable:
 
@@ -389,99 +401,160 @@ Deliverable:
 FaceSystem.Inventory.md
 ```
 
-This phase should answer:
+### Phase 1 - Runtime State / Reference Cleanup - Complete
 
-- where should Face document type plug in?
-- is runtime state renderer-independent enough?
-- are runtime object IDs stable enough?
-- can Face views reuse Panel2D pan/zoom/selection services?
-- what minimal refactor is needed before Face implementation?
+Completed at MVP level.
 
-### Phase 1 - Runtime State / Reference Cleanup
+Outcome:
 
-Only if Phase 0 finds it necessary.
+- `MachineRuntimeState` is the shared runtime-state container;
+- runtime state is consumable outside Panel2D-specific rendering;
+- machine-object references and resolver services exist;
+- Panel2D behavior remains supported.
 
-Goals:
+Continuing rule:
 
-- make runtime state consumable by Face and Panel2D;
-- avoid Panel2D-specific naming leaking too deeply;
-- introduce/confirm stable machine object references;
-- preserve existing Panel2D behavior.
+- runtime behavior should resolve through machine-object references and `MachineRuntimeState`, not through view/editor provenance fields.
 
-Do not do a giant rewrite.
+### Phase 2 - Face Document Type Skeleton - Complete
 
-### Phase 2 - Face Document Type Skeleton
+Completed at MVP level.
 
-Add:
+Outcome:
 
-- new document type enum/member;
-- Face document model;
-- create/open/save/load support;
-- basic document tab support;
-- placeholder editor surface.
+- Face document model exists;
+- Face document storage/serialization exists;
+- Face documents can be created/opened/saved through the workspace/document flow;
+- Face document tabs/surfaces are integrated with the editor shell.
 
-Initial Face document can contain no elements or a minimal element list.
+### Phase 3 - Face Element Model - Complete
 
-### Phase 3 - Face Element Model
+Completed at MVP level.
 
-Add initial Face elements:
+Outcome:
 
-- artwork rectangle;
-- lamp window;
-- display window;
-- reel window;
-- button hit area.
+- Face elements exist for artwork, lamp windows, reel windows, display windows, button hit areas, and mask/cutout-style geometry;
+- elements can retain editor/source provenance;
+- elements can carry runtime-object references for play/runtime behavior.
 
-Include references to runtime objects and/or Panel2D elements.
+### Phase 4 - Face Edit View 2D Layered MVP - Complete
 
-### Phase 4 - Face Edit View 2D Layered MVP
+Completed at MVP level.
 
-Add a simple 2D Face Edit View:
+Outcome:
 
-- Skia render surface;
-- pan/zoom;
-- selection;
-- move/resize;
-- layer visibility/lock basics;
-- inspector integration where practical.
+- 2D Face Edit View exists;
+- Face elements render in document space;
+- selection/editing workflows exist;
+- Face artwork can be shown in the editor;
+- the implementation remains renderer-neutral and does not require Unity.
 
-Do not build full 3D.
+### Phase 5 - Face Play View MVP - Complete
 
-### Phase 5 - Face Play View MVP
+Completed at MVP level.
 
-Add Face Play View:
+Outcome:
 
-- read-only;
-- same runtime state as Panel2D;
-- button/input hit testing;
-- keyboard shortcut routing;
-- live lamps/displays/reels if model supports them.
+- Face Play View exists as a read-only/play surface;
+- Face Play View renders Face documents using shared runtime state;
+- live runtime visuals are resolved from `MachineRuntimeState` through machine-object references;
+- provenance-only Panel2D links are not the runtime behavior contract.
 
-Initial rendering may be 2D/pseudo-3D.
+Follow-up input work is now tracked in Phase 7 and Phase 8.
 
-### Phase 6 - Face Generation From Panel2D Selection
+### Phase 6 - Face Generation From Panel2D Selection - Complete
 
-Add workflow to create Face elements from selected Panel2D areas/elements.
+Completed at MVP level.
 
-Examples:
+Outcome:
 
-- selected Panel2D lamp elements -> Face lamp windows;
-- selected reel elements -> Face reel windows;
-- selected display elements -> Face display windows;
-- selected input-linked lamps/buttons -> Face button hit areas.
+- Face documents/elements can be generated from Panel2D regions/selections;
+- generated Face elements can include artwork and converted lamp windows;
+- generated elements may retain `LinkedPanel2DElementId` as provenance for editor/generation workflows;
+- generated runtime behavior must still resolve through machine-object references and `MachineRuntimeState`.
 
-This can be simple and incremental.
+### Phase 7 - Face Input System MVP - Future
 
-### Phase 7 - 3D Preview Investigation
+Goal:
 
-Only after Face document/edit/play MVPs are stable.
+- harden Face button/input behavior as a first-class Face runtime feature.
+
+Planned work:
+
+- confirm Face button hit testing resolves to machine input references;
+- ensure pointer down/up/release-all behavior matches Panel2D Play View semantics;
+- support disabled/hidden/locked runtime input behavior consistently;
+- add non-WPF tests for Face input target resolution and hit testing;
+- verify Face input behavior does not depend on `LinkedPanel2DElementId`.
+
+### Phase 8 - Keyboard Input Routing - Future
+
+Goal:
+
+- make keyboard shortcuts and focus behavior consistent across Panel2D Play View and Face Play View.
+
+Planned work:
+
+- route focused Face Play View key down/up events through the shared play input router;
+- normalize shortcut matching with the existing input map behavior;
+- ensure release-all behavior when focus is lost or play mode closes;
+- add tests for keyboard routing where practical.
+
+### Phase 9 - Runtime Displays MVP - Future
+
+Goal:
+
+- complete runtime-driven display rendering for Face Play View.
+
+Planned work:
+
+- render alpha/segment display windows from `MachineRuntimeState`;
+- render reel windows from `MachineRuntimeState`;
+- validate display/reel reference resolution through machine-object references;
+- add serialization/defaulting tests for display and reel Face elements;
+- keep display runtime behavior independent of `LinkedPanel2DElementId`.
+
+### Phase 10 - Visual Fidelity Layer - Future
+
+Goal:
+
+- improve 2D/pseudo-3D visual quality without coupling the Face document format to a specific renderer.
+
+Planned work:
+
+- refine artwork compositing, lamp mask/tray visuals, opacity, glow, and depth cues;
+- add material/depth metadata only where it is renderer-neutral;
+- improve editor/play visual parity;
+- avoid pixel-perfect tests unless a stable renderer contract exists.
+
+### Phase 11 - 3D Preview Investigation - Future
+
+Goal:
+
+- investigate practical 3D preview options after the Face 2D/edit/play workflows are stable.
 
 Explore:
 
-- simple in-editor pseudo-3D;
-- HelixToolkit or similar;
-- Unity-hosted/external preview;
-- export path to Unity renderer project.
+- in-editor pseudo-3D beyond the current 2D layered view;
+- HelixToolkit or similar WPF-compatible preview technology;
+- Unity-hosted or external preview approaches;
+- export/import constraints for a future renderer pipeline.
+
+This phase is investigative. Do not commit to Unity-specific document fields during this phase.
+
+### Phase 12 - Unity Renderer Integration Planning - Future
+
+Goal:
+
+- plan, but not yet implement, a Unity renderer integration path.
+
+Planned work:
+
+- define the Face document data Unity would consume;
+- identify required asset packaging and runtime-state bridge boundaries;
+- define how machine-object references map to renderer-side runtime updates;
+- document editor/export responsibilities versus renderer responsibilities;
+- produce an implementation plan before any Unity-specific runtime/editor code is added.
 
 ## Tests
 
@@ -500,28 +573,23 @@ Avoid heavy visual/pixel-perfect tests.
 
 ## Manual Verification Expectations
 
-After Phase 0:
-
-- inventory clearly identifies required refactors;
-- no major behavior changes unless explicitly part of cleanup.
-
-After Phase 2:
+Completed MVP checks that should continue to be regression-tested:
 
 - Face document can be created/opened/saved;
-- existing Panel2D workflows still work.
+- existing Panel2D workflows still work;
+- Face Edit View opens and renders Face elements/artwork;
+- Face Edit View supports basic document-space editing workflows;
+- Face Play View opens and renders against `MachineRuntimeState`;
+- generated Face documents retain provenance without making provenance the runtime identity path.
 
-After Phase 4:
+Future phase verification should focus on:
 
-- Face Edit View opens;
-- pan/zoom works;
-- selection/move/resize basics work.
-
-After Phase 5:
-
-- Face Play View opens;
-- MAME runtime state appears;
-- clickable buttons send inputs;
-- keyboard shortcuts work when focused.
+- Phase 7: Face pointer/button input resolves through machine-object references;
+- Phase 8: keyboard shortcuts work when Face Play View is focused and release cleanly when focus is lost;
+- Phase 9: reels and displays render from `MachineRuntimeState` through machine-object references;
+- Phase 10: visual-fidelity improvements do not change document/runtime identity contracts;
+- Phase 11: 3D preview investigation does not introduce renderer-specific document coupling;
+- Phase 12: Unity integration planning clearly separates editor/export responsibilities from renderer responsibilities.
 
 ## Out Of Scope Initially
 
@@ -538,10 +606,10 @@ Do not implement initially:
 
 ## Important Guidance For Codex
 
-Work one phase at a time.
+Work one future phase at a time.
 
-Do not start implementation beyond the current phase unless instructed.
+Do not start implementation beyond the current requested phase unless instructed.
 
-For the first Codex pass, only complete Phase 0 inventory/readiness and recommend minimal refactors.
+Preserve the completed Face MVP architecture when adding future phases: runtime behavior flows through machine-object references and `MachineRuntimeState`; `LinkedPanel2DElementId` remains provenance/editor/generation data only.
 
 John will test/review after each phase before continuing.


### PR DESCRIPTION
### Motivation

- Bring the FACE_SYSTEM_ARCHITECTURE_PLAN.md document up to date with implemented Face system foundations so the plan reflects current code. 
- Make explicit that runtime behavior for Face Play View must resolve via machine-object references and shared runtime state rather than editor provenance fields. 
- Replace the old phase roadmap with a forward roadmap starting at Phase 7 now that Phases 0–6 are delivered at MVP level.

### Description

- Added a "Current Implementation State" section that enumerates implemented foundations including `MachineRuntimeState`, machine-object references, persisted Face documents, Face Edit/Play views, Face generation, and artwork support in `WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md`. 
- Updated the "Runtime State Direction" and "Runtime Object References" guidance to reflect `MachineRuntimeState` as the renderer-independent runtime container and to treat Panel2D element IDs as provenance only. 
- Changed the Face document model guidance so typed `LinkedMachineObjectId` (machine-object references) is the runtime identity path and `LinkedPanel2DElementId` is retained only for provenance/editor/generation workflows. 
- Marked Phases 0–6 as complete at MVP level and replaced the future roadmap with Phases 7–12 (Face Input System MVP through Unity Renderer Integration Planning), and added the explicit Face Play View rules that runtime behavior must resolve through `MachineObjectReference` and `MachineRuntimeState` and must not depend on `LinkedPanel2DElementId`.

### Testing

- Ran `git diff --check` to validate the working tree diff had no whitespace/format issues and it completed successfully. 
- Ran `git status --short` to confirm only the intended documentation file was modified and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a250cd4f3888327a7b674da1f0298f7)