### PR TITLE
Face Mask Layer Extraction MVP — model, storage, extraction, docs, and tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/FACE_SYSTEM_ARCHITECTURE_PLAN.md
@@ -19,16 +19,27 @@ Current Panel2D work gives Oasis:
 - shared Skia renderer;
 - runtime-state driven visuals.
 
-The Face system should represent the physical/presentation side of the fruit machine:
+The Face system should represent the physical/presentation side of the fruit machine. The long-term physical model is no longer treated as `Artwork + Lamp Windows`; it is:
 
-- glass artwork;
-- lamp mask;
-- lamp tray;
-- physical button locations;
-- reel windows;
-- display windows;
-- depths/materials;
-- future Unity renderer data.
+```text
+FaceArtworkLayer
+FaceMaskLayer
+Runtime Objects
+    Lamps
+    Buttons
+    Displays
+    Reels
+Future Tray Geometry
+```
+
+In this model:
+
+- artwork is the printed artwork layer;
+- mask is the single opaque printed layer behind the artwork, aligned to the same face-sized source region;
+- runtime objects are the machine-controlled lamps, buttons, displays, and reels;
+- tray geometry is a future representation of the physical lamp tray/light containment behind the mask.
+
+Important: the mask layer is one face-sized layer aligned to the artwork. It is not a persisted collection of independent lamp mask images. Per-lamp extraction may be used internally during generation, but persisted Face documents should store one aligned `FaceMaskLayer` plus provenance/extraction metadata.
 
 Recommended user-facing name:
 
@@ -53,7 +64,7 @@ The Face system is no longer only a pre-implementation proposal. The project now
 - machine-object reference types and resolution services;
 - persisted Face documents and Face document storage;
 - Face document creation/open/save support;
-- Face element models, including lamp, reel, display, button, mask/cutout, and artwork elements;
+- Face models, including artwork elements, runtime-linked lamp/reel/display/button elements, and an aligned Face mask layer model;
 - a 2D Face Edit View with document-space rendering and editing workflows;
 - Face generation from Panel2D regions/selections;
 - Face artwork import/rendering support;
@@ -189,6 +200,8 @@ FaceDocument
     Id
     Name
     SourcePanel2DDocumentId optional
+    SourceRegion optional
+    FaceMaskLayer optional
     Layers[]
     Elements[]
 ```
@@ -196,12 +209,14 @@ FaceDocument
 Layer concepts:
 
 ```text
-GlassArtworkLayer
-LampMaskLayer
-LampTrayLayer
-ReelWindowLayer
-DisplayWindowLayer
-ButtonLayer
+FaceArtworkLayer
+FaceMaskLayer
+RuntimeObjectLayers
+    Lamps
+    Buttons
+    Displays
+    Reels
+FutureTrayGeometry
 ```
 
 Element concepts:
@@ -212,7 +227,7 @@ FaceLampWindowElement
 FaceReelWindowElement
 FaceDisplayWindowElement
 FaceButtonElement
-FaceMaskCutoutElement
+FaceMaskLayer metadata (single aligned mask, not per-lamp elements)
 ```
 
 Core fields:
@@ -444,7 +459,7 @@ Outcome:
 - 2D Face Edit View exists;
 - Face elements render in document space;
 - selection/editing workflows exist;
-- Face element models cover the current MVP surface, including lamps, reels, displays, button hit areas, mask/cutout-style geometry, and artwork;
+- Face models cover the current MVP surface, including artwork, an aligned Face mask layer, lamps, reels, displays, and button hit areas;
 - elements can retain editor/source provenance;
 - elements can carry runtime-object references for play/runtime behavior;
 - the implementation remains renderer-neutral and does not require Unity.
@@ -661,7 +676,7 @@ Manual verification steps:
 
 Next recommended phase:
 
-- Phase 10.5 is complete. Phase 11A should start with Lamp Visual Fidelity, focused on lamp presentation improvements without changing the regeneration metadata contract or the `LinkedMachineObjectReference` -> `MachineRuntimeState` runtime contract.
+- Phase 10.5 is complete. Phase 11A should start with Face Mask Layer Extraction MVP, focused on creating one persisted face-sized mask layer aligned to the artwork/source region while preserving the regeneration metadata contract and the `LinkedMachineObjectReference` -> `MachineRuntimeState` runtime contract.
 
 
 ### Phase 10.5 - Face Generation / Regeneration UX - Complete
@@ -704,27 +719,61 @@ Manual verification steps:
 
 Next recommended phase:
 
-- Phase 11A should be **Lamp Visual Fidelity**, focused narrowly on Face lamp presentation improvements such as lamp glow, artwork blending for lit/unlit lamp regions, and lamp-mask/tray presentation where possible. It should not add 3D preview, Unity integration, or runtime identity changes.
+- Phase 11A should be **Face Mask Layer Extraction MVP**, focused on generating and persisting one aligned Face mask layer before visual-fidelity work. Tray geometry remains deferred, and per-lamp extraction is only an implementation detail.
 
-### Phase 11 - Visual Fidelity Layer - Future
+### Phase 11A - Face Mask Layer Extraction MVP - Current
 
-Recommended first slice:
+Purpose:
 
