### PR TITLE
Add Face runtime export service and runtime asset schema (Phase 1-2)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ConvertMfmeAutomationCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ConvertMfmeAutomationCommandTests.cs
@@ -101,7 +101,7 @@ public sealed class ConvertMfmeAutomationCommandTests
     {
         public bool WasCalled { get; private set; }
 
-        public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath)
+        public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null)
         {
             WasCalled = true;
             return current;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using OasisEditor;
+using OasisEditor.Automation;
 using SkiaSharp;
 using Xunit;
 
@@ -95,6 +96,32 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         using var exportedArtwork = SKBitmap.Decode(result.ArtworkPath);
         Assert.NotNull(exportedArtwork);
         Assert.Equal(128, exportedArtwork.GetPixel(0, 0).Alpha);
+    }
+
+
+    [Fact]
+    public void SaveDocument_ForFaceWithProject_ExportsRuntimePackageAndPersistsAssetReferences()
+    {
+        var artworkPath = Path.Combine(_assetsDirectory, "artwork.png");
+        var maskPath = Path.Combine(_generatedDirectory, "source-mask.png");
+        var facePath = Path.Combine(_projectDirectory, "front.face");
+        WriteSolidPng(artworkPath, 4, 4, new SKColor(0, 255, 0, 192));
+        WriteSolidPng(maskPath, 4, 4, SKColors.White);
+        var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
+        var current = new DocumentTabViewModel(
+            EditorDocument.CreateFaceStub("Front Face").MarkDirty(),
+            faceDocumentJson: FaceDocumentStorage.Serialize(document));
+
+        var saved = new DocumentSaveService().SaveDocument(current, facePath, CreateProject());
+
+        Assert.False(saved.IsDirty);
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "face.runtime.json")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "artwork.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "mask.png")));
+        Assert.True(FaceDocumentStorage.TryReadValidated(File.ReadAllText(facePath), out var persisted, out var error), error);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", persisted.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", persisted.RuntimeRenderAssets.ArtworkPath);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", persisted.RuntimeRenderAssets.MaskPath);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using OasisEditor;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceRuntimeExportServiceTests : IDisposable
+{
+    private readonly string _projectDirectory;
+    private readonly string _assetsDirectory;
+    private readonly string _generatedDirectory;
+
+    public FaceRuntimeExportServiceTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceRuntimeExportTests-{Guid.NewGuid():N}");
+        _assetsDirectory = Path.Combine(_projectDirectory, "Assets");
+        _generatedDirectory = Path.Combine(_projectDirectory, "Generated");
+        Directory.CreateDirectory(_assetsDirectory);
+        Directory.CreateDirectory(_generatedDirectory);
+    }
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsRuntimeRenderAssets()
+    {
+        var generatedUtc = new DateTime(2026, 6, 10, 1, 2, 3, DateTimeKind.Utc);
+        var source = new FaceDocumentModel
+        {
+            Id = "face-runtime",
+            Title = "Runtime Face",
+            RuntimeRenderAssets = new FaceRuntimeRenderAssetsModel
+            {
+                ManifestPath = "Generated/Faces/face-runtime/runtime/face.runtime.json",
+                ArtworkPath = "Generated/Faces/face-runtime/runtime/artwork.png",
+                MaskPath = "Generated/Faces/face-runtime/runtime/mask.png",
+                TrayIdPath = null,
+                LampIds0Path = null,
+                LampWeights0Path = null,
+                LampIds1Path = null,
+                LampWeights1Path = null,
+                Width = 320,
+                Height = 240,
+                GeneratedUtc = generatedUtc
+            }
+        };
+
+        var json = FaceDocumentStorage.Serialize(source);
+
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        Assert.Equal(2, file.SchemaVersion);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", file.RuntimeRenderAssets!.ArtworkPath);
+        Assert.Equal(320, file.RuntimeRenderAssets.Width);
+
+        var model = FaceDocumentStorage.ToModel(file);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", model.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", model.RuntimeRenderAssets.MaskPath);
+        Assert.Equal(240, model.RuntimeRenderAssets.Height);
+        Assert.Equal(generatedUtc, model.RuntimeRenderAssets.GeneratedUtc);
+    }
+
+    [Fact]
+    public void Export_WritesManifestArtworkAndMask_AndUpdatesDocumentRuntimeAssets()
+    {
+        var artworkPath = Path.Combine(_assetsDirectory, "artwork.png");
+        var maskPath = Path.Combine(_generatedDirectory, "source-mask.png");
+        WriteSolidPng(artworkPath, 4, 4, new SKColor(255, 0, 0, 128));
+        WriteSolidPng(maskPath, 4, 4, SKColors.White);
+        var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
+        var project = CreateProject();
+
+        var result = new FaceRuntimeExportService().Export(document, project);
+
+        Assert.True(File.Exists(result.ManifestPath));
+        Assert.True(File.Exists(result.ArtworkPath));
+        Assert.True(File.Exists(result.MaskPath));
+        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", result.Document.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", result.Document.RuntimeRenderAssets.ArtworkPath);
+        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", result.Document.RuntimeRenderAssets.MaskPath);
+        Assert.Equal(4, result.Document.RuntimeRenderAssets.Width);
+        Assert.Equal(4, result.Document.RuntimeRenderAssets.Height);
+
+        using var manifestJson = JsonDocument.Parse(File.ReadAllText(result.ManifestPath));
+        var root = manifestJson.RootElement;
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("face-runtime", root.GetProperty("faceId").GetString());
+        Assert.Equal("artwork.png", root.GetProperty("artwork").GetString());
+        Assert.Equal("mask.png", root.GetProperty("mask").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("trayId").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("lampIds0").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("lampWeights0").ValueKind);
+        var lamp = root.GetProperty("lamps")[0];
+        Assert.Equal(24, lamp.GetProperty("lampId").GetInt32());
+        Assert.Equal("lamp:24", lamp.GetProperty("machineReference").GetString());
+
+        using var exportedArtwork = SKBitmap.Decode(result.ArtworkPath);
+        Assert.NotNull(exportedArtwork);
+        Assert.Equal(128, exportedArtwork.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void Export_WithMissingArtworkAsset_ThrowsFileNotFoundException()
+    {
+        var maskPath = Path.Combine(_generatedDirectory, "source-mask.png");
+        WriteSolidPng(maskPath, 4, 4, SKColors.White);
+        var document = CreateDocument("Assets/missing.png", "Generated/source-mask.png");
+
+        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject()));
+        Assert.Contains("Artwork element", exception.Message);
+    }
+
+    [Fact]
+    public void Export_WithMissingMaskAsset_ThrowsFileNotFoundException()
+    {
+        var artworkPath = Path.Combine(_assetsDirectory, "artwork.png");
+        WriteSolidPng(artworkPath, 4, 4, SKColors.Red);
+        var document = CreateDocument("Assets/artwork.png", "Generated/missing-mask.png");
+
+        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject()));
+        Assert.Contains("Face mask layer", exception.Message);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_projectDirectory))
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+
+    private EditorProject CreateProject()
+    {
+        return new EditorProject
+        {
+            Name = "Runtime Export Tests",
+            ProjectFilePath = Path.Combine(_projectDirectory, "Runtime Export Tests.oasis"),
+            ProjectDirectory = _projectDirectory,
+            AssetsDirectory = _assetsDirectory,
+            MachinesDirectory = Path.Combine(_projectDirectory, "Machines"),
+            GeneratedDirectory = _generatedDirectory
+        };
+    }
+
+    private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath)
+    {
+        return new FaceDocumentModel
+        {
+            Id = "face-runtime",
+            Title = "Runtime Face",
+            SourceRegion = new FaceSourceRegionModel
+            {
+                X = 0,
+                Y = 0,
+                Width = 4,
+                Height = 4
+            },
+            MaskLayer = new FaceMaskLayerModel
+            {
+                AssetPath = maskAssetPath,
+                Width = 4,
+                Height = 4,
+                GeneratedUtc = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc)
+            },
+            Elements =
+            [
+                new FaceArtworkElement
+                {
+                    ObjectId = "artwork",
+                    Name = "Artwork",
+                    X = 0,
+                    Y = 0,
+                    Width = 4,
+                    Height = 4,
+                    IsVisible = true,
+                    AssetPath = artworkAssetPath
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "lamp-24",
+                    Name = "Lamp 24",
+                    X = 1,
+                    Y = 1,
+                    Width = 2,
+                    Height = 2,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(24)
+                },
+                new FaceReelDisplayElement
+                {
+                    ObjectId = "reel-1",
+                    Name = "Reel 1",
+                    X = 2,
+                    Y = 0,
+                    Width = 1,
+                    Height = 4,
+                    LinkedMachineObjectReference = MachineObjectReference.Reel(1)
+                }
+            ]
+        };
+    }
+
+    private static void WriteSolidPng(string path, int width, int height, SKColor color)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(color);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -33,12 +33,19 @@ internal sealed class MfmeExtractImportService : IMfmeExtractImportService
 
 public interface IDocumentSaveService
 {
-    DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath);
+    DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null);
 }
 
 public sealed class DocumentSaveService : IDocumentSaveService
 {
-    public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath)
+    private readonly FaceRuntimeExportService _faceRuntimeExportService;
+
+    public DocumentSaveService(FaceRuntimeExportService? faceRuntimeExportService = null)
+    {
+        _faceRuntimeExportService = faceRuntimeExportService ?? new FaceRuntimeExportService();
+    }
+
+    public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null)
     {
         ArgumentNullException.ThrowIfNull(current);
         if (string.IsNullOrWhiteSpace(savePath))
@@ -46,7 +53,27 @@ public sealed class DocumentSaveService : IDocumentSaveService
             throw new ArgumentException("Save path is required.", nameof(savePath));
         }
 
