### PR TITLE
Add Face alpha display MVP

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -531,15 +531,19 @@ FaceSevenSegmentDisplayElement
 
 Do not use `LinkedPanel2DElementId` for Face Play View runtime behavior. Retain it only for provenance, generation workflows, and editor workflows.
 
-### Phase 9B - Alpha Display MVP - Future
+### Phase 9B - Alpha Display MVP - Complete
 
-Goals:
+Completed at MVP level.
 
-- add `FaceAlphaDisplayElement` as the dedicated Face element for alpha display visuals;
-- generate Face alpha display elements from Panel2D alpha displays;
-- update Face alpha display visuals through `MachineRuntimeState`;
-- render alpha displays in Face Edit View;
-- render alpha displays in Face Play View.
+Outcome:
+
+- `FaceAlphaDisplayElement` is now the dedicated Face element for alpha display visuals;
+- generated Face documents create alpha display Face elements from contained Panel2D alpha displays;
+- alpha Face elements serialize/deserialize with machine-object references, provenance-only Panel2D element links, display type, color, decimal-point, comma-tail, and reversal metadata;
+- Face Edit View renders alpha display elements from `MachineRuntimeState`;
+- Face Play View renders alpha display elements from `MachineRuntimeState`;
+- MAME VFD/segment output updates Face alpha displays live through `MachineObjectReference.AlphaDisplay`;
+- existing lamp, seven-segment, and input behavior remain unchanged.
 
 Runtime rule:
 
@@ -656,7 +660,7 @@ Completed MVP checks that should continue to be regression-tested:
 Future phase verification should focus on:
 
 - Phase 9A: complete - seven-segment displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
-- Phase 9B: alpha displays generate and render from `MachineRuntimeState` through machine-object references;
+- Phase 9B: complete - alpha displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
 - Phase 9C: reel displays generate and render from `MachineRuntimeState` through machine-object references, with correctness prioritized over animation fidelity;
 - Phase 10: Face regeneration uses provenance metadata while preserving runtime identity through machine-object references;
 - Phase 11: visual-fidelity improvements do not change document/runtime identity contracts;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -202,4 +202,55 @@ public sealed class FaceDocumentRoundTripTests
         Assert.True(element.ShowDecimalPoint);
     }
 
+    [Fact]
+    public void Serialize_AndRead_RoundTripsAlphaDisplayElement()
+    {
+        var source = new FaceDocumentModel
+        {
+            Id = "face-alpha-doc",
+            Title = "Alpha Face",
+            Elements =
+            [
+                new FaceAlphaDisplayElement
+                {
+                    ObjectId = "face-alpha-4",
+                    Name = "Alpha 4",
+                    X = 1,
+                    Y = 2,
+                    Width = 160,
+                    Height = 32,
+                    LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(4),
+                    LinkedPanel2DElementId = "panel-alpha-4",
+                    SegmentDisplayType = "bfm16seg",
+                    OnColorHex = "#FF4040",
+                    OffColorHex = "#200808",
+                    ShowDecimalPoint = true,
+                    ShowCommaTail = true,
+                    IsReversed = true
+                }
+            ]
+        };
+
+        var json = FaceDocumentStorage.Serialize(source);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var stored = Assert.Single(file.Elements!);
+        Assert.Equal("alphaDisplay", stored.Kind);
+        Assert.Equal("alpha:4", stored.LinkedMachineObjectReference);
+        Assert.Equal("panel-alpha-4", stored.LinkedPanel2DElementId);
+        Assert.Equal("bfm16seg", stored.SegmentDisplayType);
+        Assert.True(stored.ShowCommaTail);
+        Assert.True(stored.IsReversed);
+
+        var model = FaceDocumentStorage.ToModel(file);
+        var alpha = Assert.IsType<FaceAlphaDisplayElement>(Assert.Single(model.Elements));
+        Assert.Equal("alpha:4", alpha.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("panel-alpha-4", alpha.LinkedPanel2DElementId);
+        Assert.Equal("bfm16seg", alpha.SegmentDisplayType);
+        Assert.Equal("#FF4040", alpha.OnColorHex);
+        Assert.Equal("#200808", alpha.OffColorHex);
+        Assert.True(alpha.ShowDecimalPoint);
+        Assert.True(alpha.ShowCommaTail);
+        Assert.True(alpha.IsReversed);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -249,4 +249,36 @@ public sealed class FaceGenerationServiceTests
         Assert.True(element.IsReversed);
     }
 
+    [Fact]
+    public void GenerateFromPanelRegion_ConvertsAlphaWithoutDisplayNumberToDefaultMachineReference()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "alpha-no-number",
+                    Name = "Segment Alpha",
+                    Kind = PanelElementKind.Alpha,
+                    X = 125,
+                    Y = 235,
+                    Width = 160,
+                    Height = 32,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 220, 120)),
+            "Generated Face",
+            "panel-doc-1");
+
+        var element = Assert.IsType<FaceAlphaDisplayElement>(result.Document.Elements[1]);
+        Assert.Equal("alpha:0", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("alpha-no-number", element.LinkedPanel2DElementId);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -199,4 +199,54 @@ public sealed class FaceGenerationServiceTests
         Assert.True(element.ShowDecimalPoint);
     }
 
