### PR TITLE
Face renderer: add mask-based lamp illumination and mask asset handling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
@@ -1,0 +1,111 @@
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class Face2DRendererMaskIlluminationTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly string _maskPath;
+
+    public Face2DRendererMaskIlluminationTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceRendererMaskTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+        _maskPath = Path.Combine(_testDirectory, "mask.png");
+    }
+
+    [Fact]
+    public void Render_LampOff_DrawsNoLampRectangleOverArtwork()
+    {
+        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10)]);
+        var renderer = new Face2DRenderer(FaceRuntimeStateResolver.Instance, _ => _maskPath);
+        var runtimeState = new MachineRuntimeState();
+        var document = CreateDocument();
+
+        using var surface = SKSurface.Create(new SKImageInfo(20, 20, SKColorType.Bgra8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.White);
+
+        renderer.Render(surface.Canvas, document, runtimeState, new PanelViewportTransform());
+
+        using var snapshot = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(snapshot);
+        Assert.Equal(SKColors.White, bitmap.GetPixel(10, 10));
+        Assert.Equal(SKColors.White, bitmap.GetPixel(14, 10));
+    }
+
+    [Fact]
+    public void Render_LampOn_UsesRadialMaskIlluminationInsteadOfRectangleShape()
+    {
+        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10)]);
+        var renderer = new Face2DRenderer(FaceRuntimeStateResolver.Instance, _ => _maskPath);
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(17), 1d);
+        var document = CreateDocument();
+
+        using var surface = SKSurface.Create(new SKImageInfo(20, 20, SKColorType.Bgra8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.White);
+
+        renderer.Render(surface.Canvas, document, runtimeState, new PanelViewportTransform());
+
+        using var snapshot = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(snapshot);
+        Assert.NotEqual(SKColors.White, bitmap.GetPixel(10, 10));
+        Assert.NotEqual(SKColors.White, bitmap.GetPixel(14, 10));
+        Assert.Equal(SKColors.White, bitmap.GetPixel(12, 10));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    private static FaceDocumentModel CreateDocument()
+    {
+        return new FaceDocumentModel
+        {
+            Title = "Mask Renderer Face",
+            MaskLayer = new FaceMaskLayerModel
+            {
+                Id = "face-mask-layer",
+                Name = "Face Mask",
+                AssetPath = "mask.png",
+                Width = 20,
+                Height = 20
+            },
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "lamp-window-17",
+                    Name = "Lamp 17",
+                    X = 9,
+                    Y = 9,
+                    Width = 2,
+                    Height = 2,
+                    IsVisible = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(17)
+                }
+            ]
+        };
+    }
+
+    private static void WriteMask(string path, int width, int height, IReadOnlyCollection<(int X, int Y)> opaquePixels)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Opaque);
+        bitmap.Erase(SKColors.Black);
+        foreach (var (x, y) in opaquePixels)
+        {
+            bitmap.SetPixel(x, y, SKColors.White);
+        }
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.OpenWrite(path);
+        data.SaveTo(stream);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
@@ -19,7 +19,7 @@ public sealed class Face2DRendererMaskIlluminationTests : IDisposable
     [Fact]
     public void Render_LampOff_DrawsNoLampRectangleOverArtwork()
     {
-        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10)]);
+        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10), (18, 10)]);
         var renderer = new Face2DRenderer(FaceRuntimeStateResolver.Instance, _ => _maskPath);
         var runtimeState = new MachineRuntimeState();
         var document = CreateDocument();
@@ -33,12 +33,13 @@ public sealed class Face2DRendererMaskIlluminationTests : IDisposable
         using var bitmap = SKBitmap.FromImage(snapshot);
         Assert.Equal(SKColors.White, bitmap.GetPixel(10, 10));
         Assert.Equal(SKColors.White, bitmap.GetPixel(14, 10));
