### PR TITLE
Add Face seven-segment display MVP

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -507,16 +507,19 @@ Outcome:
 - existing Panel2D keyboard behavior is preserved while Face keyboard routing uses the same public dispatch surface;
 - tests cover the shared dispatch facade across Panel2D pointer, Face pointer, keyboard down/up, and release-all behavior.
 
-### Phase 9A - Seven Segment Display MVP - Future
+### Phase 9A - Seven Segment Display MVP - Complete
 
-Goals:
+Completed at MVP level.
 
-- add `FaceSevenSegmentDisplayElement` as the dedicated Face element for seven-segment display visuals;
-- generate Face seven-segment display elements from Panel2D seven-segment displays;
-- support serialization/deserialization for the new element type and its runtime/provenance references;
-- render seven-segment displays in Face Edit View;
-- render seven-segment displays in Face Play View;
-- resolve runtime state via `MachineObjectReference` and `MachineRuntimeState`.
+Outcome:
+
+- `FaceSevenSegmentDisplayElement` is now the dedicated Face element for seven-segment display visuals;
+- generated Face documents create seven-segment Face elements from contained Panel2D seven-segment displays;
+- seven-segment Face elements serialize/deserialize with machine-object references, provenance-only Panel2D element links, and MVP display color metadata;
+- Face Edit View renders seven-segment display elements from `MachineRuntimeState`;
+- Face Play View renders seven-segment display elements from `MachineRuntimeState`;
+- MAME digit output updates Face seven-segment displays live through `MachineObjectReference.SevenSegmentDisplay`;
+- existing lamp and input behavior remain unchanged.
 
 Runtime rule:
 
@@ -652,7 +655,7 @@ Completed MVP checks that should continue to be regression-tested:
 
 Future phase verification should focus on:
 
-- Phase 9A: seven-segment displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
+- Phase 9A: complete - seven-segment displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
 - Phase 9B: alpha displays generate and render from `MachineRuntimeState` through machine-object references;
 - Phase 9C: reel displays generate and render from `MachineRuntimeState` through machine-object references, with correctness prioritized over animation fidelity;
 - Phase 10: Face regeneration uses provenance metadata while preserving runtime identity through machine-object references;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -154,4 +154,52 @@ public sealed class FaceDocumentRoundTripTests
             if (File.Exists(tempPath)) File.Delete(tempPath);
         }
     }
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsSevenSegmentDisplayElement()
+    {
+        var source = new FaceDocumentModel
+        {
+            Id = "face-seven",
+            Title = "Displays",
+            Elements =
+            [
+                new FaceSevenSegmentDisplayElement
+                {
+                    ObjectId = "face-seven-3",
+                    Name = "Credit Digit",
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    IsVisible = true,
+                    IsLocked = true,
+                    LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(3),
+                    LinkedPanel2DElementId = "panel-seven-3",
+                    OnColorHex = "#FF2020",
+                    OffColorHex = "#220404",
+                    ShowDecimalPoint = true
+                }
+            ]
+        };
+
+        var json = FaceDocumentStorage.Serialize(source);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var saved = Assert.Single(file.Elements!);
+        Assert.Equal("sevenSegmentDisplay", saved.Kind);
+        Assert.Equal("sevenSegment:3", saved.LinkedMachineObjectReference);
+        Assert.Equal("panel-seven-3", saved.LinkedPanel2DElementId);
+        Assert.Equal("#FF2020", saved.OnColorHex);
+        Assert.Equal("#220404", saved.OffColorHex);
+        Assert.True(saved.ShowDecimalPoint);
+
+        var model = FaceDocumentStorage.ToModel(file);
+        var element = Assert.IsType<FaceSevenSegmentDisplayElement>(Assert.Single(model.Elements));
+        Assert.Equal("sevenSegment:3", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("panel-seven-3", element.LinkedPanel2DElementId);
+        Assert.Equal("#FF2020", element.OnColorHex);
+        Assert.Equal("#220404", element.OffColorHex);
+        Assert.True(element.ShowDecimalPoint);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -155,4 +155,48 @@ public sealed class FaceGenerationServiceTests
         Assert.Equal(5d, element.X);
         Assert.Equal(5d, element.Y);
     }
+    [Fact]
+    public void GenerateFromPanelRegion_ConvertsContainedSevenSegmentDisplaysWithMachineReferences()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "seven-3",
+                    Name = "Credit Digit",
+                    Kind = PanelElementKind.SevenSegment,
+                    X = 120,
+                    Y = 230,
+                    Width = 24,
+                    Height = 36,
+                    DisplayNumber = 3,
+                    OnColorHex = "#FF2020",
+                    OffColorHex = "#220404",
+                    ShowDecimalPoint = true,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 200, 150)),
+            "Generated Face",
+            "panel-doc-1");
+
+        Assert.Equal(1, result.ConvertedSevenSegmentDisplayCount);
+        var element = Assert.IsType<FaceSevenSegmentDisplayElement>(result.Document.Elements[1]);
+        Assert.Equal("face-seven-3", element.ObjectId);
+        Assert.Equal("Credit Digit", element.Name);
+        Assert.Equal(20d, element.X);
+        Assert.Equal(30d, element.Y);
+        Assert.Equal("sevenSegment:3", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("seven-3", element.LinkedPanel2DElementId);
+        Assert.Equal("#FF2020", element.OnColorHex);
+        Assert.Equal("#220404", element.OffColorHex);
+        Assert.True(element.ShowDecimalPoint);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
@@ -38,4 +38,41 @@ public sealed class FaceRuntimeStateResolverTests
 
         Assert.Equal(0d, intensity);
     }