-- Phase 11A - Lamp Visual Fidelity.
+- generate a single monochrome `FaceMaskLayer` asset aligned to the Face artwork/source region;
+- persist mask-layer metadata such as `SourcePanel2DDocumentId`, `SourceRegion`, extraction threshold, generated UTC timestamp, asset path, and useful per-lamp contribution metadata;
+- preserve enough extraction metadata for future tray generation without making per-lamp extraction a runtime dependency.
+
+Important boundaries:
+
+- mask extraction precedes visual-fidelity work;
+- the persisted model is one face-sized mask layer, not one mask asset per lamp;
+- per-lamp extraction is an implementation detail used to build the union mask;
+- tray geometry is intentionally deferred;
+- do not implement glow, bloom, blur, emission rendering, runtime mask rendering, tray extraction, tray simulation, light leakage simulation, 3D preview, or Unity integration in Phase 11A.
+
+Extraction direction:
+
+```text
+For each source lamp participating in Face generation:
+    background/artwork pixels
+    lamp-on pixels
+    brightness delta
+    threshold
+    binary contribution mask
+    union/max composite into the single face-sized FaceMaskLayer
+```
+
+The mask answers: **where can light escape?** Future tray geometry answers: **which bulb is responsible for the light?**
+
+### Phase 11B - Face Mask Layer System - Future
 
 Goals:
 
-- lamp glow;
-- artwork blending;
-- masks;
-- lamp trays;
-- presentation improvements.
+- expose/edit/inspect the Face mask layer as a first-class layer in Face tooling;
+- add mask validation, replacement/regeneration controls, and clearer asset/provenance UX;
+- define how renderers should consume the mask layer later without coupling runtime behavior to per-lamp extraction metadata.
 
-Important:
+### Phase 11C - Lamp Visual Fidelity - Future
 
-- no runtime architecture changes in this phase;
-- rendering quality only;
-- visual-fidelity improvements must not change the `MachineObjectReference` -> `MachineRuntimeState` runtime contract.
+Goals:
+
+- lamp presentation improvements after the mask layer exists;
+- artwork blending and mask-aware lamp rendering investigation;
+- renderer-side quality improvements that preserve the `MachineObjectReference` -> `MachineRuntimeState` contract.
+
+### Phase 11D - Display/Reel Visual Fidelity - Future
+
+Goals:
+
+- display and reel presentation improvements after the mask-layer foundation;
+- improved window/material treatment for displays and reels;
+- no runtime identity or document ownership changes unless separately planned.
 
 ### Phase 12 - 3D Preview Investigation - Future
 

--- a/WindowsNetProjects/OasisEditor/FaceSystem.Inventory.md
+++ b/WindowsNetProjects/OasisEditor/FaceSystem.Inventory.md
@@ -47,6 +47,48 @@ Recommended readiness path:
 4. reuse Panel2D viewport math and command patterns, but extract the WPF-specific pieces before sharing them with Face;
 5. add Face to document type/open/save only in Phase 2 after those seams exist.
 
+
+## Revised physical Face layer model
+
+The Face architecture is no longer understood as `Artwork + Lamp Windows`. The long-term physical model is:
+
+```text
+Artwork Layer
+Mask Layer
+Runtime Objects
+    Lamps
+    Buttons
+    Displays
+    Reels
+Future Tray Geometry
+```
+
+### Artwork Layer
+
+The artwork layer is the printed visible artwork for the machine face. It is aligned to the source Panel2D region used to generate the Face document and remains separate from machine-controlled runtime state.
+
+### Mask Layer
+
+The mask layer is the opaque printed layer behind the artwork. It is a single face-sized monochrome layer aligned to the artwork/source region. It is not a collection of independent per-lamp mask images. Per-lamp extraction may be used internally to generate the mask, but the persisted Face model stores one unioned `FaceMaskLayer` plus provenance/extraction metadata.
+
+Question: **Where can light escape?**
+
+Answer: **Mask layer.**
+
+### Runtime Objects
+
+Runtime objects are the machine-controlled elements: lamps, buttons/inputs, displays, and reels. They continue to resolve through machine-object references and runtime state rather than through mask pixels.
+
+### Future Tray Geometry
+
+Tray geometry will eventually describe the physical lamp tray/light containment and bulb responsibility behind the mask.
+
+Question: **Which bulb is responsible for the light?**
+
+Answer: **Tray geometry (future).**
+
+Tray extraction is expected to be derived later from the same source data used for mask extraction, including per-lamp contribution bounds and pixel counts where practical. Tray extraction is intentionally outside the scope of Phase 11A.
+
 ## Machine objects vs visual elements
 
 The long-term architecture should explicitly distinguish logical **Machine Objects** from document-specific **Visual Elements**.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -14,6 +14,40 @@ public sealed class FaceDocumentRoundTripTests
             Id = "face-1",
             Title = "Front Face",
             Summary = "Physical face summary",
