### PR TITLE
Implement Face input system MVP

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -473,19 +473,17 @@ Outcome:
 - generated elements may retain `LinkedPanel2DElementId` as provenance for editor/generation workflows;
 - generated runtime behavior must still resolve through machine-object references and `MachineRuntimeState`.
 
-### Phase 7 - Face Input System MVP - Future
+### Phase 7 - Face Input System MVP - Complete
 
-Goal:
+Completed at MVP level.
 
-- harden Face button/input behavior as a first-class Face runtime feature.
+Outcome:
 
-Planned work:
-
-- confirm Face button hit testing resolves to machine input references;
-- ensure pointer down/up/release-all behavior matches Panel2D Play View semantics;
-- support disabled/hidden/locked runtime input behavior consistently;
-- add non-WPF tests for Face input target resolution and hit testing;
-- verify Face input behavior does not depend on `LinkedPanel2DElementId`.
+- `FaceButtonElement` is persisted as a first-class Face element;
+- generated Face documents can create button elements from Panel2D-linked input definitions where source data is available;
+- Face button hit testing resolves through `MachineInputReference`/`MachineObjectReference.Input`;
+- Face Play View pointer down/up uses the shared play input dispatch path and MAME command service;
+- Face runtime input behavior does not depend on `LinkedPanel2DElementId`, which remains provenance/editor metadata.
 
 ### Phase 8 - Keyboard Input Routing - Future
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceInputSystemTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceInputSystemTests.cs
@@ -1,0 +1,166 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceInputSystemTests
+{
+    [Fact]
+    public void FaceButtonElement_RoundTripsMachineInputReference()
+    {
+        var document = new FaceDocumentModel
+        {
+            Title = "Buttons",
+            Elements =
+            [
+                new FaceButtonElement
+                {
+                    ObjectId = "face-button-start",
+                    Name = "Start",
+                    X = 10,
+                    Y = 20,
+                    Width = 80,
+                    Height = 30,
+                    LinkedInputReference = MachineInputReference.FromInputId("start"),
+                    LinkedMachineObjectReference = MachineObjectReference.Input("start"),
+                    LinkedPanel2DElementId = "source-panel-button"
+                }
+            ]
+        };
+
+        var json = FaceDocumentStorage.Serialize(document);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var model = FaceDocumentStorage.ToModel(file);
+
+        var button = Assert.IsType<FaceButtonElement>(Assert.Single(model.Elements));
+        Assert.Equal("input:start", button.LinkedInputReference?.ToString());
+        Assert.Equal("input:start", button.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("source-panel-button", button.LinkedPanel2DElementId);
+    }
+
+    [Fact]
+    public void FaceInputTargetResolver_UsesMachineInputReferenceNotPanelProvenance()
+    {
+        var resolver = FaceInputTargetResolver.Instance;
+        var elements = new FaceElementModel[]
+        {
+            new FaceButtonElement
+            {
+                ObjectId = "face-button",
+                X = 0,
+                Y = 0,
+                Width = 100,
+                Height = 50,
+                LinkedInputReference = MachineInputReference.FromInputId("collect"),
+                LinkedMachineObjectReference = MachineObjectReference.Input("collect"),
+                LinkedPanel2DElementId = "not-used-for-routing"
+            }
+        };
+
+        var resolved = resolver.TryResolveInputReference(elements, new Point(25, 20), out var inputReference);
+
+        Assert.True(resolved);
+        Assert.Equal("input:collect", inputReference.ToString());
+    }
+
+    [Fact]
+    public void FaceInputTargetResolver_IgnoresButtonsWithoutMachineInputReference()
+    {
+        var resolver = FaceInputTargetResolver.Instance;
+        var elements = new FaceElementModel[]
+        {
+            new FaceButtonElement
+            {
+                ObjectId = "face-button",
+                X = 0,
+                Y = 0,
+                Width = 100,
+                Height = 50,
+                LinkedPanel2DElementId = "panel-button-only"
+            }
+        };
+
+        var resolved = resolver.TryResolveInputReference(elements, new Point(25, 20), out _);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void GenerateFromPanelRegion_CreatesButtonsFromLinkedInputVisuals()
+    {
+        var visualId = Guid.NewGuid();
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = visualId.ToString("D"),
+                    Name = "Panel Start",
+                    Kind = PanelElementKind.Rectangle,
+                    X = 110,
+                    Y = 220,
+                    Width = 40,
+                    Height = 30,
+                    IsVisible = true
+                }
+            ]
+        };
+        var inputs = new[]
+        {
+            new InputDefinitionModel
+            {
+                Id = "start",
+                Name = "Start",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "2",
+                LinkedVisualElementId = visualId
+            }
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 100, 100)),
+            "Generated",
+            "panel-doc",
+            inputs);
+
+        Assert.Equal(1, result.ConvertedButtonCount);
+        var button = Assert.IsType<FaceButtonElement>(Assert.Single(result.Document.Elements.OfType<FaceButtonElement>()));
+        Assert.Equal("Start", button.Name);
+        Assert.Equal(10d, button.X);
+        Assert.Equal(20d, button.Y);
+        Assert.Equal("input:start", button.LinkedInputReference?.ToString());
+        Assert.Equal(visualId.ToString("D"), button.LinkedPanel2DElementId);
+    }
+
+    [Fact]
+    public async Task FacePlayViewPointerInputRouter_RoutesThroughExistingMameInputPath()
+    {
+        var runner = new FakeMameProcessRunner();
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        var faceRouter = new FacePlayViewPointerInputRouter(
+            inputRouter,
+            [new InputDefinitionModel { Id = "start", Kind = InputDefinitionKind.Button, ButtonNumber = "2" }]);
+        var inputReference = MachineInputReference.FromInputId("start");
+
+        var pressed = await faceRouter.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, inputReference, isFocused: true, CancellationToken.None);
+        var released = await faceRouter.TryHandlePointerUpAsync(FruitMachinePlatformType.MPU4, inputReference, isFocused: true, CancellationToken.None);
+
+        Assert.True(pressed);
+        Assert.True(released);
+        Assert.Equal(new[] { "set_input_value ORANGE1 4 1", "set_input_value ORANGE1 4 0" }, runner.Commands);
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -54,3 +54,8 @@ public sealed class FaceArtworkProvenanceModel
 public sealed class FaceLampWindowElement : FaceElementModel
 {
 }