+
+    [Fact]
+    public void GetSevenSegmentCellMasks_UsesMachineObjectReference()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetSegmentCellMasksIfChanged(MachineObjectReference.SevenSegmentDisplay(3), [0x5B]);
+        runtimeState.SetSegmentCellMasksIfChanged("panel-seven-3", [0x06]);
+        var display = new FaceSevenSegmentDisplayElement
+        {
+            ObjectId = "face-seven-3",
+            LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(3),
+            LinkedPanel2DElementId = "panel-seven-3"
+        };
+
+        var masks = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellMasks(display, runtimeState);
+
+        Assert.Single(masks);
+        Assert.Equal(0x5B, masks[0]);
+    }
+
+    [Fact]
+    public void GetSevenSegmentCellMasks_IgnoresLinkedPanel2DElementIdWhenMachineReferenceIsMissing()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetSegmentCellMasksIfChanged("panel-seven-3", [0x06]);
+        var display = new FaceSevenSegmentDisplayElement
+        {
+            ObjectId = "face-seven-3",
+            LinkedPanel2DElementId = "panel-seven-3"
+        };
+
+        var masks = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellMasks(display, runtimeState);
+
+        Assert.Single(masks);
+        Assert.Equal(0, masks[0]);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -118,6 +118,34 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.Equal(4, masks[15]);
     }
 
