### PR TITLE
Face: Add Reel Display MVP (Phase 9C)

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -555,20 +555,24 @@ FaceAlphaDisplayElement
 
 Do not use `LinkedPanel2DElementId` for Face Play View runtime behavior. Retain it only for provenance, generation workflows, and editor workflows.
 
-### Phase 9C - Reel Display MVP - Future
+### Phase 9C - Reel Display MVP - Complete
 
-Goals:
+Completed at MVP level.
 
-- add `FaceReelDisplayElement` as the dedicated Face element for reel display/window visuals;
-- generate Face reel display elements from Panel2D reels;
-- update Face reel visuals through `MachineRuntimeState`;
-- render reel displays in Face Edit View;
-- render reel displays in Face Play View.
+Outcome:
+
+- `FaceReelDisplayElement` is now the dedicated Face element for reel display/window visuals;
+- generated Face documents create reel display Face elements from contained Panel2D reels;
+- reel display Face elements serialize/deserialize with machine-object references, provenance-only Panel2D element links, reel strip asset path, stops, visible scale, band offset, and reversal metadata;
+- Face Edit View renders reel display elements from `MachineRuntimeState`;
+- Face Play View renders reel display elements from `MachineRuntimeState`;
+- MAME reel output updates Face reel displays live through `MachineObjectReference.Reel`;
+- existing lamp, input, seven-segment display, and alpha display behavior remain unchanged.
 
 Notes:
 
-- reel animation fidelity is not required initially;
-- focus on correctness and runtime plumbing before presentation polish.
+- reel animation fidelity remains intentionally out of scope for the MVP;
+- runtime plumbing correctness is prioritized over presentation polish.
 
 Runtime rule:
 
@@ -661,7 +665,7 @@ Future phase verification should focus on:
 
 - Phase 9A: complete - seven-segment displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
 - Phase 9B: complete - alpha displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
-- Phase 9C: reel displays generate and render from `MachineRuntimeState` through machine-object references, with correctness prioritized over animation fidelity;
+- Phase 9C: complete - reel displays serialize, generate, and render from `MachineRuntimeState` through machine-object references, with correctness prioritized over animation fidelity;
 - Phase 10: Face regeneration uses provenance metadata while preserving runtime identity through machine-object references;
 - Phase 11: visual-fidelity improvements do not change document/runtime identity contracts;
 - Phase 12: 3D preview investigation does not introduce renderer-specific document coupling;
@@ -689,3 +693,25 @@ Do not start implementation beyond the current requested phase unless instructed
 Preserve the completed Face MVP architecture when adding future phases: runtime behavior flows through machine-object references and `MachineRuntimeState`; `LinkedPanel2DElementId` remains provenance/editor/generation data only.
 
 John will test/review after each phase before continuing.
+
+## Manual Verification Steps - Phase 9C Reel Display MVP
+
+1. Open an Oasis project containing a Panel2D document with at least one reel element that has a valid display/reel number.
+2. Generate a Face document from a region that fully contains the Panel2D reel.
+3. Confirm the generated Face hierarchy includes a Reel Displays group and a generated reel display element.
+4. Save the Face document, close it, reopen it, and confirm the reel display persists with its machine reference (`reel:<number>`) and provenance-only `LinkedPanel2DElementId`.
+5. Open the Face document in Face Edit View and confirm the reel window renders as either the configured reel strip image or the MVP placeholder strip.
+6. Open the same Face document in Face Play View and confirm the same reel display renders.
+7. Start MAME for the machine and confirm reel output changes move/update the Face reel display live.
+8. Confirm lamps, inputs/buttons, seven-segment displays, and alpha displays still update exactly as they did before Phase 9C.
+9. Inspect a generated reel display and confirm runtime behavior still resolves through `MachineObjectReference.Reel` and `MachineRuntimeState`; `LinkedPanel2DElementId` should only identify the source Panel2D element for provenance/editor workflows.
+
+## Runtime Display Consolidation Recommendations Before Face Regeneration
+
+Before implementing Face Regeneration, add a focused Runtime Display Consolidation phase to reduce duplicated display plumbing while preserving the established runtime contract. Recommended scope:
+
+- introduce a small shared renderer-facing adapter/helper for Face and Panel2D runtime displays so reels, seven-segment displays, and alpha displays consistently resolve `MachineObjectReference` values before rendering;
+- clarify whether `MachineRuntimeState` reel positions are raw machine positions, platform-normalized positions, or visual-effective positions, then document that contract before regeneration starts preserving/reusing reel metadata;
+- centralize common Face display metadata serialization patterns so future display types do not repeatedly update storage, generation, hierarchy, selection, renderer, and runtime resolver code by hand;
+- keep `LinkedPanel2DElementId` as generation/regeneration provenance only and add regression tests for every runtime display type to prevent accidental fallback to Panel2D element IDs;
+- add a lightweight display notification helper so MAME adapters can publish Face visual invalidations by machine reference without duplicating per-display matching code.

--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -567,6 +567,7 @@ Outcome:
 - Face Edit View renders reel display elements from `MachineRuntimeState`;
 - Face Play View renders reel display elements from `MachineRuntimeState`;
 - MAME reel output updates Face reel displays live through `MachineObjectReference.Reel`;
+- Face reel displays apply the same MVP platform/stop internal reel offsets used by Panel2D reel rendering so Impact, MPU4, Scorpion4, and other stop-count-specific adjustments stay aligned between Panel2D and Face views;
 - existing lamp, input, seven-segment display, and alpha display behavior remain unchanged.
 
 Notes:
@@ -700,9 +701,9 @@ John will test/review after each phase before continuing.
 2. Generate a Face document from a region that fully contains the Panel2D reel.
 3. Confirm the generated Face hierarchy includes a Reel Displays group and a generated reel display element.
 4. Save the Face document, close it, reopen it, and confirm the reel display persists with its machine reference (`reel:<number>`) and provenance-only `LinkedPanel2DElementId`.
-5. Open the Face document in Face Edit View and confirm the reel window renders as either the configured reel strip image or the MVP placeholder strip.
+5. Open the Face document in Face Edit View and confirm the reel window renders as either the configured reel strip image or the MVP placeholder strip, with the same platform/stop offset alignment as the source Panel2D reel.
 6. Open the same Face document in Face Play View and confirm the same reel display renders.
-7. Start MAME for the machine and confirm reel output changes move/update the Face reel display live.
+7. Start MAME for the machine and confirm reel output changes move/update the Face reel display live and remains visually aligned with the corresponding Panel2D reel position for the selected fruit-machine platform and reel stop count.
 8. Confirm lamps, inputs/buttons, seven-segment displays, and alpha displays still update exactly as they did before Phase 9C.
 9. Inspect a generated reel display and confirm runtime behavior still resolves through `MachineObjectReference.Reel` and `MachineRuntimeState`; `LinkedPanel2DElementId` should only identify the source Panel2D element for provenance/editor workflows.
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
@@ -1,0 +1,143 @@
+using System.Windows;
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceReelDisplayTests
+{
+    [Fact]
+    public void GenerateFromPanelRegion_ConvertsContainedReelsWithMachineReferences()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "reel-2",
+                    Name = "Reel 2",
+                    Kind = PanelElementKind.Reel,
+                    X = 120,
+                    Y = 230,
+                    Width = 48,
+                    Height = 120,
+                    DisplayNumber = 2,
+                    AssetPath = "Assets/Reels/reel2.png",
+                    Stops = 16,
+                    VisibleScale = 0.33d,
+                    BandOffset = 0.125d,
+                    IsReversed = true,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(100, 200, 200, 200)),
+            "Generated Face",
+            "panel-doc-1");
+
+        Assert.Equal(1, result.ConvertedReelDisplayCount);
+        var element = Assert.IsType<FaceReelDisplayElement>(result.Document.Elements[1]);
+        Assert.Equal("face-reel-2", element.ObjectId);
+        Assert.Equal("Reel 2", element.Name);
+        Assert.Equal(20d, element.X);
+        Assert.Equal(30d, element.Y);
+        Assert.Equal("reel:2", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("reel-2", element.LinkedPanel2DElementId);
+        Assert.Equal("Assets/Reels/reel2.png", element.AssetPath);
+        Assert.Equal(16, element.Stops);
+        Assert.Equal(0.33d, element.VisibleScale);
+        Assert.Equal(0.125d, element.BandOffset);
+        Assert.True(element.IsReversed);
+    }
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsReelDisplayElement()
+    {
+        var source = new FaceDocumentModel
+        {
+            Id = "face-reel-doc",
+            Title = "Reel Face",
+            Elements =
+            [
+                new FaceReelDisplayElement
+                {
+                    ObjectId = "face-reel-2",
+                    Name = "Reel 2",
+                    X = 1,
+                    Y = 2,
+                    Width = 50,
+                    Height = 120,
+                    IsVisible = true,
+                    IsLocked = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Reel(2),
+                    LinkedPanel2DElementId = "panel-reel-2",
+                    AssetPath = "Assets/Reels/reel2.png",
+                    Stops = 16,
+                    VisibleScale = 0.5d,
+                    BandOffset = 0.25d,
+                    IsReversed = true
+                }
+            ]
+        };
+
+        var json = FaceDocumentStorage.Serialize(source);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var saved = Assert.Single(file.Elements!);
+        Assert.Equal("reelDisplay", saved.Kind);
+        Assert.Equal("reel:2", saved.LinkedMachineObjectReference);
+        Assert.Equal("panel-reel-2", saved.LinkedPanel2DElementId);
+        Assert.Equal("Assets/Reels/reel2.png", saved.AssetPath);
+        Assert.Equal(16, saved.Stops);
+        Assert.Equal(0.5d, saved.VisibleScale);
+        Assert.Equal(0.25d, saved.BandOffset);
+        Assert.True(saved.IsReversed);
+
+        var model = FaceDocumentStorage.ToModel(file);
+        var element = Assert.IsType<FaceReelDisplayElement>(Assert.Single(model.Elements));
+        Assert.Equal("reel:2", element.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("panel-reel-2", element.LinkedPanel2DElementId);
+        Assert.Equal("Assets/Reels/reel2.png", element.AssetPath);
+        Assert.Equal(16, element.Stops);
+        Assert.Equal(0.5d, element.VisibleScale);
+        Assert.Equal(0.25d, element.BandOffset);
+        Assert.True(element.IsReversed);
+    }
+
+    [Fact]
+    public void RuntimeResolver_UsesMachineReferenceAndIgnoresLinkedPanelElementId()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetReelPositionIfChanged(MachineObjectReference.Reel(2), 83d);
+        runtimeState.SetReelPositionIfChanged("panel-reel-2", 12d);
+        var reel = new FaceReelDisplayElement
+        {
+            ObjectId = "face-reel-2",
+            LinkedMachineObjectReference = MachineObjectReference.Reel(2),
+            LinkedPanel2DElementId = "panel-reel-2"
+        };
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(reel, runtimeState);
+
+        Assert.Equal(83d, position);
+    }
+
+    [Fact]
+    public void RuntimeResolver_ReturnsZeroWhenOnlyLinkedPanelElementIdHasState()
+    {
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetReelPositionIfChanged("panel-reel-2", 12d);
+        var reel = new FaceReelDisplayElement
+        {
+            ObjectId = "face-reel-2",
+            LinkedPanel2DElementId = "panel-reel-2"
+        };
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(reel, runtimeState);
+
+        Assert.Equal(0d, position);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
@@ -140,4 +140,44 @@ public sealed class FaceReelDisplayTests
 
         Assert.Equal(0d, position);
     }
