### PR TITLE
Face regeneration UX: provenance, diagnostics, and source workflow (Phase 10.5)

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -661,9 +661,56 @@ Manual verification steps:
 
 Next recommended phase:
 
-- Phase 11 should remain the Visual Fidelity Layer, focused only on rendering/presentation improvements such as lamp glow, artwork blending, masks, and lamp trays. It should not change the regeneration metadata contract or the `LinkedMachineObjectReference` -> `MachineRuntimeState` runtime contract.
+- Phase 10.5 is complete. Phase 11A should start with Lamp Visual Fidelity, focused on lamp presentation improvements without changing the regeneration metadata contract or the `LinkedMachineObjectReference` -> `MachineRuntimeState` runtime contract.
+
+
+### Phase 10.5 - Face Generation / Regeneration UX - Complete
+
+Completed as a small workflow/discoverability phase before visual-fidelity work.
+
+Outcome:
+
+- Face document provenance is visible in the Inspector when a Face document is selected without a specific Face element selected, including source Panel2D document metadata, source region, generated element count, and last regenerated timestamp;
+- generated and regenerated Face documents persist `LastRegeneratedAtUtc` metadata so the user can see when the source region was last replayed;
+- the File menu now exposes both **Regenerate Face** and **Open Source Panel2D**, making the regeneration workflow and source-location workflow discoverable from the active Face document;
+- **Regenerate Face** remains visible/enabled for Faces with regeneration metadata even when the source Panel2D is not currently open, so execution can report a clear missing-source diagnostic instead of silently hiding the workflow;
+- Face validation diagnostics now report missing source Panel2D documents, invalid/missing source regions, missing artwork/reel assets, missing machine references, and mismatched machine-reference kinds through the existing Output log path where appropriate;
+- the Face Inspector surfaces a machine-reference warning count for the selected Face document as a lightweight diagnostic summary.
+
+Regeneration/source UX contract:
+
+```text
+Face document selected
+    -> Inspector shows provenance and diagnostics summary
+    -> File > Open Source Panel2D activates the open source tab when available
+    -> File > Regenerate Face replays SourcePanel2DDocumentId + SourceRegion
+    -> Output log reports missing-source / missing-asset / missing-reference diagnostics
+```
+
+Important boundaries preserved:
+
+- no visual-fidelity changes were added;
+- no 3D preview behavior was added;
+- no Unity integration behavior was added;
+- `LinkedMachineObjectReference` remains the Face runtime identity path, while `LinkedPanel2DElementId` remains provenance/regeneration metadata only.
+
+Manual verification steps:
+
+1. Open a project with a Panel2D source document and a generated Face document.
+2. Select the Face document with no Face element selected and confirm the Inspector shows Source Panel2D Document, Source Region, Generated Element Count, Last Regenerated, and workflow command guidance.
+3. Run **File -> Open Source Panel2D** and confirm the source Panel2D tab is activated when it is open.
+4. Close or do not open the source Panel2D, select the Face, run **File -> Regenerate Face**, and confirm the Output log reports that the source Panel2D could not be located.
+5. Create a Face with a missing artwork/reel asset path or remove a runtime-linked element's machine reference, then regenerate or invoke the source-location workflow and confirm Output log diagnostics identify the missing data.
+
+Next recommended phase:
+
+- Phase 11A should be **Lamp Visual Fidelity**, focused narrowly on Face lamp presentation improvements such as lamp glow, artwork blending for lit/unlit lamp regions, and lamp-mask/tray presentation where possible. It should not add 3D preview, Unity integration, or runtime identity changes.
 
 ### Phase 11 - Visual Fidelity Layer - Future
+
+Recommended first slice:
+
+- Phase 11A - Lamp Visual Fidelity.
 
 Goals:
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRegenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRegenerationServiceTests.cs
@@ -153,6 +153,7 @@ public sealed class FaceRegenerationServiceTests
 
         Assert.Contains(result.Document.Elements, element => element.ObjectId == "manual-lamp-window");
         Assert.DoesNotContain(result.Document.Elements, element => element.ObjectId == "stale-generated-lamp");