+
+public sealed class FaceButtonElement : FaceElementModel
+{
+    public MachineInputReference? LinkedInputReference { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -43,6 +43,12 @@ public static class FaceDocumentStorage
                     Id = "layer-lamp-windows",
                     Name = "Lamp Windows",
                     IsVisible = true
+                },
+                new FaceLayerFile
+                {
+                    Id = "layer-buttons",
+                    Name = "Buttons",
+                    IsVisible = true
                 }
             ],
             Elements = []
@@ -218,8 +224,9 @@ public static class FaceDocumentStorage
             reference = parsedReference;
         }
 
-        return string.Equals(file.Kind, "artwork", StringComparison.OrdinalIgnoreCase)
-            ? new FaceArtworkElement
+        if (string.Equals(file.Kind, "artwork", StringComparison.OrdinalIgnoreCase))
+        {
+            return new FaceArtworkElement
             {
                 ObjectId = file.ObjectId ?? string.Empty,
                 Name = file.Name ?? string.Empty,
@@ -235,8 +242,29 @@ public static class FaceDocumentStorage
                 SourcePanel2DDocumentId = file.SourcePanel2DDocumentId,
                 SourceRegion = ToModel(file.SourceRegion),
                 Provenance = ToModel(file.ArtworkProvenance)
-            }
-            : new FaceLampWindowElement
+            };
+        }
+
+        if (string.Equals(file.Kind, "button", StringComparison.OrdinalIgnoreCase))
+        {
+            var linkedInputReference = ResolveInputReference(file.LinkedInputReference, reference);
+            return new FaceButtonElement
+            {
+                ObjectId = file.ObjectId ?? string.Empty,
+                Name = file.Name ?? string.Empty,
+                X = file.X,
+                Y = file.Y,
+                Width = file.Width,
+                Height = file.Height,
+                IsVisible = file.IsVisible,
+                IsLocked = file.IsLocked,
+                LinkedMachineObjectReference = linkedInputReference?.Reference ?? reference,
+                LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+                LinkedInputReference = linkedInputReference
+            };
+        }
+
+        return new FaceLampWindowElement
         {
             ObjectId = file.ObjectId ?? string.Empty,
             Name = file.Name ?? string.Empty,
@@ -249,6 +277,24 @@ public static class FaceDocumentStorage
             LinkedMachineObjectReference = reference,
             LinkedPanel2DElementId = file.LinkedPanel2DElementId
         };