+        Assert.Equal(SKColors.White, bitmap.GetPixel(18, 10));
     }
 
     [Fact]
     public void Render_LampOn_UsesRadialMaskIlluminationInsteadOfRectangleShape()
     {
-        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10)]);
+        WriteMask(_maskPath, 20, 20, [(10, 10), (14, 10), (18, 10)]);
         var renderer = new Face2DRenderer(FaceRuntimeStateResolver.Instance, _ => _maskPath);
         var runtimeState = new MachineRuntimeState();
         runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(17), 1d);
@@ -54,6 +55,7 @@ public sealed class Face2DRendererMaskIlluminationTests : IDisposable
         Assert.NotEqual(SKColors.White, bitmap.GetPixel(10, 10));
         Assert.NotEqual(SKColors.White, bitmap.GetPixel(14, 10));
         Assert.Equal(SKColors.White, bitmap.GetPixel(12, 10));
+        Assert.Equal(SKColors.White, bitmap.GetPixel(18, 10));
     }
 
     public void Dispose()
@@ -75,7 +77,22 @@ public sealed class Face2DRendererMaskIlluminationTests : IDisposable
                 Name = "Face Mask",
                 AssetPath = "mask.png",
                 Width = 20,
-                Height = 20
+                Height = 20,
+                Contributions =
+                [
+                    new FaceMaskContributionModel
+                    {
+                        LinkedMachineObjectReference = MachineObjectReference.Lamp(17),
+                        Bounds = new FaceSourceRegionModel
+                        {
+                            X = 10,
+                            Y = 10,
+                            Width = 5,
+                            Height = 1
+                        },
+                        PixelCount = 2
+                    }
+                ]
             },
             Elements =
             [

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -148,7 +148,7 @@ public sealed class Face2DRenderer : IFace2DRenderer
         {
             BlendMode = SKBlendMode.DstIn,
             IsAntialias = true,
-            FilterQuality = SKFilterQuality.Linear
+            FilterQuality = SKFilterQuality.Medium
         };
 
         canvas.SaveLayer(maskRect, null);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -5,7 +5,7 @@ namespace OasisEditor.Rendering;
 
 public interface IFace2DRenderer
 {
-    void Render(SKCanvas canvas, IReadOnlyList<FaceElementModel> elements, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform);
+    void Render(SKCanvas canvas, FaceDocumentModel faceDocument, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform);
 }
 
 public sealed class Face2DRenderer : IFace2DRenderer
@@ -13,6 +13,7 @@ public sealed class Face2DRenderer : IFace2DRenderer
     private readonly IFaceRuntimeStateResolver _runtimeStateResolver;
     private readonly Func<string?, string?> _assetPathResolver;
     private readonly Dictionary<string, SKImage?> _cachedArtworkImages = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, SKImage?> _cachedMaskImages = new(StringComparer.OrdinalIgnoreCase);
 
     public Face2DRenderer()
         : this(FaceRuntimeStateResolver.Instance, ResolveDefaultAssetPath)
@@ -25,21 +26,20 @@ public sealed class Face2DRenderer : IFace2DRenderer
         _assetPathResolver = assetPathResolver ?? throw new ArgumentNullException(nameof(assetPathResolver));
     }
 
