### PR TITLE
Runtime display consolidation: shared Face reference index and resolver cleanup

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -585,6 +585,30 @@ FaceReelDisplayElement
 
 Do not use `LinkedPanel2DElementId` for Face Play View runtime behavior. Retain it only for provenance, generation workflows, and editor workflows.
 
+
+### Phase 9D - Runtime Display Consolidation - Complete
+
+Completed as a focused cleanup, review, consolidation, and documentation phase.
+
+Outcome:
+
+- Face runtime display resolution now has one shared helper for mapping Face runtime display elements back to `MachineObjectReference` values for visual invalidation;
+- reel, seven-segment, and alpha MAME adapters use the shared Face reference-index helper instead of open-coded per-display object-id matching where invalidating Face visuals;
+- `FaceRuntimeStateResolver` uses a single typed machine-reference validation path for lamps, reels, seven-segment displays, and alpha displays;
+- regression coverage verifies that Face runtime display indexing groups machine-reference-linked elements and ignores provenance-only `LinkedPanel2DElementId` links;
+- no new runtime display types, visual-fidelity effects, regeneration behavior, 3D preview, or Unity integration were added.
+
+Runtime rule preserved:
+
+```text
+Face runtime display element
+    -> LinkedMachineObjectReference
+        -> MachineRuntimeState
+            -> shared renderer primitive / input dispatch path
+```
+
+`LinkedPanel2DElementId` remains provenance/editor/regeneration metadata only. Runtime resolution and invalidation should not fall back to Panel2D element IDs.
+
 ### Phase 10 - Face Regeneration - Future
 
 Goals:
@@ -636,6 +660,58 @@ Goals:
 
 Planned output should clearly separate editor/export responsibilities from Unity renderer responsibilities and preserve machine-object identity as the synchronization contract.
 
+
+## Runtime Display Architecture Summary
+
+The current Face runtime-display architecture has three deliberately separate responsibilities.
+
+### 1. Runtime identity and state
+
+`MachineObjectReference` is the identity contract for runtime-linked visuals. Lamps, reels, seven-segment displays, alpha displays, and inputs/buttons are represented by typed machine references, while `MachineRuntimeState` stores renderer-neutral values such as lamp intensity, raw reel position, segment masks, segment brightness, and input state. Panel2D element IDs may still exist in state for legacy Panel2D rendering compatibility, but Face runtime behavior must resolve through machine references.
+
+Reel state has a specific split:
+
+- MAME adapters write the machine-reference reel value as a wrapped raw machine position in the 96-position runtime domain;
+- Face reel rendering resolves a visual-effective position from that raw value using the Face reel element's stops, reversal, band offset, and the current platform;
+- Panel2D continues to keep its legacy object-id keyed effective reel values for existing Panel2D behavior.
+
+This split keeps Face from depending on Panel2D element IDs while preserving Panel2D compatibility.
+
+### 2. Renderer-facing resolution
+
+`FaceRuntimeStateResolver` is the Face renderer-facing adapter for runtime values. It validates that each Face element's `LinkedMachineObjectReference` has the expected kind, then reads the corresponding value from `MachineRuntimeState`. The resolver covers lamps, reels, seven-segment displays, and alpha displays. Buttons use the Face input-target resolver and shared play input router because their runtime behavior is command/input dispatch rather than visual display state.
+
+Face display renderers reuse existing Skia primitives where possible:
+
+- Face reels call the same reel-strip rendering primitive used by Panel2D reels;
+- Face seven-segment displays call the same seven-segment rendering primitive used by Panel2D;
+- Face alpha displays call the same alpha/segment rendering primitive used by Panel2D;
+- Face lamps and buttons remain Face-specific simple MVP shapes until a later visual-fidelity phase explicitly changes presentation.
+
+### 3. Update and invalidation fanout
+
+MAME adapters update `MachineRuntimeState` on the UI thread, then notify the visual surfaces that need repainting. Panel2D invalidation still uses Panel2D object IDs. Face invalidation uses Face element object IDs discovered from machine references through the shared Face runtime display reference index. This keeps invalidation consistent across reels, seven-segment displays, and alpha displays and prevents accidental dependency on `LinkedPanel2DElementId`.
+
+Current taxonomy:
+
+| Runtime category | Panel2D visual | Face visual | Runtime reference | Runtime/display notes |
+| --- | --- | --- | --- | --- |
+| Lamp | `PanelElementKind.Lamp` | `FaceLampWindowElement` | `MachineObjectKind.Lamp` | Resolver reads lamp intensity from `MachineRuntimeState`. |
+| Button/input | input-linked Panel2D visual plus input definition | `FaceButtonElement` | `MachineObjectKind.Input` / `MachineInputReference` | Uses shared play input dispatch; not a display renderer. |
+| Reel | `PanelElementKind.Reel` | `FaceReelDisplayElement` | `MachineObjectKind.Reel` | Machine state is raw 96-step position; Face derives visual-effective position from Face metadata and platform. |
+| Seven segment | `PanelElementKind.SevenSegment` | `FaceSevenSegmentDisplayElement` | `MachineObjectKind.SevenSegmentDisplay` | Resolver reads one mask/brightness cell from `MachineRuntimeState`. |
+| Alpha display | `PanelElementKind.Alpha` | `FaceAlphaDisplayElement` | `MachineObjectKind.AlphaDisplay` | Resolver reads 16 mask/brightness cells from `MachineRuntimeState`; display geometry remains visual metadata. |
+
+### Consolidation guidance
+
+Future work should continue consolidating around these seams instead of adding per-display special cases:
+
+- add runtime-linked Face display invalidation through the shared reference index;
+- add renderer-facing runtime reads through `FaceRuntimeStateResolver`;
+- keep serialization/generation metadata on the Face element models, but keep runtime identity in `LinkedMachineObjectReference`;
+- keep `LinkedPanel2DElementId` as provenance only, especially for Phase 10 regeneration;
+- avoid changing visual fidelity, animation behavior, or renderer ownership during architecture/cleanup phases.
+
 ## Tests
 
 Add non-WPF tests where practical:
@@ -667,6 +743,7 @@ Future phase verification should focus on:
 - Phase 9A: complete - seven-segment displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
 - Phase 9B: complete - alpha displays serialize, generate, and render from `MachineRuntimeState` through machine-object references;
 - Phase 9C: complete - reel displays serialize, generate, and render from `MachineRuntimeState` through machine-object references, with correctness prioritized over animation fidelity;
+- Phase 9D: complete - runtime display resolution and invalidation are consolidated/documented without adding display types or visual-fidelity behavior;
 - Phase 10: Face regeneration uses provenance metadata while preserving runtime identity through machine-object references;
 - Phase 11: visual-fidelity improvements do not change document/runtime identity contracts;
 - Phase 12: 3D preview investigation does not introduce renderer-specific document coupling;
@@ -695,6 +772,17 @@ Preserve the completed Face MVP architecture when adding future phases: runtime 
 
 John will test/review after each phase before continuing.
 
+## Manual Verification Steps - Phase 9D Runtime Display Consolidation
+
+1. Open an Oasis project containing a Panel2D document with lamps, buttons/inputs, reels, seven-segment displays, and alpha displays.
+2. Open or generate a Face document that contains Face lamp windows, buttons, reel displays, seven-segment displays, and alpha displays linked by machine-object references.
+3. Start MAME for the machine and confirm each Face display updates live from runtime state: lamps change intensity, reels move, seven-segment masks update, and alpha/VFD masks and brightness update.
+4. Confirm the corresponding Panel2D displays continue updating exactly as before.
+5. Confirm Face buttons still dispatch pointer down/up through the shared play input path and that keyboard shortcuts still work in Face Play View.
+6. Save, close, and reopen the Face document and confirm runtime-linked display elements still contain their machine references.
+7. Inspect Face runtime-linked elements and confirm `LinkedPanel2DElementId` is present only as provenance/source metadata; deleting or changing provenance-only links should not be required for live runtime display updates when machine references are valid.
+8. Confirm no new display visual effects, Face Regeneration behavior, 3D preview, or Unity integration behavior appears in this phase.
+
 ## Manual Verification Steps - Phase 9C Reel Display MVP
 
 1. Open an Oasis project containing a Panel2D document with at least one reel element that has a valid display/reel number.
@@ -707,12 +795,17 @@ John will test/review after each phase before continuing.
 8. Confirm lamps, inputs/buttons, seven-segment displays, and alpha displays still update exactly as they did before Phase 9C.
 9. Inspect a generated reel display and confirm runtime behavior still resolves through `MachineObjectReference.Reel` and `MachineRuntimeState`; `LinkedPanel2DElementId` should only identify the source Panel2D element for provenance/editor workflows.
 
-## Runtime Display Consolidation Recommendations Before Face Regeneration
+## Runtime Display Consolidation Status Before Face Regeneration
 
-Before implementing Face Regeneration, add a focused Runtime Display Consolidation phase to reduce duplicated display plumbing while preserving the established runtime contract. Recommended scope:
+Phase 9D completed the low-risk consolidation that should happen before Face Regeneration. Completed items:
 