+            MaskLayer = new FaceMaskLayerModel
+            {
+                Id = "face-mask-layer",
+                Name = "Face Mask",
+                AssetPath = "Generated/Faces/face-1-mask.png",
+                SourcePanel2DDocumentId = "panel-doc-1",
+                SourceRegion = new FaceSourceRegionModel
+                {
+                    X = 100,
+                    Y = 200,
+                    Width = 320,
+                    Height = 240
+                },
+                ExtractionThreshold = 24,
+                GeneratedUtc = new DateTime(2026, 6, 7, 1, 0, 0, DateTimeKind.Utc),
+                Width = 320,
+                Height = 240,
+                Contributions =
+                [
+                    new FaceMaskContributionModel
+                    {
+                        SourcePanel2DElementId = "panel-lamp-17",
+                        LinkedMachineObjectReference = MachineObjectReference.Lamp(17),
+                        Bounds = new FaceSourceRegionModel
+                        {
+                            X = 10,
+                            Y = 20,
+                            Width = 30,
+                            Height = 40
+                        },
+                        PixelCount = 42
+                    }
+                ]
+            },
             Layers =
             [
                 new FaceLayerModel
@@ -88,6 +122,13 @@ public sealed class FaceDocumentRoundTripTests
         Assert.Equal("face-1", savedDocument.Id);
         Assert.Equal("Front Face", savedDocument.Title);
         Assert.Equal("Physical face summary", savedDocument.Summary);
+        Assert.Equal("Generated/Faces/face-1-mask.png", savedDocument.MaskLayer!.AssetPath);
+        Assert.Equal(24, savedDocument.MaskLayer.ExtractionThreshold);
+        Assert.Equal(320, savedDocument.MaskLayer.Width);
+        var maskContribution = Assert.Single(savedDocument.MaskLayer.Contributions!);
+        Assert.Equal("panel-lamp-17", maskContribution.SourcePanel2DElementId);
+        Assert.Equal("lamp:17", maskContribution.LinkedMachineObjectReference);
+        Assert.Equal(42, maskContribution.PixelCount);
         var layer = Assert.Single(savedDocument.Layers!);
         Assert.Equal("lamps", layer.Id);
         Assert.Equal("Lamp Windows", layer.Name);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMaskLayerExtractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMaskLayerExtractionTests.cs
@@ -1,0 +1,108 @@
+using System.Windows;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceMaskLayerExtractionTests : IDisposable
+{
+    private readonly string _projectDirectory;
+
+    public FaceMaskLayerExtractionTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceMaskTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(_projectDirectory, "Assets"));
+        Directory.CreateDirectory(Path.Combine(_projectDirectory, "Generated"));
+    }
+
+    [Fact]
+    public void GenerateFromPanelRegion_CreatesSingleFaceSizedMaskLayerAsset()
+    {
+        WriteSolidPng(Path.Combine(_projectDirectory, "Assets", "background.png"), 4, 4, SKColors.Black);
+        WriteLampPng(Path.Combine(_projectDirectory, "Assets", "lamp.png"));
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "background-1",
+                    Kind = PanelElementKind.Background,
+                    X = 0,
+                    Y = 0,
+                    Width = 4,
+                    Height = 4,
+                    AssetPath = "Assets/background.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Kind = PanelElementKind.Lamp,
+                    X = 1,
+                    Y = 1,
+                    Width = 2,
+                    Height = 2,
+                    AssetPath = "Assets/lamp.png",
+                    DisplayNumber = 7
+                }
+            ]
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            FaceSourceRegionModel.FromRect(new Rect(0, 0, 4, 4)),
+            "Mask Face",
+            "panel-doc",
+            [],
+            _projectDirectory,
+            Path.Combine(_projectDirectory, "Generated"));
+
+        var maskLayer = Assert.NotNull(result.Document.MaskLayer);
+        Assert.Equal(4, maskLayer.Width);
+        Assert.Equal(4, maskLayer.Height);
+        Assert.Equal("panel-doc", maskLayer.SourcePanel2DDocumentId);
+        Assert.Equal(FaceMaskLayerExtractionService.DefaultExtractionThreshold, maskLayer.ExtractionThreshold);
+        Assert.StartsWith("Generated/Faces/", maskLayer.AssetPath);
+        Assert.True(File.Exists(Path.Combine(_projectDirectory, maskLayer.AssetPath!.Replace('/', Path.DirectorySeparatorChar))));
+        var contribution = Assert.Single(maskLayer.Contributions);
+        Assert.Equal("lamp-1", contribution.SourcePanel2DElementId);
+        Assert.Equal("lamp:7", contribution.LinkedMachineObjectReference?.ToString());
+        Assert.Equal(2, contribution.PixelCount);
+        Assert.Equal(1d, contribution.Bounds!.X);
+        Assert.Equal(1d, contribution.Bounds.Y);
+        Assert.Equal(2d, contribution.Bounds.Width);
+        Assert.Equal(2d, contribution.Bounds.Height);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_projectDirectory))
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+
+    private static void WriteSolidPng(string path, int width, int height, SKColor color)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        bitmap.Erase(color);
+        SavePng(bitmap, path);
+    }
+
+    private static void WriteLampPng(string path)
+    {
+        using var bitmap = new SKBitmap(2, 2);
+        bitmap.Erase(SKColors.Black);
+        bitmap.SetPixel(0, 0, SKColors.White);
+        bitmap.SetPixel(1, 1, SKColors.White);
+        SavePng(bitmap, path);
+    }
+
+    private static void SavePng(SKBitmap bitmap, string path)
+    {
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMaskLayerExtractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMaskLayerExtractionTests.cs
@@ -57,7 +57,8 @@ public sealed class FaceMaskLayerExtractionTests : IDisposable
             _projectDirectory,
             Path.Combine(_projectDirectory, "Generated"));
 
-        var maskLayer = Assert.NotNull(result.Document.MaskLayer);
+        Assert.NotNull(result.Document.MaskLayer);
+        var maskLayer = result.Document.MaskLayer!;
         Assert.Equal(4, maskLayer.Width);
         Assert.Equal(4, maskLayer.Height);
         Assert.Equal("panel-doc", maskLayer.SourcePanel2DDocumentId);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -8,8 +8,31 @@ public sealed class FaceDocumentModel
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionModel? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }
+    public FaceMaskLayerModel? MaskLayer { get; init; }
     public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
     public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
