### PR TITLE
Add texture-driven Face CPU preview with Skia renderer and tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
@@ -53,7 +53,7 @@ public sealed class FaceTexturePreviewRendererTests : IDisposable
         var runtimeState = new MachineRuntimeState();
         runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(7), 1d);
 
-        using var result = renderer.Render(CreateDocument(), runtimeState);
+        using var result = renderer.Render(CreateDocument(width: 1, height: 1), runtimeState);
 
         Assert.True(result.Rendered);
         Assert.NotNull(result.Bitmap);
@@ -74,7 +74,7 @@ public sealed class FaceTexturePreviewRendererTests : IDisposable
         WriteSolidPng("lampWeights0.png", 1, 1, new SKColor(255, 0, 0, 255));
         var renderer = CreateRenderer();
 
-        using var result = renderer.Render(CreateDocument(), new MachineRuntimeState());
+        using var result = renderer.Render(CreateDocument(width: 1, height: 1), new MachineRuntimeState());
 
         Assert.True(result.Rendered);
         Assert.NotNull(result.Bitmap);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
@@ -1,0 +1,170 @@
+using OasisEditor;
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceTexturePreviewRendererTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public FaceTexturePreviewRendererTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceTexturePreviewTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    [Fact]
+    public void Render_MissingRuntimeRenderAssets_ReturnsFallbackReason()
+    {
+        var renderer = CreateRenderer();
+        var result = renderer.Render(new FaceDocumentModel(), new MachineRuntimeState());
+
+        Assert.False(result.Rendered);
+        Assert.Equal("missing runtime render assets", result.FallbackReason);
+    }
+
+    [Fact]
+    public void Render_DimensionMismatch_ReturnsFallbackReason()
+    {
+        WriteSolidPng("artwork.png", 2, 2, new SKColor(100, 80, 60, 255));
+        WriteSolidPng("mask.png", 3, 2, SKColors.White);
+        WriteSolidPng("trayId.png", 2, 2, SKColors.Black);
+        WriteSolidPng("lampIds0.png", 2, 2, new SKColor(7, 0, 0, 255));
+        WriteSolidPng("lampWeights0.png", 2, 2, new SKColor(255, 0, 0, 255));
+        var renderer = CreateRenderer();
+
+        using var result = renderer.Render(CreateDocument(), new MachineRuntimeState());
+
+        Assert.False(result.Rendered);
+        Assert.Contains("dimension mismatch", result.FallbackReason);
+    }
+
+    [Fact]
+    public void Render_LampIdAndWeight_ProducesExpectedLitPixel()
+    {
+        WriteSolidPng("artwork.png", 1, 1, new SKColor(100, 40, 20, 192));
+        WriteSolidPng("mask.png", 1, 1, SKColors.White);
+        WriteSolidPng("trayId.png", 1, 1, new SKColor(1, 0, 0, 255));
+        WriteSolidPng("lampIds0.png", 1, 1, new SKColor(7, 0, 0, 255));
+        WriteSolidPng("lampWeights0.png", 1, 1, new SKColor(255, 0, 0, 255));
+        var renderer = CreateRenderer();
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(7), 1d);
+
+        using var result = renderer.Render(CreateDocument(), runtimeState);
+
+        Assert.True(result.Rendered);
+        Assert.NotNull(result.Bitmap);
+        var pixel = result.Bitmap.GetPixel(0, 0);
+        Assert.Equal(125, pixel.Red);
+        Assert.Equal(50, pixel.Green);
+        Assert.Equal(25, pixel.Blue);
+        Assert.Equal(192, pixel.Alpha);
+    }
+
+    [Fact]
+    public void Render_ZeroLampState_LeavesArtworkAtAmbientOnly()
+    {
+        WriteSolidPng("artwork.png", 1, 1, new SKColor(100, 40, 20, 255));
+        WriteSolidPng("mask.png", 1, 1, SKColors.White);
+        WriteSolidPng("trayId.png", 1, 1, new SKColor(1, 0, 0, 255));
+        WriteSolidPng("lampIds0.png", 1, 1, new SKColor(7, 0, 0, 255));
+        WriteSolidPng("lampWeights0.png", 1, 1, new SKColor(255, 0, 0, 255));
+        var renderer = CreateRenderer();
+
+        using var result = renderer.Render(CreateDocument(), new MachineRuntimeState());
+
+        Assert.True(result.Rendered);
+        Assert.NotNull(result.Bitmap);
+        var pixel = result.Bitmap.GetPixel(0, 0);
+        Assert.Equal(25, pixel.Red);
+        Assert.Equal(10, pixel.Green);
+        Assert.Equal(5, pixel.Blue);
+        Assert.Equal(255, pixel.Alpha);
+    }
+
+    [Fact]
+    public void Render_PreservesArtworkAlpha()
+    {
+        WriteSolidPng("artwork.png", 2, 1, SKColors.Transparent);
+        WritePixel("artwork.png", 0, 0, 2, 1, new SKColor(100, 100, 100, 0));
+        WritePixel("artwork.png", 1, 0, 2, 1, new SKColor(100, 100, 100, 127));
+        WriteSolidPng("mask.png", 2, 1, SKColors.White);
+        WriteSolidPng("trayId.png", 2, 1, new SKColor(1, 0, 0, 255));
+        WriteSolidPng("lampIds0.png", 2, 1, new SKColor(7, 0, 0, 255));
+        WriteSolidPng("lampWeights0.png", 2, 1, new SKColor(255, 0, 0, 255));
+        var renderer = CreateRenderer();
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(7), 1d);
+
+        using var result = renderer.Render(CreateDocument(width: 2, height: 1), runtimeState);
+
+        Assert.True(result.Rendered);
+        Assert.NotNull(result.Bitmap);
+        Assert.Equal(0, result.Bitmap.GetPixel(0, 0).Alpha);
+        Assert.Equal(127, result.Bitmap.GetPixel(1, 0).Alpha);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+
+    private FaceTexturePreviewRenderer CreateRenderer()
+    {
+        return new FaceTexturePreviewRenderer(
+            path => string.IsNullOrWhiteSpace(path) ? null : Path.Combine(_testDirectory, path),
+            new FaceTexturePreviewSettings
+            {
+                AmbientStrength = 0.25d,
+                EmissionStrength = 1d,
+                MaskStrength = 1d
+            });
+    }
+
+    private static FaceDocumentModel CreateDocument(int width = 2, int height = 2)
+    {
+        return new FaceDocumentModel
+        {
+            RuntimeRenderAssets = new FaceRuntimeRenderAssetsModel
+            {
+                ArtworkPath = "artwork.png",
+                MaskPath = "mask.png",
+                TrayIdPath = "trayId.png",
+                LampIds0Path = "lampIds0.png",
+                LampWeights0Path = "lampWeights0.png",
+                Width = width,
+                Height = height
+            }
+        };
+    }
+
+    private void WriteSolidPng(string relativePath, int width, int height, SKColor color)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        bitmap.Erase(color);
+        WriteBitmap(relativePath, bitmap);
+    }
+
+    private void WritePixel(string relativePath, int x, int y, int width, int height, SKColor color)
+    {
+        using var bitmap = SKBitmap.Decode(Path.Combine(_testDirectory, relativePath));
+        bitmap.SetPixel(x, y, color);
+        WriteBitmap(relativePath, bitmap);
+    }
+
+    private void WriteBitmap(string relativePath, SKBitmap bitmap)
+    {
+        var path = Path.Combine(_testDirectory, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(path);
+        data.SaveTo(stream);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO;
 using SkiaSharp;
 
@@ -14,6 +15,9 @@ public sealed class Face2DRenderer : IFace2DRenderer
     private readonly Func<string?, string?> _assetPathResolver;
     private readonly Dictionary<string, SKImage?> _cachedArtworkImages = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SKImage?> _cachedMaskImages = new(StringComparer.OrdinalIgnoreCase);
+    private readonly IFaceTexturePreviewRenderer _texturePreviewRenderer;
+
+    internal string? LastTexturePreviewFallbackReason { get; private set; }
 
     public Face2DRenderer()
         : this(FaceRuntimeStateResolver.Instance, ResolveDefaultAssetPath)
@@ -21,9 +25,15 @@ public sealed class Face2DRenderer : IFace2DRenderer
     }
 
     internal Face2DRenderer(IFaceRuntimeStateResolver runtimeStateResolver, Func<string?, string?> assetPathResolver)
+        : this(runtimeStateResolver, assetPathResolver, new FaceTexturePreviewRenderer(assetPathResolver))
+    {
+    }
+
+    internal Face2DRenderer(IFaceRuntimeStateResolver runtimeStateResolver, Func<string?, string?> assetPathResolver, IFaceTexturePreviewRenderer texturePreviewRenderer)
     {
         _runtimeStateResolver = runtimeStateResolver ?? throw new ArgumentNullException(nameof(runtimeStateResolver));
         _assetPathResolver = assetPathResolver ?? throw new ArgumentNullException(nameof(assetPathResolver));
+        _texturePreviewRenderer = texturePreviewRenderer ?? throw new ArgumentNullException(nameof(texturePreviewRenderer));
     }
 
     public void Render(SKCanvas canvas, FaceDocumentModel faceDocument, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform)
@@ -39,7 +49,10 @@ public sealed class Face2DRenderer : IFace2DRenderer
             DrawArtwork(canvas, artwork, viewportTransform);
         }
 
