### PR TITLE
Complete Face Play View keyboard routing

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -485,18 +485,20 @@ Outcome:
 - Face Play View pointer down/up uses the shared play input dispatch path and MAME command service;
 - Face runtime input behavior does not depend on `LinkedPanel2DElementId`, which remains provenance/editor metadata.
 
-### Phase 8 - Keyboard Input Routing - Future
+### Phase 8 - Keyboard Input Routing - Complete
 
 Goal:
 
 - make keyboard shortcuts and focus behavior consistent across Panel2D Play View and Face Play View.
 
-Planned work:
+Outcome:
 
-- route focused Face Play View key down/up events through the shared play input router;
-- normalize shortcut matching with the existing input map behavior;
-- ensure release-all behavior when focus is lost or play mode closes;
-- add tests for keyboard routing where practical.
+- Play View input routing now has a document-neutral dispatch facade for keyboard input, Panel2D pointer targets, and Face machine-input targets;
+- focused Face Play View key down/up events route through the shared play input router;
+- shortcut matching continues to use the existing input map normalization behavior;
+- active play inputs are released when Play View focus is lost or the view closes;
+- existing Panel2D keyboard behavior is preserved while Face keyboard routing uses the same public dispatch surface;
+- tests cover the shared dispatch facade across Panel2D pointer, Face pointer, keyboard down/up, and release-all behavior.
 
 ### Phase 9 - Runtime Displays MVP - Future
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputDispatcherTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputDispatcherTests.cs
@@ -1,0 +1,130 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PlayViewInputDispatcherTests
+{
+    [Fact]
+    public async Task TryHandlePointerDownAsync_PanelVisualTarget_RoutesThroughSharedInputPath()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var dispatcher = CreateDispatcher(
+            runner,
+            new InputDefinitionModel
+            {
+                Id = "panel-start",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "2",
+                LinkedVisualElementId = visualId
+            });
+
+        var pressed = await dispatcher.TryHandlePointerDownAsync(
+            FruitMachinePlatformType.MPU4,
+            PlayInputTarget.ForPanelVisualElement(visualId),
+            isFocused: true,
+            CancellationToken.None);
+
+        Assert.True(pressed);
+        Assert.Equal(new[] { "set_input_value ORANGE1 4 1" }, runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandlePointerDownAsync_FaceMachineInputTarget_RoutesThroughSharedInputPath()
+    {
+        var runner = new FakeMameProcessRunner();
+        var dispatcher = CreateDispatcher(
+            runner,
+            new InputDefinitionModel
+            {
+                Id = "face-start",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "2"
+            });
+
+        var pressed = await dispatcher.TryHandlePointerDownAsync(
+            FruitMachinePlatformType.MPU4,
+            PlayInputTarget.ForMachineInput(MachineInputReference.FromInputId("face-start")),
+            isFocused: true,
+            CancellationToken.None);
+
+        Assert.True(pressed);
+        Assert.Equal(new[] { "set_input_value ORANGE1 4 1" }, runner.Commands);
+    }
+
+    [Fact]
+    public async Task TryHandleKeyDownAndUpAsync_UsesNormalizedShortcutForFaceAndPanelDocuments()
+    {
+        var runner = new FakeMameProcessRunner();
+        var dispatcher = CreateDispatcher(
+            runner,
+            new InputDefinitionModel
+            {
+                Id = "keyboard-start",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "2",
+                KeyboardShortcut = "Space"
+            });
+
+        var pressed = await dispatcher.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "SPACE", isFocused: true, isRepeat: false, CancellationToken.None);
+        var released = await dispatcher.TryHandleKeyUpAsync(FruitMachinePlatformType.MPU4, "space", isFocused: true, CancellationToken.None);
+
+        Assert.True(pressed);
+        Assert.True(released);
+        Assert.True(dispatcher.CanResolveShortcut("SPACE"));
+        Assert.Equal(new[] { "set_input_value ORANGE1 4 1", "set_input_value ORANGE1 4 0" }, runner.Commands);
+    }
+
+    [Fact]
+    public async Task ReleaseAllActiveAsync_ReleasesKeyboardAndPointerInputsOnFocusLoss()
+    {
+        var runner = new FakeMameProcessRunner();
+        var visualId = Guid.NewGuid();
+        var dispatcher = CreateDispatcher(
+            runner,
+            new InputDefinitionModel
+            {
+                Id = "panel-start",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "2",
+                LinkedVisualElementId = visualId
+            },
+            new InputDefinitionModel
+            {
+                Id = "keyboard-collect",
+                Kind = InputDefinitionKind.Button,
+                ButtonNumber = "3",
+                KeyboardShortcut = "C"
+            });
+
+        await dispatcher.TryHandlePointerDownAsync(FruitMachinePlatformType.MPU4, PlayInputTarget.ForPanelVisualElement(visualId), isFocused: true, CancellationToken.None);
+        await dispatcher.TryHandleKeyDownAsync(FruitMachinePlatformType.MPU4, "C", isFocused: true, isRepeat: false, CancellationToken.None);
+
+        var released = await dispatcher.ReleaseAllActiveAsync(FruitMachinePlatformType.MPU4, CancellationToken.None);
+
+        Assert.Equal(2, released);
+        Assert.Equal(4, runner.Commands.Count);
+        Assert.Contains("set_input_value ORANGE1 4 1", runner.Commands);
+        Assert.Contains("set_input_value ORANGE1 8 1", runner.Commands);
+        Assert.Contains("set_input_value ORANGE1 4 0", runner.Commands);
+        Assert.Contains("set_input_value ORANGE1 8 0", runner.Commands);
+    }
+
+    private static PlayViewInputDispatcher CreateDispatcher(FakeMameProcessRunner runner, params InputDefinitionModel[] inputDefinitions)
+    {
+        var inputRouter = new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), runner);
+        return new PlayViewInputDispatcher(inputRouter, inputDefinitions);
+    }
+
+    private sealed class FakeMameProcessRunner : IMameProcessRunner
+    {
+        public List<string> Commands { get; } = [];
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken)
+        {
+            Commands.Add(command);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -81,9 +81,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IInputMapDiagnosticsService _inputMapDiagnosticsService = new InputMapDiagnosticsService(new MameInputPortResolver());
     private IReadOnlyList<InputMapDiagnostic> _inputMapDiagnostics = [];
     private PlayViewInputRouter? _playViewInputRouter;
-    private PlayViewKeyboardInputRouter? _playViewKeyboardInputRouter;
-    private PlayViewPointerInputRouter? _playViewPointerInputRouter;
-    private FacePlayViewPointerInputRouter? _facePlayViewPointerInputRouter;
+    private PlayViewInputDispatcher? _playViewInputDispatcher;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
@@ -1306,14 +1304,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public async Task<bool> TryHandlePlayViewKeyDownAsync(string keyboardShortcut, bool isFocused, bool isRepeat, CancellationToken cancellationToken)
     {
         var canRoute = EnsurePlayViewInputRouter();
-        var router = EnsurePlayViewKeyboardInputRouter();
-        if (router is null)
+        var dispatcher = EnsurePlayViewInputDispatcher();
+        if (dispatcher is null)
         {
             return false;
         }
 
-        var handled = await router.TryHandleKeyDownAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, isRepeat, cancellationToken).ConfigureAwait(false);
-        if (!handled && canRoute && isFocused && !isRepeat && !router.CanResolveShortcut(keyboardShortcut))
+        var handled = await dispatcher.TryHandleKeyDownAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, isRepeat, cancellationToken).ConfigureAwait(false);
+        if (!handled && canRoute && isFocused && !isRepeat && !dispatcher.CanResolveShortcut(keyboardShortcut))
         {
             AddOutputEntry($"Play View key input unresolved: '{keyboardShortcut}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
         }
@@ -1323,71 +1321,79 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public Task<bool> TryHandlePlayViewKeyUpAsync(string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
     {
-        var router = EnsurePlayViewKeyboardInputRouter();
-        if (router is null)
+        var dispatcher = EnsurePlayViewInputDispatcher();
+        if (dispatcher is null)
         {
             return Task.FromResult(false);
         }
 
-        return router.TryHandleKeyUpAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, cancellationToken);
+        return dispatcher.TryHandleKeyUpAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, cancellationToken);
     }
 
