### PR TITLE
Face regeneration MVP: add regeneration service, command, and tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -609,19 +609,59 @@ Face runtime display element
 
 `LinkedPanel2DElementId` remains provenance/editor/regeneration metadata only. Runtime resolution and invalidation should not fall back to Panel2D element IDs.
 
-### Phase 10 - Face Regeneration - Future
+### Phase 10 - Face Regeneration MVP - Complete
 
-Goals:
+Completed as a workflow/data-management MVP.
 
-- regenerate Face content from source Panel2D data;
-- preserve manual Face edits where practical;
-- use existing provenance metadata:
-  - `SourcePanel2DDocumentId`;
-  - `SourceRegion`;
-  - `LinkedPanel2DElementId`;
-  - `MachineObjectReference`.
+Outcome:
 
-Regeneration may use `LinkedPanel2DElementId` and other provenance fields to correlate generated content with source Panel2D content, but regenerated Face Play View runtime behavior must still resolve through `MachineObjectReference` and `MachineRuntimeState`.
+- added a user-facing **Regenerate Face** command for open Face documents that still carry regeneration metadata;
+- regeneration locates the original open Panel2D source document through `SourcePanel2DDocumentId` and requires a valid `SourceRegion`;
+- regeneration re-runs the existing Panel2D-to-Face generation path rather than adding separate visual-fidelity logic;
+- generated Face artwork, lamp windows, buttons, seven-segment displays, alpha displays, and reel displays are rebuilt from the current Panel2D source region;
+- generated elements are correlated using regeneration metadata, primarily `LinkedPanel2DElementId` plus Face element kind;
+- existing generated Face element object IDs and `LinkedMachineObjectReference` values are preserved when a regenerated match exists, so runtime identity survives regeneration;
+- manual Face-only elements without regeneration keys are appended back to the regenerated document so they are not destroyed unnecessarily;
+- stale generated elements whose provenance no longer appears in the regenerated source set are removed without introducing advanced conflict-resolution UI;
+- Face document saving now preserves document-level `SourcePanel2DDocumentId` and `SourceRegion` metadata.
+
+Regeneration contract:
+
+```text
+FaceDocument
+    SourcePanel2DDocumentId
+    SourceRegion
+    Elements[]
+        LinkedPanel2DElementId
+        LinkedMachineObjectReference
+```
+
+Runtime rule preserved:
+
+```text
+Face Play View
+    -> Face element LinkedMachineObjectReference
+        -> MachineRuntimeState
+```
+
+`LinkedPanel2DElementId` is used only to correlate generated Face content with Panel2D source content during regeneration. It remains provenance/editor/regeneration metadata and is not used for Face Play View runtime state resolution.
+
+Manual verification steps:
+
+1. Open a project with a Panel2D document containing artwork plus lamps, buttons, seven-segment displays, alpha displays, and reels.
+2. Open the source Panel2D document and use **File -> Generate Face From Region...** to create a Face from a valid source region.
+3. Add or move a manual Face-only lamp window or other Face element that does not have `LinkedPanel2DElementId` metadata.
+4. Change the source Panel2D element geometry/properties inside the same source region.
+5. Select the generated Face document and run **File -> Regenerate Face**.
+6. Verify generated artwork, lamps, buttons, seven-segment displays, alpha displays, and reels update to match the source Panel2D region.
+7. Verify matched regenerated elements keep their existing `LinkedMachineObjectReference` values.
+8. Verify the manual Face-only element remains present after regeneration.
+9. Run the existing Face Play View and confirm lamp/display/reel/button behavior is unchanged.
+10. Re-open the Panel2D document and confirm existing Panel2D edit/play behavior is unchanged.
+
+Next recommended phase:
+
+- Phase 11 should remain the Visual Fidelity Layer, focused only on rendering/presentation improvements such as lamp glow, artwork blending, masks, and lamp trays. It should not change the regeneration metadata contract or the `LinkedMachineObjectReference` -> `MachineRuntimeState` runtime contract.
 
 ### Phase 11 - Visual Fidelity Layer - Future
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRegenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRegenerationServiceTests.cs
@@ -1,0 +1,217 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceRegenerationServiceTests
+{
+    [Fact]
+    public void Regenerate_UpdatesGeneratedElementsAndPreservesRuntimeReferencesAndManualElements()
+    {
+        var sourcePanel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Start Lamp Updated",
+                    Kind = PanelElementKind.Lamp,
+                    X = 130,
+                    Y = 240,
+                    Width = 35,
+                    Height = 45,
+                    DisplayNumber = 1,
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "seven-2",
+                    Name = "Credits",
+                    Kind = PanelElementKind.SevenSegment,
+                    X = 170,
+                    Y = 250,
+                    Width = 42,
+                    Height = 24,
+                    DisplayNumber = 2,
+                    OnColorHex = "#FF0000",
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "alpha-3",
+                    Name = "Message",
+                    Kind = PanelElementKind.Alpha,
+                    X = 220,
+                    Y = 250,
+                    Width = 100,
+                    Height = 28,
+                    DisplayNumber = 3,
+                    SegmentDisplayType = "bfm16seg",
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "reel-4",
+                    Name = "Reel Four",
+                    Kind = PanelElementKind.Reel,
+                    X = 120,
+                    Y = 300,
+                    Width = 50,
+                    Height = 120,
+                    DisplayNumber = 4,
+                    AssetPath = "Assets/Reels/updated.png",
+                    Stops = 16,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var existingFace = new FaceDocumentModel
+        {
+            Id = "face-1",
+            Title = "Face",
+            SourcePanel2DDocumentId = "panel-doc",
+            SourceRegion = FaceSourceRegionModel.FromRect(new Rect(100, 200, 300, 300)),
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "custom-face-lamp-id",
+                    Name = "Old Start Lamp",
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(99),
+                    LinkedPanel2DElementId = "lamp-1"
+                },
+                new FaceSevenSegmentDisplayElement
+                {
+                    ObjectId = "custom-seven-id",
+                    LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(77),
+                    LinkedPanel2DElementId = "seven-2"
+                },
+                new FaceAlphaDisplayElement
+                {
+                    ObjectId = "custom-alpha-id",
+                    LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(88),
+                    LinkedPanel2DElementId = "alpha-3"
+                },
+                new FaceReelDisplayElement
+                {
+                    ObjectId = "custom-reel-id",
+                    LinkedMachineObjectReference = MachineObjectReference.Reel(66),
+                    LinkedPanel2DElementId = "reel-4"
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "manual-lamp-window",
+                    Name = "Manual Face Lamp",
+                    X = 1,
+                    Y = 2,
+                    Width = 3,
+                    Height = 4,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(5)
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "stale-generated-lamp",
+                    LinkedPanel2DElementId = "lamp-removed",
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(6)
+                }
+            ]
+        };
+
+        var result = new FaceRegenerationService().Regenerate(existingFace, sourcePanel);
+
+        Assert.Equal(4, result.UpdatedElementCount);
+        Assert.Equal(1, result.AddedElementCount); // source-region artwork placeholder
+        Assert.Equal(1, result.RemovedGeneratedElementCount);
+        Assert.Equal(1, result.PreservedManualElementCount);
+
+        var lamp = Assert.IsType<FaceLampWindowElement>(result.Document.Elements.Single(element => element.ObjectId == "custom-face-lamp-id"));
+        Assert.Equal("Start Lamp Updated", lamp.Name);
+        Assert.Equal(30d, lamp.X);
+        Assert.Equal(40d, lamp.Y);
+        Assert.Equal(35d, lamp.Width);
+        Assert.Equal(45d, lamp.Height);
+        Assert.Equal("lamp:99", lamp.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("lamp-1", lamp.LinkedPanel2DElementId);
+
+        var sevenSegment = Assert.IsType<FaceSevenSegmentDisplayElement>(result.Document.Elements.Single(element => element.ObjectId == "custom-seven-id"));
+        Assert.Equal("sevenSegment:77", sevenSegment.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("#FF0000", sevenSegment.OnColorHex);
+
+        var alpha = Assert.IsType<FaceAlphaDisplayElement>(result.Document.Elements.Single(element => element.ObjectId == "custom-alpha-id"));
+        Assert.Equal("alpha:88", alpha.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("bfm16seg", alpha.SegmentDisplayType);
+
+        var reel = Assert.IsType<FaceReelDisplayElement>(result.Document.Elements.Single(element => element.ObjectId == "custom-reel-id"));
+        Assert.Equal("reel:66", reel.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("Assets/Reels/updated.png", reel.AssetPath);
+
+        Assert.Contains(result.Document.Elements, element => element.ObjectId == "manual-lamp-window");
+        Assert.DoesNotContain(result.Document.Elements, element => element.ObjectId == "stale-generated-lamp");
+    }
+
+    [Fact]
+    public void Regenerate_UpdatesButtonsAndPreservesInputReference()
+    {
+        var buttonGuid = Guid.NewGuid();
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = buttonGuid.ToString("N"),
+                    Name = "Start Button Visual",
+                    Kind = PanelElementKind.Lamp,
+                    X = 125,
+                    Y = 240,
+                    Width = 40,
+                    Height = 30,
+                    DisplayNumber = 7,
+                    IsVisible = true
+                }
+            ]
+        };
+        var inputDefinitions = new[]
+        {
+            new InputDefinitionModel
+            {
+                Id = "start",
+                Name = "Start Button Updated",
+                LinkedVisualElementId = buttonGuid
+            }
+        };
+        var existingFace = new FaceDocumentModel
+        {
+            Id = "face-buttons",
+            Title = "Face Buttons",
+            SourcePanel2DDocumentId = "panel-doc",
+            SourceRegion = FaceSourceRegionModel.FromRect(new Rect(100, 200, 100, 100)),
+            Elements =
+            [
+                new FaceButtonElement
+                {
+                    ObjectId = "custom-button-id",
+                    Name = "Old Button",
+                    LinkedPanel2DElementId = buttonGuid.ToString("N"),
+                    LinkedMachineObjectReference = MachineObjectReference.Input("custom-start"),
+                    LinkedInputReference = new MachineInputReference(MachineObjectReference.Input("custom-start"))
+                }
+            ]
+        };
+
+        var result = new FaceRegenerationService().Regenerate(existingFace, panel, inputDefinitions);
+
+        var button = Assert.IsType<FaceButtonElement>(result.Document.Elements.Single(element => element.ObjectId == "custom-button-id"));
+        Assert.Equal("Start Button Updated", button.Name);
+        Assert.Equal(25d, button.X);
+        Assert.Equal(40d, button.Y);
+        Assert.Equal("input:custom-start", button.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("input:custom-start", button.LinkedInputReference?.ToString());
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -1,0 +1,280 @@
+namespace OasisEditor;
+
+internal sealed class FaceRegenerationResult
+{
+    public FaceRegenerationResult(FaceDocumentModel document, int updatedElementCount, int addedElementCount, int removedGeneratedElementCount, int preservedManualElementCount, FaceGenerationResult generationResult)
+    {
+        Document = document;
+        UpdatedElementCount = updatedElementCount;
+        AddedElementCount = addedElementCount;
+        RemovedGeneratedElementCount = removedGeneratedElementCount;
+        PreservedManualElementCount = preservedManualElementCount;
+        GenerationResult = generationResult;
+    }
+
+    public FaceDocumentModel Document { get; }
+    public int UpdatedElementCount { get; }
+    public int AddedElementCount { get; }
+    public int RemovedGeneratedElementCount { get; }
+    public int PreservedManualElementCount { get; }
+    public FaceGenerationResult GenerationResult { get; }
+}
+
+internal sealed class FaceRegenerationService
+{
+    private readonly FaceGenerationService _generationService;
+
+    public FaceRegenerationService(FaceGenerationService? generationService = null)
+    {
+        _generationService = generationService ?? new FaceGenerationService();
+    }
+
+    public FaceRegenerationResult Regenerate(
+        FaceDocumentModel existingFace,
+        Panel2DDocumentModel sourcePanel,
+        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null)
+    {
+        ArgumentNullException.ThrowIfNull(existingFace);
+        ArgumentNullException.ThrowIfNull(sourcePanel);
+
+        if (string.IsNullOrWhiteSpace(existingFace.SourcePanel2DDocumentId))
+        {
+            throw new InvalidOperationException("Face document does not contain SourcePanel2DDocumentId regeneration metadata.");
+        }
+
+        if (existingFace.SourceRegion is not { IsValid: true } sourceRegion)
+        {
+            throw new InvalidOperationException("Face document does not contain a valid SourceRegion regeneration metadata value.");
+        }
+
+        var generated = _generationService.GenerateFromPanelRegion(
+            sourcePanel,
+            sourceRegion,
+            existingFace.Title,
+            existingFace.SourcePanel2DDocumentId,
+            inputDefinitions ?? []);
+
+        var existingGeneratedByKey = existingFace.Elements
+            .Select(element => new KeyValuePair<string, FaceElementModel>(CreateRegenerationKey(element), element))
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
+            .GroupBy(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        var regeneratedKeys = new HashSet<string>(StringComparer.Ordinal);
+        var mergedElements = new List<FaceElementModel>();
+        var updatedElementCount = 0;
+        var addedElementCount = 0;
+
+        foreach (var regeneratedElement in generated.Document.Elements)
+        {
+            var key = CreateRegenerationKey(regeneratedElement);
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                regeneratedKeys.Add(key);
+            }
+
+            if (!string.IsNullOrWhiteSpace(key) && existingGeneratedByKey.TryGetValue(key, out var existingElement))
+            {
+                mergedElements.Add(PreserveRuntimeIdentity(regeneratedElement, existingElement));
+                updatedElementCount++;
+                continue;
+            }
+
+            mergedElements.Add(regeneratedElement);
+            addedElementCount++;
+        }
+
+        var preservedManualElements = new List<FaceElementModel>();
+        var removedGeneratedElementCount = 0;
+        foreach (var existingElement in existingFace.Elements)
+        {
+            var key = CreateRegenerationKey(existingElement);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                preservedManualElements.Add(existingElement);
+                continue;
+            }
+
+            if (!regeneratedKeys.Contains(key))
+            {
+                removedGeneratedElementCount++;
+            }
+        }
+
+        mergedElements.AddRange(preservedManualElements);
+
+        var regeneratedDocument = new FaceDocumentModel
+        {
+            Id = existingFace.Id,
+            Title = existingFace.Title,
+            Summary = $"Regenerated from Panel2D source region ({Format(sourceRegion.X)}, {Format(sourceRegion.Y)}, {Format(sourceRegion.Width)}, {Format(sourceRegion.Height)}).",
+            SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
+            SourceRegion = sourceRegion,
+            Layers = existingFace.Layers.Count > 0 ? existingFace.Layers : generated.Document.Layers,
+            Elements = mergedElements.ToArray()
+        };
+
+        return new FaceRegenerationResult(
+            regeneratedDocument,
+            updatedElementCount,
+            addedElementCount,
+            removedGeneratedElementCount,
+            preservedManualElements.Count,
+            generated);
+    }
+
+    private static FaceElementModel PreserveRuntimeIdentity(FaceElementModel regeneratedElement, FaceElementModel existingElement)
+    {
+        var machineReference = existingElement.LinkedMachineObjectReference is MachineObjectReference existingReference && !existingReference.IsEmpty
+            ? existingReference
+            : regeneratedElement.LinkedMachineObjectReference;
+
+        return regeneratedElement switch
+        {
+            FaceArtworkElement artwork => new FaceArtworkElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = artwork.Name,
+                X = artwork.X,
+                Y = artwork.Y,
+                Width = artwork.Width,
+                Height = artwork.Height,
+                IsVisible = artwork.IsVisible,
+                IsLocked = artwork.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = artwork.LinkedPanel2DElementId,
+                AssetPath = artwork.AssetPath,
+                SourcePanel2DDocumentId = artwork.SourcePanel2DDocumentId,
+                SourceRegion = artwork.SourceRegion,
+                Provenance = artwork.Provenance
+            },
+            FaceReelDisplayElement reel => new FaceReelDisplayElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = reel.Name,
+                X = reel.X,
+                Y = reel.Y,
+                Width = reel.Width,
+                Height = reel.Height,
+                IsVisible = reel.IsVisible,
+                IsLocked = reel.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = reel.LinkedPanel2DElementId,
+                AssetPath = reel.AssetPath,
+                Stops = reel.Stops,
+                VisibleScale = reel.VisibleScale,
+                BandOffset = reel.BandOffset,
+                IsReversed = reel.IsReversed
+            },
+            FaceSevenSegmentDisplayElement sevenSegment => new FaceSevenSegmentDisplayElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = sevenSegment.Name,
+                X = sevenSegment.X,
+                Y = sevenSegment.Y,
+                Width = sevenSegment.Width,
+                Height = sevenSegment.Height,
+                IsVisible = sevenSegment.IsVisible,
+                IsLocked = sevenSegment.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = sevenSegment.LinkedPanel2DElementId,
+                OnColorHex = sevenSegment.OnColorHex,
+                OffColorHex = sevenSegment.OffColorHex,
+                ShowDecimalPoint = sevenSegment.ShowDecimalPoint
+            },
+            FaceAlphaDisplayElement alpha => new FaceAlphaDisplayElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = alpha.Name,
+                X = alpha.X,
+                Y = alpha.Y,
+                Width = alpha.Width,
+                Height = alpha.Height,
+                IsVisible = alpha.IsVisible,
+                IsLocked = alpha.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = alpha.LinkedPanel2DElementId,
+                SegmentDisplayType = alpha.SegmentDisplayType,
+                OnColorHex = alpha.OnColorHex,
+                OffColorHex = alpha.OffColorHex,
+                ShowDecimalPoint = alpha.ShowDecimalPoint,
+                ShowCommaTail = alpha.ShowCommaTail,
+                IsReversed = alpha.IsReversed
+            },
+            FaceButtonElement button => new FaceButtonElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = button.Name,
+                X = button.X,
+                Y = button.Y,
+                Width = button.Width,
+                Height = button.Height,
+                IsVisible = button.IsVisible,
+                IsLocked = button.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = button.LinkedPanel2DElementId,
+                LinkedInputReference = existingElement is FaceButtonElement existingButton && existingButton.LinkedInputReference is not null
+                    ? existingButton.LinkedInputReference
+                    : button.LinkedInputReference
+            },
+            FaceLampWindowElement lamp => new FaceLampWindowElement
+            {
+                ObjectId = existingElement.ObjectId,
+                Name = lamp.Name,
+                X = lamp.X,
+                Y = lamp.Y,
+                Width = lamp.Width,
+                Height = lamp.Height,
+                IsVisible = lamp.IsVisible,
+                IsLocked = lamp.IsLocked,
+                LinkedMachineObjectReference = machineReference,
+                LinkedPanel2DElementId = lamp.LinkedPanel2DElementId
+            },
+            _ => regeneratedElement
+        };
+    }
+
+    private static string CreateRegenerationKey(FaceElementModel element)
+    {
+        if (element is FaceArtworkElement artwork)
+        {
+            if (!string.IsNullOrWhiteSpace(artwork.LinkedPanel2DElementId))
+            {
+                return $"artwork:{artwork.LinkedPanel2DElementId.Trim()}";
+            }
+
+            if (IsGeneratedArtworkRegion(artwork))
+            {
+                return "artwork:source-region";
+            }
+
+            return string.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(element.LinkedPanel2DElementId))
+        {
+            return string.Empty;
+        }
+
+        var prefix = element switch
+        {
+            FaceButtonElement => "button",
+            FaceReelDisplayElement => "reel",
+            FaceSevenSegmentDisplayElement => "sevenSegment",
+            FaceAlphaDisplayElement => "alpha",
+            FaceLampWindowElement => "lamp",
+            _ => element.GetType().Name
+        };
+
+        return $"{prefix}:{element.LinkedPanel2DElementId.Trim()}";
+    }
+
+    private static bool IsGeneratedArtworkRegion(FaceArtworkElement artwork)
+    {
+        return artwork.Provenance is not null
+            || artwork.SourceRegion is not null
+            || !string.IsNullOrWhiteSpace(artwork.SourcePanel2DDocumentId);
+    }
+
+    private static string Format(double value) => Math.Round(value, 2).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -55,6 +55,8 @@
                           Command="{Binding OpenFaceStubCommand}" />
                 <MenuItem Header="Generate Face From _Region..."
                           Command="{Binding GenerateFaceFromRegionCommand}" />