+    [Fact]
+    public void RuntimeResolver_AppliesPlatformAndStopOffsetToMachineReferencePosition()
+    {
+        var runtimeState = new MachineRuntimeState
+        {
+            FruitMachinePlatform = FruitMachinePlatformType.Impact
+        };
+        runtimeState.SetReelPositionIfChanged(MachineObjectReference.Reel(2), 0d);
+        var reel = new FaceReelDisplayElement
+        {
+            ObjectId = "face-reel-2",
+            LinkedMachineObjectReference = MachineObjectReference.Reel(2),
+            Stops = 16
+        };
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(reel, runtimeState);
+
+        Assert.Equal(88.32d, position, 2);
+    }
+
+    [Fact]
+    public void RuntimeResolver_AppliesMpu4PlatformReversalLikePanelReels()
+    {
+        var runtimeState = new MachineRuntimeState
+        {
+            FruitMachinePlatform = FruitMachinePlatformType.MPU4
+        };
+        runtimeState.SetReelPositionIfChanged(MachineObjectReference.Reel(2), 12d);
+        var reel = new FaceReelDisplayElement
+        {
+            ObjectId = "face-reel-2",
+            LinkedMachineObjectReference = MachineObjectReference.Reel(2),
+            Stops = 16
+        };
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(reel, runtimeState);
+
+        Assert.Equal(79.2d, position, 2);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
@@ -18,4 +18,70 @@ public sealed class MameReelRuntimeAdapterTests
 
         Assert.Equal(expected, actual, 6);
     }
+    [Fact]
+    public void ApplyReelState_UpdatesFaceReelDisplaysByMachineObjectReference()
+    {
+        var document = CreateFaceDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MameReelRuntimeAdapter(
+            () => [document],
+            () => FruitMachinePlatformType.None,
+            () => false,
+            _ => { },
+            action => dispatches.Add(action));
+        FaceVisualStateChangedEvent? changedEvent = null;
+        document.FaceVisualStateChanged += ev => changedEvent = ev;
+
+        adapter.ApplyReelState(2, 83);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        Assert.Equal(83d, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(2)));
+        Assert.NotNull(changedEvent);
+        Assert.Contains("face-reel-2", changedEvent!.ObjectIds);
+    }
+
+    [Fact]
+    public void ApplyReelState_DoesNotUpdateFaceReelDisplayFromLinkedPanel2DElementIdOnly()
+    {
+        var document = CreateFaceDocument(machineReference: MachineObjectReference.Empty, linkedPanel2DElementId: "panel-reel-2");
+        var dispatches = new List<Action>();
+        var adapter = new MameReelRuntimeAdapter(
+            () => [document],
+            () => FruitMachinePlatformType.None,
+            () => false,
+            _ => { },
+            action => dispatches.Add(action));
+        var eventCount = 0;
+        document.FaceVisualStateChanged += _ => eventCount++;
+
+        adapter.ApplyReelState(2, 83);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        Assert.Equal(83d, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(2)));
+        Assert.Equal(0, eventCount);
+    }
+
+    private static DocumentTabViewModel CreateFaceDocument(MachineObjectReference? machineReference = null, string? linkedPanel2DElementId = null)
+    {
+        var faceDocument = EditorDocument.CreateFromFile(
+            "face.face",
+            "face",
+            "face");
+        var tab = new DocumentTabViewModel(faceDocument);
+        tab.SetFaceElements(
+        [
+            new FaceReelDisplayElement
+            {
+                ObjectId = "face-reel-2",
+                LinkedMachineObjectReference = machineReference ?? MachineObjectReference.Reel(2),
+                LinkedPanel2DElementId = linkedPanel2DElementId
+            }
+        ]);
+        return tab;
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
@@ -25,7 +25,7 @@ public sealed class MameReelRuntimeAdapterTests
         var dispatches = new List<Action>();
         var adapter = new MameReelRuntimeAdapter(
             () => [document],
-            () => FruitMachinePlatformType.None,
+            () => FruitMachinePlatformType.Impact,
             () => false,
             _ => { },
             action => dispatches.Add(action));
@@ -37,7 +37,10 @@ public sealed class MameReelRuntimeAdapterTests
         var dispatch = Assert.Single(dispatches);
         dispatch();
 
+        Assert.Equal(FruitMachinePlatformType.Impact, document.RuntimeState.FruitMachinePlatform);
         Assert.Equal(83d, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(2)));
+        var faceReel = Assert.IsType<FaceReelDisplayElement>(Assert.Single(document.GetFaceElements()));
+        Assert.Equal(75.32d, FaceRuntimeStateResolver.Instance.GetReelPosition(faceReel, document.RuntimeState), 2);
         Assert.NotNull(changedEvent);
         Assert.Contains("face-reel-2", changedEvent!.ObjectIds);
     }
@@ -78,7 +81,8 @@ public sealed class MameReelRuntimeAdapterTests
             {
                 ObjectId = "face-reel-2",
                 LinkedMachineObjectReference = machineReference ?? MachineObjectReference.Reel(2),
-                LinkedPanel2DElementId = linkedPanel2DElementId
+                LinkedPanel2DElementId = linkedPanel2DElementId,
+                Stops = 16
             }
         ]);
         return tab;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -55,6 +55,15 @@ public sealed class FaceLampWindowElement : FaceElementModel
 {
 }
 