+    [Fact]
+    public void GenerateFromPanelRegion_ConvertsContainedAlphaDisplaysWithMachineReferences()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "alpha-10",
+                    Name = "Message Display",
+                    Kind = PanelElementKind.Alpha,
+                    X = 125,
+                    Y = 235,
+                    Width = 160,
+                    Height = 32,
+                    DisplayNumber = 10,
+                    SegmentDisplayType = "bfm16seg",
+                    OnColorHex = "#FF4040",
+                    OffColorHex = "#200808",
+                    ShowDecimalPoint = true,
+                    ShowCommaTail = true,
+                    IsReversed = true,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 220, 120)),
+            "Generated Face",
+            "panel-doc-1");
+
+        Assert.Equal(1, result.ConvertedAlphaDisplayCount);
+        var element = Assert.IsType<FaceAlphaDisplayElement>(result.Document.Elements[1]);
+        Assert.Equal("face-alpha-10", element.ObjectId);
+        Assert.Equal("Message Display", element.Name);
+        Assert.Equal(25d, element.X);
+        Assert.Equal(35d, element.Y);
+        Assert.Equal("alpha:10", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("alpha-10", element.LinkedPanel2DElementId);
+        Assert.Equal("bfm16seg", element.SegmentDisplayType);
+        Assert.Equal("#FF4040", element.OnColorHex);
+        Assert.Equal("#200808", element.OffColorHex);
+        Assert.True(element.ShowDecimalPoint);
+        Assert.True(element.ShowCommaTail);
+        Assert.True(element.IsReversed);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
@@ -75,4 +75,39 @@ public sealed class FaceRuntimeStateResolverTests
         Assert.Equal(0, masks[0]);
     }
 
+    [Fact]
+    public void GetAlphaCellMasks_UsesMachineObjectReference()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetSegmentCellMasksIfChanged(MachineObjectReference.AlphaDisplay(10), [1, 2, 3]);
+        runtimeState.SetSegmentCellMasksIfChanged("panel-alpha-10", [9, 9, 9]);
+        var display = new FaceAlphaDisplayElement
+        {
+            ObjectId = "face-alpha-10",
+            LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(10),
+            LinkedPanel2DElementId = "panel-alpha-10"
+        };
+
+        var masks = FaceRuntimeStateResolver.Instance.GetAlphaCellMasks(display, runtimeState);
+
+        Assert.Equal(new[] { 1, 2, 3 }, masks);
+    }
+
+    [Fact]
+    public void GetAlphaCellMasks_IgnoresLinkedPanel2DElementIdWhenMachineReferenceIsMissing()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetSegmentCellMasksIfChanged("panel-alpha-10", [9, 9, 9]);
+        var display = new FaceAlphaDisplayElement
+        {
+            ObjectId = "face-alpha-10",
+            LinkedPanel2DElementId = "panel-alpha-10"
+        };
+
+        var masks = FaceRuntimeStateResolver.Instance.GetAlphaCellMasks(display, runtimeState);
+
+        Assert.Equal(16, masks.Length);
+        Assert.All(masks, mask => Assert.Equal(0, mask));
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineObjectReferenceResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineObjectReferenceResolverTests.cs
@@ -26,6 +26,22 @@ public sealed class MachineObjectReferenceResolverTests
         Assert.Equal(expectedId, reference.Id);
     }
 