+                <MenuItem Header="_Regenerate Face"
+                          Command="{Binding RegenerateFaceCommand}" />
                 <MenuItem Header="New _Cabinet3D Stub"
                           Command="{Binding OpenCabinet3DStubCommand}" />
                 <MenuItem Header="New _Machine Stub"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -106,6 +106,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenPanel2DStubCommand = new RelayCommand(OpenPanel2DStubDocument, CanOpenUntitledDocument);
         OpenFaceStubCommand = new RelayCommand(OpenFaceStubDocument, CanOpenUntitledDocument);
         GenerateFaceFromRegionCommand = new RelayCommand(GenerateFaceFromRegion, CanGenerateFaceFromRegion);
+        RegenerateFaceCommand = new RelayCommand(RegenerateFace, CanRegenerateFace);
         OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
@@ -392,6 +393,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenPanel2DStubCommand { get; }
     public ICommand OpenFaceStubCommand { get; }
     public ICommand GenerateFaceFromRegionCommand { get; }
+    public ICommand RegenerateFaceCommand { get; }
     public ICommand OpenCabinet3DStubCommand { get; }
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
@@ -1003,6 +1005,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         _documentWorkspace.GenerateFaceFromSelectedPanel2DRegion(dialog.SourceRegion);
+    }
+
+    private bool CanRegenerateFace()
+    {
+        return _documentWorkspace.CanRegenerateSelectedFace();
+    }
+
+    private void RegenerateFace()
+    {
+        if (!CanRegenerateFace())
+        {
+            return;
+        }
+
+        _documentWorkspace.RegenerateSelectedFace();
     }
 
     private void OpenCabinet3DStubDocument()