-        var content = DocumentWorkspaceViewModel.BuildDocumentContent(current);
+        var faceDocumentJson = current.FaceDocumentJson;
+        var contentSource = current;
+        if (current.Document.DocumentType == EditorDocumentType.Face && project is not null)
+        {
+            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project);
+            faceDocumentJson = FaceDocumentStorage.Serialize(exportResult.Document);
+            contentSource = new DocumentTabViewModel(
+                current.Document,
+                current.PanelLayoutJson,
+                current.DocumentId,
+                current.CommandService,
+                current.RuntimeState,
+                faceDocumentJson)
+            {
+                PanelZoom = current.PanelZoom,
+                PanelPanX = current.PanelPanX,
+                PanelPanY = current.PanelPanY
+            };
+        }
+
+        var content = DocumentWorkspaceViewModel.BuildDocumentContent(contentSource);
         File.WriteAllText(savePath, content);
 
         return new DocumentTabViewModel(
@@ -55,7 +82,7 @@ public sealed class DocumentSaveService : IDocumentSaveService
             current.DocumentId,
             current.CommandService,
             current.RuntimeState,
-            current.FaceDocumentJson)
+            faceDocumentJson)
         {
             PanelZoom = current.PanelZoom,
             PanelPanX = current.PanelPanX,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -8,9 +8,25 @@ public sealed class FaceDocumentModel
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionModel? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }
+    public FaceRuntimeRenderAssetsModel? RuntimeRenderAssets { get; init; }
     public FaceMaskLayerModel? MaskLayer { get; init; }
     public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
     public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