+        Assert.NotNull(result.Document.LastRegeneratedAtUtc);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceValidationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceValidationServiceTests.cs
@@ -1,0 +1,55 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceValidationServiceTests
+{
+    [Fact]
+    public void Validate_ReportsMissingSourceAssetsAndMachineReferences()
+    {
+        var face = new FaceDocumentModel
+        {
+            Id = "face-validation",
+            Title = "Face Validation",
+            SourcePanel2DDocumentId = "missing-panel",
+            SourceRegion = FaceSourceRegionModel.FromRect(new Rect(0, 0, 100, 100)),
+            Elements =
+            [
+                new FaceArtworkElement
+                {
+                    ObjectId = "artwork-1",
+                    Name = "Artwork",
+                    AssetPath = "Assets/Missing/artwork.png"
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Lamp"
+                },
+                new FaceReelDisplayElement
+                {
+                    ObjectId = "reel-1",
+                    Name = "Reel",
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(1)
+                }
+            ]
+        };
+        var project = new EditorProject
+        {
+            Name = "Test",
+            ProjectFilePath = "/tmp/project.oasis",
+            ProjectDirectory = "/tmp",
+            AssetsDirectory = "/tmp/Assets",
+            MachinesDirectory = "/tmp/Machines",
+            GeneratedDirectory = "/tmp/Generated"
+        };
+
+        var diagnostics = new FaceValidationService().Validate(face, project, []);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.SourcePanel2D.NotOpen");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.ArtworkAsset.Missing");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.MachineReference.Missing");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.MachineReference.KindMismatch");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -7,6 +7,7 @@ public sealed class FaceDocumentModel
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionModel? SourceRegion { get; init; }
+    public DateTime? LastRegeneratedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
     public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -148,6 +148,7 @@ public static class FaceDocumentStorage
             Summary = file.Summary,
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
             SourceRegion = ToModel(file.SourceRegion),