+public sealed class FaceReelDisplayElement : FaceElementModel
+{
+    public string? AssetPath { get; init; }
+    public int? Stops { get; init; }
+    public double? VisibleScale { get; init; }
+    public double? BandOffset { get; init; }
+    public bool IsReversed { get; init; }
+}
+
 public sealed class FaceSevenSegmentDisplayElement : FaceElementModel
 {
     public string? OnColorHex { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -251,6 +251,29 @@ public static class FaceDocumentStorage
             };
         }
 
+        if (string.Equals(file.Kind, "reelDisplay", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(file.Kind, "reel", StringComparison.OrdinalIgnoreCase))
+        {
+            return new FaceReelDisplayElement
+            {
+                ObjectId = file.ObjectId ?? string.Empty,
+                Name = file.Name ?? string.Empty,
+                X = file.X,
+                Y = file.Y,
+                Width = file.Width,
+                Height = file.Height,
+                IsVisible = file.IsVisible,
+                IsLocked = file.IsLocked,
+                LinkedMachineObjectReference = reference,
+                LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+                AssetPath = file.AssetPath,
+                Stops = file.Stops,
+                VisibleScale = file.VisibleScale,
+                BandOffset = file.BandOffset,
+                IsReversed = file.IsReversed
+            };
+        }
+
         if (string.Equals(file.Kind, "sevenSegmentDisplay", StringComparison.OrdinalIgnoreCase)
             || string.Equals(file.Kind, "sevenSegment", StringComparison.OrdinalIgnoreCase))
         {
@@ -376,6 +399,7 @@ public static class FaceDocumentStorage
             {
                 FaceArtworkElement => "artwork",
                 FaceButtonElement => "button",
+                FaceReelDisplayElement => "reelDisplay",
                 FaceAlphaDisplayElement => "alphaDisplay",
                 FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
                 FaceLampWindowElement => "lampWindow",
@@ -394,9 +418,12 @@ public static class FaceDocumentStorage
             OffColorHex = model switch { FaceSevenSegmentDisplayElement sevenSegment => sevenSegment.OffColorHex, FaceAlphaDisplayElement alpha => alpha.OffColorHex, _ => null },
             ShowDecimalPoint = model switch { FaceSevenSegmentDisplayElement sevenSegment => sevenSegment.ShowDecimalPoint, FaceAlphaDisplayElement alpha => alpha.ShowDecimalPoint, _ => false },
             ShowCommaTail = model is FaceAlphaDisplayElement alphaComma && alphaComma.ShowCommaTail,
-            IsReversed = model is FaceAlphaDisplayElement alphaReversed && alphaReversed.IsReversed,
+            IsReversed = model switch { FaceAlphaDisplayElement alphaReversed => alphaReversed.IsReversed, FaceReelDisplayElement reelReversed => reelReversed.IsReversed, _ => false },
             SegmentDisplayType = model is FaceAlphaDisplayElement alphaDisplay ? alphaDisplay.SegmentDisplayType : null,
-            AssetPath = model is FaceArtworkElement artwork ? artwork.AssetPath : null,
+            Stops = model is FaceReelDisplayElement reelDisplay ? reelDisplay.Stops : null,
+            VisibleScale = model is FaceReelDisplayElement reelVisibleScale ? reelVisibleScale.VisibleScale : null,
+            BandOffset = model is FaceReelDisplayElement reelBandOffset ? reelBandOffset.BandOffset : null,
+            AssetPath = model switch { FaceArtworkElement artwork => artwork.AssetPath, FaceReelDisplayElement reel => reel.AssetPath, _ => null },
             SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
             ArtworkProvenance = model is FaceArtworkElement artworkProvenance ? ToFile(artworkProvenance.Provenance) : null
@@ -472,6 +499,9 @@ public sealed record FaceElementFile
     public bool ShowCommaTail { get; init; }
     public bool IsReversed { get; init; }
     public string? SegmentDisplayType { get; init; }
+    public int? Stops { get; init; }
+    public double? VisibleScale { get; init; }
+    public double? BandOffset { get; init; }
     public string? AssetPath { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -48,6 +48,24 @@ internal static class FaceElementModelUpdater
                 SourceRegion = artwork.SourceRegion,
                 Provenance = artwork.Provenance
             },
+            FaceReelDisplayElement reelDisplay => new FaceReelDisplayElement
+            {
+                ObjectId = existing.ObjectId,
+                Name = update.Name ?? existing.Name,
+                X = update.X ?? existing.X,
+                Y = update.Y ?? existing.Y,
+                Width = update.Width ?? existing.Width,
+                Height = update.Height ?? existing.Height,
+                IsVisible = update.IsVisible ?? existing.IsVisible,
+                IsLocked = update.IsLocked ?? existing.IsLocked,
+                LinkedMachineObjectReference = linkedMachineObjectReference,
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                AssetPath = reelDisplay.AssetPath,
+                Stops = reelDisplay.Stops,
+                VisibleScale = reelDisplay.VisibleScale,
+                BandOffset = reelDisplay.BandOffset,
+                IsReversed = reelDisplay.IsReversed
+            },
             FaceLampWindowElement => new FaceLampWindowElement
             {
                 ObjectId = existing.ObjectId,
@@ -189,6 +207,7 @@ internal static class FaceSelectionService
         {
             FaceArtworkElement => "artwork",
             FaceButtonElement => "button",
+            FaceReelDisplayElement => "reelDisplay",
             FaceSevenSegmentDisplayElement => "sevenSegmentDisplay",
             FaceAlphaDisplayElement => "alphaDisplay",
             FaceLampWindowElement => "lampWindow",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -50,7 +50,7 @@ public sealed class FaceSourceRegionModel
 
 internal sealed class FaceGenerationResult
 {
-    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount, int convertedSevenSegmentDisplayCount, int convertedAlphaDisplayCount)
+    public FaceGenerationResult(FaceDocumentModel document, int convertedLampCount, int artworkElementCount, int convertedButtonCount, int convertedSevenSegmentDisplayCount, int convertedAlphaDisplayCount, int convertedReelDisplayCount)
     {
         Document = document;
         ConvertedLampCount = convertedLampCount;
@@ -58,6 +58,7 @@ internal sealed class FaceGenerationResult
         ConvertedButtonCount = convertedButtonCount;
         ConvertedSevenSegmentDisplayCount = convertedSevenSegmentDisplayCount;
         ConvertedAlphaDisplayCount = convertedAlphaDisplayCount;
+        ConvertedReelDisplayCount = convertedReelDisplayCount;
     }
 
     public FaceDocumentModel Document { get; }
@@ -66,6 +67,7 @@ internal sealed class FaceGenerationResult
     public int ConvertedButtonCount { get; }
     public int ConvertedSevenSegmentDisplayCount { get; }
     public int ConvertedAlphaDisplayCount { get; }
+    public int ConvertedReelDisplayCount { get; }
 }
 
 internal sealed class FaceGenerationService
@@ -97,6 +99,10 @@ internal sealed class FaceGenerationService
         var lampWindows = sourcePanel.Elements
             .Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region))
             .Select(element => CreateLampWindow(element, region))
+            .ToArray();
+        var reelDisplays = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Reel && IsContainedBy(element, region))
+            .Select(element => CreateReelDisplay(element, region))
             .ToArray();
         var sevenSegmentDisplays = sourcePanel.Elements
             .Where(element => element.Kind == PanelElementKind.SevenSegment && IsContainedBy(element, region))
@@ -143,10 +149,10 @@ internal sealed class FaceGenerationService
                     IsVisible = true
                 }
             ],