+}
+
+public sealed class FaceRuntimeRenderAssetsModel
+{
+    public string? ManifestPath { get; init; }
+    public string? ArtworkPath { get; init; }
+    public string? MaskPath { get; init; }
+    public string? TrayIdPath { get; init; }
+    public string? LampIds0Path { get; init; }
+    public string? LampWeights0Path { get; init; }
+    public string? LampIds1Path { get; init; }
+    public string? LampWeights1Path { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public DateTime GeneratedUtc { get; init; }
 }
 
 public sealed class FaceMaskLayerModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -5,7 +5,7 @@ namespace OasisEditor;
 
 public static class FaceDocumentStorage
 {
-    public const int CurrentSchemaVersion = 1;
+    public const int CurrentSchemaVersion = 2;
 
     private static readonly JsonSerializerOptions s_readOptions = new()
     {
@@ -155,6 +155,7 @@ public static class FaceDocumentStorage
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
             SourceRegion = ToModel(file.SourceRegion),
             LastRegeneratedAtUtc = file.LastRegeneratedAtUtc,
+            RuntimeRenderAssets = ToModel(file.RuntimeRenderAssets),
             MaskLayer = ToModel(file.MaskLayer),
             Layers = (file.Layers ?? [])
                 .Select(layer => new FaceLayerModel
@@ -183,6 +184,7 @@ public static class FaceDocumentStorage
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
             SourceRegion = ToFile(model.SourceRegion),
             LastRegeneratedAtUtc = model.LastRegeneratedAtUtc,
+            RuntimeRenderAssets = ToFile(model.RuntimeRenderAssets),
             MaskLayer = ToFile(model.MaskLayer),
             SavedAtUtc = DateTime.UtcNow,
             Layers = model.Layers.Select(layer => new FaceLayerFile
@@ -193,6 +195,52 @@ public static class FaceDocumentStorage
                 IsLocked = layer.IsLocked
             }).ToArray(),
             Elements = model.Elements.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceRuntimeRenderAssetsModel? ToModel(FaceRuntimeRenderAssetsFile? file)
+    {
+        if (file is null)
+        {
+            return null;
+        }
+
+        return new FaceRuntimeRenderAssetsModel
+        {
+            ManifestPath = file.ManifestPath,
+            ArtworkPath = file.ArtworkPath,
+            MaskPath = file.MaskPath,
+            TrayIdPath = file.TrayIdPath,
+            LampIds0Path = file.LampIds0Path,
+            LampWeights0Path = file.LampWeights0Path,
+            LampIds1Path = file.LampIds1Path,
+            LampWeights1Path = file.LampWeights1Path,
+            Width = file.Width,
+            Height = file.Height,
+            GeneratedUtc = file.GeneratedUtc
+        };
+    }
+
+    private static FaceRuntimeRenderAssetsFile? ToFile(FaceRuntimeRenderAssetsModel? model)
+    {
+        if (model is null)
+        {
+            return null;
+        }
+
+        return new FaceRuntimeRenderAssetsFile
+        {
+            ManifestPath = model.ManifestPath,
+            ArtworkPath = model.ArtworkPath,
+            MaskPath = model.MaskPath,
+            TrayIdPath = model.TrayIdPath,
+            LampIds0Path = model.LampIds0Path,
+            LampWeights0Path = model.LampWeights0Path,
+            LampIds1Path = model.LampIds1Path,
+            LampWeights1Path = model.LampWeights1Path,
+            Width = model.Width,
+            Height = model.Height,
+            GeneratedUtc = model.GeneratedUtc
         };
     }
 
@@ -542,10 +590,26 @@ public sealed record FaceDocumentFile
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }
+    public FaceRuntimeRenderAssetsFile? RuntimeRenderAssets { get; init; }
     public FaceMaskLayerFile? MaskLayer { get; init; }
     public DateTime SavedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
     public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];
+}
+
+public sealed record FaceRuntimeRenderAssetsFile
+{
+    public string? ManifestPath { get; init; }
+    public string? ArtworkPath { get; init; }
+    public string? MaskPath { get; init; }
+    public string? TrayIdPath { get; init; }
+    public string? LampIds0Path { get; init; }
+    public string? LampWeights0Path { get; init; }
+    public string? LampIds1Path { get; init; }
+    public string? LampWeights1Path { get; init; }
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public DateTime GeneratedUtc { get; init; }
 }
 
 public sealed record FaceMaskLayerFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -1,0 +1,409 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SkiaSharp;