+}
+
+public sealed class FaceMaskLayerModel
+{
+    public string Id { get; init; } = "face-mask-layer";
+    public string Name { get; init; } = "Face Mask";
+    public string? AssetPath { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionModel? SourceRegion { get; init; }
+    public byte ExtractionThreshold { get; init; }
+    public DateTime GeneratedUtc { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public IReadOnlyList<FaceMaskContributionModel> Contributions { get; init; } = [];
+}
+
+public sealed class FaceMaskContributionModel
+{
+    public string? SourcePanel2DElementId { get; init; }
+    public MachineObjectReference? LinkedMachineObjectReference { get; init; }
+    public FaceSourceRegionModel? Bounds { get; init; }
+    public int PixelCount { get; init; }
 }
 
 public sealed class FaceLayerModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -40,8 +40,14 @@ public static class FaceDocumentStorage
                 },
                 new FaceLayerFile
                 {
-                    Id = "layer-lamp-windows",
-                    Name = "Lamp Windows",
+                    Id = "layer-face-mask",
+                    Name = "Face Mask",
+                    IsVisible = true
+                },
+                new FaceLayerFile
+                {
+                    Id = "layer-runtime-lamps",
+                    Name = "Runtime Lamps",
                     IsVisible = true
                 },
                 new FaceLayerFile
@@ -149,6 +155,7 @@ public static class FaceDocumentStorage
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
             SourceRegion = ToModel(file.SourceRegion),
             LastRegeneratedAtUtc = file.LastRegeneratedAtUtc,
+            MaskLayer = ToModel(file.MaskLayer),
             Layers = (file.Layers ?? [])
                 .Select(layer => new FaceLayerModel
                 {
@@ -176,6 +183,7 @@ public static class FaceDocumentStorage
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
             SourceRegion = ToFile(model.SourceRegion),
             LastRegeneratedAtUtc = model.LastRegeneratedAtUtc,
+            MaskLayer = ToFile(model.MaskLayer),
             SavedAtUtc = DateTime.UtcNow,
             Layers = model.Layers.Select(layer => new FaceLayerFile
             {
@@ -185,6 +193,80 @@ public static class FaceDocumentStorage
                 IsLocked = layer.IsLocked
             }).ToArray(),
             Elements = model.Elements.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceMaskLayerModel? ToModel(FaceMaskLayerFile? file)
+    {
+        if (file is null)
+        {
+            return null;
+        }
+
+        return new FaceMaskLayerModel
+        {
+            Id = string.IsNullOrWhiteSpace(file.Id) ? "face-mask-layer" : file.Id.Trim(),
+            Name = string.IsNullOrWhiteSpace(file.Name) ? "Face Mask" : file.Name.Trim(),
+            AssetPath = file.AssetPath,
+            SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
+            SourceRegion = ToModel(file.SourceRegion),
+            ExtractionThreshold = file.ExtractionThreshold,
+            GeneratedUtc = file.GeneratedUtc,
+            Width = file.Width,
+            Height = file.Height,
+            Contributions = (file.Contributions ?? [])
+                .Select(ToModel)
+                .ToArray()
+        };
+    }
+
+    private static FaceMaskContributionModel ToModel(FaceMaskContributionFile file)
+    {
+        MachineObjectReference? reference = null;
+        if (MachineObjectReference.TryParse(file.LinkedMachineObjectReference, out var parsedReference))
+        {
+            reference = parsedReference;
+        }
+
+        return new FaceMaskContributionModel
+        {
+            SourcePanel2DElementId = file.SourcePanel2DElementId,
+            LinkedMachineObjectReference = reference,
+            Bounds = ToModel(file.Bounds),
+            PixelCount = file.PixelCount
+        };
+    }
+
+    private static FaceMaskLayerFile? ToFile(FaceMaskLayerModel? model)
+    {
+        if (model is null)
+        {
+            return null;
+        }
+
+        return new FaceMaskLayerFile
+        {
+            Id = model.Id,
+            Name = model.Name,
+            AssetPath = model.AssetPath,
+            SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
+            SourceRegion = ToFile(model.SourceRegion),
+            ExtractionThreshold = model.ExtractionThreshold,
+            GeneratedUtc = model.GeneratedUtc,
+            Width = model.Width,
+            Height = model.Height,
+            Contributions = model.Contributions.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceMaskContributionFile ToFile(FaceMaskContributionModel model)
+    {
+        return new FaceMaskContributionFile
+        {
+            SourcePanel2DElementId = model.SourcePanel2DElementId,
+            LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
+            Bounds = ToFile(model.Bounds),
+            PixelCount = model.PixelCount
         };
     }
 
@@ -460,9 +542,32 @@ public sealed record FaceDocumentFile
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }
+    public FaceMaskLayerFile? MaskLayer { get; init; }
     public DateTime SavedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
     public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];
+}
+
+public sealed record FaceMaskLayerFile
+{
+    public string? Id { get; init; }
+    public string? Name { get; init; }
+    public string? AssetPath { get; init; }
+    public string? SourcePanel2DDocumentId { get; init; }
+    public FaceSourceRegionFile? SourceRegion { get; init; }
+    public byte ExtractionThreshold { get; init; }
+    public DateTime GeneratedUtc { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public IReadOnlyList<FaceMaskContributionFile>? Contributions { get; init; } = [];
+}
+
+public sealed record FaceMaskContributionFile
+{
+    public string? SourcePanel2DElementId { get; init; }
+    public string? LinkedMachineObjectReference { get; init; }
+    public FaceSourceRegionFile? Bounds { get; init; }
+    public int PixelCount { get; init; }
 }
 
 public sealed record FaceSourceRegionFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -73,10 +73,12 @@ internal sealed class FaceGenerationResult
 internal sealed class FaceGenerationService
 {
     private readonly IMachineObjectReferenceResolver _machineObjectReferenceResolver;
+    private readonly FaceMaskLayerExtractionService _maskLayerExtractionService;
 
     public FaceGenerationService(IMachineObjectReferenceResolver? machineObjectReferenceResolver = null)
     {
         _machineObjectReferenceResolver = machineObjectReferenceResolver ?? MachineObjectReferenceResolver.Instance;
+        _maskLayerExtractionService = new FaceMaskLayerExtractionService(_machineObjectReferenceResolver);
     }
 
     public FaceGenerationResult GenerateFromPanelRegion(
@@ -84,7 +86,9 @@ internal sealed class FaceGenerationService
         FaceSourceRegionModel sourceRegion,
         string title,
         string? sourcePanel2DDocumentId = null,
-        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null)
+        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null,
+        string? projectDirectory = null,
+        string? generatedDirectory = null)
     {
         ArgumentNullException.ThrowIfNull(sourcePanel);
         ArgumentNullException.ThrowIfNull(sourceRegion);
@@ -115,14 +119,17 @@ internal sealed class FaceGenerationService
         var buttons = CreateButtonElements(sourcePanel, region, inputDefinitions ?? []);
 
         var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim();
+        var faceDocumentId = Guid.NewGuid().ToString("N");
+        var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(sourcePanel, region, faceDocumentId, sourcePanel2DDocumentId, projectDirectory, generatedDirectory);
         var document = new FaceDocumentModel
         {
-            Id = Guid.NewGuid().ToString("N"),
+            Id = faceDocumentId,
             Title = resolvedTitle,
             Summary = $"Generated from Panel2D source region ({Format(region.X)}, {Format(region.Y)}, {Format(region.Width)}, {Format(region.Height)}).",
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(sourcePanel2DDocumentId) ? null : sourcePanel2DDocumentId.Trim(),
             SourceRegion = sourceRegion,
             LastRegeneratedAtUtc = DateTime.UtcNow,
+            MaskLayer = maskLayer,
             Layers =
             [
                 new FaceLayerModel
@@ -133,8 +140,14 @@ internal sealed class FaceGenerationService
                 },
                 new FaceLayerModel
                 {
-                    Id = "layer-lamp-windows",
-                    Name = "Lamp Windows",
+                    Id = "layer-face-mask",
+                    Name = "Face Mask",
+                    IsVisible = true
+                },
+                new FaceLayerModel
+                {
+                    Id = "layer-runtime-lamps",
+                    Name = "Runtime Lamps",
                     IsVisible = true
                 },
                 new FaceLayerModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using SkiaSharp;
 using System.Windows;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
@@ -191,7 +191,9 @@ internal sealed class FaceMaskLayerExtractionService
             return null;
         }
 
-        var facesDirectory = Path.Combine(generatedDirectory, "Faces");
+        var normalizedProjectDirectory = Path.GetFullPath(projectDirectory);
+        var normalizedGeneratedDirectory = Path.GetFullPath(generatedDirectory);
+        var facesDirectory = Path.Combine(normalizedGeneratedDirectory, "Faces");
         Directory.CreateDirectory(facesDirectory);
         var safeId = string.IsNullOrWhiteSpace(faceDocumentId) ? Guid.NewGuid().ToString("N") : SanitizeFileName(faceDocumentId);
         var fullPath = Path.Combine(facesDirectory, $"{safeId}-mask.png");
@@ -211,7 +213,12 @@ internal sealed class FaceMaskLayerExtractionService
         using var stream = File.Open(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
         data.SaveTo(stream);
 
-        return Path.GetRelativePath(projectDirectory, fullPath).Replace('\\', '/');
+        if (!File.Exists(fullPath))
+        {
+            throw new IOException($"Face mask layer asset was not written: {fullPath}");
+        }
+
+        return Path.GetRelativePath(normalizedProjectDirectory, fullPath).Replace('\\', '/');
     }
 
     private static bool TryResolveAssetPath(string? assetPath, string? projectDirectory, out string resolvedPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMaskLayerExtractionService.cs
@@ -1,0 +1,275 @@
+using SkiaSharp;
+using System.Windows;
+
+namespace OasisEditor;
+
+internal sealed class FaceMaskLayerExtractionService
+{
+    public const byte DefaultExtractionThreshold = 24;
+
+    private readonly IMachineObjectReferenceResolver _machineObjectReferenceResolver;
+
+    public FaceMaskLayerExtractionService(IMachineObjectReferenceResolver? machineObjectReferenceResolver = null)
+    {
+        _machineObjectReferenceResolver = machineObjectReferenceResolver ?? MachineObjectReferenceResolver.Instance;
+    }
+
+    public FaceMaskLayerModel? GenerateMaskLayer(
+        Panel2DDocumentModel sourcePanel,
+        Rect region,
+        string faceDocumentId,
+        string? sourcePanel2DDocumentId,
+        string? projectDirectory,
+        string? generatedDirectory,
+        byte extractionThreshold = DefaultExtractionThreshold)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePanel);
+
+        if (region.Width <= 0 || region.Height <= 0)
+        {
+            return null;
+        }
+
+        var width = Math.Max(1, (int)Math.Ceiling(region.Width));
+        var height = Math.Max(1, (int)Math.Ceiling(region.Height));
+        var maskPixels = new byte[width * height];
+        var contributions = new List<FaceMaskContributionModel>();
+        var backgrounds = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Background && Intersects(element, region))
+            .Select(element => new SourceImageElement(element, TryLoadBitmap(element.AssetPath, projectDirectory)))
+            .Where(source => source.Bitmap is not null)
+            .ToArray();
+
+        foreach (var lamp in sourcePanel.Elements.Where(element => element.Kind == PanelElementKind.Lamp && IsContainedBy(element, region)))
+        {
+            using var lampBitmap = TryLoadBitmap(lamp.AssetPath, projectDirectory);
+            if (lampBitmap is null)
+            {
+                continue;
+            }
+
+            var contribution = CompositeLampContribution(maskPixels, width, height, region, backgrounds, lamp, lampBitmap, extractionThreshold);
+            if (contribution.PixelCount <= 0 || contribution.Bounds is null)
+            {
+                continue;
+            }
+
+            _machineObjectReferenceResolver.TryGetReference(lamp, out var machineReference);
+            contributions.Add(new FaceMaskContributionModel
+            {
+                SourcePanel2DElementId = string.IsNullOrWhiteSpace(lamp.ObjectId) ? null : lamp.ObjectId,
+                LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+                Bounds = contribution.Bounds,
+                PixelCount = contribution.PixelCount
+            });
+        }
+
+        foreach (var background in backgrounds)
+        {
+            background.Bitmap?.Dispose();
+        }
+
+        var assetPath = SaveMask(maskPixels, width, height, faceDocumentId, projectDirectory, generatedDirectory);
+        return new FaceMaskLayerModel
+        {
+            Id = "face-mask-layer",
+            Name = "Face Mask",
+            AssetPath = assetPath,
+            SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(sourcePanel2DDocumentId) ? null : sourcePanel2DDocumentId.Trim(),
+            SourceRegion = FaceSourceRegionModel.FromRect(region),
+            ExtractionThreshold = extractionThreshold,
+            GeneratedUtc = DateTime.UtcNow,
+            Width = width,
+            Height = height,
+            Contributions = contributions.ToArray()
+        };
+    }
+
+    private static ContributionResult CompositeLampContribution(
+        byte[] maskPixels,
+        int width,
+        int height,
+        Rect region,
+        IReadOnlyList<SourceImageElement> backgrounds,
+        PanelElementModel lamp,
+        SKBitmap lampBitmap,
+        byte threshold)
+    {
+        var left = Math.Max(0, (int)Math.Floor(lamp.X - region.X));
+        var top = Math.Max(0, (int)Math.Floor(lamp.Y - region.Y));
+        var right = Math.Min(width, (int)Math.Ceiling(lamp.X + lamp.Width - region.X));
+        var bottom = Math.Min(height, (int)Math.Ceiling(lamp.Y + lamp.Height - region.Y));
+        var count = 0;
+        var minX = width;
+        var minY = height;
+        var maxX = -1;
+        var maxY = -1;
+
+        for (var y = top; y < bottom; y++)
+        {
+            for (var x = left; x < right; x++)
+            {
+                var documentX = region.X + x + 0.5;
+                var documentY = region.Y + y + 0.5;
+                var on = Sample(lampBitmap, lamp, documentX, documentY);
+                if (on.Alpha == 0)
+                {
+                    continue;
+                }
+
+                var background = SampleBackground(backgrounds, documentX, documentY);
+                var delta = Brightness(on) - Brightness(background);
+                if (delta < threshold)
+                {
+                    continue;
+                }
+
+                maskPixels[(y * width) + x] = 255;
+                count++;
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        var bounds = maxX < minX || maxY < minY
+            ? null
+            : FaceSourceRegionModel.FromRect(new Rect(minX, minY, (maxX - minX) + 1, (maxY - minY) + 1));
+        return new ContributionResult(bounds, count);
+    }
+
+    private static SKColor SampleBackground(IReadOnlyList<SourceImageElement> backgrounds, double documentX, double documentY)
+    {
+        for (var i = backgrounds.Count - 1; i >= 0; i--)
+        {
+            var source = backgrounds[i];
+            if (source.Bitmap is not null && Contains(source.Element, documentX, documentY))
+            {
+                return Sample(source.Bitmap, source.Element, documentX, documentY);
+            }
+        }
+
+        return SKColors.Black;
+    }
+
+    private static SKColor Sample(SKBitmap bitmap, PanelElementModel element, double documentX, double documentY)
+    {
+        if (element.Width <= 0 || element.Height <= 0 || bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            return SKColors.Black;
+        }
+
+        var u = Math.Clamp((documentX - element.X) / element.Width, 0d, 0.999999d);
+        var v = Math.Clamp((documentY - element.Y) / element.Height, 0d, 0.999999d);
+        var x = Math.Clamp((int)Math.Floor(u * bitmap.Width), 0, bitmap.Width - 1);
+        var y = Math.Clamp((int)Math.Floor(v * bitmap.Height), 0, bitmap.Height - 1);
+        return bitmap.GetPixel(x, y);
+    }
+
+    private static double Brightness(SKColor color)
+    {
+        return ((0.2126 * color.Red) + (0.7152 * color.Green) + (0.0722 * color.Blue)) * (color.Alpha / 255d);
+    }
+
+    private static SKBitmap? TryLoadBitmap(string? assetPath, string? projectDirectory)
+    {
+        if (!TryResolveAssetPath(assetPath, projectDirectory, out var resolvedPath) || !File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        return codec is null ? null : SKBitmap.Decode(codec);
+    }
+
+    private static string? SaveMask(byte[] maskPixels, int width, int height, string faceDocumentId, string? projectDirectory, string? generatedDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(projectDirectory) || string.IsNullOrWhiteSpace(generatedDirectory))
+        {
+            return null;
+        }
+
+        var facesDirectory = Path.Combine(generatedDirectory, "Faces");
+        Directory.CreateDirectory(facesDirectory);
+        var safeId = string.IsNullOrWhiteSpace(faceDocumentId) ? Guid.NewGuid().ToString("N") : SanitizeFileName(faceDocumentId);
+        var fullPath = Path.Combine(facesDirectory, $"{safeId}-mask.png");
+
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var value = maskPixels[(y * width) + x];
+                bitmap.SetPixel(x, y, new SKColor(value, value, value, 255));
+            }
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Open(fullPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+
+        return Path.GetRelativePath(projectDirectory, fullPath).Replace('\\', '/');
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, string? projectDirectory, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+        {
+            return false;
+        }
+
+        resolvedPath = Path.GetFullPath(Path.Combine(projectDirectory, candidate.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar)));
+        return true;
+    }
+
+    private static bool Contains(PanelElementModel element, double documentX, double documentY)
+    {
+        return documentX >= element.X
+            && documentY >= element.Y
+            && documentX < element.X + element.Width
+            && documentY < element.Y + element.Height;
+    }
+
+    private static bool IsContainedBy(PanelElementModel element, Rect region)
+    {
+        var left = element.X;
+        var top = element.Y;
+        var right = element.X + element.Width;
+        var bottom = element.Y + element.Height;
+        return left >= region.Left
+            && top >= region.Top
+            && right <= region.Right
+            && bottom <= region.Bottom;
+    }
+
+    private static bool Intersects(PanelElementModel element, Rect region)
+    {
+        return element.Width > 0
+            && element.Height > 0
+            && new Rect(element.X, element.Y, element.Width, element.Height).IntersectsWith(region);
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return string.Concat(value.Select(character => invalid.Contains(character) ? '_' : character));
+    }
+
+    private sealed record SourceImageElement(PanelElementModel Element, SKBitmap? Bitmap);
+    private sealed record ContributionResult(FaceSourceRegionModel? Bounds, int PixelCount);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -32,7 +32,9 @@ internal sealed class FaceRegenerationService
     public FaceRegenerationResult Regenerate(
         FaceDocumentModel existingFace,
         Panel2DDocumentModel sourcePanel,
-        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null)
+        IReadOnlyList<InputDefinitionModel>? inputDefinitions = null,
+        string? projectDirectory = null,
+        string? generatedDirectory = null)
     {
         ArgumentNullException.ThrowIfNull(existingFace);
         ArgumentNullException.ThrowIfNull(sourcePanel);
@@ -52,7 +54,9 @@ internal sealed class FaceRegenerationService
             sourceRegion,
             existingFace.Title,
             existingFace.SourcePanel2DDocumentId,
-            inputDefinitions ?? []);
+            inputDefinitions ?? [],
+            projectDirectory,
+            generatedDirectory);
 
         var existingGeneratedByKey = existingFace.Elements
             .Select(element => new KeyValuePair<string, FaceElementModel>(CreateRegenerationKey(element), element))
@@ -111,7 +115,8 @@ internal sealed class FaceRegenerationService
             SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
             SourceRegion = sourceRegion,
             LastRegeneratedAtUtc = DateTime.UtcNow,
-            Layers = existingFace.Layers.Count > 0 ? existingFace.Layers : generated.Document.Layers,
+            MaskLayer = generated.Document.MaskLayer,
+            Layers = EnsureFaceMaskLayer(existingFace.Layers.Count > 0 ? existingFace.Layers : generated.Document.Layers),
             Elements = mergedElements.ToArray()
         };
 
@@ -122,6 +127,20 @@ internal sealed class FaceRegenerationService
             removedGeneratedElementCount,
             preservedManualElements.Count,
             generated);