+    [Fact]
+    public void TryGetReference_AlphaWithoutDisplayNumber_DefaultsToFirstAlphaDisplay()
+    {
+        var element = new PanelElementModel
+        {
+            ObjectId = "alpha-visual-1",
+            Kind = PanelElementKind.Alpha
+        };
+
+        var resolved = MachineObjectReferenceResolver.Instance.TryGetReference(element, out var reference);
+
+        Assert.True(resolved);
+        Assert.Equal(MachineObjectKind.AlphaDisplay, reference.Kind);
+        Assert.Equal("0", reference.Id);
+    }
+
     private static PanelElementKind ResolvePanelElementKind(string kindName)
     {
         return kindName switch

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -62,6 +62,16 @@ public sealed class FaceSevenSegmentDisplayElement : FaceElementModel
     public bool ShowDecimalPoint { get; init; }
 }
 
+public sealed class FaceAlphaDisplayElement : FaceElementModel
+{
+    public string? SegmentDisplayType { get; init; }
+    public string? OnColorHex { get; init; }
+    public string? OffColorHex { get; init; }
+    public bool ShowDecimalPoint { get; init; }
+    public bool ShowCommaTail { get; init; }
+    public bool IsReversed { get; init; }
+}
+
 public sealed class FaceButtonElement : FaceElementModel
 {
     public MachineInputReference? LinkedInputReference { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -272,6 +272,30 @@ public static class FaceDocumentStorage
             };
         }
 