+    [Fact]
+    public void ApplySegmentState_UpdatesFaceSevenSegmentThroughMachineReference()
+    {
+        var document = CreateDocument();
+        document.SetFaceElements([
+            new FaceSevenSegmentDisplayElement
+            {
+                ObjectId = "face-seven-3",
+                LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(3),
+                LinkedPanel2DElementId = "seven-ignored"
+            }
+        ]);
+        var changedFaceIds = new List<string>();
+        document.FaceVisualStateChanged += changed => changedFaceIds.AddRange(changed.ObjectIds);
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(3, 0x5B, MameSegmentOutputType.Digit);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks(MachineObjectReference.SevenSegmentDisplay(3), 1);
+        Assert.Single(masks);
+        Assert.Equal(0x5B, masks[0]);
+        Assert.Contains("face-seven-3", changedFaceIds);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -55,6 +55,13 @@ public sealed class FaceLampWindowElement : FaceElementModel
 {
 }
 
+public sealed class FaceSevenSegmentDisplayElement : FaceElementModel
+{
+    public string? OnColorHex { get; init; }
+    public string? OffColorHex { get; init; }
+    public bool ShowDecimalPoint { get; init; }
+}
+
 public sealed class FaceButtonElement : FaceElementModel
 {
     public MachineInputReference? LinkedInputReference { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -46,6 +46,12 @@ public static class FaceDocumentStorage
                 },
                 new FaceLayerFile
                 {
+                    Id = "layer-displays",
+                    Name = "Displays",
+                    IsVisible = true
+                },
+                new FaceLayerFile
+                {
                     Id = "layer-buttons",
                     Name = "Buttons",
                     IsVisible = true
@@ -245,6 +251,27 @@ public static class FaceDocumentStorage
             };
         }
 
+        if (string.Equals(file.Kind, "sevenSegmentDisplay", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(file.Kind, "sevenSegment", StringComparison.OrdinalIgnoreCase))
+        {
+            return new FaceSevenSegmentDisplayElement
+            {
+                ObjectId = file.ObjectId ?? string.Empty,
+                Name = file.Name ?? string.Empty,
+                X = file.X,
+                Y = file.Y,
+                Width = file.Width,
+                Height = file.Height,
+                IsVisible = file.IsVisible,
+                IsLocked = file.IsLocked,
+                LinkedMachineObjectReference = reference,
+                LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+                OnColorHex = file.OnColorHex,
+                OffColorHex = file.OffColorHex,
+                ShowDecimalPoint = file.ShowDecimalPoint
+            };
+        }
+
         if (string.Equals(file.Kind, "button", StringComparison.OrdinalIgnoreCase))
         {
             var linkedInputReference = ResolveInputReference(file.LinkedInputReference, reference);
@@ -325,6 +352,7 @@ public static class FaceDocumentStorage
             {
                 FaceArtworkElement => "artwork",
                 FaceButtonElement => "button",
+                FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
                 FaceLampWindowElement => "lampWindow",
                 _ => "unknown"
             },
@@ -337,6 +365,9 @@ public static class FaceDocumentStorage
             LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
             LinkedPanel2DElementId = model.LinkedPanel2DElementId,
             LinkedInputReference = model is FaceButtonElement button ? button.LinkedInputReference?.ToString() : null,
+            OnColorHex = model is FaceSevenSegmentDisplayElement sevenSegment ? sevenSegment.OnColorHex : null,
+            OffColorHex = model is FaceSevenSegmentDisplayElement sevenSegmentOff ? sevenSegmentOff.OffColorHex : null,
+            ShowDecimalPoint = model is FaceSevenSegmentDisplayElement sevenSegmentDecimal && sevenSegmentDecimal.ShowDecimalPoint,
             AssetPath = model is FaceArtworkElement artwork ? artwork.AssetPath : null,
             SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
@@ -407,6 +438,9 @@ public sealed record FaceElementFile
     public string? LinkedMachineObjectReference { get; init; }
     public string? LinkedPanel2DElementId { get; init; }
     public string? LinkedInputReference { get; init; }
+    public string? OnColorHex { get; init; }
+    public string? OffColorHex { get; init; }
+    public bool ShowDecimalPoint { get; init; }
     public string? AssetPath { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -61,6 +61,22 @@ internal static class FaceElementModelUpdater
                 LinkedMachineObjectReference = linkedMachineObjectReference,
                 LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId
             },
+            FaceSevenSegmentDisplayElement sevenSegmentDisplay => new FaceSevenSegmentDisplayElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                OnColorHex = sevenSegmentDisplay.OnColorHex,
+                OffColorHex = sevenSegmentDisplay.OffColorHex,
+                ShowDecimalPoint = sevenSegmentDisplay.ShowDecimalPoint
+            },
             FaceButtonElement button => new FaceButtonElement
             {
                 ObjectId = existing.ObjectId,
@@ -154,6 +170,7 @@ internal static class FaceSelectionService
         {
             FaceArtworkElement => "artwork",
             FaceButtonElement => "button",
+            FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
             FaceLampWindowElement => "lampWindow",
             _ => "unknown"
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -50,18 +50,20 @@ public sealed class FaceSourceRegionModel
 
 internal sealed class FaceGenerationResult
 {
-    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount)
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount, int convertedSevenSegmentDisplayCount)
     {
         Document = document;
         ConvertedLampCount = convertedLampCount;
         ArtworkElementCount = artworkElementCount;
         ConvertedButtonCount = convertedButtonCount;
+        ConvertedSevenSegmentDisplayCount = convertedSevenSegmentDisplayCount;
     }
 
     public FaceDocumentModel Document { get; }
     public int ConvertedLampCount { get; }
     public int ArtworkElementCount { get; }
     public int ConvertedButtonCount { get; }
+    public int ConvertedSevenSegmentDisplayCount { get; }
 }
 
 internal sealed class FaceGenerationService
@@ -94,6 +96,10 @@ internal sealed class FaceGenerationService
             .Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region))
             .Select(element => CreateLampWindow(element, region))
             .ToArray();