+    }
+
+    private static IReadOnlyList<FaceLayerModel> EnsureFaceMaskLayer(IReadOnlyList<FaceLayerModel> layers)
+    {
+        if (layers.Any(layer => string.Equals(layer.Id, "layer-face-mask", StringComparison.OrdinalIgnoreCase)))
+        {
+            return layers;
+        }
+
+        return layers
+            .Take(1)
+            .Concat([new FaceLayerModel { Id = "layer-face-mask", Name = "Face Mask", IsVisible = true }])
+            .Concat(layers.Skip(1))
+            .ToArray();
     }
 
     private static FaceElementModel PreserveRuntimeIdentity(FaceElementModel regeneratedElement, FaceElementModel existingElement)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -134,6 +134,7 @@ public sealed class DocumentWorkspaceViewModel
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Generated face document from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).");
         _addOutputEntry($"Generated face '{document.Title}' from Panel2D region with {result.ArtworkElementCount} artwork element(s), {result.ConvertedLampCount} lamp window(s), {result.ConvertedReelDisplayCount} reel display(s), {result.ConvertedSevenSegmentDisplayCount} seven-segment display(s), {result.ConvertedAlphaDisplayCount} alpha display(s), and {result.ConvertedButtonCount} button(s).", OutputLogStatus.Info);