+        if (string.Equals(file.Kind, "alphaDisplay", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(file.Kind, "alpha", StringComparison.OrdinalIgnoreCase))
+        {
+            return new FaceAlphaDisplayElement
+            {
+                ObjectId = file.ObjectId ?? string.Empty,
+                Name = file.Name ?? string.Empty,
+                X = file.X,
+                Y = file.Y,
+                Width = file.Width,
+                Height = file.Height,
+                IsVisible = file.IsVisible,
+                IsLocked = file.IsLocked,
+                LinkedMachineObjectReference = reference,
+                LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+                SegmentDisplayType = file.SegmentDisplayType,
+                OnColorHex = file.OnColorHex,
+                OffColorHex = file.OffColorHex,
+                ShowDecimalPoint = file.ShowDecimalPoint,
+                ShowCommaTail = file.ShowCommaTail,
+                IsReversed = file.IsReversed
+            };
+        }
+
         if (string.Equals(file.Kind, "button", StringComparison.OrdinalIgnoreCase))
         {
             var linkedInputReference = ResolveInputReference(file.LinkedInputReference, reference);
@@ -352,6 +376,7 @@ public static class FaceDocumentStorage
             {
                 FaceArtworkElement => "artwork",
                 FaceButtonElement => "button",
+                FaceAlphaDisplayElement => "alphaDisplay",
                 FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
                 FaceLampWindowElement => "lampWindow",
                 _ => "unknown"
@@ -365,9 +390,12 @@ public static class FaceDocumentStorage
             LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
             LinkedPanel2DElementId = model.LinkedPanel2DElementId,
             LinkedInputReference = model is FaceButtonElement button ? button.LinkedInputReference?.ToString() : null,
-            OnColorHex = model is FaceSevenSegmentDisplayElement sevenSegment ? sevenSegment.OnColorHex : null,
-            OffColorHex = model is FaceSevenSegmentDisplayElement sevenSegmentOff ? sevenSegmentOff.OffColorHex : null,
-            ShowDecimalPoint = model is FaceSevenSegmentDisplayElement sevenSegmentDecimal && sevenSegmentDecimal.ShowDecimalPoint,
+            OnColorHex = model switch { FaceSevenSegmentDisplayElement sevenSegment => sevenSegment.OnColorHex, FaceAlphaDisplayElement alpha => alpha.OnColorHex, _ => null },
+            OffColorHex = model switch { FaceSevenSegmentDisplayElement sevenSegment => sevenSegment.OffColorHex, FaceAlphaDisplayElement alpha => alpha.OffColorHex, _ => null },
+            ShowDecimalPoint = model switch { FaceSevenSegmentDisplayElement sevenSegment => sevenSegment.ShowDecimalPoint, FaceAlphaDisplayElement alpha => alpha.ShowDecimalPoint, _ => false },
+            ShowCommaTail = model is FaceAlphaDisplayElement alphaComma && alphaComma.ShowCommaTail,
+            IsReversed = model is FaceAlphaDisplayElement alphaReversed && alphaReversed.IsReversed,
+            SegmentDisplayType = model is FaceAlphaDisplayElement alphaDisplay ? alphaDisplay.SegmentDisplayType : null,
             AssetPath = model is FaceArtworkElement artwork ? artwork.AssetPath : null,
             SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
@@ -441,6 +469,9 @@ public sealed record FaceElementFile
     public string? OnColorHex { get; init; }
     public string? OffColorHex { get; init; }
     public bool ShowDecimalPoint { get; init; }
+    public bool ShowCommaTail { get; init; }
+    public bool IsReversed { get; init; }
+    public string? SegmentDisplayType { get; init; }
     public string? AssetPath { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -77,6 +77,25 @@ internal static class FaceElementModelUpdater
                 OffColorHex = sevenSegmentDisplay.OffColorHex,
                 ShowDecimalPoint = sevenSegmentDisplay.ShowDecimalPoint
             },
+            FaceAlphaDisplayElement alphaDisplay => new FaceAlphaDisplayElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                SegmentDisplayType = alphaDisplay.SegmentDisplayType,
+                OnColorHex = alphaDisplay.OnColorHex,
+                OffColorHex = alphaDisplay.OffColorHex,
+                ShowDecimalPoint = alphaDisplay.ShowDecimalPoint,
+                ShowCommaTail = alphaDisplay.ShowCommaTail,
+                IsReversed = alphaDisplay.IsReversed
+            },
             FaceButtonElement button => new FaceButtonElement
             {
                 ObjectId = existing.ObjectId,
@@ -171,6 +190,7 @@ internal static class FaceSelectionService
             FaceArtworkElement => "artwork",
             FaceButtonElement => "button",
             FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
+            FaceAlphaDisplayElement => "alphaDisplay",
             FaceLampWindowElement => "lampWindow",
             _ => "unknown"
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -50,13 +50,14 @@ public sealed class FaceSourceRegionModel
 
 internal sealed class FaceGenerationResult
 {
-    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount, int convertedSevenSegmentDisplayCount)
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount, int convertedSevenSegmentDisplayCount, int convertedAlphaDisplayCount)
     {
         Document = document;
         ConvertedLampCount = convertedLampCount;
         ArtworkElementCount = artworkElementCount;
         ConvertedButtonCount = convertedButtonCount;
         ConvertedSevenSegmentDisplayCount = convertedSevenSegmentDisplayCount;
+        ConvertedAlphaDisplayCount = convertedAlphaDisplayCount;
     }
 
     public FaceDocumentModel Document { get; }
@@ -64,6 +65,7 @@ internal sealed class FaceGenerationResult
     public int ArtworkElementCount { get; }
     public int ConvertedButtonCount { get; }
     public int ConvertedSevenSegmentDisplayCount { get; }
+    public int ConvertedAlphaDisplayCount { get; }
 }
 
 internal sealed class FaceGenerationService
@@ -99,6 +101,10 @@ internal sealed class FaceGenerationService
         var sevenSegmentDisplays = sourcePanel.Elements
             .Where(element => element.Kind == PanelElementKind.SevenSegment && IsContainedBy(element, region))
             .Select(element => CreateSevenSegmentDisplay(element, region))
+            .ToArray();
+        var alphaDisplays = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Alpha && IsContainedBy(element, region))
+            .Select(element => CreateAlphaDisplay(element, region))
             .ToArray();
         var buttons = CreateButtonElements(sourcePanel, region, inputDefinitions ?? []);
 
@@ -137,10 +143,10 @@ internal sealed class FaceGenerationService
                     IsVisible = true
                 }
             ],
-            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(sevenSegmentDisplays).Concat(buttons).ToArray()
+            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray()
         };
 