+        var sevenSegmentDisplays = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.SevenSegment && IsContainedBy(element, region))
+            .Select(element => CreateSevenSegmentDisplay(element, region))
+            .ToArray();
         var buttons = CreateButtonElements(sourcePanel, region, inputDefinitions ?? []);
 
         var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim();
@@ -120,15 +126,21 @@ internal sealed class FaceGenerationService
                 },
                 new FaceLayerModel
                 {
+                    Id = "layer-displays",
+                    Name = "Displays",
+                    IsVisible = true
+                },
+                new FaceLayerModel
+                {
                     Id = "layer-buttons",
                     Name = "Buttons",
                     IsVisible = true
                 }
             ],
-            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(buttons).ToArray()
+            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(sevenSegmentDisplays).Concat(buttons).ToArray()
         };
 
-        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length);
+        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length);
     }
 
     private static FaceArtworkElement[] CreateArtworkElements(
@@ -214,6 +226,28 @@ internal sealed class FaceGenerationService
             IsLocked = sourceElement.IsLocked,
             LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
             LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId
+        };
+    }
+
+    private FaceSevenSegmentDisplayElement CreateSevenSegmentDisplay(PanelElementModel sourceElement, Rect region)
+    {
+        _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
+
+        return new FaceSevenSegmentDisplayElement
+        {
+            ObjectId = CreateGeneratedElementId(sourceElement),
+            Name = sourceElement.Name ?? string.Empty,
+            X = Math.Round(sourceElement.X - region.X, 2),
+            Y = Math.Round(sourceElement.Y - region.Y, 2),
+            Width = Math.Round(sourceElement.Width, 2),
+            Height = Math.Round(sourceElement.Height, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            OnColorHex = sourceElement.OnColorHex,
+            OffColorHex = sourceElement.OffColorHex,
+            ShowDecimalPoint = sourceElement.ShowDecimalPoint
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -4,6 +4,9 @@ public interface IFaceRuntimeStateResolver
 {
     bool TryGetLampReference(FaceLampWindowElement lampWindow, out MachineObjectReference reference);
     double GetLampIntensity(FaceLampWindowElement lampWindow, MachineRuntimeState runtimeState);
+    bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference);
+    int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState);
+    double[] GetSevenSegmentCellBrightness(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState);
 }
 
 public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
@@ -29,5 +32,32 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         return TryGetLampReference(lampWindow, out var reference)
             ? runtimeState.GetLampIntensity(reference)
             : 0d;
+    }
+
+    public bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        reference = display.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
+        return reference.Kind == MachineObjectKind.SevenSegmentDisplay && !reference.IsEmpty;
+    }
+
+    public int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        return TryGetSevenSegmentDisplayReference(display, out var reference)
+            ? runtimeState.GetSegmentCellMasks(reference, 1)
+            : new int[1];
+    }
+
+    public double[] GetSevenSegmentCellBrightness(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        return TryGetSevenSegmentDisplayReference(display, out var reference)
+            ? runtimeState.GetSegmentCellBrightness(reference, 1)
+            : [1d];
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -66,6 +66,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         {
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
             var changedFaceObjectIds = new HashSet<string>(StringComparer.Ordinal);
+            var changedMachineReferences = new HashSet<MachineObjectReference>();
 
             foreach (var (cellId, state) in snapshot)
             {
@@ -119,14 +120,13 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 if (_machineObjectReferenceResolver.TryGetReference(element, out var machineReference)
                     && !machineReference.IsEmpty)
                 {
-                    document.RuntimeState.SetSegmentCellMasksIfChanged(machineReference, cellMasks);
-                    if (element.Kind == PanelElementKind.Alpha)
+                    var machineMaskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(machineReference, cellMasks);
+                    var machineBrightnessChanged = element.Kind == PanelElementKind.Alpha
+                        ? document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, cellBrightness)
+                        : document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, [1d]);
+                    if (machineMaskChanged || machineBrightnessChanged)
                     {
-                        document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, cellBrightness);
-                    }
-                    else
-                    {
-                        document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, [1d]);
+                        changedMachineReferences.Add(machineReference);
                     }
                 }
 
@@ -150,7 +150,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
                 var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(reference, [mask]);
                 var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, [1d]);