-            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray()
+            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(reelDisplays).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray()
         };
 
-        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length, alphaDisplays.Length);
+        return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length, alphaDisplays.Length, reelDisplays.Length);
     }
 
     private static FaceArtworkElement[] CreateArtworkElements(
@@ -232,6 +238,30 @@ internal sealed class FaceGenerationService
             IsLocked = sourceElement.IsLocked,
             LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
             LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId
+        };
+    }
+
+    private FaceReelDisplayElement CreateReelDisplay(PanelElementModel sourceElement, Rect region)
+    {
+        _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
+
+        return new FaceReelDisplayElement
+        {
+            ObjectId = CreateGeneratedElementId(sourceElement),
+            Name = string.IsNullOrWhiteSpace(sourceElement.Name) ? "Reel Display" : sourceElement.Name.Trim(),
+            X = Math.Round(sourceElement.X - region.X, 2),
+            Y = Math.Round(sourceElement.Y - region.Y, 2),
+            Width = Math.Round(sourceElement.Width, 2),
+            Height = Math.Round(sourceElement.Height, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            AssetPath = sourceElement.AssetPath,
+            Stops = sourceElement.Stops,
+            VisibleScale = sourceElement.VisibleScale,
+            BandOffset = sourceElement.BandOffset,
+            IsReversed = sourceElement.IsReversed == true
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -4,6 +4,8 @@ public interface IFaceRuntimeStateResolver
 {
     bool TryGetLampReference(FaceLampWindowElement lampWindow, out MachineObjectReference reference);
     double GetLampIntensity(FaceLampWindowElement lampWindow, MachineRuntimeState runtimeState);
+    bool TryGetReelDisplayReference(FaceReelDisplayElement reelDisplay, out MachineObjectReference reference);
+    double GetReelPosition(FaceReelDisplayElement reelDisplay, MachineRuntimeState runtimeState);
     bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference);
     bool TryGetAlphaDisplayReference(FaceAlphaDisplayElement display, out MachineObjectReference reference);
     int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState);
@@ -35,6 +37,30 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         return TryGetLampReference(lampWindow, out var reference)
             ? runtimeState.GetLampIntensity(reference)
             : 0d;
+    }
+
+    public bool TryGetReelDisplayReference(FaceReelDisplayElement reelDisplay, out MachineObjectReference reference)
+    {
+        ArgumentNullException.ThrowIfNull(reelDisplay);
+        reference = reelDisplay.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
+        return reference.Kind == MachineObjectKind.Reel && !reference.IsEmpty;
+    }
+
+    public double GetReelPosition(FaceReelDisplayElement reelDisplay, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(reelDisplay);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        var position = TryGetReelDisplayReference(reelDisplay, out var reference)
+            ? runtimeState.GetReelPosition(reference)
+            : 0d;
+        var offset = reelDisplay.BandOffset.GetValueOrDefault(0d) * 96d;
+        if (reelDisplay.IsReversed && position != 0d)
+        {
+            position = 96d - (((position % 96d) + 96d) % 96d);
+        }
+
+        return position + offset;
     }
 
     public bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -51,16 +51,35 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         ArgumentNullException.ThrowIfNull(reelDisplay);
         ArgumentNullException.ThrowIfNull(runtimeState);
 
-        var position = TryGetReelDisplayReference(reelDisplay, out var reference)
+        var rawPosition = TryGetReelDisplayReference(reelDisplay, out var reference)
             ? runtimeState.GetReelPosition(reference)
             : 0d;
-        var offset = reelDisplay.BandOffset.GetValueOrDefault(0d) * 96d;
-        if (reelDisplay.IsReversed && position != 0d)
-        {
-            position = 96d - (((position % 96d) + 96d) % 96d);
-        }
 
-        return position + offset;
+        return ResolveEffectiveReelPosition(
+            rawPosition,
+            reelDisplay.Stops.GetValueOrDefault(1),
+            reelDisplay.IsReversed,
+            reelDisplay.BandOffset.GetValueOrDefault(0d),
+            runtimeState.FruitMachinePlatform);
+    }
+
+    internal static double ResolveEffectiveReelPosition(double rawReelPosition, int stops, bool reelReversed, double reelBandOffset, FruitMachinePlatformType platform)
+    {
+        const double positionsPerRevolution = 96d;
+        var safeStops = Math.Max(1, stops);
+        var wrapped = ((rawReelPosition % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
+        var shouldReverse = RequiresPlatformReversal(platform) ^ reelReversed;
+        var directionAdjusted = shouldReverse && wrapped != 0d
+            ? positionsPerRevolution - wrapped
+            : wrapped;
+        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(platform, safeStops);
+        var offsetAdjusted = directionAdjusted + ((platformOffset + reelBandOffset) * positionsPerRevolution);
+        return ((offsetAdjusted % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
+    }
+
+    private static bool RequiresPlatformReversal(FruitMachinePlatformType platform)
+    {
+        return platform == FruitMachinePlatformType.MPU4;
     }
 
     public bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
@@ -14,6 +14,7 @@ public class MachineRuntimeState
     private readonly Dictionary<string, double[]> _segmentBrightnessByMachineObjectId = new(StringComparer.Ordinal);
 
     public string? LampTestObjectId { get; set; }
+    public FruitMachinePlatformType FruitMachinePlatform { get; set; } = FruitMachinePlatformType.None;
 
     public bool IsLampTestActive => !string.IsNullOrWhiteSpace(LampTestObjectId);
 
@@ -213,6 +214,7 @@ public class MachineRuntimeState
     public void Clear()
     {
         LampTestObjectId = null;
+        FruitMachinePlatform = FruitMachinePlatformType.None;
         _lampIntensityByObjectId.Clear();
         _reelPositionByObjectId.Clear();
         _temporaryReelOffsetByObjectId.Clear();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -497,6 +497,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 return;
             }
 
+            foreach (var document in OpenDocuments)
+            {
+                document.RuntimeState.FruitMachinePlatform = value;
+                var faceReelObjectIds = document.GetFaceElements()
+                    .OfType<FaceReelDisplayElement>()
+                    .Select(element => element.ObjectId)
+                    .Where(objectId => !string.IsNullOrWhiteSpace(objectId))
+                    .ToArray();
+                document.NotifyFaceVisualPreviewChanged(faceReelObjectIds);
+            }
+
             if (LoadedProject is not null)
             {
                 LoadedProject.FruitMachinePlatform = value;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -65,8 +65,10 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         var documents = _documentProvider().ToArray();
         PruneDocumentCaches(documents);
 
+        var platform = _platformProvider();
         foreach (var document in documents)
         {
+            document.RuntimeState.FruitMachinePlatform = platform;
             var objectIdsByReel = GetOrBuildReelMapping(document);
             var faceObjectIdsByReel = GetFaceReelMapping(document);
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -68,11 +68,23 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         foreach (var document in documents)
         {
             var objectIdsByReel = GetOrBuildReelMapping(document);
+            var faceObjectIdsByReel = GetFaceReelMapping(document);
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+            var changedFaceObjectIds = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var (reelId, reelValue) in snapshot)
             {
                 var reelReference = MachineObjectReference.Reel(reelId);
+                var machinePosition = ResolveMachineReelPosition(reelValue);
+                if (document.RuntimeState.SetReelPositionIfChanged(reelReference, machinePosition)
+                    && faceObjectIdsByReel.TryGetValue(reelReference, out var matchingFaceObjectIds))
+                {
+                    foreach (var faceObjectId in matchingFaceObjectIds)
+                    {
+                        changedFaceObjectIds.Add(faceObjectId);
+                    }
+                }
+
                 if (!objectIdsByReel.TryGetValue(reelReference, out var objectIds) || objectIds.Length == 0)
                 {
                     continue;
@@ -101,6 +113,11 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
             {
                 document.NotifyPanelVisualPreviewChanged(changedObjectIds);
             }
+
+            if (changedFaceObjectIds.Count > 0)
+            {
+                document.NotifyFaceVisualPreviewChanged(changedFaceObjectIds);
+            }
         }
     }
 
@@ -114,6 +131,22 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
                 staleEntry.Detach();
             }
         }
+    }
+
+    private static IReadOnlyDictionary<MachineObjectReference, string[]> GetFaceReelMapping(DocumentTabViewModel document)
+    {
+        return document.GetFaceElements()
+            .OfType<FaceReelDisplayElement>()
+            .Select(element => new
+            {
+                Element = element,
+                Reference = element.LinkedMachineObjectReference ?? MachineObjectReference.Empty
+            })
+            .Where(item => !string.IsNullOrWhiteSpace(item.Element.ObjectId)
+                && item.Reference.Kind == MachineObjectKind.Reel
+                && !item.Reference.IsEmpty)
+            .GroupBy(item => item.Reference, item => item.Element)
+            .ToDictionary(group => group.Key, group => group.Select(element => element.ObjectId).Distinct(StringComparer.Ordinal).ToArray());
     }
 
     private IReadOnlyDictionary<MachineObjectReference, string[]> GetOrBuildReelMapping(DocumentTabViewModel document)
@@ -143,6 +176,11 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
 
         cacheEntry.Replace(mapping);
         return cacheEntry.MappingByReelId;
+    }
+
+    private static double ResolveMachineReelPosition(int rawReelValue)
+    {
+        return ((rawReelValue % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
     }
 
     private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, out double effectiveReelPosition, out int stops, out double normalizedPosition)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -41,6 +41,11 @@ public sealed class Face2DRenderer : IFace2DRenderer
             DrawLampWindow(canvas, lampWindow, runtimeState, viewportTransform);
         }
 
+        foreach (var reelDisplay in elements.OfType<FaceReelDisplayElement>())
+        {
+            DrawReelDisplay(canvas, reelDisplay, runtimeState, viewportTransform);
+        }
+
         foreach (var sevenSegmentDisplay in elements.OfType<FaceSevenSegmentDisplayElement>())
         {
             DrawSevenSegmentDisplay(canvas, sevenSegmentDisplay, runtimeState, viewportTransform);
@@ -111,6 +116,25 @@ public sealed class Face2DRenderer : IFace2DRenderer
         canvas.DrawRect(rect, strokePaint);
     }
 
+
+    private void DrawReelDisplay(SKCanvas canvas, FaceReelDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
+    {
+        var rect = ToRect(element);
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var position = _runtimeStateResolver.GetReelPosition(element, runtimeState);
+        ReelElementRenderer.RenderReelDisplay(canvas, rect, element.AssetPath, position, element.Stops.GetValueOrDefault(1), element.VisibleScale);
+    }
 
     private void DrawSevenSegmentDisplay(SKCanvas canvas, FaceSevenSegmentDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -21,26 +21,37 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
 
         var stops = Math.Max(1, element.Stops.GetValueOrDefault(1));
         var reelPosition = context.RuntimeState.GetEffectiveReelPosition(element.ObjectId);
-        var wrappedOffset = ComputeWrappedOffset(reelPosition, stops);
+        RenderReelDisplay(context.Canvas, bounds, element.AssetPath, reelPosition, stops, element.VisibleScale);
+    }
+
+    public static void RenderReelDisplay(SKCanvas canvas, SKRect bounds, string? assetPath, double reelPosition, int stops, double? visibleScale)
+    {
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        var safeStops = Math.Max(1, stops);
+        var wrappedOffset = ComputeWrappedOffset(reelPosition, safeStops);
 
         using var clipPath = new SKPath();
         clipPath.AddRect(bounds);
 
-        context.Canvas.Save();
-        context.Canvas.ClipPath(clipPath);
+        canvas.Save();
+        canvas.ClipPath(clipPath);
 
-        if (TryGetStripImage(element.AssetPath, out var stripImage))
+        if (TryGetStripImage(assetPath, out var stripImage))
         {
-            DrawStripImage(context.Canvas, bounds, stripImage, wrappedOffset, reelPosition, stops, element.VisibleScale);
+            DrawStripImage(canvas, bounds, stripImage, wrappedOffset, reelPosition, safeStops, visibleScale);
         }
         else
         {
             var cellHeight = bounds.Height;
-            DrawStripPlaceholder(context.Canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight), bounds.Width, cellHeight, stops);
-            DrawStripPlaceholder(context.Canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight) + cellHeight, bounds.Width, cellHeight, stops);
+            DrawStripPlaceholder(canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight), bounds.Width, cellHeight, safeStops);
+            DrawStripPlaceholder(canvas, bounds.Left, bounds.Top - (float)(wrappedOffset * cellHeight) + cellHeight, bounds.Width, cellHeight, safeStops);
         }
 
-        context.Canvas.Restore();
+        canvas.Restore();
     }
 
     internal static double ComputeWrappedOffset(double position, int stops)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -293,7 +293,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         var faceRuntimeElementIds = _faceDocumentModel.Elements
             .Where(element => !string.IsNullOrWhiteSpace(element.ObjectId)
                 && element.LinkedMachineObjectReference is MachineObjectReference reference
-                && reference.Kind is MachineObjectKind.Lamp or MachineObjectKind.SevenSegmentDisplay or MachineObjectKind.AlphaDisplay
+                && reference.Kind is MachineObjectKind.Lamp or MachineObjectKind.Reel or MachineObjectKind.SevenSegmentDisplay or MachineObjectKind.AlphaDisplay
                 && !reference.IsEmpty)
             .Select(element => element.ObjectId)
             .ToHashSet(StringComparer.Ordinal);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -329,11 +329,13 @@ public sealed class DocumentWorkspaceViewModel
     private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null, string? faceDocumentJson = null)
     {
         var documentId = Guid.NewGuid();
+        var runtimeState = _runtimeStateStore.GetOrCreate(documentId);
+        runtimeState.FruitMachinePlatform = _getLoadedProject()?.FruitMachinePlatform ?? FruitMachinePlatformType.None;
         return new DocumentTabViewModel(
             document,
             panelLayoutJson,
             documentId,
-            runtimeState: _runtimeStateStore.GetOrCreate(documentId),
+            runtimeState: runtimeState,
             faceDocumentJson: faceDocumentJson);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -127,8 +127,8 @@ public sealed class DocumentWorkspaceViewModel
         var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
-        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
-        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
+        _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
+        _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
         return document;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/FaceHierarchyProvider.cs
@@ -24,6 +24,10 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
             .OfType<FaceLampWindowElement>()
             .Select((element, index) => CreateElementItem(element, index, "Lamp Window", "lampWindow"))
             .ToArray();
+        var reelDisplays = faceDocument.GetFaceElements()
+            .OfType<FaceReelDisplayElement>()
+            .Select((element, index) => CreateElementItem(element, index, "Reel Display", "reelDisplay"))
+            .ToArray();
         var sevenSegmentDisplays = faceDocument.GetFaceElements()
             .OfType<FaceSevenSegmentDisplayElement>()
             .Select((element, index) => CreateElementItem(element, index, "Seven Segment Display", "sevenSegmentDisplay"))
@@ -46,6 +50,11 @@ public sealed class FaceHierarchyProvider : IDocumentHierarchyProvider
         if (lampWindows.Length > 0)
         {
             groups.Add(new HierarchyItemViewModel($"Lamp Windows ({lampWindows.Length})", "group:lampWindow", isGroup: true, children: lampWindows));
+        }
+
+        if (reelDisplays.Length > 0)
+        {
+            groups.Add(new HierarchyItemViewModel($"Reel Displays ({reelDisplays.Length})", "group:reelDisplay", isGroup: true, children: reelDisplays));
         }
 
         if (sevenSegmentDisplays.Length > 0)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -170,6 +170,12 @@ public partial class SkiaFaceEditView : UserControl
         foreach (var element in document.GetFaceElements().Where(element => element is not FaceArtworkElement))
         {
             var rect = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
+            if (element is FaceReelDisplayElement reelDisplay)
+            {
+                DrawReelElement(canvas, document, reelDisplay, rect, hiddenPaint);
+                continue;
+            }
+
             if (element is FaceSevenSegmentDisplayElement sevenSegmentDisplay)
             {
                 DrawSevenSegmentElement(canvas, document, sevenSegmentDisplay, rect, hiddenPaint);
@@ -210,6 +216,23 @@ public partial class SkiaFaceEditView : UserControl
                 (float)Math.Max(0d, selectedElement.Height),
                 selectionPaint);
         }
+    }
+
+    private static void DrawReelElement(SKCanvas canvas, DocumentTabViewModel document, FaceReelDisplayElement element, SKRect rect, SKPaint hiddenPaint)
+    {
+        if (rect.Width <= 0f || rect.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!element.IsVisible)
+        {
+            canvas.DrawRect(rect, hiddenPaint);
+            return;
+        }
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(element, document.RuntimeState);
+        ReelElementRenderer.RenderReelDisplay(canvas, rect, element.AssetPath, position, element.Stops.GetValueOrDefault(1), element.VisibleScale);
     }
 
     private static void DrawSevenSegmentElement(SKCanvas canvas, DocumentTabViewModel document, FaceSevenSegmentDisplayElement element, SKRect rect, SKPaint hiddenPaint)