-        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length);
+        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length, alphaDisplays.Length);
     }
 
     private static FaceArtworkElement[] CreateArtworkElements(
@@ -248,6 +254,31 @@ internal sealed class FaceGenerationService
             OnColorHex = sourceElement.OnColorHex,
             OffColorHex = sourceElement.OffColorHex,
             ShowDecimalPoint = sourceElement.ShowDecimalPoint
+        };
+    }
+
+    private FaceAlphaDisplayElement CreateAlphaDisplay(PanelElementModel sourceElement, Rect region)
+    {
+        _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
+
+        return new FaceAlphaDisplayElement
+        {
+            ObjectId = CreateGeneratedElementId(sourceElement),
+            Name = string.IsNullOrWhiteSpace(sourceElement.Name) ? "Alpha Display" : sourceElement.Name.Trim(),
+            X = Math.Round(sourceElement.X - region.X, 2),
+            Y = Math.Round(sourceElement.Y - region.Y, 2),
+            Width = Math.Round(sourceElement.Width, 2),
+            Height = Math.Round(sourceElement.Height, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            SegmentDisplayType = sourceElement.SegmentDisplayType,
+            OnColorHex = sourceElement.OnColorHex,
+            OffColorHex = sourceElement.OffColorHex,
+            ShowDecimalPoint = sourceElement.ShowDecimalPoint,
+            ShowCommaTail = sourceElement.ShowCommaTail,
+            IsReversed = sourceElement.IsReversed == true
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -5,8 +5,11 @@ public interface IFaceRuntimeStateResolver
     bool TryGetLampReference(FaceLampWindowElement lampWindow, out MachineObjectReference reference);
     double GetLampIntensity(FaceLampWindowElement lampWindow, MachineRuntimeState runtimeState);
     bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference);
+    bool TryGetAlphaDisplayReference(FaceAlphaDisplayElement display, out MachineObjectReference reference);
     int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState);
     double[] GetSevenSegmentCellBrightness(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState);
+    int[] GetAlphaCellMasks(FaceAlphaDisplayElement display, MachineRuntimeState runtimeState);
+    double[] GetAlphaCellBrightness(FaceAlphaDisplayElement display, MachineRuntimeState runtimeState);
 }
 
 public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
@@ -41,6 +44,13 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         return reference.Kind == MachineObjectKind.SevenSegmentDisplay && !reference.IsEmpty;
     }
 
+    public bool TryGetAlphaDisplayReference(FaceAlphaDisplayElement display, out MachineObjectReference reference)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        reference = display.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
+        return reference.Kind == MachineObjectKind.AlphaDisplay && !reference.IsEmpty;
+    }
+
     public int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState)
     {
         ArgumentNullException.ThrowIfNull(display);
@@ -59,5 +69,25 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         return TryGetSevenSegmentDisplayReference(display, out var reference)
             ? runtimeState.GetSegmentCellBrightness(reference, 1)
             : [1d];
+    }
+
+    public int[] GetAlphaCellMasks(FaceAlphaDisplayElement display, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        return TryGetAlphaDisplayReference(display, out var reference)
+            ? runtimeState.GetSegmentCellMasks(reference, 16)
+            : new int[16];
+    }
+
+    public double[] GetAlphaCellBrightness(FaceAlphaDisplayElement display, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        return TryGetAlphaDisplayReference(display, out var reference)
+            ? runtimeState.GetSegmentCellBrightness(reference, 16)
+            : Enumerable.Repeat(1d, 16).ToArray();
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineObjectReferenceResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineObjectReferenceResolver.cs
@@ -19,6 +19,12 @@ internal sealed class MachineObjectReferenceResolver : IMachineObjectReferenceRe
         ArgumentNullException.ThrowIfNull(element);
         reference = MachineObjectReference.Empty;
 
+        if (element.Kind == PanelElementKind.Alpha)
+        {
+            reference = MachineObjectReference.AlphaDisplay(element.DisplayNumber.GetValueOrDefault(0));
+            return !reference.IsEmpty;
+        }
+
         if (!element.DisplayNumber.HasValue)
         {
             return false;
@@ -28,7 +34,6 @@ internal sealed class MachineObjectReferenceResolver : IMachineObjectReferenceRe
         {
             PanelElementKind.Lamp => MachineObjectReference.Lamp(element.DisplayNumber.Value),
             PanelElementKind.Reel => MachineObjectReference.Reel(element.DisplayNumber.Value),
-            PanelElementKind.Alpha => MachineObjectReference.AlphaDisplay(element.DisplayNumber.Value),
             PanelElementKind.SevenSegment => MachineObjectReference.SevenSegmentDisplay(element.DisplayNumber.Value),
             _ => MachineObjectReference.Empty
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -156,6 +156,41 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 }
             }
 
+            foreach (var faceDisplay in document.GetFaceElements().OfType<FaceAlphaDisplayElement>())
+            {
+                if (string.IsNullOrWhiteSpace(faceDisplay.ObjectId)
+                    || faceDisplay.LinkedMachineObjectReference is not MachineObjectReference reference
+                    || reference.Kind != MachineObjectKind.AlphaDisplay
+                    || reference.IsEmpty
+                    || !int.TryParse(reference.Id, out var baseIndex))
+                {
+                    continue;
+                }
+
+                var cellMasks = new int[16];
+                var cellBrightness = new double[16];
+                var reversePlatformAlphaCells = RequiresPlatformAlphaCellReversal(_platformProvider());
+                for (var i = 0; i < cellMasks.Length; i++)
+                {
+                    var sourceOffset = reversePlatformAlphaCells ? cellMasks.Length - 1 - i : i;
+                    if (_latestVfdMasksByCell.TryGetValue(baseIndex + sourceOffset, out var mask))
+                    {
+                        cellMasks[i] = NormalizeMameMaskForSelectedDisplayType(mask, faceDisplay.SegmentDisplayType);
+                    }
+
+                    cellBrightness[i] = _latestVfdBrightnessByDisplay.TryGetValue(baseIndex, out var brightness)
+                        ? brightness
+                        : 1d;
+                }
+
+                var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(reference, cellMasks);
+                var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, cellBrightness);
+                if (maskChanged || brightnessChanged || changedMachineReferences.Contains(reference))
+                {
+                    changedFaceObjectIds.Add(faceDisplay.ObjectId);
+                }
+            }
+
             if (changedObjectIds.Count > 0)
             {
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -31,22 +31,56 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         }
 
         var displayType = string.IsNullOrWhiteSpace(element.SegmentDisplayType) ? "led16seg" : element.SegmentDisplayType!;