+    }
+
+    private static MachineInputReference? ResolveInputReference(string? linkedInputReference, MachineObjectReference? linkedMachineObjectReference)
+    {
+        if (MachineObjectReference.TryParse(linkedInputReference, out var parsedInputReference)
+            && parsedInputReference.Kind == MachineObjectKind.Input)
+        {
+            return new MachineInputReference(parsedInputReference);
+        }
+
+        if (linkedMachineObjectReference is MachineObjectReference reference
+            && reference.Kind == MachineObjectKind.Input
+            && !reference.IsEmpty)
+        {
+            return new MachineInputReference(reference);
+        }
+
+        return null;
     }
 
     private static FaceArtworkProvenanceModel? ToModel(FaceArtworkProvenanceFile? file)
@@ -278,6 +324,7 @@ public static class FaceDocumentStorage
             Kind = model switch
             {
                 FaceArtworkElement => "artwork",
+                FaceButtonElement => "button",
                 FaceLampWindowElement => "lampWindow",
                 _ => "unknown"
             },
@@ -289,6 +336,7 @@ public static class FaceDocumentStorage
             IsLocked = model.IsLocked,
             LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
             LinkedPanel2DElementId = model.LinkedPanel2DElementId,
+            LinkedInputReference = model is FaceButtonElement button ? button.LinkedInputReference?.ToString() : null,
             AssetPath = model is FaceArtworkElement artwork ? artwork.AssetPath : null,
             SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
@@ -358,6 +406,7 @@ public sealed record FaceElementFile
     public bool IsLocked { get; init; }
     public string? LinkedMachineObjectReference { get; init; }
     public string? LinkedPanel2DElementId { get; init; }
+    public string? LinkedInputReference { get; init; }
     public string? AssetPath { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -61,6 +61,22 @@ internal static class FaceElementModelUpdater
                 LinkedMachineObjectReference = linkedMachineObjectReference,
                 LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId
             },
+            FaceButtonElement button => new FaceButtonElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                LinkedInputReference = linkedMachineObjectReference is MachineObjectReference reference && reference.Kind == MachineObjectKind.Input && !reference.IsEmpty
+                    ? new MachineInputReference(reference)
+                    : button.LinkedInputReference
+            },
             _ => existing
         };
     }
@@ -137,6 +153,7 @@ internal static class FaceSelectionService
         return element switch
         {
             FaceArtworkElement => "artwork",
+            FaceButtonElement => "button",
             FaceLampWindowElement => "lampWindow",
             _ => "unknown"
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -50,16 +50,18 @@ public sealed class FaceSourceRegionModel
 
 internal sealed class FaceGenerationResult
 {
-    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount)
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount)
     {
         Document = document;
         ConvertedLampCount = convertedLampCount;
         ArtworkElementCount = artworkElementCount;
+        ConvertedButtonCount = convertedButtonCount;
     }
 
     public FaceDocumentModel Document { get; }
     public int ConvertedLampCount { get; }
     public int ArtworkElementCount { get; }
+    public int ConvertedButtonCount { get; }
 }
 
 internal sealed class FaceGenerationService
@@ -75,7 +77,8 @@ internal sealed class FaceGenerationService
         Panel2DDocumentModel sourcePanel,
         FaceSourceRegionModel sourceRegion,
         string title,
-        string? sourcePanel2DDocumentId = null)
+        string? sourcePanel2DDocumentId = null,
+        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null)
     {
         ArgumentNullException.ThrowIfNull(sourcePanel);
         ArgumentNullException.ThrowIfNull(sourceRegion);
@@ -91,6 +94,7 @@ internal sealed class FaceGenerationService
             .Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region))
             .Select(element => CreateLampWindow(element, region))
             .ToArray();