-    public void Render(SKCanvas canvas, IReadOnlyList<FaceElementModel> elements, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform)
+    public void Render(SKCanvas canvas, FaceDocumentModel faceDocument, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform)
     {
         ArgumentNullException.ThrowIfNull(canvas);
-        ArgumentNullException.ThrowIfNull(elements);
+        ArgumentNullException.ThrowIfNull(faceDocument);
         ArgumentNullException.ThrowIfNull(runtimeState);
+
+        var elements = faceDocument.Elements;
 
         foreach (var artwork in elements.OfType<FaceArtworkElement>())
         {
             DrawArtwork(canvas, artwork, viewportTransform);
         }
 
-        foreach (var lampWindow in elements.OfType<FaceLampWindowElement>())
-        {
-            DrawLampWindow(canvas, lampWindow, runtimeState, viewportTransform);
-        }
+        DrawLampIllumination(canvas, faceDocument.MaskLayer, elements.OfType<FaceLampWindowElement>(), runtimeState);
 
         foreach (var reelDisplay in elements.OfType<FaceReelDisplayElement>())
         {
@@ -87,35 +87,83 @@ public sealed class Face2DRenderer : IFace2DRenderer
         canvas.DrawRect(destination, strokePaint);
     }
 
-    private void DrawLampWindow(SKCanvas canvas, FaceLampWindowElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
+    private void DrawLampIllumination(SKCanvas canvas, FaceMaskLayerModel? maskLayer, IEnumerable<FaceLampWindowElement> lampWindows, MachineRuntimeState runtimeState)
     {
-        var rect = ToRect(element);
-        if (rect.Width <= 0f || rect.Height <= 0f)
+        if (maskLayer is null || !TryGetMaskImage(maskLayer.AssetPath, out var maskImage))
         {
             return;
         }
 
-        if (!element.IsVisible)
+        var maskRect = ResolveMaskDestinationRect(maskLayer, maskImage);
+        if (maskRect.Width <= 0f || maskRect.Height <= 0f)
         {
-            using var hiddenPaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x80, 0x80, 0x80), StrokeWidth = (float)(1d / viewport.NormalizedZoom), IsAntialias = true };
-            canvas.DrawRect(rect, hiddenPaint);
             return;
         }
 
-        var intensity = Math.Clamp(_runtimeStateResolver.GetLampIntensity(element, runtimeState), 0d, 1d);
-        var fillColor = intensity <= 0.0001d
-            ? new SKColor(0x20, 0x20, 0x20, 0xA8)
-            : new SKColor(0xFF, 0xD5, 0x4F, (byte)Math.Clamp(96 + (int)(159 * intensity), 0, 255));
-        var strokeColor = intensity <= 0.0001d
-            ? new SKColor(0xB0, 0xB0, 0xB0, 0xD0)
-            : new SKColor(0xFF, 0xF1, 0x76, 0xFF);
+        foreach (var element in lampWindows)
+        {
+            if (!element.IsVisible || element.Width <= 0d || element.Height <= 0d)
+            {
+                continue;
+            }
 
-        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = fillColor, IsAntialias = true };
-        using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = strokeColor, StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
-        canvas.DrawRect(rect, fillPaint);
-        canvas.DrawRect(rect, strokePaint);
+            var intensity = Math.Clamp(_runtimeStateResolver.GetLampIntensity(element, runtimeState), 0d, 1d);
+            if (intensity <= 0.0001d)
+            {
+                continue;
+            }
+
+            DrawSingleLampIllumination(canvas, maskImage, maskRect, element, intensity);
+        }
     }
 