+        var cellMasks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 16);
+        var cellBrightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 16);
+        RenderAlphaDisplay(
+            context.Canvas,
+            bounds,
+            cellMasks,
+            cellBrightness,
+            displayType,
+            element.OnColorHex,
+            element.OffColorHex,
+            element.ShowDecimalPoint,
+            element.ShowCommaTail,
+            element.IsReversed == true);
+    }
+
+    internal static void RenderAlphaDisplay(
+        SKCanvas canvas,
+        SKRect bounds,
+        int[] cellMasks,
+        double[] cellBrightness,
+        string? displayType,
+        string? onColorHex,
+        string? offColorHex,
+        bool showDecimalPoint,
+        bool showCommaTail,
+        bool isReversed)
+    {
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        displayType = string.IsNullOrWhiteSpace(displayType) ? "led16seg" : displayType.Trim();
         var definition = GetDefinition(displayType);
         if (definition is null)
         {
             return;
         }
 
-        var cellMasks = context.RuntimeState.GetSegmentCellMasks(element.ObjectId, 16);
+        cellMasks ??= [];
+        cellBrightness ??= [];
         var defaultMask = BuildDefaultMask(definition);
-        var cellBrightness = context.RuntimeState.GetSegmentCellBrightness(element.ObjectId, 16);
 
-        var onColor = SkiaColorParser.ParseOrDefault(element.OnColorHex, new SKColor(255, 64, 64));
+        _ = offColorHex;
+        var onColor = SkiaColorParser.ParseOrDefault(onColorHex, new SKColor(255, 64, 64));
         var offColor = ScaleBrightness(onColor, 0.10d);
         var backgroundColor = ScaleBrightness(onColor, 0.04d);
 
         using var backgroundPaint = new SKPaint { Color = backgroundColor, Style = SKPaintStyle.Fill, IsAntialias = true };
-        context.Canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
+        canvas.DrawRoundRect(bounds, 2f, 2f, backgroundPaint);
 
         var marginX = bounds.Width * 0.05f;
         var marginY = bounds.Height * 0.1f;
@@ -70,14 +104,14 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
 
         for (var cellIndex = 0; cellIndex < cellCount; cellIndex++)
         {
-            var dataIndex = element.IsReversed == true ? (cellCount - 1 - cellIndex) : cellIndex;
+            var dataIndex = isReversed ? (cellCount - 1 - cellIndex) : cellIndex;
             var mask = dataIndex < cellMasks.Length ? cellMasks[dataIndex] : defaultMask;
             var litAmount = dataIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[dataIndex], 0d, 1d) : 1d;
             var brightnessBucket = (int)Math.Round(litAmount * 4d);
-            var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor, element.ShowDecimalPoint, element.ShowCommaTail);
+            var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor, showDecimalPoint, showCommaTail);
             var visual = GetOrCreateVisual(key, definition);
             var cellRect = SKRect.Create(originX + (cellIndex * scaledPitch), originY, scaledCellWidth, scaledCellHeight);