+        var buttons = CreateButtonElements(sourcePanel, region, inputDefinitions ?? []);
 
         var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim();
         var document = new FaceDocumentModel
@@ -113,12 +117,18 @@ internal sealed class FaceGenerationService
                     Id = "layer-lamp-windows",
                     Name = "Lamp Windows",
                     IsVisible = true
+                },
+                new FaceLayerModel
+                {
+                    Id = "layer-buttons",
+                    Name = "Buttons",
+                    IsVisible = true
                 }
             ],
-            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).ToArray()
+            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(buttons).ToArray()
         };
 
-        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length);
+        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length);
     }
 
     private static FaceArtworkElement[] CreateArtworkElements(
@@ -207,11 +217,70 @@ internal sealed class FaceGenerationService
         };
     }
 
+    private FaceButtonElement[] CreateButtonElements(Panel2DDocumentModel sourcePanel, Rect region, IReadOnlyList<InputDefinitionModel> inputDefinitions)
+    {
+        if (inputDefinitions.Count == 0)
+        {
+            return [];
+        }
+
+        var elementsByGuid = sourcePanel.Elements
+            .Where(element => Guid.TryParse(element.ObjectId, out _))
+            .GroupBy(element => Guid.Parse(element.ObjectId), element => element)
+            .ToDictionary(group => group.Key, group => group.First());
+
+        var buttons = new List<FaceButtonElement>();
+        foreach (var input in inputDefinitions)
+        {
+            if (input is null)
+            {
+                continue;
+            }
+
+            if (input.LinkedVisualElementId is not Guid visualElementId
+                || !elementsByGuid.TryGetValue(visualElementId, out var sourceElement)
+                || !IsContainedBy(sourceElement, region))
+            {
+                continue;
+            }
+
+            _machineObjectReferenceResolver.TryGetReference(input, out var inputReference);
+            if (inputReference.IsEmpty || inputReference.Kind != MachineObjectKind.Input)
+            {
+                continue;
+            }
+
+            buttons.Add(new FaceButtonElement
+            {
+                ObjectId = CreateGeneratedButtonElementId(sourceElement, input),
+                Name = string.IsNullOrWhiteSpace(input.Name) ? sourceElement.Name ?? string.Empty : input.Name.Trim(),
+                X = Math.Round(sourceElement.X - region.X, 2),
+                Y = Math.Round(sourceElement.Y - region.Y, 2),
+                Width = Math.Round(sourceElement.Width, 2),
+                Height = Math.Round(sourceElement.Height, 2),
+                IsVisible = sourceElement.IsVisible,
+                IsLocked = sourceElement.IsLocked,
+                LinkedMachineObjectReference = inputReference,
+                LinkedInputReference = new MachineInputReference(inputReference),
+                LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId
+            });
+        }
+
+        return buttons.ToArray();
+    }
+
     private static string CreateGeneratedElementId(PanelElementModel sourceElement)
     {
         return string.IsNullOrWhiteSpace(sourceElement.ObjectId)
             ? Guid.NewGuid().ToString("N")
             : $"face-{sourceElement.ObjectId.Trim()}";
+    }
+
+    private static string CreateGeneratedButtonElementId(PanelElementModel sourceElement, InputDefinitionModel inputDefinition)
+    {
+        var sourcePart = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? Guid.NewGuid().ToString("N") : sourceElement.ObjectId.Trim();
+        var inputPart = string.IsNullOrWhiteSpace(inputDefinition.Id) ? "input" : inputDefinition.Id.Trim();
+        return $"face-button-{inputPart}-{sourcePart}";
     }
 
     private static string CreateGeneratedArtworkElementId(PanelElementModel sourceElement)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceInputRouting.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceInputRouting.cs