+    private static void DrawSingleLampIllumination(SKCanvas canvas, SKImage maskImage, SKRect maskRect, FaceLampWindowElement element, double intensity)
+    {
+        // Lamp window bounds define the light source origin only; the mask alpha defines the visible shape.
+        var center = new SKPoint((float)(element.X + (element.Width / 2d)), (float)(element.Y + (element.Height / 2d)));
+        var radius = ResolveLampIlluminationRadius(maskRect, center);
+        if (radius <= 0f)
+        {
+            return;
+        }
+
+        var alpha = (byte)Math.Clamp(28 + (int)(156 * intensity), 0, 184);
+        var inner = new SKColor(0xFF, 0xE8, 0x7A, alpha);
+        var middle = new SKColor(0xFF, 0xC9, 0x3D, (byte)Math.Clamp(alpha * 0.58d, 0d, 255d));
+        var outer = new SKColor(0xFF, 0xA0, 0x20, 0);
+
+        using var shader = SKShader.CreateRadialGradient(
+            center,
+            radius,
+            [inner, middle, outer],
+            [0f, 0.38f, 1f],
+            SKShaderTileMode.Clamp);
+        using var illuminationPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Fill,
+            Shader = shader,
+            IsAntialias = true
+        };
+        using var maskPaint = new SKPaint
+        {
+            BlendMode = SKBlendMode.DstIn,
+            IsAntialias = true,
+            FilterQuality = SKFilterQuality.Linear
+        };
+
+        canvas.SaveLayer(maskRect, null);
+        canvas.DrawRect(maskRect, illuminationPaint);
+        canvas.DrawImage(maskImage, SKRect.Create(0f, 0f, maskImage.Width, maskImage.Height), maskRect, maskPaint);
+        canvas.Restore();
+    }
+
+    private static float ResolveLampIlluminationRadius(SKRect maskRect, SKPoint center)
+    {
+        var farthestX = Math.Max(Math.Abs(center.X - maskRect.Left), Math.Abs(center.X - maskRect.Right));
+        var farthestY = Math.Max(Math.Abs(center.Y - maskRect.Top), Math.Abs(center.Y - maskRect.Bottom));
+        var faceRadius = Math.Sqrt((farthestX * farthestX) + (farthestY * farthestY));
+        return (float)Math.Max(1d, faceRadius * 0.45d);
+    }
 
     private void DrawReelDisplay(SKCanvas canvas, FaceReelDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
     {
@@ -228,7 +276,7 @@ public sealed class Face2DRenderer : IFace2DRenderer
 
         if (!_cachedArtworkImages.TryGetValue(resolvedPath, out var cached))
         {
-            cached = LoadArtworkImage(resolvedPath);
+            cached = LoadImage(resolvedPath);
             _cachedArtworkImages[resolvedPath] = cached;
         }
 
@@ -241,7 +289,31 @@ public sealed class Face2DRenderer : IFace2DRenderer
         return true;
     }
 
-    private static SKImage? LoadArtworkImage(string resolvedPath)
+    private bool TryGetMaskImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        var resolvedPath = _assetPathResolver(assetPath);
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            return false;
+        }
+
+        if (!_cachedMaskImages.TryGetValue(resolvedPath, out var cached))
+        {
+            cached = LoadMaskAlphaImage(resolvedPath);
+            _cachedMaskImages[resolvedPath] = cached;
+        }
+
+        if (cached is null)
+        {
+            return false;
+        }
+
+        image = cached;
+        return true;
+    }
+
+    private static SKImage? LoadImage(string resolvedPath)
     {
         if (!File.Exists(resolvedPath))
         {
@@ -256,6 +328,33 @@ public sealed class Face2DRenderer : IFace2DRenderer
 
         using var bitmap = SKBitmap.Decode(codec);
         return bitmap is null ? null : SKImage.FromBitmap(bitmap);
+    }
+
+    private static SKImage? LoadMaskAlphaImage(string resolvedPath)
+    {
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var source = SKBitmap.Decode(resolvedPath);
+        if (source is null)
+        {
+            return null;
+        }
+
+        using var alphaMask = new SKBitmap(source.Width, source.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        for (var y = 0; y < source.Height; y++)
+        {
+            for (var x = 0; x < source.Width; x++)
+            {
+                var pixel = source.GetPixel(x, y);
+                var alpha = (byte)Math.Clamp(Math.Max(pixel.Red, Math.Max(pixel.Green, pixel.Blue)) * (pixel.Alpha / 255d), 0d, 255d);
+                alphaMask.SetPixel(x, y, new SKColor(0xFF, 0xFF, 0xFF, alpha));
+            }
+        }
+
+        return SKImage.FromBitmap(alphaMask);
     }
 
     private static string? ResolveDefaultAssetPath(string? assetPath)
@@ -280,6 +379,13 @@ public sealed class Face2DRenderer : IFace2DRenderer
             .Replace('/', Path.DirectorySeparatorChar)
             .Replace('\\', Path.DirectorySeparatorChar);
         return Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+    }
+
+    private static SKRect ResolveMaskDestinationRect(FaceMaskLayerModel maskLayer, SKImage maskImage)
+    {
+        var width = maskLayer.Width > 0 ? maskLayer.Width : maskImage.Width;
+        var height = maskLayer.Height > 0 ? maskLayer.Height : maskImage.Height;
+        return SKRect.Create(0f, 0f, width, height);
     }
 
     private static SKRect ResolveArtworkSourceRect(FaceArtworkElement element, SKImage image)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -113,15 +113,73 @@ public sealed class Face2DRenderer : IFace2DRenderer
                 continue;
             }
 