-    public async Task<bool> TryHandlePlayViewPointerDownAsync(Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
+    public Task<bool> TryHandlePlayViewPointerDownAsync(Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
     {
-        var canRoute = EnsurePlayViewInputRouter();
-        var router = EnsurePlayViewPointerInputRouter();
-        if (router is null)
-        {
-            return false;
-        }
-
-        var handled = await router.TryHandlePointerDownAsync(SelectedFruitMachinePlatform, visualElementId, isFocused, cancellationToken).ConfigureAwait(false);
-        if (!handled && canRoute && isFocused)
-        {
-            AddOutputEntry($"Play View pointer input unresolved for visual '{visualElementId}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
-        }
-
-        return handled;
+        return TryHandlePlayViewPointerDownAsync(
+            PlayInputTarget.ForPanelVisualElement(visualElementId),
+            isFocused,
+            $"Play View pointer input unresolved for visual '{visualElementId}'",
+            cancellationToken);
     }
 
     public Task<bool> TryHandlePlayViewPointerUpAsync(Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
     {
-        var router = EnsurePlayViewPointerInputRouter();
-        if (router is null)
-        {
-            return Task.FromResult(false);
-        }
-
-        return router.TryHandlePointerUpAsync(SelectedFruitMachinePlatform, visualElementId, isFocused, cancellationToken);
+        return TryHandlePlayViewPointerUpAsync(PlayInputTarget.ForPanelVisualElement(visualElementId), isFocused, cancellationToken);
     }
 
-    public async Task<bool> TryHandleFacePlayViewPointerDownAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    public Task<bool> TryHandlePlayViewPointerDownAsync(PlayInputTarget inputTarget, bool isFocused, CancellationToken cancellationToken)
+    {
+        return TryHandlePlayViewPointerDownAsync(
+            inputTarget,
+            isFocused,
+            $"Play View pointer input unresolved for {inputTarget}",
+            cancellationToken);
+    }
+
+    private async Task<bool> TryHandlePlayViewPointerDownAsync(PlayInputTarget inputTarget, bool isFocused, string unresolvedMessage, CancellationToken cancellationToken)
     {
         var canRoute = EnsurePlayViewInputRouter();
-        var router = EnsureFacePlayViewPointerInputRouter();
-        if (router is null)
+        var dispatcher = EnsurePlayViewInputDispatcher();
+        if (dispatcher is null)
         {
             return false;
         }
 
-        var handled = await router.TryHandlePointerDownAsync(SelectedFruitMachinePlatform, inputReference, isFocused, cancellationToken).ConfigureAwait(false);
+        var handled = await dispatcher.TryHandlePointerDownAsync(SelectedFruitMachinePlatform, inputTarget, isFocused, cancellationToken).ConfigureAwait(false);
         if (!handled && canRoute && isFocused)
         {
-            AddOutputEntry($"Face Play View pointer input unresolved for machine input '{inputReference}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
+            AddOutputEntry($"{unresolvedMessage} on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
         }
 
         return handled;
     }
 
-    public Task<bool> TryHandleFacePlayViewPointerUpAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    public Task<bool> TryHandlePlayViewPointerUpAsync(PlayInputTarget inputTarget, bool isFocused, CancellationToken cancellationToken)
     {
-        var router = EnsureFacePlayViewPointerInputRouter();
-        if (router is null)
+        var dispatcher = EnsurePlayViewInputDispatcher();
+        if (dispatcher is null)
         {
             return Task.FromResult(false);
         }
 
-        return router.TryHandlePointerUpAsync(SelectedFruitMachinePlatform, inputReference, isFocused, cancellationToken);
+        return dispatcher.TryHandlePointerUpAsync(SelectedFruitMachinePlatform, inputTarget, isFocused, cancellationToken);
+    }
+
+    public Task<bool> TryHandleFacePlayViewPointerDownAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        return TryHandlePlayViewPointerDownAsync(
+            PlayInputTarget.ForMachineInput(inputReference),
+            isFocused,
+            $"Face Play View pointer input unresolved for machine input '{inputReference}'",
+            cancellationToken);
+    }
+
+    public Task<bool> TryHandleFacePlayViewPointerUpAsync(MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
+    {
+        return TryHandlePlayViewPointerUpAsync(PlayInputTarget.ForMachineInput(inputReference), isFocused, cancellationToken);
     }
 
     public Task<int> ReleaseAllPlayViewInputsAsync(string reason, CancellationToken cancellationToken)
@@ -1402,14 +1408,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return 0;
         }
 
-        EnsurePlayViewKeyboardInputRouter();
-        EnsurePlayViewPointerInputRouter();
-        EnsureFacePlayViewPointerInputRouter();
+        var dispatcher = EnsurePlayViewInputDispatcher();
+        if (dispatcher is null)
+        {
+            return 0;
+        }
 
-        var byInputId = (LoadedProject?.InputDefinitions ?? [])
-            .Where(definition => !string.IsNullOrWhiteSpace(definition.Id))
-            .ToDictionary(definition => definition.Id, definition => definition, StringComparer.Ordinal);
-        var released = await _playViewInputRouter.ReleaseAllAsync(SelectedFruitMachinePlatform, byInputId, cancellationToken).ConfigureAwait(false);
+        var released = await dispatcher.ReleaseAllActiveAsync(SelectedFruitMachinePlatform, cancellationToken).ConfigureAwait(false);
         if (released > 0)
         {
             AddOutputEntry($"Play View released {released} active input(s) due to {reason}.", OutputLogStatus.Info);
@@ -1418,37 +1423,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return released;
     }
 
-    private PlayViewKeyboardInputRouter? EnsurePlayViewKeyboardInputRouter()
+    private PlayViewInputDispatcher? EnsurePlayViewInputDispatcher()
     {
         if (!EnsurePlayViewInputRouter())
         {
             return null;
         }
 
-        _playViewKeyboardInputRouter ??= new PlayViewKeyboardInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
-        return _playViewKeyboardInputRouter;
-    }
-
-    private PlayViewPointerInputRouter? EnsurePlayViewPointerInputRouter()
-    {
-        if (!EnsurePlayViewInputRouter())
-        {
-            return null;
-        }
-
-        _playViewPointerInputRouter ??= new PlayViewPointerInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
-        return _playViewPointerInputRouter;
-    }
-
-    private FacePlayViewPointerInputRouter? EnsureFacePlayViewPointerInputRouter()
-    {
-        if (!EnsurePlayViewInputRouter())
-        {
-            return null;
-        }
-
-        _facePlayViewPointerInputRouter ??= new FacePlayViewPointerInputRouter(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
-        return _facePlayViewPointerInputRouter;
+        _playViewInputDispatcher ??= new PlayViewInputDispatcher(_playViewInputRouter!, LoadedProject?.InputDefinitions ?? []);
+        return _playViewInputDispatcher;
     }
 
     private bool EnsurePlayViewInputRouter()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputDispatcher.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputDispatcher.cs
@@ -1,0 +1,105 @@
+namespace OasisEditor;
+
+public enum PlayInputTargetKind
+{
+    None = 0,
+    PanelVisualElement,
+    MachineInput
+}
+
+public readonly record struct PlayInputTarget
+{
+    private PlayInputTarget(PlayInputTargetKind kind, Guid panelVisualElementId, MachineInputReference machineInputReference)
+    {
+        Kind = kind;
+        PanelVisualElementId = panelVisualElementId;
+        MachineInputReference = machineInputReference;
+    }
+
+    public PlayInputTargetKind Kind { get; }
+    public Guid PanelVisualElementId { get; }
+    public MachineInputReference MachineInputReference { get; }
+
+    public static PlayInputTarget ForPanelVisualElement(Guid visualElementId)
+    {
+        return new PlayInputTarget(PlayInputTargetKind.PanelVisualElement, visualElementId, default);
+    }
+
+    public static PlayInputTarget ForMachineInput(MachineInputReference inputReference)
+    {
+        return new PlayInputTarget(PlayInputTargetKind.MachineInput, Guid.Empty, inputReference);
+    }
+
+    public override string ToString()
+    {
+        return Kind switch
+        {
+            PlayInputTargetKind.PanelVisualElement => $"panel visual '{PanelVisualElementId}'",
+            PlayInputTargetKind.MachineInput => $"machine input '{MachineInputReference}'",
+            _ => "none"
+        };
+    }
+}
+
+public sealed class PlayViewInputDispatcher
+{
+    private readonly PlayViewInputRouter _inputRouter;
+    private readonly PlayViewKeyboardInputRouter _keyboardInputRouter;
+    private readonly PlayViewPointerInputRouter _panelPointerInputRouter;
+    private readonly FacePlayViewPointerInputRouter _facePointerInputRouter;
+    private readonly Dictionary<string, InputDefinitionModel> _inputDefinitionsById;
+
+    public PlayViewInputDispatcher(PlayViewInputRouter inputRouter, IEnumerable<InputDefinitionModel> inputDefinitions)
+    {
+        _inputRouter = inputRouter ?? throw new ArgumentNullException(nameof(inputRouter));
+        ArgumentNullException.ThrowIfNull(inputDefinitions);
+
+        var definitions = inputDefinitions.Where(input => input is not null).ToArray();
+        _keyboardInputRouter = new PlayViewKeyboardInputRouter(_inputRouter, definitions);
+        _panelPointerInputRouter = new PlayViewPointerInputRouter(_inputRouter, definitions);
+        _facePointerInputRouter = new FacePlayViewPointerInputRouter(_inputRouter, definitions);
+        _inputDefinitionsById = definitions
+            .Where(definition => !string.IsNullOrWhiteSpace(definition.Id))
+            .ToDictionary(definition => definition.Id, definition => definition, StringComparer.Ordinal);
+    }
+
+    public bool CanResolveShortcut(string keyboardShortcut)
+    {
+        return _keyboardInputRouter.CanResolveShortcut(keyboardShortcut);
+    }
+
+    public Task<bool> TryHandleKeyDownAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, bool isRepeat, CancellationToken cancellationToken)
+    {
+        return _keyboardInputRouter.TryHandleKeyDownAsync(platform, keyboardShortcut, isFocused, isRepeat, cancellationToken);
+    }
+
+    public Task<bool> TryHandleKeyUpAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
+    {
+        return _keyboardInputRouter.TryHandleKeyUpAsync(platform, keyboardShortcut, isFocused, cancellationToken);
+    }
+
+    public Task<bool> TryHandlePointerDownAsync(FruitMachinePlatformType platform, PlayInputTarget inputTarget, bool isFocused, CancellationToken cancellationToken)
+    {
+        return inputTarget.Kind switch
+        {
+            PlayInputTargetKind.PanelVisualElement => _panelPointerInputRouter.TryHandlePointerDownAsync(platform, inputTarget.PanelVisualElementId, isFocused, cancellationToken),
+            PlayInputTargetKind.MachineInput => _facePointerInputRouter.TryHandlePointerDownAsync(platform, inputTarget.MachineInputReference, isFocused, cancellationToken),
+            _ => Task.FromResult(false)
+        };
+    }
+
+    public Task<bool> TryHandlePointerUpAsync(FruitMachinePlatformType platform, PlayInputTarget inputTarget, bool isFocused, CancellationToken cancellationToken)
+    {
+        return inputTarget.Kind switch
+        {
+            PlayInputTargetKind.PanelVisualElement => _panelPointerInputRouter.TryHandlePointerUpAsync(platform, inputTarget.PanelVisualElementId, isFocused, cancellationToken),
+            PlayInputTargetKind.MachineInput => _facePointerInputRouter.TryHandlePointerUpAsync(platform, inputTarget.MachineInputReference, isFocused, cancellationToken),
+            _ => Task.FromResult(false)
+        };
+    }
+
+    public Task<int> ReleaseAllActiveAsync(FruitMachinePlatformType platform, CancellationToken cancellationToken)
+    {
+        return _inputRouter.ReleaseAllAsync(platform, _inputDefinitionsById, cancellationToken);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml
@@ -10,6 +10,7 @@
              PreviewKeyDown="OnRootPreviewKeyDown"
              PreviewKeyUp="OnRootPreviewKeyUp"
              PreviewTextInput="OnRootPreviewTextInput"
+             LostKeyboardFocus="OnRootLostKeyboardFocus"
              d:DesignHeight="450"
              d:DesignWidth="700">
     <Grid>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -58,10 +58,11 @@ public partial class PlayView : UserControl
         AttachPreProcessInputHandler();
     }
 
-    private void OnUnloaded(object sender, RoutedEventArgs e)
+    private async void OnUnloaded(object sender, RoutedEventArgs e)
     {
         _renderThrottleTimer.Stop();
         DetachPreProcessInputHandler();
+        await ReleasePlayViewInputsAsync("Play View close");
     }
 
     private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -182,7 +183,7 @@ public partial class PlayView : UserControl
             {
                 if (ViewModel is not null && TryResolveSkiaFaceInputReference(current, out var inputReference))
                 {
-                    if (await ViewModel.TryHandleFacePlayViewPointerDownAsync(inputReference, isFocused: true, CancellationToken.None))
+                    if (await ViewModel.TryHandlePlayViewPointerDownAsync(PlayInputTarget.ForMachineInput(inputReference), isFocused: true, CancellationToken.None))
                     {
                         _activeFacePointerInputReference = inputReference;
                         PlaySkiaSurface.CaptureMouse();
@@ -261,7 +262,7 @@ public partial class PlayView : UserControl
                 _activeFacePointerInputReference = null;
                 if (ViewModel is not null)
                 {
-                    await ViewModel.TryHandleFacePlayViewPointerUpAsync(activeFaceInputReference, isFocused: true, CancellationToken.None);
+                    await ViewModel.TryHandlePlayViewPointerUpAsync(PlayInputTarget.ForMachineInput(activeFaceInputReference), isFocused: true, CancellationToken.None);
                 }
 
                 if (PlaySkiaSurface.IsMouseCaptured)
@@ -423,29 +424,42 @@ public partial class PlayView : UserControl
             _activeFacePointerInputReference = null;
             if (ViewModel is not null)
             {
-                await ViewModel.TryHandleFacePlayViewPointerUpAsync(activeFaceInputReference, isFocused: true, CancellationToken.None);
+                await ViewModel.TryHandlePlayViewPointerUpAsync(PlayInputTarget.ForMachineInput(activeFaceInputReference), isFocused: true, CancellationToken.None);
             }
         }
     }
 
     private async void OnPlayCanvasLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs eventArgs)
     {
-        if (ViewModel is null)
+        await ReleasePlayViewInputsAsync("Play View focus loss");
+    }
+
+    private async void OnRootLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs eventArgs)
+    {
+        if (IsKeyboardFocusWithin)
         {
             return;
         }
 
-        await ViewModel.ReleaseAllPlayViewInputsAsync("Play View focus loss", CancellationToken.None);
+        await ReleasePlayViewInputsAsync("Play View focus loss");
     }
 
     private async void OnPlayCanvasUnloaded(object sender, RoutedEventArgs eventArgs)
     {
+        await ReleasePlayViewInputsAsync("Play View close");
+    }
+
+    private async Task ReleasePlayViewInputsAsync(string reason)
+    {
+        _pendingTextInputKey = null;
+        _activeShortcutByKey.Clear();
+
         if (ViewModel is null)
         {
             return;
         }
 
-        await ViewModel.ReleaseAllPlayViewInputsAsync("Play View close", CancellationToken.None);
+        await ViewModel.ReleaseAllPlayViewInputsAsync(reason, CancellationToken.None);
     }
 
     private void UpdatePlaySkiaHoverCursor(Point current)
@@ -705,7 +719,7 @@ public partial class PlayView : UserControl
 
     private async Task TryRouteKeyDownAsync(KeyEventArgs eventArgs)
     {
-        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin || ViewModel.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin)
         {
             return;
         }
@@ -728,7 +742,7 @@ public partial class PlayView : UserControl
 
     private async Task TryRouteKeyUpAsync(KeyEventArgs eventArgs)
     {
-        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin || ViewModel.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin)
         {
             return;
         }
@@ -806,7 +820,7 @@ public partial class PlayView : UserControl
 
     private async Task TryRouteTextInputAsync(TextCompositionEventArgs eventArgs)
     {
-        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin || _pendingTextInputKey is null || ViewModel.SelectedDocument?.Document.DocumentType == EditorDocumentType.Face)
+        if (eventArgs.Handled || ViewModel is null || !IsKeyboardFocusWithin || _pendingTextInputKey is null)
         {
             return;
         }


### PR DESCRIPTION
### Motivation
- Provide a document-neutral public surface for Play View input so Panel2D pointer input, Face pointer input, and future Face keyboard input share the same dispatch path.
- Route focused Face Play View key down/up through the existing shortcut normalization and MAME input dispatcher without changing runtime behavior.
- Ensure active play inputs are released cleanly when Play View focus is lost or the view is closed.

### Description
- Add `PlayViewInputDispatcher` and `PlayInputTarget` to provide a neutral facade that dispatches keyboard shortcuts and pointer targets (Panel visual elements or Machine input references) into the existing `PlayViewInputRouter` path.
- Update `MainWindowViewModel` to use the new dispatcher for Play View keyboard `TryHandlePlayViewKeyDown/KeyUp` and for pointer down/up (Panel2D and Face) while keeping previous public overloads and unresolved-input warnings.
- Change `PlayView` to route Face pointer interactions through `PlayInputTarget.ForMachineInput(...)` and remove the Face-document guard so keyboard key-down/key-up and text-input fallback use the shared normalized shortcut path.
- Add focus-loss and unload handling in `PlayView` to clear active shortcut state and call the dispatcher to release all active inputs on focus loss or close.
- Add unit tests `PlayViewInputDispatcherTests` to cover Panel2D pointer routing, Face machine-input pointer routing, normalized keyboard down/up routing, and release-all behavior; update FACE_SYSTEM_ARCHITECTURE_PLAN.md to mark Phase 8 complete.

### Testing
- Added `OasisEditor.Tests/PlayViewInputDispatcherTests.cs` covering pointer and keyboard routing and release-all behavior (new unit tests included in the commit).
- Ran `git diff --check` with no issues reported.
- Attempted `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` but `dotnet` is not available in this environment so the test suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2516702dc0832796d8feffbe7fdfa6)