@@ -3182,6 +3199,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (GenerateFaceFromRegionCommand is RelayCommand generateFaceRelayCommand)
         {
             generateFaceRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (RegenerateFaceCommand is RelayCommand regenerateFaceRelayCommand)
+        {
+            regenerateFaceRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (OpenCabinet3DStubCommand is RelayCommand openCabinetRelayCommand)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -160,9 +160,23 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         return true;
     }
 
+    internal void SetFaceDocument(FaceDocumentModel model, PanelChangeEvent? faceChange = null)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        _faceDocumentModel = model;
+        _faceDocumentJson = GetFaceDocumentJson();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
+
+        if (faceChange is PanelChangeEvent change)
+        {
+            PanelChanged?.Invoke(change);
+        }
+    }
+
     internal void SetFaceElements(IReadOnlyList<FaceElementModel> elements, PanelChangeEvent? faceChange = null)
     {
-        _faceDocumentModel = new FaceDocumentModel
+        SetFaceDocument(new FaceDocumentModel
         {
             Id = _faceDocumentModel.Id,
             Title = _faceDocumentModel.Title,
@@ -171,14 +185,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             SourceRegion = _faceDocumentModel.SourceRegion,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()
-        };
-        _faceDocumentJson = GetFaceDocumentJson();
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
-
-        if (faceChange is PanelChangeEvent change)
-        {
-            PanelChanged?.Invoke(change);
-        }
+        }, faceChange);
     }
 
     internal Panel2DDocumentModel GetPanelDocument()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -23,6 +23,7 @@ public sealed class DocumentWorkspaceViewModel
     private readonly Automation.IPanel2DDocumentCreationService _panel2dCreationService;
     private readonly Automation.IFaceDocumentCreationService _faceCreationService;
     private readonly FaceGenerationService _faceGenerationService = new();