-- introduce a small shared renderer-facing adapter/helper for Face and Panel2D runtime displays so reels, seven-segment displays, and alpha displays consistently resolve `MachineObjectReference` values before rendering;
-- clarify whether `MachineRuntimeState` reel positions are raw machine positions, platform-normalized positions, or visual-effective positions, then document that contract before regeneration starts preserving/reusing reel metadata;
-- centralize common Face display metadata serialization patterns so future display types do not repeatedly update storage, generation, hierarchy, selection, renderer, and runtime resolver code by hand;
-- keep `LinkedPanel2DElementId` as generation/regeneration provenance only and add regression tests for every runtime display type to prevent accidental fallback to Panel2D element IDs;
-- add a lightweight display notification helper so MAME adapters can publish Face visual invalidations by machine reference without duplicating per-display matching code.
+- Face renderer-facing runtime display resolution is centralized in `FaceRuntimeStateResolver` for lamps, reels, seven-segment displays, and alpha displays;
+- Face visual invalidation by machine reference is centralized through a lightweight reference-index helper used by reel and segment MAME adapters;
+- the reel runtime contract is documented: machine-reference reel positions are raw wrapped 96-position values, and Face elements derive their visual-effective position from element metadata plus platform;
+- regression coverage verifies that the Face reference-index path ignores provenance-only `LinkedPanel2DElementId` links.
+
+Remaining recommendations for Phase 10 and later:
+
+- keep Face Regeneration correlation based on provenance metadata, but preserve runtime identity through `LinkedMachineObjectReference`;
+- consider centralizing Face display metadata serialization/generation patterns only if Phase 10 touches the same storage/generation fields repeatedly;
+- keep visual fidelity, 3D preview, and Unity-facing changes out of Phase 10 unless a later plan explicitly requests them.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeDisplayReferenceIndexTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeDisplayReferenceIndexTests.cs
@@ -1,0 +1,52 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceRuntimeDisplayReferenceIndexTests
+{
+    [Fact]
+    public void GetObjectIdsByReference_GroupsRuntimeDisplayElementsByMachineReference()
+    {
+        var document = CreateFaceDocument([
+            new FaceReelDisplayElement { ObjectId = "face-reel-a", LinkedMachineObjectReference = MachineObjectReference.Reel(2) },
+            new FaceReelDisplayElement { ObjectId = "face-reel-b", LinkedMachineObjectReference = MachineObjectReference.Reel(2) },
+            new FaceReelDisplayElement { ObjectId = "face-reel-other", LinkedMachineObjectReference = MachineObjectReference.Reel(3) },
+            new FaceSevenSegmentDisplayElement { ObjectId = "face-seven-2", LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(2) }
+        ]);
+
+        var index = FaceRuntimeDisplayReferenceIndex.GetObjectIdsByReference<FaceReelDisplayElement>(document, MachineObjectKind.Reel);
+
+        var objectIds = Assert.Contains(MachineObjectReference.Reel(2), index);
+        Assert.Equal(["face-reel-a", "face-reel-b"], objectIds);
+        Assert.DoesNotContain(MachineObjectReference.SevenSegmentDisplay(2), index.Keys);
+    }
+
+    [Fact]
+    public void AddObjectIdsForReference_IgnoresProvenanceOnlyLinks()
+    {
+        var document = CreateFaceDocument([
+            new FaceAlphaDisplayElement
+            {
+                ObjectId = "face-alpha-10",
+                LinkedPanel2DElementId = "panel-alpha-10"
+            }
+        ]);
+        var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
+
+        FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceAlphaDisplayElement>(
+            document,
+            MachineObjectReference.AlphaDisplay(10),
+            changedObjectIds);
+
+        Assert.Empty(changedObjectIds);
+    }
+
+    private static DocumentTabViewModel CreateFaceDocument(IReadOnlyList<FaceElementModel> elements)
+    {
+        var faceDocument = EditorDocument.CreateFromFile("face.face", "face", "face");
+        var tab = new DocumentTabViewModel(faceDocument);
+        tab.SetFaceElements(elements);
+        return tab;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeDisplayReferenceIndex.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeDisplayReferenceIndex.cs
@@ -1,0 +1,64 @@
+namespace OasisEditor;
+
+internal static class FaceRuntimeDisplayReferenceIndex
+{
+    public static IReadOnlyDictionary<MachineObjectReference, string[]> GetObjectIdsByReference<TElement>(DocumentTabViewModel document, MachineObjectKind expectedKind)
+        where TElement : FaceElementModel
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        return document.GetFaceElements()
+            .OfType<TElement>()
+            .Select(element => new
+            {
+                Element = element,
+                Reference = element.LinkedMachineObjectReference ?? MachineObjectReference.Empty
+            })
+            .Where(item => !string.IsNullOrWhiteSpace(item.Element.ObjectId)
+                && item.Reference.Kind == expectedKind
+                && !item.Reference.IsEmpty)
+            .GroupBy(item => item.Reference, item => item.Element.ObjectId, MachineObjectReferenceComparer.Instance)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Distinct(StringComparer.Ordinal).ToArray(),
+                MachineObjectReferenceComparer.Instance);
+    }
+
+    public static void AddObjectIdsForReference<TElement>(DocumentTabViewModel document, MachineObjectReference reference, ISet<string> destination)
+        where TElement : FaceElementModel
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        if (reference.IsEmpty)
+        {
+            return;
+        }
+
+        var objectIdsByReference = GetObjectIdsByReference<TElement>(document, reference.Kind);
+        if (!objectIdsByReference.TryGetValue(reference, out var objectIds))
+        {
+            return;
+        }
+
+        foreach (var objectId in objectIds)
+        {
+            destination.Add(objectId);
+        }
+    }
+
+    private sealed class MachineObjectReferenceComparer : IEqualityComparer<MachineObjectReference>
+    {
+        public static MachineObjectReferenceComparer Instance { get; } = new();
+
+        public bool Equals(MachineObjectReference x, MachineObjectReference y)
+        {
+            return x.Kind == y.Kind && string.Equals(x.Id, y.Id, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(MachineObjectReference obj)
+        {
+            return HashCode.Combine(obj.Kind, StringComparer.Ordinal.GetHashCode(obj.Id ?? string.Empty));
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -24,9 +24,7 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
 
     public bool TryGetLampReference(FaceLampWindowElement lampWindow, out MachineObjectReference reference)
     {
-        ArgumentNullException.ThrowIfNull(lampWindow);
-        reference = lampWindow.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
-        return reference.Kind == MachineObjectKind.Lamp && !reference.IsEmpty;
+        return TryGetReference(lampWindow, MachineObjectKind.Lamp, out reference);
     }
 
     public double GetLampIntensity(FaceLampWindowElement lampWindow, MachineRuntimeState runtimeState)
@@ -41,9 +39,7 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
 
     public bool TryGetReelDisplayReference(FaceReelDisplayElement reelDisplay, out MachineObjectReference reference)
     {
-        ArgumentNullException.ThrowIfNull(reelDisplay);
-        reference = reelDisplay.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
-        return reference.Kind == MachineObjectKind.Reel && !reference.IsEmpty;
+        return TryGetReference(reelDisplay, MachineObjectKind.Reel, out reference);
     }
 
     public double GetReelPosition(FaceReelDisplayElement reelDisplay, MachineRuntimeState runtimeState)
@@ -84,16 +80,19 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
 
     public bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference)
     {
-        ArgumentNullException.ThrowIfNull(display);
-        reference = display.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
-        return reference.Kind == MachineObjectKind.SevenSegmentDisplay && !reference.IsEmpty;
+        return TryGetReference(display, MachineObjectKind.SevenSegmentDisplay, out reference);
     }
 
     public bool TryGetAlphaDisplayReference(FaceAlphaDisplayElement display, out MachineObjectReference reference)
     {
-        ArgumentNullException.ThrowIfNull(display);
-        reference = display.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
-        return reference.Kind == MachineObjectKind.AlphaDisplay && !reference.IsEmpty;
+        return TryGetReference(display, MachineObjectKind.AlphaDisplay, out reference);
+    }
+
+    private static bool TryGetReference(FaceElementModel element, MachineObjectKind expectedKind, out MachineObjectReference reference)
+    {
+        ArgumentNullException.ThrowIfNull(element);
+        reference = element.LinkedMachineObjectReference ?? MachineObjectReference.Empty;
+        return reference.Kind == expectedKind && !reference.IsEmpty;
     }
 
     public int[] GetSevenSegmentCellMasks(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -70,7 +70,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         {
             document.RuntimeState.FruitMachinePlatform = platform;
             var objectIdsByReel = GetOrBuildReelMapping(document);
-            var faceObjectIdsByReel = GetFaceReelMapping(document);
+            var faceObjectIdsByReel = FaceRuntimeDisplayReferenceIndex.GetObjectIdsByReference<FaceReelDisplayElement>(document, MachineObjectKind.Reel);
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
             var changedFaceObjectIds = new HashSet<string>(StringComparer.Ordinal);
 
@@ -133,22 +133,6 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
                 staleEntry.Detach();
             }
         }
-    }
-
-    private static IReadOnlyDictionary<MachineObjectReference, string[]> GetFaceReelMapping(DocumentTabViewModel document)
-    {
-        return document.GetFaceElements()
-            .OfType<FaceReelDisplayElement>()
-            .Select(element => new
-            {
-                Element = element,
-                Reference = element.LinkedMachineObjectReference ?? MachineObjectReference.Empty
-            })
-            .Where(item => !string.IsNullOrWhiteSpace(item.Element.ObjectId)
-                && item.Reference.Kind == MachineObjectKind.Reel
-                && !item.Reference.IsEmpty)
-            .GroupBy(item => item.Reference, item => item.Element)
-            .ToDictionary(group => group.Key, group => group.Select(element => element.ObjectId).Distinct(StringComparer.Ordinal).ToArray());
     }
 
     private IReadOnlyDictionary<MachineObjectReference, string[]> GetOrBuildReelMapping(DocumentTabViewModel document)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -127,6 +127,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                     if (machineMaskChanged || machineBrightnessChanged)
                     {
                         changedMachineReferences.Add(machineReference);
+                        AddChangedFaceDisplayObjectIds(document, machineReference, changedFaceObjectIds);
                     }
                 }
 
@@ -152,7 +153,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, [1d]);
                 if (maskChanged || brightnessChanged || changedMachineReferences.Contains(reference))
                 {
-                    changedFaceObjectIds.Add(faceDisplay.ObjectId);
+                    FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceSevenSegmentDisplayElement>(document, reference, changedFaceObjectIds);
                 }
             }
 