@@ -1,0 +1,126 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+public interface IFaceInputTargetResolver
+{
+    bool TryResolveInputReference(IReadOnlyList<FaceElementModel> elements, Point documentPoint, out MachineInputReference inputReference);
+}
+
+public sealed class FaceInputTargetResolver : IFaceInputTargetResolver
+{
+    public static FaceInputTargetResolver Instance { get; } = new();
+
+    private FaceInputTargetResolver()
+    {
+    }
+
+    public bool TryResolveInputReference(IReadOnlyList<FaceElementModel> elements, Point documentPoint, out MachineInputReference inputReference)
+    {
+        ArgumentNullException.ThrowIfNull(elements);
+        inputReference = default;
+
+        foreach (var button in elements.OfType<FaceButtonElement>().Reverse())
+        {
+            if (!button.IsVisible || button.IsLocked || !Contains(button, documentPoint))
+            {
+                continue;
+            }
+
+            if (TryGetInputReference(button, out inputReference))
+            {
+                return true;
+            }
+        }
+
+        inputReference = default;
+        return false;
+    }
+
+    public static bool TryGetInputReference(FaceButtonElement button, out MachineInputReference inputReference)
+    {
+        ArgumentNullException.ThrowIfNull(button);
+
+        if (button.LinkedInputReference is MachineInputReference linkedInputReference
+            && !linkedInputReference.Reference.IsEmpty
+            && linkedInputReference.Reference.Kind == MachineObjectKind.Input)
+        {
+            inputReference = linkedInputReference;
+            return true;
+        }
+
+        if (button.LinkedMachineObjectReference is MachineObjectReference linkedMachineObjectReference
+            && !linkedMachineObjectReference.IsEmpty
+            && linkedMachineObjectReference.Kind == MachineObjectKind.Input)
+        {
+            inputReference = new MachineInputReference(linkedMachineObjectReference);
+            return true;
+        }
+
+        inputReference = default;
+        return false;
+    }
+
+    private static bool Contains(FaceElementModel element, Point documentPoint)
+    {
+        return documentPoint.X >= element.X
+            && documentPoint.X <= element.X + element.Width
+            && documentPoint.Y >= element.Y
+            && documentPoint.Y <= element.Y + element.Height;
+    }
+}
+
+public sealed class FacePlayViewPointerInputRouter
+{
+    private readonly PlayViewInputRouter _inputRouter;
+    private readonly Dictionary<string, InputDefinitionModel> _inputsByMachineInputId;
+
+    public FacePlayViewPointerInputRouter(PlayViewInputRouter inputRouter, IEnumerable<InputDefinitionModel> inputDefinitions)
+    {
+        _inputRouter = inputRouter ?? throw new ArgumentNullException(nameof(inputRouter));
+        ArgumentNullException.ThrowIfNull(inputDefinitions);
+
+        _inputsByMachineInputId = new Dictionary<string, InputDefinitionModel>(StringComparer.Ordinal);
+        foreach (var input in inputDefinitions)
+        {
+            if (input is null || string.IsNullOrWhiteSpace(input.Id))
+            {
+                continue;
+            }
+
+            var reference = MachineInputReference.FromInputId(input.Id);
+            if (!reference.Reference.IsEmpty && !_inputsByMachineInputId.ContainsKey(reference.Reference.Id))
+            {
+                _inputsByMachineInputId[reference.Reference.Id] = input;
+            }
+        }
+    }
+
+    public Task<bool> TryHandlePointerDownAsync(FruitMachinePlatformType platform, MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        if (!isFocused || !TryResolveInput(inputReference, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+    }
+
+    public Task<bool> TryHandlePointerUpAsync(FruitMachinePlatformType platform, MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        if (!isFocused || !TryResolveInput(inputReference, out var input))
+        {
+            return Task.FromResult(false);
+        }
+
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+    }
+
+    private bool TryResolveInput(MachineInputReference inputReference, out InputDefinitionModel input)
+    {
+        input = null!;
+        return inputReference.Reference.Kind == MachineObjectKind.Input
+            && !inputReference.Reference.IsEmpty
+            && _inputsByMachineInputId.TryGetValue(inputReference.Reference.Id, out input);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -83,6 +83,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private PlayViewInputRouter? _playViewInputRouter;
     private PlayViewKeyboardInputRouter? _playViewKeyboardInputRouter;
     private PlayViewPointerInputRouter? _playViewPointerInputRouter;
+    private FacePlayViewPointerInputRouter? _facePlayViewPointerInputRouter;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -1360,6 +1361,35 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return router.TryHandlePointerUpAsync(SelectedFruitMachinePlatform, visualElementId, isFocused, cancellationToken);
     }
 
+    public async Task<bool> TryHandleFacePlayViewPointerDownAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        var canRoute = EnsurePlayViewInputRouter();
+        var router = EnsureFacePlayViewPointerInputRouter();
+        if (router is null)
+        {
+            return false;
+        }
+
+        var handled = await router.TryHandlePointerDownAsync(SelectedFruitMachinePlatform, inputReference, isFocused, cancellationToken).ConfigureAwait(false);
+        if (!handled && canRoute && isFocused)
+        {
+            AddOutputEntry($"Face Play View pointer input unresolved for machine input '{inputReference}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
+        }
+
+        return handled;
+    }
+
+    public Task<bool> TryHandleFacePlayViewPointerUpAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        var router = EnsureFacePlayViewPointerInputRouter();
+        if (router is null)
+        {
+            return Task.FromResult(false);
+        }
+
+        return router.TryHandlePointerUpAsync(SelectedFruitMachinePlatform, inputReference, isFocused, cancellationToken);
+    }
+
     public Task<int> ReleaseAllPlayViewInputsAsync(string reason, CancellationToken cancellationToken)
     {
         return ReleaseAllPlayViewInputsCoreAsync(reason, cancellationToken);
@@ -1374,6 +1404,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         EnsurePlayViewKeyboardInputRouter();
         EnsurePlayViewPointerInputRouter();
+        EnsureFacePlayViewPointerInputRouter();
 
         var byInputId = (LoadedProject?.InputDefinitions ?? [])
             .Where(definition => !string.IsNullOrWhiteSpace(definition.Id))
@@ -1407,6 +1438,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         _playViewPointerInputRouter ??= new PlayViewPointerInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
         return _playViewPointerInputRouter;
+    }
+
+    private FacePlayViewPointerInputRouter? EnsureFacePlayViewPointerInputRouter()
+    {
+        if (!EnsurePlayViewInputRouter())
+        {
+            return null;
+        }
+
+        _facePlayViewPointerInputRouter ??= new FacePlayViewPointerInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
+        return _facePlayViewPointerInputRouter;
     }
 
     private bool EnsurePlayViewInputRouter()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -40,6 +40,11 @@ public sealed class Face2DRenderer : IFace2DRenderer
         {
             DrawLampWindow(canvas, lampWindow, runtimeState, viewportTransform);
         }
+
+        foreach (var button in elements.OfType<FaceButtonElement>())
+        {
+            DrawButton(canvas, button, viewportTransform);
+        }
     }
 
     private void DrawArtwork(SKCanvas canvas, FaceArtworkElement element, PanelViewportTransform viewport)
@@ -94,6 +99,37 @@ public sealed class Face2DRenderer : IFace2DRenderer
         using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = strokeColor, StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
         canvas.DrawRect(rect, fillPaint);
         canvas.DrawRect(rect, strokePaint);
+    }
+
+    private static void DrawButton(SKCanvas canvas, FaceButtonElement element, PanelViewportTransform viewport)
+    {
+        var rect = ToRect(element);
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+            canvas.DrawRoundRect(rect, 6f, 6f, hiddenPaint);
+            return;
+        }
+
+        var hasInput = FaceInputTargetResolver.TryGetInputReference(element, out _);
+        var fillColor = hasInput
+            ? new SKColor(0x2E, 0x7D, 0x32, 0xD8)
+            : new SKColor(0x55, 0x55, 0x55, 0xC8);
+        var strokeColor = element.IsLocked
+            ? new SKColor(0x9E, 0x9E, 0x9E, 0xF0)
+            : hasInput
+                ? new SKColor(0x81, 0xC7, 0x84, 0xFF)
+                : new SKColor(0xCC, 0xCC, 0xCC, 0xE8);
+
+        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = fillColor, IsAntialias = true };
+        using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = strokeColor, StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
+        canvas.DrawRoundRect(rect, 6f, 6f, fillPaint);
+        canvas.DrawRoundRect(rect, 6f, 6f, strokePaint);
     }
 
     private bool TryGetArtworkImage(string? assetPath, out SKImage image)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -120,14 +120,15 @@ public sealed class DocumentWorkspaceViewModel
             sourceDocument.GetPanelDocument(),
             sourceRegion,
             title,