+            LastRegeneratedAtUtc = file.LastRegeneratedAtUtc,
             Layers = (file.Layers ?? [])
                 .Select(layer => new FaceLayerModel
                 {
@@ -174,6 +175,7 @@ public static class FaceDocumentStorage
             Summary = model.Summary,
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
             SourceRegion = ToFile(model.SourceRegion),
+            LastRegeneratedAtUtc = model.LastRegeneratedAtUtc,
             SavedAtUtc = DateTime.UtcNow,
             Layers = model.Layers.Select(layer => new FaceLayerFile
             {
@@ -457,6 +459,7 @@ public sealed record FaceDocumentFile
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }
+    public DateTime? LastRegeneratedAtUtc { get; init; }
     public DateTime SavedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
     public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -122,6 +122,7 @@ internal sealed class FaceGenerationService
             Summary = $"Generated from Panel2D source region ({Format(region.X)}, {Format(region.Y)}, {Format(region.Width)}, {Format(region.Height)}).",
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(sourcePanel2DDocumentId) ? null : sourcePanel2DDocumentId.Trim(),
             SourceRegion = sourceRegion,
+            LastRegeneratedAtUtc = DateTime.UtcNow,
             Layers =
             [
                 new FaceLayerModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -110,6 +110,7 @@ internal sealed class FaceRegenerationService
             Summary = $"Regenerated from Panel2D source region ({Format(sourceRegion.X)}, {Format(sourceRegion.Y)}, {Format(sourceRegion.Width)}, {Format(sourceRegion.Height)}).",
             SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
             SourceRegion = sourceRegion,
+            LastRegeneratedAtUtc = DateTime.UtcNow,
             Layers = existingFace.Layers.Count > 0 ? existingFace.Layers : generated.Document.Layers,
             Elements = mergedElements.ToArray()
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceValidationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceValidationService.cs
@@ -1,0 +1,185 @@
+using System.IO;
+using System.Linq;
+
+namespace OasisEditor;
+
+public enum FaceValidationSeverity
+{
+    Info,
+    Warning,
+    Error
+}
+
+public sealed record FaceValidationDiagnostic(FaceValidationSeverity Severity, string Code, string Message);
+
+public sealed class FaceValidationService
+{
+    public IReadOnlyList<FaceValidationDiagnostic> Validate(
+        FaceDocumentModel faceDocument,
+        EditorProject? project,
+        IReadOnlyList<DocumentTabViewModel> openDocuments)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+        ArgumentNullException.ThrowIfNull(openDocuments);
+
+        var diagnostics = new List<FaceValidationDiagnostic>();
+        ValidateSourcePanel(faceDocument, openDocuments, diagnostics);
+        ValidateArtworkAssets(faceDocument, project, diagnostics);
+        ValidateMachineReferences(faceDocument, diagnostics);
+        return diagnostics;
+    }
+
+    private static void ValidateSourcePanel(
+        FaceDocumentModel faceDocument,
+        IReadOnlyList<DocumentTabViewModel> openDocuments,
+        List<FaceValidationDiagnostic> diagnostics)
+    {
+        var sourceId = faceDocument.SourcePanel2DDocumentId?.Trim();
+        if (string.IsNullOrWhiteSpace(sourceId))
+        {
+            diagnostics.Add(new FaceValidationDiagnostic(
+                FaceValidationSeverity.Warning,
+                "Face.SourcePanel2D.Missing",
+                "Face does not contain Source Panel2D metadata, so regeneration cannot locate its source document."));
+            return;
+        }
+
+        if (faceDocument.SourceRegion is not { IsValid: true })
+        {
+            diagnostics.Add(new FaceValidationDiagnostic(
+                FaceValidationSeverity.Warning,
+                "Face.SourceRegion.Missing",
+                "Face does not contain a valid source region, so regeneration cannot be replayed."));
+        }
+
+        var sourceIsOpen = openDocuments.Any(document =>
+            document.Document.DocumentType == EditorDocumentType.Panel2D
+            && (string.Equals(document.DocumentId.ToString("N"), sourceId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(document.DocumentId.ToString("D"), sourceId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(document.FilePath, sourceId, StringComparison.OrdinalIgnoreCase)));
+        if (!sourceIsOpen)
+        {
+            diagnostics.Add(new FaceValidationDiagnostic(
+                FaceValidationSeverity.Warning,
+                "Face.SourcePanel2D.NotOpen",
+                $"Source Panel2D document '{sourceId}' is not currently open."));
+        }
+    }
+
+    private static void ValidateArtworkAssets(
+        FaceDocumentModel faceDocument,
+        EditorProject? project,
+        List<FaceValidationDiagnostic> diagnostics)
+    {
+        foreach (var artwork in faceDocument.Elements.OfType<FaceArtworkElement>())
+        {
+            if (string.IsNullOrWhiteSpace(artwork.AssetPath))
+            {
+                continue;
+            }
+
+            var resolvedPath = ResolveProjectPath(project, artwork.AssetPath.Trim());
+            if (resolvedPath is null || !File.Exists(resolvedPath))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.ArtworkAsset.Missing",
+                    $"Artwork element '{DisplayName(artwork)}' references missing asset '{artwork.AssetPath}'."));
+            }
+        }
+
+        foreach (var reel in faceDocument.Elements.OfType<FaceReelDisplayElement>())
+        {
+            if (string.IsNullOrWhiteSpace(reel.AssetPath))
+            {
+                continue;
+            }
+
+            var resolvedPath = ResolveProjectPath(project, reel.AssetPath.Trim());
+            if (resolvedPath is null || !File.Exists(resolvedPath))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.ReelAsset.Missing",
+                    $"Reel display '{DisplayName(reel)}' references missing asset '{reel.AssetPath}'."));
+            }
+        }
+    }
+
+    private static void ValidateMachineReferences(FaceDocumentModel faceDocument, List<FaceValidationDiagnostic> diagnostics)
+    {
+        foreach (var element in faceDocument.Elements)
+        {
+            var expectedKind = element switch
+            {
+                FaceLampWindowElement => MachineObjectKind.Lamp,
+                FaceReelDisplayElement => MachineObjectKind.Reel,
+                FaceSevenSegmentDisplayElement => MachineObjectKind.SevenSegmentDisplay,
+                FaceAlphaDisplayElement => MachineObjectKind.AlphaDisplay,
+                FaceButtonElement => MachineObjectKind.Input,
+                _ => (MachineObjectKind?)null
+            };
+
+            if (expectedKind is null)
+            {
+                continue;
+            }
+
+            if (element.LinkedMachineObjectReference is not MachineObjectReference reference || reference.IsEmpty)
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.MachineReference.Missing",
+                    $"{NicifyElementKind(element)} '{DisplayName(element)}' does not have a machine reference."));
+                continue;
+            }
+
+            if (reference.Kind != expectedKind.Value)
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.MachineReference.KindMismatch",
+                    $"{NicifyElementKind(element)} '{DisplayName(element)}' references '{reference}', but expected a {expectedKind.Value} reference."));
+            }
+        }
+    }
+
+    private static string? ResolveProjectPath(EditorProject? project, string assetPath)
+    {
+        if (Path.IsPathRooted(assetPath))
+        {
+            return assetPath;
+        }
+
+        if (project is null)
+        {
+            return null;
+        }
+
+        var projectRelative = Path.GetFullPath(Path.Combine(project.ProjectDirectory, assetPath));
+        if (File.Exists(projectRelative))
+        {
+            return projectRelative;
+        }
+
+        return Path.GetFullPath(Path.Combine(project.AssetsDirectory, assetPath));
+    }
+
+    private static string DisplayName(FaceElementModel element)
+    {
+        return string.IsNullOrWhiteSpace(element.Name) ? element.ObjectId : element.Name.Trim();
+    }
+
+    private static string NicifyElementKind(FaceElementModel element)
+    {
+        return element switch
+        {
+            FaceReelDisplayElement => "Reel display",
+            FaceSevenSegmentDisplayElement => "Seven-segment display",
+            FaceAlphaDisplayElement => "Alpha display",
+            FaceButtonElement => "Button",
+            FaceLampWindowElement => "Lamp window",
+            _ => "Face element"
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -57,6 +57,8 @@
                           Command="{Binding GenerateFaceFromRegionCommand}" />
                 <MenuItem Header="_Regenerate Face"
                           Command="{Binding RegenerateFaceCommand}" />
+                <MenuItem Header="Open Source _Panel2D"
+                          Command="{Binding OpenSourcePanel2DCommand}" />
                 <MenuItem Header="New _Cabinet3D Stub"
                           Command="{Binding OpenCabinet3DStubCommand}" />
                 <MenuItem Header="New _Machine Stub"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -107,6 +107,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenFaceStubCommand = new RelayCommand(OpenFaceStubDocument, CanOpenUntitledDocument);
         GenerateFaceFromRegionCommand = new RelayCommand(GenerateFaceFromRegion, CanGenerateFaceFromRegion);
         RegenerateFaceCommand = new RelayCommand(RegenerateFace, CanRegenerateFace);
+        OpenSourcePanel2DCommand = new RelayCommand(OpenSourcePanel2D, CanOpenSourcePanel2D);
         OpenCabinet3DStubCommand = new RelayCommand(OpenCabinet3DStubDocument, CanOpenUntitledDocument);
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         OpenDocumentCommand = new RelayCommand(OpenDocument, CanOpenDocument);
@@ -394,6 +395,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenFaceStubCommand { get; }
     public ICommand GenerateFaceFromRegionCommand { get; }
     public ICommand RegenerateFaceCommand { get; }
+    public ICommand OpenSourcePanel2DCommand { get; }
     public ICommand OpenCabinet3DStubCommand { get; }
     public ICommand OpenMachineStubCommand { get; }
     public ICommand OpenDocumentCommand { get; }
@@ -1020,6 +1022,21 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         _documentWorkspace.RegenerateSelectedFace();
+    }
+
+    private bool CanOpenSourcePanel2D()
+    {
+        return _documentWorkspace.CanOpenSourcePanel2DForSelectedFace();
+    }
+
+    private void OpenSourcePanel2D()
+    {
+        if (!CanOpenSourcePanel2D())
+        {
+            return;
+        }
+
+        _documentWorkspace.OpenSourcePanel2DForSelectedFace();
     }
 
     private void OpenCabinet3DStubDocument()
@@ -3204,6 +3221,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (RegenerateFaceCommand is RelayCommand regenerateFaceRelayCommand)
         {
             regenerateFaceRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (OpenSourcePanel2DCommand is RelayCommand openSourcePanelRelayCommand)
+        {
+            openSourcePanelRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (OpenCabinet3DStubCommand is RelayCommand openCabinetRelayCommand)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -24,6 +24,7 @@ public sealed class DocumentWorkspaceViewModel
     private readonly Automation.IFaceDocumentCreationService _faceCreationService;
     private readonly FaceGenerationService _faceGenerationService = new();
     private readonly FaceRegenerationService _faceRegenerationService = new();
+    private readonly FaceValidationService _faceValidationService = new();
 
     private int _untitledDocumentCounter = 1;
     private int _panelDocumentCounter = 1;
@@ -130,15 +131,55 @@ public sealed class DocumentWorkspaceViewModel
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
         _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
+        LogFaceDiagnostics(result.Document);
         return document;
     }
 
     public bool CanRegenerateSelectedFace()
     {
         var selectedDocument = _getSelectedDocument();
-        return _getLoadedProject() is not null
-            && selectedDocument is { Document.DocumentType: EditorDocumentType.Face }
-            && TryFindSourcePanelDocument(selectedDocument.GetFaceDocument(), out _);
+        if (_getLoadedProject() is null || selectedDocument is not { Document.DocumentType: EditorDocumentType.Face })
+        {
+            return false;
+        }
+
+        var faceDocument = selectedDocument.GetFaceDocument();
+        return !string.IsNullOrWhiteSpace(faceDocument.SourcePanel2DDocumentId)
+            && faceDocument.SourceRegion is { IsValid: true };
+    }
+
+    public bool CanOpenSourcePanel2DForSelectedFace()
+    {
+        var selectedDocument = _getSelectedDocument();
+        if (_getLoadedProject() is null || selectedDocument is not { Document.DocumentType: EditorDocumentType.Face })
+        {
+            return false;
+        }
+
+        return !string.IsNullOrWhiteSpace(selectedDocument.GetFaceDocument().SourcePanel2DDocumentId);
+    }
+
+    public bool OpenSourcePanel2DForSelectedFace()
+    {
+        var selectedDocument = _getSelectedDocument();
+        if (_getLoadedProject() is null || selectedDocument is not { Document.DocumentType: EditorDocumentType.Face })
+        {
+            return false;
+        }
+
+        var faceDocument = selectedDocument.GetFaceDocument();
+        if (!TryFindSourcePanelDocument(faceDocument, out var sourcePanelDocument))
+        {
+            _setStatusMessage("Unable to open Face source: source Panel2D document is not open.");
+            _addOutputEntry(BuildSourcePanelMissingMessage(faceDocument), OutputLogStatus.Warning);
+            LogFaceDiagnostics(faceDocument);
+            return false;
+        }
+
+        _setSelectedDocument(sourcePanelDocument);
+        _setStatusMessage($"Opened source Panel2D for face '{selectedDocument.Title}': {sourcePanelDocument.Title}");
+        _addOutputEntry($"Activated source Panel2D document '{sourcePanelDocument.Title}' for face '{selectedDocument.Title}'.", OutputLogStatus.Info);
+        return true;
     }
 
     public bool RegenerateSelectedFace()
@@ -153,7 +194,8 @@ public sealed class DocumentWorkspaceViewModel
         if (!TryFindSourcePanelDocument(existingFace, out var sourcePanelDocument))
         {
             _setStatusMessage("Unable to regenerate Face: source Panel2D document is not open.");
-            _addOutputEntry("Face regeneration skipped because the source Panel2D document could not be located among open documents.", OutputLogStatus.Warning);
+            _addOutputEntry(BuildSourcePanelMissingMessage(existingFace), OutputLogStatus.Warning);
+            LogFaceDiagnostics(existingFace);
             return false;
         }
 
@@ -176,7 +218,36 @@ public sealed class DocumentWorkspaceViewModel
 
         _setStatusMessage($"Regenerated face '{selectedDocument.Title}' from source Panel2D.");
         _addOutputEntry($"Regenerated face '{selectedDocument.Title}' from source Panel2D with {result.UpdatedElementCount} updated generated element(s), {result.AddedElementCount} added generated element(s), {result.RemovedGeneratedElementCount} removed stale generated element(s), and {result.PreservedManualElementCount} preserved manual element(s).", OutputLogStatus.Info);
+        LogFaceDiagnostics(result.Document);
         return true;
+    }
+
+    public IReadOnlyList<FaceValidationDiagnostic> ValidateSelectedFace()
+    {
+        var selectedDocument = _getSelectedDocument();
+        if (selectedDocument is not { Document.DocumentType: EditorDocumentType.Face })
+        {
+            return [];
+        }
+
+        return _faceValidationService.Validate(selectedDocument.GetFaceDocument(), _getLoadedProject(), _openDocuments.ToArray());
+    }
+
+    private void LogFaceDiagnostics(FaceDocumentModel faceDocument)
+    {
+        var diagnostics = _faceValidationService.Validate(faceDocument, _getLoadedProject(), _openDocuments.ToArray());
+        foreach (var diagnostic in diagnostics)
+        {
+            _addOutputEntry($"Face validation ({diagnostic.Code}): {diagnostic.Message}", diagnostic.Severity == FaceValidationSeverity.Error ? OutputLogStatus.Error : OutputLogStatus.Warning);
+        }
+    }
+
+    private static string BuildSourcePanelMissingMessage(FaceDocumentModel faceDocument)
+    {
+        var sourceId = string.IsNullOrWhiteSpace(faceDocument.SourcePanel2DDocumentId)
+            ? "<missing>"
+            : faceDocument.SourcePanel2DDocumentId.Trim();
+        return $"Face source Panel2D document '{sourceId}' could not be located among open documents. Open the source Panel2D tab, then retry.";
     }
 
     private bool TryFindSourcePanelDocument(FaceDocumentModel faceDocument, out DocumentTabViewModel sourcePanelDocument)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -304,6 +304,15 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Face
+            && (selection is not PanelSelectionInfo selectedFaceSelection
+                || !selectedDocument.TryGetFaceElement(selectedFaceSelection, out _)))
+        {
+            RebuildFaceDocumentPropertyRows(selectedDocument);
+            return;
+        }
+
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
         {
             _hadInspectorSelection = false;
@@ -379,6 +388,14 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
             return !string.Equals(_lastInspectorSelectionObjectId, selectedFaceElement.ObjectId, StringComparison.Ordinal)
                 || !string.Equals(_lastInspectorFaceSelectionKind, FaceSelectionService.GetKindToken(selectedFaceElement), StringComparison.Ordinal);
+        }
+
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Face
+            && (selection is not PanelSelectionInfo selectedFaceSelection
+                || !selectedDocument.TryGetFaceElement(selectedFaceSelection, out _)))
+        {
+            return true;
         }
 
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
@@ -542,6 +559,29 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference ?? string.Empty));
         }