-            DrawSingleLampIllumination(canvas, maskImage, maskRect, element, intensity);
+            if (!TryResolveLampIlluminationTarget(maskLayer, maskImage, maskRect, element, out var target))
+            {
+                continue;
+            }
+
+            DrawSingleLampIllumination(canvas, maskImage, target.LayerRect, target.MaskSourceRect, element, intensity);
         }
     }
 
-    private static void DrawSingleLampIllumination(SKCanvas canvas, SKImage maskImage, SKRect maskRect, FaceLampWindowElement element, double intensity)
+    private bool TryResolveLampIlluminationTarget(
+        FaceMaskLayerModel maskLayer,
+        SKImage maskImage,
+        SKRect maskRect,
+        FaceLampWindowElement element,
+        out LampIlluminationTarget target)
     {
-        // Lamp window bounds define the light source origin only; the mask alpha defines the visible shape.
+        if (_runtimeStateResolver.TryGetLampReference(element, out var reference)
+            && TryResolveContributionBounds(maskLayer, reference, out var contributionBounds)
+            && TryIntersect(contributionBounds, maskRect, out var layerRect))
+        {
+            target = new LampIlluminationTarget(layerRect, ResolveMaskSourceRect(layerRect, maskRect, maskImage));
+            return true;
+        }
+
+        var fallbackBounds = ResolveFallbackLampBounds(element);
+        if (TryIntersect(fallbackBounds, maskRect, out var fallbackLayerRect))
+        {
+            target = new LampIlluminationTarget(fallbackLayerRect, ResolveMaskSourceRect(fallbackLayerRect, maskRect, maskImage));
+            return true;
+        }
+
+        target = default;
+        return false;
+    }
+
+    private static bool TryResolveContributionBounds(FaceMaskLayerModel maskLayer, MachineObjectReference reference, out SKRect bounds)
+    {
+        bounds = default;
+        var hasBounds = false;
+        var referenceText = reference.ToString();
+        foreach (var contribution in maskLayer.Contributions)
+        {
+            if (contribution.Bounds is not FaceSourceRegionModel contributionBounds
+                || contribution.LinkedMachineObjectReference is not MachineObjectReference contributionReference
+                || !string.Equals(contributionReference.ToString(), referenceText, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rect = ToRect(contributionBounds);
+            if (rect.Width <= 0f || rect.Height <= 0f)
+            {
+                continue;
+            }
+
+            bounds = hasBounds ? Union(bounds, rect) : rect;
+            hasBounds = true;
+        }
+
+        return hasBounds;
+    }
+
+    private static void DrawSingleLampIllumination(SKCanvas canvas, SKImage maskImage, SKRect layerRect, SKRect maskSourceRect, FaceLampWindowElement element, double intensity)
+    {
+        // Lamp window bounds define the light source origin only; contribution/mask bounds define the rendered area.
         var center = new SKPoint((float)(element.X + (element.Width / 2d)), (float)(element.Y + (element.Height / 2d)));
-        var radius = ResolveLampIlluminationRadius(maskRect, center);
+        var radius = ResolveLampIlluminationRadius(layerRect, center);
         if (radius <= 0f)
         {
             return;
@@ -151,18 +209,66 @@ public sealed class Face2DRenderer : IFace2DRenderer
             FilterQuality = SKFilterQuality.Medium
         };
 
-        canvas.SaveLayer(maskRect, null);
-        canvas.DrawRect(maskRect, illuminationPaint);
-        canvas.DrawImage(maskImage, SKRect.Create(0f, 0f, maskImage.Width, maskImage.Height), maskRect, maskPaint);
+        canvas.SaveLayer(layerRect, null);
+        canvas.DrawRect(layerRect, illuminationPaint);
+        canvas.DrawImage(maskImage, maskSourceRect, layerRect, maskPaint);
         canvas.Restore();
     }
 
-    private static float ResolveLampIlluminationRadius(SKRect maskRect, SKPoint center)
+    private static float ResolveLampIlluminationRadius(SKRect layerRect, SKPoint center)
     {
-        var farthestX = Math.Max(Math.Abs(center.X - maskRect.Left), Math.Abs(center.X - maskRect.Right));
-        var farthestY = Math.Max(Math.Abs(center.Y - maskRect.Top), Math.Abs(center.Y - maskRect.Bottom));
-        var faceRadius = Math.Sqrt((farthestX * farthestX) + (farthestY * farthestY));
-        return (float)Math.Max(1d, faceRadius * 0.45d);
+        var farthestX = Math.Max(Math.Abs(center.X - layerRect.Left), Math.Abs(center.X - layerRect.Right));
+        var farthestY = Math.Max(Math.Abs(center.Y - layerRect.Top), Math.Abs(center.Y - layerRect.Bottom));
+        var layerRadius = Math.Sqrt((farthestX * farthestX) + (farthestY * farthestY));
+        return (float)Math.Max(1d, layerRadius * 1.15d);
+    }
+
+    private static SKRect ResolveFallbackLampBounds(FaceLampWindowElement element)
+    {
+        var centerX = (float)(element.X + (element.Width / 2d));
+        var centerY = (float)(element.Y + (element.Height / 2d));
+        var radius = (float)Math.Max(1d, Math.Max(element.Width, element.Height) * 1.5d);
+        return SKRect.Create(centerX - radius, centerY - radius, radius * 2f, radius * 2f);
+    }
+
+    private static SKRect ResolveMaskSourceRect(SKRect layerRect, SKRect maskRect, SKImage maskImage)
+    {
+        var scaleX = maskImage.Width / maskRect.Width;
+        var scaleY = maskImage.Height / maskRect.Height;
+        var left = (layerRect.Left - maskRect.Left) * scaleX;
+        var top = (layerRect.Top - maskRect.Top) * scaleY;
+        var right = (layerRect.Right - maskRect.Left) * scaleX;
+        var bottom = (layerRect.Bottom - maskRect.Top) * scaleY;
+        return new SKRect(
+            Math.Clamp(left, 0f, maskImage.Width),
+            Math.Clamp(top, 0f, maskImage.Height),
+            Math.Clamp(right, 0f, maskImage.Width),
+            Math.Clamp(bottom, 0f, maskImage.Height));
+    }
+
+    private static bool TryIntersect(SKRect left, SKRect right, out SKRect intersection)
+    {
+        var intersectionLeft = Math.Max(left.Left, right.Left);
+        var intersectionTop = Math.Max(left.Top, right.Top);
+        var intersectionRight = Math.Min(left.Right, right.Right);
+        var intersectionBottom = Math.Min(left.Bottom, right.Bottom);
+        if (intersectionRight <= intersectionLeft || intersectionBottom <= intersectionTop)
+        {
+            intersection = default;
+            return false;
+        }
+
+        intersection = new SKRect(intersectionLeft, intersectionTop, intersectionRight, intersectionBottom);
+        return true;
+    }
+
+    private static SKRect Union(SKRect left, SKRect right)
+    {
+        return new SKRect(
+            Math.Min(left.Left, right.Left),
+            Math.Min(left.Top, right.Top),
+            Math.Max(left.Right, right.Right),
+            Math.Max(left.Bottom, right.Bottom));
     }
 
     private void DrawReelDisplay(SKCanvas canvas, FaceReelDisplayElement element, MachineRuntimeState runtimeState, PanelViewportTransform viewport)
@@ -410,8 +516,15 @@ public sealed class Face2DRenderer : IFace2DRenderer
         return new SKRect(left, top, right, bottom);
     }
 
+    private static SKRect ToRect(FaceSourceRegionModel region)
+    {
+        return SKRect.Create((float)region.X, (float)region.Y, (float)Math.Max(0d, region.Width), (float)Math.Max(0d, region.Height));
+    }
+
     private static SKRect ToRect(FaceElementModel element)
     {
         return SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
     }
+
+    private readonly record struct LampIlluminationTarget(SKRect LayerRect, SKRect MaskSourceRect);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -183,6 +183,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             Summary = _faceDocumentModel.Summary,
             SourcePanel2DDocumentId = _faceDocumentModel.SourcePanel2DDocumentId,
             SourceRegion = _faceDocumentModel.SourceRegion,
+            LastRegeneratedAtUtc = _faceDocumentModel.LastRegeneratedAtUtc,
+            MaskLayer = _faceDocumentModel.MaskLayer,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()
         }, faceChange);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -124,7 +124,7 @@ public partial class PlayView : UserControl
         canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
         if (selected.Document.DocumentType == EditorDocumentType.Face)
         {
-            _faceRenderer.Render(canvas, selected.GetFaceElements(), selected.RuntimeState, viewport);
+            _faceRenderer.Render(canvas, selected.GetFaceDocument(), selected.RuntimeState, viewport);
         }
         else
         {


### PR DESCRIPTION
### Motivation

- Replace simple rectangle lamp drawing with masked radial illumination so lamp windows light up through a face mask asset.
- Update renderer API to accept a full `FaceDocumentModel` so mask layer and document metadata are available during rendering.

### Description

- Change `IFace2DRenderer.Render` and `Face2DRenderer.Render` to accept `FaceDocumentModel` instead of a raw element list and use `faceDocument.Elements` internally via `elements` local variable. 
- Implement mask-aware lamp illumination: add `DrawLampIllumination`, `DrawSingleLampIllumination`, and `ResolveLampIlluminationRadius` to composite a radial gradient into the face mask using `SKBlendMode.DstIn` so lighting follows mask alpha.
- Add mask image caching with `_cachedMaskImages`, and introduce `TryGetMaskImage` and `LoadMaskAlphaImage` which converts loaded mask pixels into an alpha-only SKImage to be used as a destination-in mask. Generalize artwork loading via `LoadImage` and reuse for artwork caching.
- Ensure mask destination rect resolution via `ResolveMaskDestinationRect` and skip non-visible/zero-size windows; lamp intensity gating uses `_runtimeStateResolver.GetLampIntensity`.
- Preserve `MaskLayer` and `LastRegeneratedAtUtc` in `DocumentTabViewModel.SetFaceElements` when creating the new `FaceDocumentModel` copy.
- Update Play view to call the new renderer signature (`_faceRenderer.Render(canvas, selected.GetFaceDocument(), selected.RuntimeState, viewport)`).
- Add unit tests in `Face2DRendererMaskIlluminationTests` that generate a temporary mask PNG and assert expected pixel results for lamp off (no change) and lamp on (radial illumination applied through mask alpha).

### Testing

- Added and ran `Face2DRendererMaskIlluminationTests` which create temporary mask files and verify pixel colors for lamp off/on scenarios; the tests passed.
- Ran the project test suite (`dotnet test` for `OasisEditor.Tests`) including the new tests and observed successful completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a25ae5819608327808c4e1ba6c38619)