### PR DESCRIPTION
### Motivation
- Complete Phase 9C by introducing a dedicated Face reel element and wiring it to runtime state so Face reel visuals can be generated, persisted, and updated live from MAME without using Panel2D element IDs as the runtime identity.
- Prioritize correctness of runtime plumbing and machine-object reference resolution over animation or visual-fidelity features.

### Description
- Add `FaceReelDisplayElement` model with reel metadata: `AssetPath`, `Stops`, `VisibleScale`, `BandOffset`, and `IsReversed`, and include it in `FaceDocumentModel` and storage DTOs; update `FaceDocumentStorage` to serialize/deserialize reel fields and the `reelDisplay` kind.
- Extend `FaceGenerationService` to generate reel display elements from contained Panel2D reels, preserving `MachineObjectReference.Reel` as the runtime reference and `LinkedPanel2DElementId` as provenance only, and report `ConvertedReelDisplayCount` in `FaceGenerationResult`.
- Reuse existing reel rendering code by exposing `ReelElementRenderer.RenderReelDisplay` and integrate it into both `Face2DRenderer` (Play renderer) and `SkiaFaceEditView` (Edit view) to draw reel windows using `MachineRuntimeState` positions.
- Add reel runtime resolution to `FaceRuntimeStateResolver` (`TryGetReelDisplayReference` and `GetReelPosition`) so Face visuals read reel positions via `MachineObjectReference` and `MachineRuntimeState` only (no fallback to `LinkedPanel2DElementId`).
- Update `MameReelRuntimeAdapter` to write reel positions by `MachineObjectReference.Reel`, build a face-reel mapping, and publish Face visual invalidations via `DocumentTabViewModel.NotifyFaceVisualPreviewChanged` so Face Play/Edit views update live from MAME.
- Propagate reel support to editor surfaces and view models: add reel entries in the Face hierarchy provider, include reel counts/messages in generation/status UI, and add model updater support for reel elements.
- Add unit tests covering generation, round-trip storage, runtime resolution, and MAME adapter live updates: `OasisEditor.Tests/FaceReelDisplayTests.cs` and extended `MameReelRuntimeAdapterTests.cs` for face-update behavior.
- Update `FACE_SYSTEM_ARCHITECTURE_PLAN.md` to mark Phase 9C complete, add manual verification steps, and include recommendations for a Runtime Display Consolidation phase before Face regeneration.

### Testing
- Static checks: storage/read/write helper logic and source edits validated via repository checks (no build required in this environment).
- New automated tests added: `OasisEditor.Tests/FaceReelDisplayTests` and extended `OasisEditor.Tests/MameReelRuntimeAdapterTests` to assert generation, serialization round-trip, runtime resolver semantics, and MAME-driven Face updates.
- Note: unit tests were not executed here because the container lacks the .NET SDK; run the test suite locally with `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` to verify all tests pass.
- Recommended local verification steps are appended to `FACE_SYSTEM_ARCHITECTURE_PLAN.md` and include generating a Face from Panel2D reels, save/load verification, Edit/Play view rendering, and live MAME reel updates (see document for details).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2557f4de508327b057d68cb01c4e8b)