@@ -187,7 +188,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, cellBrightness);
                 if (maskChanged || brightnessChanged || changedMachineReferences.Contains(reference))
                 {
-                    changedFaceObjectIds.Add(faceDisplay.ObjectId);
+                    FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceAlphaDisplayElement>(document, reference, changedFaceObjectIds);
                 }
             }
 
@@ -200,6 +201,21 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
             {
                 document.NotifyFaceVisualPreviewChanged(changedFaceObjectIds);
             }
+        }
+    }
+
+
+    private static void AddChangedFaceDisplayObjectIds(DocumentTabViewModel document, MachineObjectReference reference, ISet<string> changedFaceObjectIds)
+    {
+        if (reference.Kind == MachineObjectKind.SevenSegmentDisplay)
+        {
+            FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceSevenSegmentDisplayElement>(document, reference, changedFaceObjectIds);
+            return;
+        }
+
+        if (reference.Kind == MachineObjectKind.AlphaDisplay)
+        {
+            FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceAlphaDisplayElement>(document, reference, changedFaceObjectIds);
         }
     }
 


### PR DESCRIPTION
### Motivation

- Phase 9D is a focused consolidation pass to reduce duplicated runtime-display plumbing and clarify the Face runtime-display contract without adding new display types or visual-fidelity features.  
- Centralize runtime resolution and invalidation so Face visuals resolve through `MachineObjectReference` -> `MachineRuntimeState` rather than falling back to Panel2D provenance IDs.  
- Improve documentation and add low-risk tests to prevent regressions before Phase 10 (Face Regeneration).