-        DrawLampIllumination(canvas, faceDocument.MaskLayer, elements.OfType<FaceLampWindowElement>(), runtimeState);
+        if (!TryDrawTextureDrivenLampPreview(canvas, faceDocument, runtimeState))
+        {
+            DrawLampIllumination(canvas, faceDocument.MaskLayer, elements.OfType<FaceLampWindowElement>(), runtimeState);
+        }
 
         foreach (var reelDisplay in elements.OfType<FaceReelDisplayElement>())
         {
@@ -60,6 +73,27 @@ public sealed class Face2DRenderer : IFace2DRenderer
         {
             DrawButton(canvas, button, viewportTransform);
         }
+    }
+
+
+    private bool TryDrawTextureDrivenLampPreview(SKCanvas canvas, FaceDocumentModel faceDocument, MachineRuntimeState runtimeState)
+    {
+        using var result = _texturePreviewRenderer.Render(faceDocument, runtimeState);
+        if (!result.Rendered || result.Bitmap is null)
+        {
+            LastTexturePreviewFallbackReason = result.FallbackReason;
+            if (!string.IsNullOrWhiteSpace(result.FallbackReason))
+            {
+                Trace.WriteLine($"Face texture-driven preview fallback: {result.FallbackReason}");
+            }
+
+            return false;
+        }
+
+        LastTexturePreviewFallbackReason = null;
+        using var image = SKImage.FromBitmap(result.Bitmap);
+        canvas.DrawImage(image, SKRect.Create(0f, 0f, image.Width, image.Height));
+        return true;
     }
 
     private void DrawArtwork(SKCanvas canvas, FaceArtworkElement element, PanelViewportTransform viewport)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