+    private readonly FaceRegenerationService _faceRegenerationService = new();
 
     private int _untitledDocumentCounter = 1;
     private int _panelDocumentCounter = 1;
@@ -130,6 +131,75 @@ public sealed class DocumentWorkspaceViewModel
         _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
         _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
         return document;
+    }
+
+    public bool CanRegenerateSelectedFace()
+    {
+        var selectedDocument = _getSelectedDocument();
+        return _getLoadedProject() is not null
+            && selectedDocument is { Document.DocumentType: EditorDocumentType.Face }
+            && TryFindSourcePanelDocument(selectedDocument.GetFaceDocument(), out _);
+    }
+
+    public bool RegenerateSelectedFace()
+    {
+        var selectedDocument = _getSelectedDocument();
+        if (_getLoadedProject() is null || selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Face)
+        {
+            return false;
+        }
+
+        var existingFace = selectedDocument.GetFaceDocument();
+        if (!TryFindSourcePanelDocument(existingFace, out var sourcePanelDocument))
+        {
+            _setStatusMessage("Unable to regenerate Face: source Panel2D document is not open.");
+            _addOutputEntry("Face regeneration skipped because the source Panel2D document could not be located among open documents.", OutputLogStatus.Warning);
+            return false;
+        }
+
+        var result = _faceRegenerationService.Regenerate(
+            existingFace,
+            sourcePanelDocument.GetPanelDocument(),
+            _getLoadedProject()?.InputDefinitions ?? []);
+
+        selectedDocument.SetFaceDocument(
+            result.Document,
+            new PanelChangeEvent(
+                selectedDocument.DocumentId,
+                null,
+                PanelChangeProperties.Structure | PanelChangeProperties.Geometry | PanelChangeProperties.Metadata,
+                AffectsCanvas: true,
+                AffectsHierarchy: true,
+                AffectsInspectorRows: true,
+                AffectsPersistence: true));
+        selectedDocument.MarkDirty();
+
+        _setStatusMessage($"Regenerated face '{selectedDocument.Title}' from source Panel2D.");
+        _addOutputEntry($"Regenerated face '{selectedDocument.Title}' from source Panel2D with {result.UpdatedElementCount} updated generated element(s), {result.AddedElementCount} added generated element(s), {result.RemovedGeneratedElementCount} removed stale generated element(s), and {result.PreservedManualElementCount} preserved manual element(s).", OutputLogStatus.Info);
+        return true;
+    }
+
+    private bool TryFindSourcePanelDocument(FaceDocumentModel faceDocument, out DocumentTabViewModel sourcePanelDocument)
+    {
+        sourcePanelDocument = null!;
+        var sourceId = faceDocument.SourcePanel2DDocumentId?.Trim();
+        if (string.IsNullOrWhiteSpace(sourceId) || faceDocument.SourceRegion is not { IsValid: true })
+        {
+            return false;
+        }
+
+        var match = _openDocuments.FirstOrDefault(document =>
+            document.Document.DocumentType == EditorDocumentType.Panel2D
+            && (string.Equals(document.DocumentId.ToString("N"), sourceId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(document.DocumentId.ToString("D"), sourceId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(document.FilePath, sourceId, StringComparison.OrdinalIgnoreCase)));
+        if (match is null)
+        {
+            return false;
+        }
+
+        sourcePanelDocument = match;
+        return true;
     }
 
     public void OpenUntitledDocument()
@@ -408,6 +478,8 @@ public sealed class DocumentWorkspaceViewModel
                 Id = faceDocument.Id,
                 Title = document.Document.Title,
                 Summary = document.ContentSummary,
+                SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+                SourceRegion = faceDocument.SourceRegion,
                 Layers = faceDocument.Layers,
                 Elements = faceDocument.Elements
             };


### PR DESCRIPTION
### Motivation

- Implement Phase 10 (Face Regeneration MVP) to allow rebuilding generated Face content from its original Panel2D source while preserving runtime identity and provenance metadata.
- Use existing provenance fields (`SourcePanel2DDocumentId`, `SourceRegion`, `LinkedPanel2DElementId`, `LinkedMachineObjectReference`) as the authoritative regeneration contract without changing Face runtime resolution behavior.

### Description

- Add `FaceRegenerationService` that re-runs Panel2D->Face generation for a Face's `SourceRegion`, correlates generated elements by `LinkedPanel2DElementId` + kind, merges regenerated elements with existing Face elements, preserves `LinkedMachineObjectReference` when matches exist, removes stale generated items, and re-attaches manual Face-only elements.
- Wire a user command and UI entry: File -> Regenerate Face, add `RegenerateFaceCommand` in `MainWindowViewModel`, and expose regeneration flow through `DocumentWorkspaceViewModel` which locates the open source Panel2D by `SourcePanel2DDocumentId`.
- Add Document API to replace the whole Face document (`DocumentTabViewModel.SetFaceDocument`) and persist document-level `SourcePanel2DDocumentId` and `SourceRegion` when saving Face documents.
- Add xUnit regression tests exercising regeneration behavior (element updates, added/stale handling, manual preservation, and button input-reference preservation) and update the FACE_SYSTEM_ARCHITECTURE_PLAN.md to mark Phase 10 complete and document the regeneration contract and verification steps.

### Testing

- Ran repository checks `git diff --check` and `git diff --cached --check`, which reported no problems.
- Added unit tests under `OasisEditor.Tests` (new `FaceRegenerationServiceTests`) that validate regeneration merging, runtime-reference preservation, stale removal, manual-element preservation, and input/button handling, but the test suite was not executed here because `dotnet` is not available in this environment.
- Manual/functional verification steps are documented in the updated `FACE_SYSTEM_ARCHITECTURE_PLAN.md` for reviewer validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a25657fe044832784b59436b1152767)