-            context.Canvas.DrawImage(visual, cellRect);
+            canvas.DrawImage(visual, cellRect);
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -46,6 +46,11 @@ public sealed class Face2DRenderer : IFace2DRenderer
             DrawSevenSegmentDisplay(canvas, sevenSegmentDisplay, runtimeState, viewportTransform);
         }
 
+        foreach (var alphaDisplay in elements.OfType<FaceAlphaDisplayElement>())
+        {
+            DrawAlphaDisplay(canvas, alphaDisplay, runtimeState, viewportTransform);
+        }
+
         foreach (var button in elements.OfType<FaceButtonElement>())
         {
             DrawButton(canvas, button, viewportTransform);
@@ -125,6 +130,36 @@ public sealed class Face2DRenderer : IFace2DRenderer
         var masks = _runtimeStateResolver.GetSevenSegmentCellMasks(element, runtimeState);
         var brightness = _runtimeStateResolver.GetSevenSegmentCellBrightness(element, runtimeState);
         SevenSegmentElementRenderer.RenderSegmentDisplay(canvas, rect, masks, brightness, element.OnColorHex, element.OffColorHex);
+    }
+
+    private void DrawAlphaDisplay(SKCanvas canvas, FaceAlphaDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
+    {
+        var rect = ToRect(element);
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var masks = _runtimeStateResolver.GetAlphaCellMasks(element, runtimeState);
+        var brightness = _runtimeStateResolver.GetAlphaCellBrightness(element, runtimeState);
+        AlphaElementRenderer.RenderAlphaDisplay(
+            canvas,
+            rect,
+            masks,
+            brightness,
+            element.SegmentDisplayType,
+            element.OnColorHex,
+            element.OffColorHex,
+            element.ShowDecimalPoint,
+            element.ShowCommaTail,
+            element.IsReversed);
     }
 
     private static void DrawButton(SKCanvas canvas, FaceButtonElement element, PanelViewportTransform viewport)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -293,7 +293,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         var faceRuntimeElementIds = _faceDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
                 && element.LinkedMachineObjectReference is MachineObjectReference reference
-                && reference.Kind is MachineObjectKind.Lamp or MachineObjectKind.SevenSegmentDisplay
+                && reference.Kind is MachineObjectKind.Lamp or MachineObjectKind.SevenSegmentDisplay or MachineObjectKind.AlphaDisplay
                 && !reference.IsEmpty)
             .Select(element => element.ObjectId)
             .ToHashSet(StringComparer.Ordinal);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -127,8 +127,8 @@ public sealed class DocumentWorkspaceViewModel
         var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
-        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), and {result.ConvertedButtonCount} button(s).");
-        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
+        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
+        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
         return document;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -28,6 +28,10 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
             .OfType<FaceSevenSegmentDisplayElement>()
             .Select((element, index) => CreateElementItem(element, index, "Seven Segment Display", "sevenSegmentDisplay"))
             .ToArray();
+        var alphaDisplays = faceDocument.GetFaceElements()
+            .OfType<FaceAlphaDisplayElement>()
+            .Select((element, index) => CreateElementItem(element, index, "Alpha Display", "alphaDisplay"))
+            .ToArray();
         var buttons = faceDocument.GetFaceElements()
             .OfType<FaceButtonElement>()
             .Select((element, index) => CreateElementItem(element, index, "Button", "button"))
@@ -47,6 +51,11 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
         if (sevenSegmentDisplays.Length > 0)
         {
             groups.Add(new HierarchyItemViewModel($"Seven Segment Displays ({sevenSegmentDisplays.Length})", "group:sevenSegmentDisplay", isGroup: true, children: sevenSegmentDisplays));
+        }
+
+        if (alphaDisplays.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Alpha Displays ({alphaDisplays.Length})", "group:alphaDisplay", isGroup: true, children: alphaDisplays));
         }
 
         if (buttons.Length > 0)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -898,6 +898,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             FaceArtworkElement => "Face Artwork",
             FaceLampWindowElement => "Face Lamp Window",