-                if (maskChanged || brightnessChanged)
+                if (maskChanged || brightnessChanged || changedMachineReferences.Contains(reference))
                 {
                     changedFaceObjectIds.Add(faceDisplay.ObjectId);
                 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -65,6 +65,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         foreach (var document in _documentProvider())
         {
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+            var changedFaceObjectIds = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var (cellId, state) in snapshot)
             {
@@ -115,15 +116,54 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(objectId, cellMasks);
                 var brightnessChanged = element.Kind == PanelElementKind.Alpha
                     && document.RuntimeState.SetSegmentCellBrightnessIfChanged(objectId, cellBrightness);
+                if (_machineObjectReferenceResolver.TryGetReference(element, out var machineReference)
+                    && !machineReference.IsEmpty)
+                {
+                    document.RuntimeState.SetSegmentCellMasksIfChanged(machineReference, cellMasks);
+                    if (element.Kind == PanelElementKind.Alpha)
+                    {
+                        document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, cellBrightness);
+                    }
+                    else
+                    {
+                        document.RuntimeState.SetSegmentCellBrightnessIfChanged(machineReference, [1d]);
+                    }
+                }
+
                 if (maskChanged || brightnessChanged)
                 {
                     changedObjectIds.Add(objectId);
                 }
             }
 
+            foreach (var faceDisplay in document.GetFaceElements().OfType<FaceSevenSegmentDisplayElement>())
+            {
+                if (string.IsNullOrWhiteSpace(faceDisplay.ObjectId)
+                    || faceDisplay.LinkedMachineObjectReference is not MachineObjectReference reference
+                    || reference.Kind != MachineObjectKind.SevenSegmentDisplay
+                    || reference.IsEmpty
+                    || !int.TryParse(reference.Id, out var cellId)
+                    || !_latestDigitMasksByCell.TryGetValue(cellId, out var mask))
+                {
+                    continue;
+                }
+
+                var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(reference, [mask]);
+                var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, [1d]);
+                if (maskChanged || brightnessChanged)
+                {
+                    changedFaceObjectIds.Add(faceDisplay.ObjectId);
+                }
+            }
+
             if (changedObjectIds.Count > 0)
             {
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);
+            }
+
+            if (changedFaceObjectIds.Count > 0)
+            {
+                document.NotifyFaceVisualPreviewChanged(changedFaceObjectIds);
             }
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -41,6 +41,11 @@ public sealed class Face2DRenderer : IFace2DRenderer
             DrawLampWindow(canvas, lampWindow, runtimeState, viewportTransform);
         }
 
+        foreach (var sevenSegmentDisplay in elements.OfType<FaceSevenSegmentDisplayElement>())
+        {
+            DrawSevenSegmentDisplay(canvas, sevenSegmentDisplay, runtimeState, viewportTransform);
+        }
+
         foreach (var button in elements.OfType<FaceButtonElement>())
         {
             DrawButton(canvas, button, viewportTransform);
@@ -99,6 +104,27 @@ public sealed class Face2DRenderer : IFace2DRenderer
         using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = strokeColor, StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
         canvas.DrawRect(rect, fillPaint);
         canvas.DrawRect(rect, strokePaint);
+    }
+
+
+    private void DrawSevenSegmentDisplay(SKCanvas canvas, FaceSevenSegmentDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
+    {
+        var rect = ToRect(element);
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var masks = _runtimeStateResolver.GetSevenSegmentCellMasks(element, runtimeState);
+        var brightness = _runtimeStateResolver.GetSevenSegmentCellBrightness(element, runtimeState);
+        SevenSegmentElementRenderer.RenderSegmentDisplay(canvas, rect, masks, brightness, element.OnColorHex, element.OffColorHex);
     }
 
     private static void DrawButton(SKCanvas canvas, FaceButtonElement element, PanelViewportTransform viewport)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -32,27 +32,41 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
             return;
         }
 
+        var masks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 1);
+        var brightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 1);
+        RenderSegmentDisplay(context.Canvas, bounds, masks, brightness, element.OnColorHex, element.OffColorHex);
+    }
+
+    internal static void RenderSegmentDisplay(SKCanvas canvas, SKRect bounds, int[] masks, double[] brightness, string? onColorHex, string? offColorHex)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
         var definition = Definition.Value;
         if (definition is null)
         {
             return;
         }
 