+    }
+
+
+    private void RebuildFaceDocumentPropertyRows(DocumentTabViewModel selectedDocument)
+    {
+        var faceDocument = selectedDocument.GetFaceDocument();
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Panel2D Document", "Face Provenance", faceDocument.SourcePanel2DDocumentId ?? string.Empty));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Region", "Face Provenance", faceDocument.SourceRegion is not null ? FormatSourceRegion(faceDocument.SourceRegion) : string.Empty));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Generated Element Count", "Face Provenance", CountGeneratedElements(faceDocument).ToString()));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Last Regenerated", "Face Provenance", FormatTimestamp(faceDocument.LastRegeneratedAtUtc)));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Face Commands", "Workflow", "Use File > Regenerate Face or File > Open Source Panel2D."));
+
+        var missingMachineReferenceCount = CountMissingMachineReferences(faceDocument);
+        if (missingMachineReferenceCount > 0)
+        {
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Machine Reference Warnings", "Diagnostics", $"{missingMachineReferenceCount} runtime-linked element(s) are missing machine references."));
+        }
+
+        _hadInspectorSelection = false;
+        _lastInspectorSelectionObjectId = null;
+        _lastInspectorSelectionKind = null;
+        _lastInspectorFaceSelectionKind = null;
+        OnPropertyChanged(nameof(InspectorPropertyRows));
     }
 
     private void RebuildFacePropertyRows(DocumentTabViewModel selectedDocument, FaceElementModel selectedElement)