### Description

- Introduced a lightweight shared helper `FaceRuntimeDisplayReferenceIndex` to map `LinkedMachineObjectReference` values to Face element object IDs for renderer invalidation.  
- Consolidated Face runtime reference validation in `FaceRuntimeStateResolver` by adding a single `TryGetReference` validation path used for lamps, reels, seven-segment displays, and alpha displays.  
- Updated runtime adapters to use the shared index instead of per-display open-coded mappings: `MameReelRuntimeAdapter` now uses `FaceRuntimeDisplayReferenceIndex.GetObjectIdsByReference<T>` and `MameSegmentRuntimeAdapter` uses the index (and a small helper `AddChangedFaceDisplayObjectIds`) to collect Face object IDs for invalidation.  
- Documentation updates: added Phase 9D summary, a `Runtime Display Architecture Summary`, and manual verification steps to `FACE_SYSTEM_ARCHITECTURE_PLAN.md`.  
- Tests: added `FaceRuntimeDisplayReferenceIndexTests` covering grouping by machine reference and ignoring provenance-only `LinkedPanel2DElementId` links.

### Testing

- Repository static checks (`diff --check`) reported no issues.  
- New unit tests were added (`FaceRuntimeDisplayReferenceIndexTests`) to cover the shared index behavior; the tests are included but were not executed in this environment because the .NET SDK is not available.  
- An attempt to run `dotnet test OasisEditor.sln --no-restore` failed in this environment due to missing `dotnet`, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a255ee81d10832795ed5ac9a7987f54)