-        var masks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 1);
-        var brightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 1);
         var defaultMask = BuildDefaultMask(definition.Segments);
         var segmentMask = masks.Length > 0 ? masks[0] : defaultMask;
         var litAmount = brightness.Length > 0 ? Math.Clamp(brightness[0], 0d, 1d) : 1d;
 
-        var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
-        var offColor = ScaleBrightness(onColor, 0.10d);
+        var onColor = SkiaColorParser.ParseOrDefault(onColorHex, new SKColor(255, 64, 64));
+        var offColor = string.IsNullOrWhiteSpace(offColorHex)
+            ? ScaleBrightness(onColor, 0.10d)
+            : SkiaColorParser.ParseOrDefault(offColorHex, ScaleBrightness(onColor, 0.10d));
 
         var width = Math.Max(1, (int)Math.Round(bounds.Width));
         var height = Math.Max(1, (int)Math.Round(bounds.Height));
         var brightnessBucket = (int)Math.Round(Math.Clamp(litAmount, 0d, 1d) * 4d);
         var cacheKey = new SegmentVisualCacheKey(width, height, segmentMask, brightnessBucket, onColor, offColor);
         var visual = GetOrCreateVisual(cacheKey, definition);
-        context.Canvas.DrawImage(visual, bounds.Left, bounds.Top);
+        canvas.DrawImage(visual, bounds.Left, bounds.Top);
     }
 
     private static SKImage GetOrCreateVisual(SegmentVisualCacheKey cacheKey, SevenSegmentSkiaDefinition definition)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -290,17 +290,16 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             return;
         }
 
-        var faceLampIds = _faceDocumentModel.Elements
-            .OfType<FaceLampWindowElement>()
+        var faceRuntimeElementIds = _faceDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
                 && element.LinkedMachineObjectReference is MachineObjectReference reference
-                && reference.Kind == MachineObjectKind.Lamp
+                && reference.Kind is MachineObjectKind.Lamp or MachineObjectKind.SevenSegmentDisplay
                 && !reference.IsEmpty)
             .Select(element => element.ObjectId)
             .ToHashSet(StringComparer.Ordinal);
 
         var publishedObjectIds = changedObjectIds
-            .Where(objectId => !string.IsNullOrWhiteSpace(objectId) && faceLampIds.Contains(objectId))
+            .Where(objectId => !string.IsNullOrWhiteSpace(objectId) && faceRuntimeElementIds.Contains(objectId))
             .Distinct(StringComparer.Ordinal)
             .ToArray();
         if (publishedObjectIds.Length == 0)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -24,6 +24,10 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
             .OfType<FaceLampWindowElement>()
             .Select((element, index) => CreateElementItem(element, index, "Lamp Window", "lampWindow"))
             .ToArray();
+        var sevenSegmentDisplays = faceDocument.GetFaceElements()
+            .OfType<FaceSevenSegmentDisplayElement>()
+            .Select((element, index) => CreateElementItem(element, index, "Seven Segment Display", "sevenSegmentDisplay"))
+            .ToArray();
         var buttons = faceDocument.GetFaceElements()
             .OfType<FaceButtonElement>()
             .Select((element, index) => CreateElementItem(element, index, "Button", "button"))
@@ -38,6 +42,11 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
         if (lampWindows.Length > 0)
         {
             groups.Add(new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows));
+        }
+
+        if (sevenSegmentDisplays.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Seven Segment Displays ({sevenSegmentDisplays.Length})", "group:sevenSegmentDisplay", isGroup: true, children: sevenSegmentDisplays));
         }
 
         if (buttons.Length > 0)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
+using OasisEditor.Rendering;
 
 namespace OasisEditor.Views;
 
@@ -60,6 +61,7 @@ public partial class SkiaFaceEditView : UserControl
         if (_subscribedDocument is not null)
         {
             _subscribedDocument.PanelChanged -= OnDocumentChanged;
+            _subscribedDocument.FaceVisualStateChanged -= OnDocumentFaceVisualStateChanged;
             _subscribedDocument.PropertyChanged -= OnDocumentPropertyChanged;
         }
 
@@ -70,10 +72,16 @@ public partial class SkiaFaceEditView : UserControl
         }
 
         _subscribedDocument.PanelChanged += OnDocumentChanged;