@@ -903,6 +943,35 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             FaceButtonElement => "Face Button",
             _ => "Face Element"
         };
+    }
+
+
+    private static int CountGeneratedElements(FaceDocumentModel faceDocument)
+    {
+        return faceDocument.Elements.Count(element => !string.IsNullOrWhiteSpace(element.LinkedPanel2DElementId)
+            || element is FaceArtworkElement { Provenance: not null });
+    }
+
+    private static int CountMissingMachineReferences(FaceDocumentModel faceDocument)
+    {
+        return faceDocument.Elements.Count(element => IsRuntimeLinkedFaceElement(element)
+            && (element.LinkedMachineObjectReference is not MachineObjectReference reference || reference.IsEmpty));
+    }
+
+    private static bool IsRuntimeLinkedFaceElement(FaceElementModel element)
+    {
+        return element is FaceLampWindowElement
+            or FaceReelDisplayElement
+            or FaceSevenSegmentDisplayElement
+            or FaceAlphaDisplayElement
+            or FaceButtonElement;
+    }
+
+    private static string FormatTimestamp(DateTime? timestampUtc)
+    {
+        return timestampUtc.HasValue
+            ? $"{timestampUtc.Value.ToUniversalTime():yyyy-MM-dd HH:mm:ss} UTC"
+            : string.Empty;
     }
 
     private static string FormatSourceRegion(FaceSourceRegionModel region)