+            FaceSevenSegmentDisplayElement => "Face Seven Segment Display",
+            FaceAlphaDisplayElement => "Face Alpha Display",
+            FaceButtonElement => "Face Button",
             _ => "Face Element"
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -176,6 +176,12 @@ public partial class SkiaFaceEditView : UserControl
                 continue;
             }
 
+            if (element is FaceAlphaDisplayElement alphaDisplay)
+            {
+                DrawAlphaElement(canvas, document, alphaDisplay, rect, hiddenPaint);
+                continue;
+            }
+
             if (element.IsVisible)
             {
                 canvas.DrawRect(rect, fillPaint);
@@ -222,6 +228,34 @@ public partial class SkiaFaceEditView : UserControl
         var masks = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellMasks(element, document.RuntimeState);
         var brightness = FaceRuntimeStateResolver.Instance.GetSevenSegmentCellBrightness(element, document.RuntimeState);
         SevenSegmentElementRenderer.RenderSegmentDisplay(canvas, rect, masks, brightness, element.OnColorHex, element.OffColorHex);
+    }
+
+    private static void DrawAlphaElement(SKCanvas canvas, DocumentTabViewModel document, FaceAlphaDisplayElement element, SKRect rect, SKPaint hiddenPaint)
+    {
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var masks = FaceRuntimeStateResolver.Instance.GetAlphaCellMasks(element, document.RuntimeState);
+        var brightness = FaceRuntimeStateResolver.Instance.GetAlphaCellBrightness(element, document.RuntimeState);
+        AlphaElementRenderer.RenderAlphaDisplay(
+            canvas,
+            rect,
+            masks,
+            brightness,
+            element.SegmentDisplayType,
+            element.OnColorHex,
+            element.OffColorHex,
+            element.ShowDecimalPoint,
+            element.ShowCommaTail,
+            element.IsReversed);
     }
 
     private static void DrawArtworkElement(SKCanvas canvas, FaceArtworkElement element, PanelViewportTransform viewport, SKPaint hiddenPaint)


### PR DESCRIPTION
### Motivation

- Implement Phase 9B (Alpha Display MVP) so Face documents can natively represent alpha/VFD displays and render them from live runtime state via machine-level references instead of relying on Panel2D provenance IDs.

### Description

- Add `FaceAlphaDisplayElement` with metadata (`SegmentDisplayType`, `OnColorHex`, `OffColorHex`, `ShowDecimalPoint`, `ShowCommaTail`, `IsReversed`) and persist it as the `alphaDisplay` kind in `FaceDocumentStorage`, while retaining `LinkedPanel2DElementId` as provenance only.
- Extend `FaceGenerationService.GenerateFromPanelRegion` to convert `PanelElementKind.Alpha` elements into `FaceAlphaDisplayElement` and populate `LinkedMachineObjectReference` using `MachineObjectReference` resolution.
- Wire runtime resolution and rendering: add `GetAlphaCellMasks`/`GetAlphaCellBrightness` to `FaceRuntimeStateResolver`, update `MameSegmentRuntimeAdapter` to populate `MachineRuntimeState` for alpha displays, and reuse `AlphaElementRenderer.RenderAlphaDisplay` from the Panel2D renderer in both `Face2DRenderer` and `SkiaFaceEditView` to draw alpha cells from `MachineRuntimeState`.
- Add unit tests for generation, serialization/round-trip, and runtime resolution of alpha displays and update the architecture plan (`FACE_SYSTEM_ARCHITECTURE_PLAN.md`) to mark Phase 9B complete.

### Testing

- Ran `git diff --check` to validate diffs and whitespace; it passed.
- Attempted to run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` but `dotnet` is not installed in this environment so tests could not be executed here; the PR includes new and updated tests under `OasisEditor.Tests` that should be run by CI with the .NET SDK.
- New automated tests added: `FaceGenerationServiceTests` (alpha generation), `FaceDocumentRoundTripTests` (alpha persistence/round-trip), and `FaceRuntimeStateResolverTests` (alpha runtime resolution).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2542510468832791864732519d67c0)