+        _subscribedDocument.FaceVisualStateChanged += OnDocumentFaceVisualStateChanged;
         _subscribedDocument.PropertyChanged += OnDocumentPropertyChanged;
     }
 
     private void OnDocumentChanged(PanelChangeEvent _)
+    {
+        RequestRender();
+    }
+
+    private void OnDocumentFaceVisualStateChanged(FaceVisualStateChangedEvent _)
     {
         RequestRender();
     }
@@ -162,6 +170,12 @@ public partial class SkiaFaceEditView : UserControl
         foreach (var element in document.GetFaceElements().Where(element => element is not FaceArtworkElement))
         {
             var rect = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
+            if (element is FaceSevenSegmentDisplayElement sevenSegmentDisplay)
+            {
+                DrawSevenSegmentElement(canvas, document, sevenSegmentDisplay, rect, hiddenPaint);
+                continue;
+            }
+
             if (element.IsVisible)
             {
                 canvas.DrawRect(rect, fillPaint);
@@ -190,6 +204,24 @@ public partial class SkiaFaceEditView : UserControl
                 (float)Math.Max(0d, selectedElement.Height),
                 selectionPaint);
         }
+    }
+
+    private static void DrawSevenSegmentElement(SKCanvas canvas, DocumentTabViewModel document, FaceSevenSegmentDisplayElement element, SKRect rect, SKPaint hiddenPaint)
+    {
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var masks = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellMasks(element, document.RuntimeState);
+        var brightness = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellBrightness(element, document.RuntimeState);
+        SevenSegmentElementRenderer.RenderSegmentDisplay(canvas, rect, masks, brightness, element.OnColorHex, element.OffColorHex);
     }
 
     private static void DrawArtworkElement(SKCanvas canvas, FaceArtworkElement element, PanelViewportTransform viewport, SKPaint hiddenPaint)


### PR DESCRIPTION
### Motivation

- Provide a minimal, first-class seven-segment display element in Face documents so physical displays can be modeled, generated, persisted, and rendered without using Panel2D element IDs as runtime identity.
- Ensure runtime updates for seven-segment digit output flow through `MachineObjectReference` -> `MachineRuntimeState` so Face views reflect live MAME output and runtime identity is shared across representations.

### Description

- Introduced `FaceSevenSegmentDisplayElement` with MVP metadata (`OnColorHex`, `OffColorHex`, `ShowDecimalPoint`) to the Face model. (`FaceDocumentModel`)
- Added serialization/deserialization support for the new element (file-level DTO fields and conversions). (`FaceDocumentStorage`)
- Face generation now converts contained Panel2D seven-segment elements into `FaceSevenSegmentDisplayElement` while preserving `MachineObjectReference` and `LinkedPanel2DElementId` as provenance. (`FaceGenerationService`)
- Face Edit View and Face Play View render seven-segment elements using the shared Skia-based segment renderer via a new resolver path. (`SkiaFaceEditView`, `Face2DRenderer`, `SevenSegmentElementRenderer`, `FaceRuntimeStateResolver`)
- MAME segment runtime plumbing updated so digit output updates Face seven-segment displays through `MachineObjectReference.SevenSegmentDisplay` and `MachineRuntimeState` (adds machine-object keyed segment masks/brightness updates and notifies face visuals). (`MameSegmentRuntimeAdapter`, runtime state accesses)
- Hooked Face visual invalidation so face play/edit surfaces re-render on seven-segment state changes and included hierarchy entries for seven-seg elements. (`DocumentTabViewModel`, `FaceHierarchyProvider`, `FaceElementServices`)
- Added unit tests covering round-trip persistence, generation, runtime-resolution, and MAME adapter integration for seven-segment behavior. (tests under `OasisEditor.Tests`)
- Marked Phase 9A complete in the architecture plan. (`FACE_SYSTEM_ARCHITECTURE_PLAN.md`)

### Testing

- Added/updated unit tests: `FaceDocumentRoundTripTests`, `FaceGenerationServiceTests`, `FaceRuntimeStateResolverTests`, and `MameSegmentRuntimeAdapterTests` to cover serialization, generation, runtime resolution, and live update behavior; tests were added to the test project but not executed in this environment. (files in `OasisEditor.Tests`)
- Ran `git diff --check` to verify no whitespace/diff issues after changes (passed in the environment). 
- Attempted `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` but the `dotnet` CLI is not available in this environment so automated test execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a251b5ebef48327b7b57e3badeddb11)