+
+namespace OasisEditor;
+
+public sealed class FaceRuntimeExportService
+{
+    public const int RuntimeManifestSchemaVersion = 1;
+    public const string RuntimeDirectoryName = "runtime";
+    public const string ManifestFileName = "face.runtime.json";
+    public const string ArtworkFileName = "artwork.png";
+    public const string MaskFileName = "mask.png";
+
+    private static readonly JsonSerializerOptions s_manifestJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    public FaceRuntimeExportResult Export(FaceDocumentModel faceDocument, EditorProject project)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+        ArgumentNullException.ThrowIfNull(project);
+
+        if (string.IsNullOrWhiteSpace(project.ProjectDirectory))
+        {
+            throw new InvalidOperationException("Project directory is not configured.");
+        }
+
+        var width = ResolveRuntimeWidth(faceDocument);
+        var height = ResolveRuntimeHeight(faceDocument);
+        var outputDirectory = ResolveRuntimeOutputDirectory(faceDocument, project);
+        Directory.CreateDirectory(outputDirectory);
+
+        if (!Directory.Exists(outputDirectory))
+        {
+            throw new IOException($"Face runtime output directory could not be created: {outputDirectory}");
+        }
+
+        var artworkPath = Path.Combine(outputDirectory, ArtworkFileName);
+        var maskPath = Path.Combine(outputDirectory, MaskFileName);
+        ExportArtwork(faceDocument, project, width, height, artworkPath);
+        CopyMask(faceDocument, project, maskPath);
+
+        var generatedUtc = DateTime.UtcNow;
+        var manifest = CreateManifest(faceDocument, width, height);
+        var manifestPath = Path.Combine(outputDirectory, ManifestFileName);
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest, s_manifestJsonOptions));
+
+        var runtimeAssets = new FaceRuntimeRenderAssetsModel
+        {
+            ManifestPath = ToProjectRelativePath(project, manifestPath),
+            ArtworkPath = ToProjectRelativePath(project, artworkPath),
+            MaskPath = ToProjectRelativePath(project, maskPath),
+            TrayIdPath = null,
+            LampIds0Path = null,
+            LampWeights0Path = null,
+            LampIds1Path = null,
+            LampWeights1Path = null,
+            Width = width,
+            Height = height,
+            GeneratedUtc = generatedUtc
+        };
+
+        var updatedDocument = new FaceDocumentModel
+        {
+            Id = faceDocument.Id,
+            Title = faceDocument.Title,
+            Summary = faceDocument.Summary,
+            SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+            SourceRegion = faceDocument.SourceRegion,
+            LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
+            RuntimeRenderAssets = runtimeAssets,
+            MaskLayer = faceDocument.MaskLayer,
+            Layers = faceDocument.Layers,
+            Elements = faceDocument.Elements
+        };
+
+        return new FaceRuntimeExportResult(updatedDocument, manifest, outputDirectory, manifestPath, artworkPath, maskPath);
+    }
+
+    public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+        if (width <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(width), width, "Runtime manifest width must be positive.");
+        }
+
+        if (height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(height), height, "Runtime manifest height must be positive.");
+        }
+
+        return new FaceRuntimeManifest
+        {
+            SchemaVersion = RuntimeManifestSchemaVersion,
+            FaceId = faceDocument.Id,
+            Width = width,
+            Height = height,
+            Artwork = ArtworkFileName,
+            Mask = MaskFileName,
+            TrayId = null,
+            LampIds0 = null,
+            LampWeights0 = null,
+            LampIds1 = null,
+            LampWeights1 = null,
+            Lamps = faceDocument.Elements.OfType<FaceLampWindowElement>().Select(CreateLampManifestEntry).ToArray(),
+            Trays = [],
+            Reels = faceDocument.Elements.OfType<FaceReelDisplayElement>().Select(CreateDisplayManifestEntry).ToArray(),
+            SevenSegmentDisplays = faceDocument.Elements.OfType<FaceSevenSegmentDisplayElement>().Select(CreateDisplayManifestEntry).ToArray(),
+            AlphaDisplays = faceDocument.Elements.OfType<FaceAlphaDisplayElement>().Select(CreateDisplayManifestEntry).ToArray(),
+            Buttons = faceDocument.Elements.OfType<FaceButtonElement>().Select(CreateButtonManifestEntry).ToArray()
+        };
+    }
+
+    private static void ExportArtwork(FaceDocumentModel faceDocument, EditorProject project, int width, int height, string outputPath)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        foreach (var artwork in faceDocument.Elements.OfType<FaceArtworkElement>())
+        {
+            if (!artwork.IsVisible || artwork.Width <= 0d || artwork.Height <= 0d)
+            {
+                continue;
+            }
+
+            var sourcePath = ResolveExistingProjectPath(project, artwork.AssetPath, $"Artwork element '{DisplayName(artwork)}'");
+            using var image = LoadImage(sourcePath, $"Artwork element '{DisplayName(artwork)}'");
+            var destination = SKRect.Create((float)artwork.X, (float)artwork.Y, (float)artwork.Width, (float)artwork.Height);
+            var source = ResolveArtworkSourceRect(artwork, image.Width, image.Height);
+            canvas.DrawImage(image, source, destination);
+        }
+
+        using var flattenedImage = SKImage.FromBitmap(bitmap);
+        using var data = flattenedImage.Encode(SKEncodedImageFormat.Png, 100);
+        if (data is null)
+        {
+            throw new IOException("Flattened face artwork could not be encoded as PNG.");
+        }
+
+        using var stream = File.Open(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+
+    private static void CopyMask(FaceDocumentModel faceDocument, EditorProject project, string outputPath)
+    {
+        if (faceDocument.MaskLayer is null)
+        {
+            throw new InvalidOperationException("Face document does not contain a mask layer to export as runtime mask.png.");
+        }
+
+        var sourcePath = ResolveExistingProjectPath(project, faceDocument.MaskLayer.AssetPath, "Face mask layer");
+        if (string.Equals(Path.GetFullPath(sourcePath), Path.GetFullPath(outputPath), StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        File.Copy(sourcePath, outputPath, overwrite: true);
+    }
+
+    private static string ResolveRuntimeOutputDirectory(FaceDocumentModel faceDocument, EditorProject project)
+    {
+        if (string.IsNullOrWhiteSpace(project.GeneratedDirectory))
+        {
+            throw new InvalidOperationException("Project Generated directory is not configured.");
+        }
+
+        var generatedDirectory = Path.GetFullPath(project.GeneratedDirectory);
+        if (File.Exists(generatedDirectory))
+        {
+            throw new IOException($"Project Generated directory points to a file: {generatedDirectory}");
+        }
+
+        var safeFaceId = SanitizePathSegment(string.IsNullOrWhiteSpace(faceDocument.Id) ? Guid.NewGuid().ToString("N") : faceDocument.Id.Trim());
+        return Path.Combine(generatedDirectory, "Faces", safeFaceId, RuntimeDirectoryName);
+    }
+
+    private static string ResolveExistingProjectPath(EditorProject project, string? projectPath, string description)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            throw new FileNotFoundException($"{description} does not specify an asset path.");
+        }
+
+        var candidate = projectPath.Trim();
+        var paths = new List<string>();
+        if (Path.IsPathRooted(candidate))
+        {
+            paths.Add(candidate);
+        }
+        else
+        {
+            var normalizedRelative = candidate.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+            paths.Add(Path.GetFullPath(Path.Combine(project.ProjectDirectory, normalizedRelative)));
+            paths.Add(Path.GetFullPath(Path.Combine(project.AssetsDirectory, normalizedRelative)));
+        }
+
+        var resolved = paths.FirstOrDefault(File.Exists);
+        if (resolved is not null)
+        {
+            return resolved;
+        }
+
+        throw new FileNotFoundException($"{description} references missing asset '{projectPath}'.", paths.FirstOrDefault() ?? candidate);
+    }
+
+    private static SKImage LoadImage(string path, string description)
+    {
+        using var data = SKData.Create(path);
+        if (data is null)
+        {
+            throw new IOException($"{description} asset '{path}' could not be opened.");
+        }
+
+        var image = SKImage.FromEncodedData(data);
+        if (image is null)
+        {
+            throw new InvalidOperationException($"{description} asset '{path}' could not be read as an image.");
+        }
+
+        return image;
+    }
+
+    private static FaceRuntimeLampManifestEntry CreateLampManifestEntry(FaceLampWindowElement element)
+    {
+        var reference = element.LinkedMachineObjectReference?.ToString();
+        return new FaceRuntimeLampManifestEntry
+        {
+            LampId = TryGetIntId(element.LinkedMachineObjectReference, MachineObjectKind.Lamp),
+            MachineReference = string.IsNullOrWhiteSpace(reference) ? null : reference,
+            Name = element.Name,
+            TrayId = null,
+            X = element.X + (element.Width / 2d),
+            Y = element.Y + (element.Height / 2d),
+            Width = element.Width,
+            Height = element.Height
+        };
+    }
+
+    private static FaceRuntimeElementManifestEntry CreateDisplayManifestEntry(FaceElementModel element)
+    {
+        return new FaceRuntimeElementManifestEntry
+        {
+            ObjectId = element.ObjectId,
+            MachineReference = element.LinkedMachineObjectReference?.ToString(),
+            Name = element.Name,
+            X = element.X,
+            Y = element.Y,
+            Width = element.Width,
+            Height = element.Height
+        };
+    }
+
+    private static FaceRuntimeButtonManifestEntry CreateButtonManifestEntry(FaceButtonElement element)
+    {
+        return new FaceRuntimeButtonManifestEntry
+        {
+            ObjectId = element.ObjectId,
+            MachineReference = element.LinkedMachineObjectReference?.ToString(),
+            InputReference = element.LinkedInputReference?.ToString(),
+            Name = element.Name,
+            X = element.X,
+            Y = element.Y,
+            Width = element.Width,
+            Height = element.Height
+        };
+    }
+
+    private static int? TryGetIntId(MachineObjectReference? reference, MachineObjectKind expectedKind)
+    {
+        return reference is MachineObjectReference machineReference
+            && machineReference.Kind == expectedKind
+            && int.TryParse(machineReference.Id, out var id)
+            ? id
+            : null;
+    }
+
+    private static int ResolveRuntimeWidth(FaceDocumentModel faceDocument)
+    {
+        if (faceDocument.SourceRegion is { IsValid: true } sourceRegion)
+        {
+            return Math.Max(1, (int)Math.Ceiling(sourceRegion.Width));
+        }
+
+        if (faceDocument.MaskLayer is { Width: > 0 } maskLayer)
+        {
+            return maskLayer.Width;
+        }
+
+        return Math.Max(1, (int)Math.Ceiling(faceDocument.Elements.Select(element => element.X + element.Width).DefaultIfEmpty(1d).Max()));
+    }
+
+    private static int ResolveRuntimeHeight(FaceDocumentModel faceDocument)
+    {
+        if (faceDocument.SourceRegion is { IsValid: true } sourceRegion)
+        {
+            return Math.Max(1, (int)Math.Ceiling(sourceRegion.Height));
+        }
+
+        if (faceDocument.MaskLayer is { Height: > 0 } maskLayer)
+        {
+            return maskLayer.Height;
+        }
+
+        return Math.Max(1, (int)Math.Ceiling(faceDocument.Elements.Select(element => element.Y + element.Height).DefaultIfEmpty(1d).Max()));
+    }
+
+    private static SKRect ResolveArtworkSourceRect(FaceArtworkElement element, int imageWidth, int imageHeight)
+    {
+        var sourceRegion = element.SourceRegion;
+        var sourceBounds = element.Provenance?.SourceElementBounds;
+        if (sourceRegion is null || sourceBounds is null || sourceBounds.Width <= 0d || sourceBounds.Height <= 0d)
+        {
+            return SKRect.Create(0f, 0f, imageWidth, imageHeight);
+        }
+
+        var scaleX = imageWidth / sourceBounds.Width;
+        var scaleY = imageHeight / sourceBounds.Height;
+        var x = (sourceRegion.X - sourceBounds.X) * scaleX;
+        var y = (sourceRegion.Y - sourceBounds.Y) * scaleY;
+        var width = sourceRegion.Width * scaleX;
+        var height = sourceRegion.Height * scaleY;
+        var left = (float)Math.Clamp(x, 0d, imageWidth);
+        var top = (float)Math.Clamp(y, 0d, imageHeight);
+        var right = (float)Math.Clamp(x + width, left, imageWidth);
+        var bottom = (float)Math.Clamp(y + height, top, imageHeight);
+        return new SKRect(left, top, right, bottom);
+    }
+
+    private static string ToProjectRelativePath(EditorProject project, string fullPath)
+    {
+        return Path.GetRelativePath(Path.GetFullPath(project.ProjectDirectory), Path.GetFullPath(fullPath)).Replace('\\', '/');
+    }
+
+    private static string DisplayName(FaceElementModel element)
+    {
+        return string.IsNullOrWhiteSpace(element.Name) ? element.ObjectId : element.Name.Trim();
+    }
+
+    private static string SanitizePathSegment(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return string.Concat(value.Select(character => invalid.Contains(character) ? '_' : character));
+    }
+}
+
+public sealed record FaceRuntimeExportResult(
+    FaceDocumentModel Document,
+    FaceRuntimeManifest Manifest,
+    string OutputDirectory,
+    string ManifestPath,
+    string ArtworkPath,
+    string MaskPath);
+
+public sealed class FaceRuntimeManifest
+{
+    public int SchemaVersion { get; init; }
+    public string FaceId { get; init; } = string.Empty;
+    public int Width { get; init; }
+    public int Height { get; init; }
+    public string Artwork { get; init; } = string.Empty;
+    public string Mask { get; init; } = string.Empty;
+    public string? TrayId { get; init; }
+    public string? LampIds0 { get; init; }
+    public string? LampWeights0 { get; init; }
+    public string? LampIds1 { get; init; }
+    public string? LampWeights1 { get; init; }
+    public IReadOnlyList<FaceRuntimeLampManifestEntry> Lamps { get; init; } = [];
+    public IReadOnlyList<FaceRuntimeElementManifestEntry> Trays { get; init; } = [];
+    public IReadOnlyList<FaceRuntimeElementManifestEntry> Reels { get; init; } = [];
+    public IReadOnlyList<FaceRuntimeElementManifestEntry> SevenSegmentDisplays { get; init; } = [];
+    public IReadOnlyList<FaceRuntimeElementManifestEntry> AlphaDisplays { get; init; } = [];
+    public IReadOnlyList<FaceRuntimeButtonManifestEntry> Buttons { get; init; } = [];
+}
+
+public sealed class FaceRuntimeLampManifestEntry
+{
+    public int? LampId { get; init; }
+    public string? MachineReference { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public int? TrayId { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+}
+
+public class FaceRuntimeElementManifestEntry
+{
+    public string ObjectId { get; init; } = string.Empty;
+    public string? MachineReference { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+}
+
+public sealed class FaceRuntimeButtonManifestEntry : FaceRuntimeElementManifestEntry
+{
+    public string? InputReference { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1325,7 +1325,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         try
         {
-            var updatedDocument = _documentSaveService.SaveDocument(current, savePath);
+            var updatedDocument = _documentSaveService.SaveDocument(current, savePath, LoadedProject);
             _documentWorkspace.ReplaceDocument(current, updatedDocument);
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}", OutputLogStatus.Info);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -184,6 +184,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             SourcePanel2DDocumentId = _faceDocumentModel.SourcePanel2DDocumentId,
             SourceRegion = _faceDocumentModel.SourceRegion,
             LastRegeneratedAtUtc = _faceDocumentModel.LastRegeneratedAtUtc,
+            RuntimeRenderAssets = _faceDocumentModel.RuntimeRenderAssets,
             MaskLayer = _faceDocumentModel.MaskLayer,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -598,6 +598,7 @@ public sealed class DocumentWorkspaceViewModel
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourceRegion = faceDocument.SourceRegion,
                 LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
+                RuntimeRenderAssets = faceDocument.RuntimeRenderAssets,
                 MaskLayer = faceDocument.MaskLayer,
                 Layers = faceDocument.Layers,
                 Elements = faceDocument.Elements


### PR DESCRIPTION
### Motivation
- Introduce the Face runtime export architecture so the editor can produce runtime texture packages for later Unity consumption. 
- Persist runtime render asset references on Face documents so exported packages can be round-tripped and re-opened by the latest editor code. 
- Implement Phase 1 and Phase 2 from the export plan while deferring tray polygons, lamp influence textures, and Unity code. 

### Description
- Added `FaceRuntimeRenderAssetsModel` to the Face document model and exposed it on `FaceDocumentModel.RuntimeRenderAssets`, and bumped the Face document schema to `CurrentSchemaVersion = 2`. 
- Extended `FaceDocumentStorage` to serialize/deserialize the new `FaceRuntimeRenderAssetsFile` record and map it in `ToModel`/`ToFile`. 
- Implemented `FaceRuntimeExportService` which exports packages to `Generated/Faces/{faceId}/runtime/`, flattens visible artwork into `artwork.png` (preserving alpha and using existing source-region/provenance logic), copies the existing face mask into `mask.png`, and writes `face.runtime.json` manifest with null placeholders for future tray/lamp textures. 
- The manifest model includes `schemaVersion`, `faceId`, `width`, `height`, `artwork`, `mask`, tray/lamp texture placeholders, and basic `lamps`/`reels`/`displays`/`buttons` metadata; the export stores relative project paths back into the Face document `RuntimeRenderAssets`. 
- Added validation and error handling for missing artwork assets, missing mask asset, missing/invalid `Generated` directory, and clear failure modes when resources are missing. 
- Added unit tests `FaceRuntimeExportServiceTests` covering schema round-trip serialization, successful export (manifest + artwork + mask), and missing-artwork/mask failure cases. 

### Testing
- Added `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs` which contains tests for serialization round-trip and export/validation scenarios but these tests were not executed in this environment. 
- Per repository guidance the .NET/WPF build and test suite were not run inside Codex; instead `git diff --check` was executed to ensure no whitespace/error diffs and all changes were committed. 
- Local test checklist for maintainers: build the solution and run `dotnet test` (run `FaceRuntimeExportServiceTests`), create/generate a Face, save/close/reopen it, perform an export and verify `Generated/Faces/{faceId}/runtime/` contains `face.runtime.json`, `artwork.png`, and `mask.png`, and validate the manifest fields and transparency in `artwork.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29c67e30cc8327865aff6679f9ef0f)