-            sourceDocument.DocumentId.ToString("N"));
+            sourceDocument.DocumentId.ToString("N"),
+            _getLoadedProject()?.InputDefinitions ?? []);
 
         var faceJson = FaceDocumentStorage.Serialize(result.Document);
         var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
-        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s) and {result.ConvertedLampCount} lamp window(s).");
-        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s) and {result.ConvertedLampCount} lamp window(s).", OutputLogStatus.Info);
+        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), and {result.ConvertedButtonCount} button(s).");
+        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
         return document;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -24,6 +24,10 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
             .OfType<FaceLampWindowElement>()
             .Select((element, index) => CreateElementItem(element, index, "Lamp Window", "lampWindow"))
             .ToArray();
+        var buttons = faceDocument.GetFaceElements()
+            .OfType<FaceButtonElement>()
+            .Select((element, index) => CreateElementItem(element, index, "Button", "button"))
+            .ToArray();
 
         var groups = new List<HierarchyItemViewModel>();
         if (artwork.Length > 0)
@@ -34,6 +38,11 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
         if (lampWindows.Length > 0)
         {
             groups.Add(new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows));
+        }
+
+        if (buttons.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Buttons ({buttons.Length})", "group:button", isGroup: true, children: buttons));
         }
 
         return groups;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -26,6 +26,7 @@ public partial class PlayView : UserControl
     private Point _skiaPanStart;
     private Vector _skiaPanOrigin;
     private PanelElementModel? _activeReelDragElement;