+        LogFaceMaskLayerStatus(result.Document, loadedProject);
         LogFaceDiagnostics(result.Document);
         return document;
     }
@@ -224,6 +225,7 @@ public sealed class DocumentWorkspaceViewModel
 
         _setStatusMessage($"Regenerated face '{selectedDocument.Title}' from source Panel2D.");
         _addOutputEntry($"Regenerated face '{selectedDocument.Title}' from source Panel2D with {result.UpdatedElementCount} updated generated element(s), {result.AddedElementCount} added generated element(s), {result.RemovedGeneratedElementCount} removed stale generated element(s), and {result.PreservedManualElementCount} preserved manual element(s).", OutputLogStatus.Info);
+        LogFaceMaskLayerStatus(result.Document, loadedProject);
         LogFaceDiagnostics(result.Document);
         return true;
     }
@@ -237,6 +239,44 @@ public sealed class DocumentWorkspaceViewModel
         }
 
         return _faceValidationService.Validate(selectedDocument.GetFaceDocument(), _getLoadedProject(), _openDocuments.ToArray());
+    }
+
+
+    private void LogFaceMaskLayerStatus(FaceDocumentModel faceDocument, EditorProject project)
+    {
+        var maskLayer = faceDocument.MaskLayer;
+        if (maskLayer is null)
+        {
+            _addOutputEntry($"Face '{faceDocument.Title}' has no generated mask layer metadata.", OutputLogStatus.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(maskLayer.AssetPath))
+        {
+            _addOutputEntry($"Face '{faceDocument.Title}' mask layer metadata was generated, but no mask asset path was written. Check source lamp artwork assets and project Generated folder settings.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var fullPath = ResolveProjectRelativePath(project.ProjectDirectory, maskLayer.AssetPath);
+        if (File.Exists(fullPath))
+        {
+            _addOutputEntry($"Generated face mask layer asset for '{faceDocument.Title}': {fullPath}", OutputLogStatus.Info);
+            return;
+        }
+
+        _addOutputEntry($"Face '{faceDocument.Title}' references mask layer asset '{maskLayer.AssetPath}', but the file was not found at '{fullPath}'.", OutputLogStatus.Warning);
+    }
+
+    private static string ResolveProjectRelativePath(string projectDirectory, string projectRelativePath)
+    {
+        if (Path.IsPathRooted(projectRelativePath))
+        {
+            return projectRelativePath;
+        }
+
+        return Path.GetFullPath(Path.Combine(
+            projectDirectory,
+            projectRelativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar)));
     }
 
     private void LogFaceDiagnostics(FaceDocumentModel faceDocument)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -557,6 +557,8 @@ public sealed class DocumentWorkspaceViewModel
                 Summary = document.ContentSummary,
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourceRegion = faceDocument.SourceRegion,
+                LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
+                MaskLayer = faceDocument.MaskLayer,
                 Layers = faceDocument.Layers,
                 Elements = faceDocument.Elements
             };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -106,7 +106,8 @@ public sealed class DocumentWorkspaceViewModel
     public DocumentTabViewModel? GenerateFaceFromSelectedPanel2DRegion(Rect sourceRect)
     {
         var sourceDocument = _getSelectedDocument();
-        if (_getLoadedProject() is null || sourceDocument is null || sourceDocument.Document.DocumentType != EditorDocumentType.Panel2D)
+        var loadedProject = _getLoadedProject();
+        if (loadedProject is null || sourceDocument is null || sourceDocument.Document.DocumentType != EditorDocumentType.Panel2D)
         {
             return null;
         }
@@ -123,7 +124,9 @@ public sealed class DocumentWorkspaceViewModel
             sourceRegion,
             title,
             sourceDocument.DocumentId.ToString("N"),
-            _getLoadedProject()?.InputDefinitions ?? []);
+            loadedProject.InputDefinitions,
+            loadedProject.ProjectDirectory,
+            loadedProject.GeneratedDirectory);
 
         var faceJson = FaceDocumentStorage.Serialize(result.Document);
         var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(result.Document.Summary ?? "Generated Face document.");