@@ -1,0 +1,288 @@
+using System.IO;
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+public interface IFaceTexturePreviewRenderer
+{
+    FaceTexturePreviewRenderResult Render(FaceDocumentModel faceDocument, MachineRuntimeState runtimeState);
+}
+
+public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer
+{
+    private readonly Func<string?, string?> _assetPathResolver;
+    private readonly FaceTexturePreviewSettings _settings;
+
+    public FaceTexturePreviewRenderer(Func<string?, string?> assetPathResolver)
+        : this(assetPathResolver, FaceTexturePreviewSettings.Default)
+    {
+    }
+
+    public FaceTexturePreviewRenderer(Func<string?, string?> assetPathResolver, FaceTexturePreviewSettings settings)
+    {
+        _assetPathResolver = assetPathResolver ?? throw new ArgumentNullException(nameof(assetPathResolver));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public FaceTexturePreviewRenderResult Render(FaceDocumentModel faceDocument, MachineRuntimeState runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        if (!TryLoadTextures(faceDocument.RuntimeRenderAssets, out var textures, out var fallbackReason))
+        {
+            return FaceTexturePreviewRenderResult.Fallback(fallbackReason);
+        }
+
+        using (textures)
+        {
+            var output = new SKBitmap(textures.Width, textures.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+            RenderPixels(output, textures, runtimeState);
+            return FaceTexturePreviewRenderResult.FromBitmap(output);
+        }
+    }
+
+    private void RenderPixels(SKBitmap output, FaceTexturePreviewTextures textures, MachineRuntimeState runtimeState)
+    {
+        var ambient = Math.Clamp(_settings.AmbientStrength, 0d, 4d);
+        var emission = Math.Clamp(_settings.EmissionStrength, 0d, 8d);
+        var maskStrength = Math.Clamp(_settings.MaskStrength, 0d, 4d);
+
+        for (var y = 0; y < textures.Height; y++)
+        {
+            for (var x = 0; x < textures.Width; x++)
+            {
+                var artwork = textures.Artwork.GetPixel(x, y);
+                var mask = ResolveMaskValue(textures.Mask.GetPixel(x, y)) * maskStrength;
+                var visibleLight = mask * ResolveLampContribution(textures.LampIds0.GetPixel(x, y), textures.LampWeights0.GetPixel(x, y), runtimeState, _settings.LampIds0ChannelCount);
+                var litMultiplier = ambient + (visibleLight * emission);
+
+                output.SetPixel(
+                    x,
+                    y,
+                    new SKColor(
+                        ScaleChannel(artwork.Red, litMultiplier),
+                        ScaleChannel(artwork.Green, litMultiplier),
+                        ScaleChannel(artwork.Blue, litMultiplier),
+                        artwork.Alpha));
+            }
+        }
+    }
+
+    private static double ResolveLampContribution(SKColor lampIds, SKColor lampWeights, MachineRuntimeState runtimeState, int channelCount)
+    {
+        // Phase 3a populates only the first channel. Keep the channel loop explicit so
+        // additional lampIds0/lampWeights0 channels, and later lampIds1/lampWeights1, can
+        // be enabled without changing the lighting equation.
+        var clampedChannelCount = Math.Clamp(channelCount, 1, 4);
+        var contribution = ResolveLampChannel(lampIds.Red, lampWeights.Red, runtimeState);
+        if (clampedChannelCount >= 2)
+        {
+            contribution += ResolveLampChannel(lampIds.Green, lampWeights.Green, runtimeState);
+        }
+
+        if (clampedChannelCount >= 3)
+        {
+            contribution += ResolveLampChannel(lampIds.Blue, lampWeights.Blue, runtimeState);
+        }
+
+        if (clampedChannelCount >= 4)
+        {
+            contribution += ResolveLampChannel(lampIds.Alpha, lampWeights.Alpha, runtimeState);
+        }
+
+        return contribution;
+    }
+
+    private static double ResolveLampChannel(byte lampId, byte weight, MachineRuntimeState runtimeState)
+    {
+        if (lampId == 0 || weight == 0)
+        {
+            return 0d;
+        }
+
+        var lampState = Math.Clamp(runtimeState.GetLampIntensity(MachineObjectReference.Lamp(lampId)), 0d, 1d);
+        return lampState * (weight / 255d);
+    }
+
+    private static double ResolveMaskValue(SKColor maskPixel)
+    {
+        var grayscale = Math.Max(maskPixel.Red, Math.Max(maskPixel.Green, maskPixel.Blue)) / 255d;
+        return grayscale * (maskPixel.Alpha / 255d);
+    }
+
+    private static byte ScaleChannel(byte channel, double multiplier)
+    {
+        return (byte)Math.Clamp(Math.Round(channel * multiplier, MidpointRounding.AwayFromZero), 0d, 255d);
+    }
+
+    private bool TryLoadTextures(FaceRuntimeRenderAssetsModel? assets, out FaceTexturePreviewTextures textures, out string fallbackReason)
+    {
+        textures = default!;
+        if (assets is null)
+        {
+            fallbackReason = "missing runtime render assets";
+            return false;
+        }
+
+        if (!TryLoadTexture(assets.ArtworkPath, "artwork", out var artwork, out fallbackReason)
+            || !TryLoadTexture(assets.MaskPath, "mask", out var mask, out fallbackReason)
+            || !TryLoadTexture(assets.TrayIdPath, "trayId", out var trayId, out fallbackReason)
+            || !TryLoadTexture(assets.LampIds0Path, "lampIds0", out var lampIds0, out fallbackReason)
+            || !TryLoadTexture(assets.LampWeights0Path, "lampWeights0", out var lampWeights0, out fallbackReason))
+        {
+            artwork?.Dispose();
+            mask?.Dispose();
+            trayId?.Dispose();
+            lampIds0?.Dispose();
+            lampWeights0?.Dispose();
+            return false;
+        }
+
+        if (assets.Width > 0 && assets.Height > 0 && (artwork.Width != assets.Width || artwork.Height != assets.Height))
+        {
+            fallbackReason = $"dimension mismatch: artwork is {artwork.Width}x{artwork.Height}, runtime assets declare {assets.Width}x{assets.Height}";
+            DisposeAll(artwork, mask, trayId, lampIds0, lampWeights0);
+            return false;
+        }
+
+        if (!HaveMatchingDimensions(artwork, mask, trayId, lampIds0, lampWeights0))
+        {
+            fallbackReason = $"dimension mismatch: artwork={FormatDimensions(artwork)}, mask={FormatDimensions(mask)}, trayId={FormatDimensions(trayId)}, lampIds0={FormatDimensions(lampIds0)}, lampWeights0={FormatDimensions(lampWeights0)}";
+            DisposeAll(artwork, mask, trayId, lampIds0, lampWeights0);
+            return false;
+        }
+
+        textures = new FaceTexturePreviewTextures(artwork, mask, trayId, lampIds0, lampWeights0);
+        fallbackReason = string.Empty;
+        return true;
+    }
+
+    private bool TryLoadTexture(string? assetPath, string textureName, out SKBitmap bitmap, out string fallbackReason)
+    {
+        bitmap = default!;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            fallbackReason = $"missing texture path: {textureName}";
+            return false;
+        }
+
+        var resolvedPath = _assetPathResolver(assetPath);
+        if (string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            fallbackReason = $"missing texture path: {textureName} ({assetPath})";
+            return false;
+        }
+
+        if (!File.Exists(resolvedPath))
+        {
+            fallbackReason = $"missing texture file: {textureName} ({resolvedPath})";
+            return false;
+        }
+
+        bitmap = SKBitmap.Decode(resolvedPath);
+        if (bitmap is null)
+        {
+            fallbackReason = $"failed texture load: {textureName} ({resolvedPath})";
+            return false;
+        }
+
+        if (bitmap.Width <= 0 || bitmap.Height <= 0 || bitmap.ColorType == SKColorType.Unknown)
+        {
+            bitmap.Dispose();
+            bitmap = default!;
+            fallbackReason = $"unsupported or invalid texture format: {textureName} ({resolvedPath})";
+            return false;
+        }
+
+        fallbackReason = string.Empty;
+        return true;
+    }
+
+    private static bool HaveMatchingDimensions(SKBitmap first, params SKBitmap[] rest)
+    {
+        return rest.All(bitmap => bitmap.Width == first.Width && bitmap.Height == first.Height);
+    }
+
+    private static string FormatDimensions(SKBitmap bitmap)
+    {
+        return $"{bitmap.Width}x{bitmap.Height}";
+    }
+
+    private static void DisposeAll(params SKBitmap?[] bitmaps)
+    {
+        foreach (var bitmap in bitmaps)
+        {
+            bitmap?.Dispose();
+        }
+    }
+
+    private sealed class FaceTexturePreviewTextures : IDisposable
+    {
+        public FaceTexturePreviewTextures(SKBitmap artwork, SKBitmap mask, SKBitmap trayId, SKBitmap lampIds0, SKBitmap lampWeights0)
+        {
+            Artwork = artwork;
+            Mask = mask;
+            TrayId = trayId;
+            LampIds0 = lampIds0;
+            LampWeights0 = lampWeights0;
+        }
+
+        public SKBitmap Artwork { get; }
+        public SKBitmap Mask { get; }
+        public SKBitmap TrayId { get; }
+        public SKBitmap LampIds0 { get; }
+        public SKBitmap LampWeights0 { get; }
+        public int Width => Artwork.Width;
+        public int Height => Artwork.Height;
+
+        public void Dispose()
+        {
+            Artwork.Dispose();
+            Mask.Dispose();
+            TrayId.Dispose();
+            LampIds0.Dispose();
+            LampWeights0.Dispose();
+        }
+    }
+}
+
+public sealed class FaceTexturePreviewSettings
+{
+    public static FaceTexturePreviewSettings Default { get; } = new();
+
+    public double AmbientStrength { get; init; } = 0.35d;
+    public double EmissionStrength { get; init; } = 1.15d;
+    public double MaskStrength { get; init; } = 1d;
+    public int LampIds0ChannelCount { get; init; } = 1;
+}
+
+public sealed class FaceTexturePreviewRenderResult : IDisposable
+{
+    private FaceTexturePreviewRenderResult(bool rendered, SKBitmap? bitmap, string? fallbackReason)
+    {
+        Rendered = rendered;
+        Bitmap = bitmap;
+        FallbackReason = fallbackReason;
+    }
+
+    public bool Rendered { get; }
+    public SKBitmap? Bitmap { get; }
+    public string? FallbackReason { get; }
+
+    public static FaceTexturePreviewRenderResult FromBitmap(SKBitmap bitmap)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        return new FaceTexturePreviewRenderResult(true, bitmap, null);
+    }
+
+    public static FaceTexturePreviewRenderResult Fallback(string fallbackReason)
+    {
+        return new FaceTexturePreviewRenderResult(false, null, fallbackReason);
+    }
+
+    public void Dispose()
+    {
+        Bitmap?.Dispose();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
@@ -125,17 +125,32 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer
             return false;
         }
 
-        if (!TryLoadTexture(assets.ArtworkPath, "artwork", out var artwork, out fallbackReason)
-            || !TryLoadTexture(assets.MaskPath, "mask", out var mask, out fallbackReason)
-            || !TryLoadTexture(assets.TrayIdPath, "trayId", out var trayId, out fallbackReason)
-            || !TryLoadTexture(assets.LampIds0Path, "lampIds0", out var lampIds0, out fallbackReason)
-            || !TryLoadTexture(assets.LampWeights0Path, "lampWeights0", out var lampWeights0, out fallbackReason))
+        if (!TryLoadTexture(assets.ArtworkPath, "artwork", out var artwork, out fallbackReason))
         {
-            artwork?.Dispose();
-            mask?.Dispose();
-            trayId?.Dispose();
-            lampIds0?.Dispose();
-            lampWeights0?.Dispose();
+            return false;
+        }
+
+        if (!TryLoadTexture(assets.MaskPath, "mask", out var mask, out fallbackReason))
+        {
+            artwork.Dispose();
+            return false;
+        }
+
+        if (!TryLoadTexture(assets.TrayIdPath, "trayId", out var trayId, out fallbackReason))
+        {
+            DisposeAll(artwork, mask);
+            return false;
+        }
+
+        if (!TryLoadTexture(assets.LampIds0Path, "lampIds0", out var lampIds0, out fallbackReason))
+        {
+            DisposeAll(artwork, mask, trayId);
+            return false;
+        }
+
+        if (!TryLoadTexture(assets.LampWeights0Path, "lampWeights0", out var lampWeights0, out fallbackReason))
+        {
+            DisposeAll(artwork, mask, trayId, lampIds0);
             return false;
         }
 


### PR DESCRIPTION
### Motivation
- Implement Phase 3b: add an editor-side CPU preview path that validates and consumes the runtime texture contract (artwork, mask, trayId, lampIds0, lampWeights0) so the future Unity shader can rely on the same data.
- Preserve the existing radial-gradient lamp preview as a fallback and avoid touching Unity or tray-authoring systems at this stage.
- Provide strict validation and clear diagnostics so missing/invalid runtime assets cause a safe fallback without breaking artwork or display rendering.

### Description
- Added `FaceTexturePreviewRenderer` (`OasisEditor/Rendering/FaceTexturePreviewRenderer.cs`) implementing `IFaceTexturePreviewRenderer` that resolves project-relative paths, decodes required textures, validates dimensions, and produces a Skia `SKBitmap` using the shared lighting equation with ambient, emission, and mask strength tuning constants.
- Implemented the lighting equation: `visibleLight = mask * sum(lampState[id] * weight)` and `finalRgb = artworkRgb * ambient + artworkRgb * visibleLight * emission` while preserving `finalAlpha = artworkAlpha`, and structured channel handling so additional lamp ID/weight channels can be enabled later.
- Integrated the texture-driven preview into `Face2DRenderer` so it attempts the texture path first and falls back to the existing radial-gradient renderer when textures are missing/invalid, while exposing/logging a clear fallback reason.
- Added `FaceTexturePreviewRendererTests` (pure CPU/Skia unit tests) that cover missing assets fallback, dimension mismatch fallback, a lamp-id+weight lit pixel case, ambient-only output when lamp state is zero, and artwork alpha preservation.

### Testing
- Per repository constraints, no .NET/WPF unit tests were executed in this environment; `dotnet test` must be run locally by the maintainer.
- Performed an automated code hygiene check (`git diff --check`) which passed locally in the development environment used for this change.
- Added automated unit tests `FaceTexturePreviewRendererTests` under `OasisEditor.Tests` that exercise the pure CPU preview logic but these tests were not executed here due to the toolchain constraint. Please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --filter FaceTexturePreviewRendererTests` locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29dc1e4910832791848bf9845fa787)