### PR DESCRIPTION
### Motivation

- Improve discoverability of Face provenance and make regeneration behavior diagnosable before visual-fidelity work begins. 
- Surface missing-source / missing-asset / missing-machine-reference issues through existing output/inspector pathways so users can act on them. 
- Keep runtime identity (`LinkedMachineObjectReference`) unchanged while preserving `LinkedPanel2DElementId` as provenance for regeneration.

### Description

- Added persisted `LastRegeneratedAtUtc` to `FaceDocumentModel`/storage and set it during generation and regeneration so documents carry a last-regenerated timestamp. 
- Added `FaceValidationService` to validate Face documents for missing source Panel2D metadata/open tabs, invalid `SourceRegion`, missing artwork/reel asset files, missing machine references, and machine-reference kind mismatches, and exposed diagnostics as `FaceValidationDiagnostic` values. 
- Exposed a new workflow command `Open Source Panel2D` (ViewModel command and File menu) and improved regeneration UX so `Regenerate Face` remains discoverable and reports clear diagnostics when the source Panel2D is not open. 
- Enhanced the Inspector to show Face provenance when a Face document is selected with no element selected (Source Panel2D Document, Source Region, Generated Element Count, Last Regenerated timestamp, workflow guidance) and a lightweight machine-reference warning count. 
- Logged validation diagnostics to the existing output log in regeneration/generation and when source-panel lookup fails. 
- Updated the Face generation/regeneration services to set `LastRegeneratedAtUtc` on generated/regenerated documents. 
- Added/updated unit tests: `FaceValidationServiceTests` (new) and an assertion update in `FaceRegenerationServiceTests` to verify `LastRegeneratedAtUtc` is set. 
- Updated `FACE_SYSTEM_ARCHITECTURE_PLAN.md` to record Phase 10.5 completion and recommend Phase 11A (Lamp Visual Fidelity) as the next slice.

### Testing

- Added automated tests: `OasisEditor.Tests/FaceValidationServiceTests.cs` (new) and updated `OasisEditor.Tests/FaceRegenerationServiceTests.cs` to assert timestamp preservation; tests were added but not executed in this environment. 
- Per project guidance, tests were not run locally because the Codex environment lacks the Windows/.NET/WPF toolchain; instead `git diff --check` was run successfully. 
- Manual verification guidance was added to the architecture plan and should be followed during local verification: open/generate/regenerate Face documents, exercise `File -> Open Source Panel2D`, and confirm output log diagnostics and Inspector provenance rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a25865935a88327a271d9bd98e50be3)