@@ -185,7 +188,8 @@ public sealed class DocumentWorkspaceViewModel
     public bool RegenerateSelectedFace()
     {
         var selectedDocument = _getSelectedDocument();
-        if (_getLoadedProject() is null || selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Face)
+        var loadedProject = _getLoadedProject();
+        if (loadedProject is null || selectedDocument is null || selectedDocument.Document.DocumentType != EditorDocumentType.Face)
         {
             return false;
         }
@@ -202,7 +206,9 @@ public sealed class DocumentWorkspaceViewModel
         var result = _faceRegenerationService.Regenerate(
             existingFace,
             sourcePanelDocument.GetPanelDocument(),
-            _getLoadedProject()?.InputDefinitions ?? []);
+            loadedProject.InputDefinitions,
+            loadedProject.ProjectDirectory,
+            loadedProject.GeneratedDirectory);
 
         selectedDocument.SetFaceDocument(
             result.Document,


### PR DESCRIPTION
### Motivation
- Correct the Face architecture to treat the physical face as separate `FaceArtworkLayer`, a single aligned `FaceMaskLayer`, runtime objects (lamps/buttons/displays/reels), and deferred tray geometry. 
- Implement Phase 11A (Face Mask Layer Extraction MVP) to generate and persist one face-sized mask layer aligned to the Face artwork before any visual-fidelity work. 
- Preserve existing runtime contracts and explicitly defer tray extraction, glow/bloom/blur/emission rendering, runtime mask rendering, 3D preview, and Unity integration to future phases.

### Description
- Update documentation: rewritten Phase 11 roadmap and architecture narrative in `FACE_SYSTEM_ARCHITECTURE_PLAN.md` and added the revised physical Face layer model and Q&A to `FaceSystem.Inventory.md`. 
- Add persisted mask model: introduced `FaceMaskLayerModel` and `FaceMaskContributionModel` to `FaceDocumentModel` and corresponding DTOs/serialization in `FaceDocumentStorage.cs` so a single mask-layer asset and provenance persist through save/load. 
- Implement extraction: added `FaceMaskLayerExtractionService` which computes per-lamp contribution masks (brightness delta -> threshold -> binary) and unions them into a single face-sized monochrome mask PNG under `Generated/Faces`, and records per-lamp contribution bounds and pixel counts as generation metadata. 
- Integrate into generation/regeneration: `FaceGenerationService` now invokes the extraction service during face creation, `FaceRegenerationService` carries the mask forward on regenerations, and `DocumentWorkspaceViewModel` passes project/generated directories into generation/regeneration so the mask PNG can be written when project paths are available. 
- Tests and round trip: added `FaceMaskLayerExtractionTests` to verify mask asset creation and contribution metadata and extended `FaceDocumentRoundTripTests` to round-trip `MaskLayer` metadata through serialization.

### Testing
- Unit tests added: `OasisEditor.Tests/FaceMaskLayerExtractionTests.cs` (mask generation & asset) and updated `FaceDocumentRoundTripTests.cs` to include `MaskLayer` round-trip assertions. 
- No automated test suite was executed in this environment due to the project environment/toolchain constraints described in `AGENTS.md`, so the new tests were not run here. 
- Recommend running `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` locally to validate the new tests and `FaceMaskLayer` behavior (verify generated mask PNG under `Generated/Faces` and successful test pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a258d907db4832785d98b3b47fe15ee)