+    private MachineInputReference? _activeFacePointerInputReference;
     private Point _reelDragStart;
     private double _reelDragStartTemporaryOffset;
     private bool _isRenderQueued;
@@ -37,6 +38,7 @@ public partial class PlayView : UserControl
     private const double ReelDragSpeedScale = 3d;
     private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer()], "PlayView");
     private readonly IFace2DRenderer _faceRenderer = new Face2DRenderer();
+    private readonly IFaceInputTargetResolver _faceInputTargetResolver = FaceInputTargetResolver.Instance;
 
     public PlayView()
     {
@@ -176,6 +178,22 @@ public partial class PlayView : UserControl
         if (eventArgs.ChangedButton == MouseButton.Left)
         {
             var current = eventArgs.GetPosition(PlaySkiaSurface);
+            if (ViewModel?.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+            {
+                if (ViewModel is not null && TryResolveSkiaFaceInputReference(current, out var inputReference))
+                {
+                    if (await ViewModel.TryHandleFacePlayViewPointerDownAsync(inputReference, isFocused: true, CancellationToken.None))
+                    {
+                        _activeFacePointerInputReference = inputReference;
+                        PlaySkiaSurface.CaptureMouse();
+                    }
+
+                    eventArgs.Handled = true;
+                }
+
+                return;
+            }
+
             if (TryResolveSkiaReelElement(current, out var reelElement))
             {
                 BeginReelDrag(reelElement, current);
@@ -235,6 +253,28 @@ public partial class PlayView : UserControl
             {
                 EndReelDrag();
                 eventArgs.Handled = true;
+                return;
+            }
+
+            if (_activeFacePointerInputReference is MachineInputReference activeFaceInputReference)
+            {
+                _activeFacePointerInputReference = null;
+                if (ViewModel is not null)
+                {
+                    await ViewModel.TryHandleFacePlayViewPointerUpAsync(activeFaceInputReference, isFocused: true, CancellationToken.None);
+                }
+
+                if (PlaySkiaSurface.IsMouseCaptured)
+                {
+                    PlaySkiaSurface.ReleaseMouseCapture();
+                }
+
+                eventArgs.Handled = true;
+                return;
+            }
+
+            if (ViewModel?.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+            {
                 return;
             }
 
@@ -365,7 +405,7 @@ public partial class PlayView : UserControl
         CanvasPanZoomBehavior.HandleLostMouseCapture(PlayCanvas);
     }
 
-    private void OnPlaySkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
+    private async void OnPlaySkiaSurfaceLostMouseCapture(object sender, MouseEventArgs eventArgs)
     {
         if (_isSkiaPanning)
         {
@@ -376,6 +416,15 @@ public partial class PlayView : UserControl
         if (_activeReelDragElement is not null)
         {
             EndReelDrag(releaseMouseCapture: false);
+        }
+
+        if (_activeFacePointerInputReference is MachineInputReference activeFaceInputReference)
+        {
+            _activeFacePointerInputReference = null;
+            if (ViewModel is not null)
+            {
+                await ViewModel.TryHandleFacePlayViewPointerUpAsync(activeFaceInputReference, isFocused: true, CancellationToken.None);
+            }
         }
     }
 
@@ -401,6 +450,12 @@ public partial class PlayView : UserControl
 
     private void UpdatePlaySkiaHoverCursor(Point current)
     {
+        if (ViewModel?.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+        {
+            PlaySkiaSurface.Cursor = TryResolveSkiaFaceInputReference(current, out _) ? Cursors.Hand : Cursors.Arrow;
+            return;
+        }
+
         if (TryResolveSkiaReelElement(current, out _))
         {
             PlaySkiaSurface.Cursor = Cursors.ScrollNS;
@@ -490,6 +545,19 @@ public partial class PlayView : UserControl
         return false;
     }
 
+
+    private bool TryResolveSkiaFaceInputReference(Point screenPoint, out MachineInputReference inputReference)
+    {
+        var selected = ViewModel?.SelectedDocument;
+        if (selected is null || selected.Document.DocumentType != EditorDocumentType.Face)
+        {
+            inputReference = default;
+            return false;
+        }
+
+        var documentPoint = ToDocumentPoint(screenPoint);
+        return _faceInputTargetResolver.TryResolveInputReference(selected.GetFaceElements(), documentPoint, out inputReference);
+    }
 
     private bool TryResolveSkiaReelElement(Point screenPoint, out PanelElementModel reelElement)
     {


### PR DESCRIPTION
### Motivation
- Implement Phase 7: Face Input System MVP to make Face buttons first-class runtime interactors that resolve to machine inputs rather than Panel2D visuals. 
- Follow the architecture rules: Face runtime input behavior must resolve through machine-object references (`MachineInputReference`) and reuse the existing MAME input dispatch path. 

### Description
- Added a `FaceButtonElement` model with `LinkedInputReference` support and persisted `button` kind in `FaceDocumentStorage` so Face buttons can be serialized/deserialized via `FaceDocumentFile` fields. 
- Introduced `FaceInputTargetResolver` to hit-test visible/unlocked `FaceButtonElement` instances and resolve them to `MachineInputReference`, and `FacePlayViewPointerInputRouter` to map `MachineInputReference` → `InputDefinitionModel` → `PlayViewInputRouter` (MAME dispatch). 
- Extended Face generation to produce `FaceButtonElement` instances from Panel2D `LinkedVisualElementId` + project `InputDefinitionModel` when available, and preserved `LinkedPanel2DElementId` only as provenance. 
- Added Face button rendering in `Face2DRenderer` and mouse down/up handling in `PlayView` to route Face pointer events through the new Face input resolver and into the existing `PlayViewInputRouter`/`MameInputCommandService`; added `MainWindowViewModel` support methods to handle Face pointer down/up. 
- Added focused unit tests in `OasisEditor.Tests/FaceInputSystemTests.cs` covering serialization round-trip, hit testing, generation from Panel2D-linked inputs, and end-to-end routing into the MAME command path. 
- Updated the architecture plan (`FACE_SYSTEM_ARCHITECTURE_PLAN.md`) to mark Phase 7 complete and documented the intended runtime/authoring separation. 

### Testing
- Added unit tests: `OasisEditor.Tests/FaceInputSystemTests.cs` which includes tests for `FaceButtonElement` serialization, `FaceInputTargetResolver` hit testing, `FaceGenerationService` button generation, and `FacePlayViewPointerInputRouter` integration with the MAME command service. 
- Ran repository static checks (`git diff --cached --check`) with no check failures. 
- Could not execute `dotnet test OasisEditor.sln` in this environment because the `dotnet` runtime is not installed here, so automated test execution was not performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a250dd238ac8327ac735a595c416907)