### PR TITLE
Auto-author rough face trays and emitters (Phase 4A)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -50,7 +50,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var json = FaceDocumentStorage.Serialize(source);
 
         Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
-        Assert.Equal(2, file.SchemaVersion);
+        Assert.Equal(FaceDocumentStorage.CurrentSchemaVersion, file.SchemaVersion);
         Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", file.RuntimeRenderAssets!.ArtworkPath);
         Assert.Equal(320, file.RuntimeRenderAssets.Width);
         Assert.Equal("Generated/Faces/face-runtime/runtime/trayId_debug.png", file.RuntimeRenderAssets.TrayIdDebugPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
@@ -1,0 +1,234 @@
+using System.Windows;
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceTrayAutoAuthoringTests
+{
+    [Fact]
+    public void GenerateFromPanelRegion_AutoAuthorsTrayAndEmitterForLampWindowFallback()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-7",
+                    Name = "Collect",
+                    Kind = PanelElementKind.Lamp,
+                    X = 25,
+                    Y = 35,
+                    Width = 40,
+                    Height = 50,
+                    DisplayNumber = 7,
+                    IsVisible = true
+                }
+            ]
+        };
+
+        var region = FaceSourceRegionModel.FromRect(new Rect(20, 30, 100, 100));
+        var document = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            region,
+            "Face",
+            "panel-doc").Document;
+        var regenerated = new FaceGenerationService().GenerateFromPanelRegion(
+            panel,
+            region,
+            "Face",
+            "panel-doc").Document;
+
+        Assert.Equal(document.Trays.Single().ObjectId, regenerated.Trays.Single().ObjectId);
+        Assert.Equal(document.LampEmitters.Single().ObjectId, regenerated.LampEmitters.Single().ObjectId);
+
+        var tray = Assert.Single(document.Trays);
+        Assert.True(tray.IsAutoAuthored);
+        Assert.Equal("lampWindowBounds", tray.AutoAuthoringSource);
+        Assert.Equal(5d, tray.Bounds!.X);
+        Assert.Equal(5d, tray.Bounds.Y);
+        Assert.Equal(40d, tray.Bounds.Width);
+        Assert.Equal(50d, tray.Bounds.Height);
+        Assert.Equal(4, tray.Vertices.Count);
+
+        var emitter = Assert.Single(document.LampEmitters);
+        Assert.True(emitter.IsAutoAuthored);
+        Assert.Equal(tray.ObjectId, emitter.TrayObjectId);
+        Assert.Equal("lamp:7", emitter.LinkedMachineObjectReference?.ToString());
+        Assert.Equal(7, emitter.LampId);
+        Assert.Equal(25d, emitter.CenterX);
+        Assert.Equal(30d, emitter.CenterY);
+    }
+
+    [Fact]
+    public void AutoAuthor_PrefersMatchingMaskContributionBounds()
+    {
+        var document = CreateFaceWithLampAndContribution();
+
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(document);
+
+        var tray = Assert.Single(result.Trays);
+        Assert.Equal("maskContributionBounds", tray.AutoAuthoringSource);
+        Assert.Equal(8d, tray.Bounds!.X);
+        Assert.Equal(9d, tray.Bounds.Y);
+        Assert.Equal(11d, tray.Bounds.Width);
+        Assert.Equal(12d, tray.Bounds.Height);
+        Assert.Equal("lamp:3", tray.LinkedMachineObjectReference?.ToString());
+
+        var emitter = Assert.Single(result.Emitters);
+        Assert.Equal(tray.ObjectId, emitter.TrayObjectId);
+        Assert.Equal(20d, emitter.CenterX);
+        Assert.Equal(25d, emitter.CenterY);
+    }
+
+    [Fact]
+    public void AutoAuthor_UsesDeterministicIdsForSameSourceData()
+    {
+        var left = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampAndContribution());
+        var right = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampAndContribution());
+
+        Assert.Equal(left.Trays.Single().ObjectId, right.Trays.Single().ObjectId);
+        Assert.Equal(left.Emitters.Single().ObjectId, right.Emitters.Single().ObjectId);
+    }
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsAuthoredTraysAndEmitters()
+    {
+        var authored = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampAndContribution());
+        var source = CreateFaceWithLampAndContribution().WithAuthored(authored);
+
+        var json = FaceDocumentStorage.Serialize(source);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var savedTray = Assert.Single(file.Trays!);
+        var savedEmitter = Assert.Single(file.LampEmitters!);
+        Assert.True(savedTray.IsAutoAuthored);
+        Assert.True(savedEmitter.IsAutoAuthored);
+        Assert.Equal(savedTray.ObjectId, savedEmitter.TrayObjectId);
+
+        var model = FaceDocumentStorage.ToModel(file);
+        var tray = Assert.Single(model.Trays);
+        var emitter = Assert.Single(model.LampEmitters);
+        Assert.Equal(savedTray.ObjectId, tray.ObjectId);
+        Assert.Equal(4, tray.Vertices.Count);
+        Assert.Equal(tray.ObjectId, emitter.TrayObjectId);
+        Assert.Equal("lamp:3", emitter.LinkedMachineObjectReference?.ToString());
+    }
+
+    [Fact]
+    public void Validate_DetectsDuplicateIdsInvalidBoundsAndMissingTrayReferences()
+    {
+        var diagnostics = new FaceTrayAutoAuthoringService().Validate(new FaceDocumentModel
+        {
+            Trays =
+            [
+                new FaceTrayModel { ObjectId = "tray-a", Name = "A", Bounds = FaceSourceRegionModel.FromRect(new Rect(0, 0, 10, 10)) },
+                new FaceTrayModel { ObjectId = "tray-a", Name = "B", Bounds = new FaceSourceRegionModel { X = 1, Y = 1, Width = 0, Height = 10 } }
+            ],
+            LampEmitters =
+            [
+                new FaceLampEmitterElement { ObjectId = "emitter-a", TrayObjectId = "missing", CenterX = 1, CenterY = 1 },
+                new FaceLampEmitterElement { ObjectId = "emitter-a", TrayObjectId = "tray-a", CenterX = 2, CenterY = 2 }
+            ]
+        });
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.Tray.DuplicateId");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.Emitter.DuplicateId");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.Tray.Bounds.Invalid");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Code == "Face.Emitter.TrayReference.Missing");
+    }
+
+    [Fact]
+    public void DebugOverlayRenderer_DrawsTrayAndEmitterWithoutVisibleWpfWindow()
+    {
+        using var bitmap = new SKBitmap(64, 64, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var canvas = new SKCanvas(bitmap);
+        var document = new FaceDocumentModel
+        {
+            Trays =
+            [
+                new FaceTrayModel
+                {
+                    ObjectId = "tray-debug",
+                    IsAutoAuthored = true,
+                    Bounds = FaceSourceRegionModel.FromRect(new Rect(5, 5, 30, 20)),
+                    Vertices =
+                    [
+                        new FacePointModel { X = 5, Y = 5 },
+                        new FacePointModel { X = 35, Y = 5 },
+                        new FacePointModel { X = 35, Y = 25 },
+                        new FacePointModel { X = 5, Y = 25 }
+                    ]
+                }
+            ],
+            LampEmitters =
+            [
+                new FaceLampEmitterElement
+                {
+                    ObjectId = "emitter-debug",
+                    TrayObjectId = "tray-debug",
+                    LampId = 9,
+                    CenterX = 20,
+                    CenterY = 15,
+                    IsAutoAuthored = true
+                }
+            ]
+        };
+
+        var drawCount = new FaceTrayDebugOverlayRenderer().Render(canvas, document, PanelViewportTransform.Identity);
+
+        Assert.Equal(2, drawCount);
+    }
+
+    private static FaceDocumentModel CreateFaceWithLampAndContribution()
+    {
+        return new FaceDocumentModel
+        {
+            MaskLayer = new FaceMaskLayerModel
+            {
+                Contributions =
+                [
+                    new FaceMaskContributionModel
+                    {
+                        SourcePanel2DElementId = "panel-lamp-3",
+                        LinkedMachineObjectReference = MachineObjectReference.Lamp(3),
+                        Bounds = FaceSourceRegionModel.FromRect(new Rect(8, 9, 11, 12)),
+                        PixelCount = 24
+                    }
+                ]
+            },
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-panel-lamp-3",
+                    Name = "Lamp Three",
+                    X = 10,
+                    Y = 10,
+                    Width = 20,
+                    Height = 30,
+                    IsVisible = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(3),
+                    LinkedPanel2DElementId = "panel-lamp-3"
+                }
+            ]
+        };
+    }
+}
+
+internal static class FaceTrayAutoAuthoringTestExtensions
+{
+    public static FaceDocumentModel WithAuthored(this FaceDocumentModel source, FaceTrayAutoAuthoringResult authored)
+    {
+        return new FaceDocumentModel
+        {
+            Id = source.Id,
+            Title = source.Title,
+            MaskLayer = source.MaskLayer,
+            Trays = authored.Trays,
+            LampEmitters = authored.Emitters,
+            Elements = source.Elements
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -10,6 +10,8 @@ public sealed class FaceDocumentModel
     public DateTime? LastRegeneratedAtUtc { get; init; }
     public FaceRuntimeRenderAssetsModel? RuntimeRenderAssets { get; init; }
     public FaceMaskLayerModel? MaskLayer { get; init; }
+    public IReadOnlyList<FaceTrayModel> Trays { get; init; } = [];
+    public IReadOnlyList<FaceLampEmitterElement> LampEmitters { get; init; } = [];
     public IReadOnlyList<FaceLayerModel> Layers { get; init; } = [];
     public IReadOnlyList<FaceElementModel> Elements { get; init; } = [];
 }
@@ -51,6 +53,25 @@ public sealed class FaceMaskContributionModel
     public MachineObjectReference? LinkedMachineObjectReference { get; init; }
     public FaceSourceRegionModel? Bounds { get; init; }
     public int PixelCount { get; init; }
+}
+
+public sealed class FaceTrayModel
+{
+    public string ObjectId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public bool IsAutoAuthored { get; init; }
+    public string? AutoAuthoringSource { get; init; }
+    public string? SourceLampWindowObjectId { get; init; }
+    public string? SourcePanel2DElementId { get; init; }
+    public MachineObjectReference? LinkedMachineObjectReference { get; init; }
+    public FaceSourceRegionModel? Bounds { get; init; }
+    public IReadOnlyList<FacePointModel> Vertices { get; init; } = [];
+}
+
+public sealed class FacePointModel
+{
+    public double X { get; init; }
+    public double Y { get; init; }
 }
 
 public sealed class FaceLayerModel
@@ -100,10 +121,13 @@ public sealed class FaceLampWindowElement : FaceElementModel
 public sealed class FaceLampEmitterElement : FaceElementModel
 {
     public string SourceLampWindowObjectId { get; init; } = string.Empty;
+    public string TrayObjectId { get; init; } = string.Empty;
     public int TrayId { get; init; }
     public int? LampId { get; init; }
     public double CenterX { get; init; }
     public double CenterY { get; init; }
+    public bool IsAutoAuthored { get; init; }
+    public string? AutoAuthoringSource { get; init; }
 }
 
 public sealed class FaceReelDisplayElement : FaceElementModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -5,7 +5,7 @@ namespace OasisEditor;
 
 public static class FaceDocumentStorage
 {
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = 3;
 
     private static readonly JsonSerializerOptions s_readOptions = new()
     {
@@ -157,6 +157,8 @@ public static class FaceDocumentStorage
             LastRegeneratedAtUtc = file.LastRegeneratedAtUtc,
             RuntimeRenderAssets = ToModel(file.RuntimeRenderAssets),
             MaskLayer = ToModel(file.MaskLayer),
+            Trays = (file.Trays ?? []).Select(ToModel).ToArray(),
+            LampEmitters = (file.LampEmitters ?? []).Select(ToModel).ToArray(),
             Layers = (file.Layers ?? [])
                 .Select(layer => new FaceLayerModel
                 {
@@ -186,6 +188,8 @@ public static class FaceDocumentStorage
             LastRegeneratedAtUtc = model.LastRegeneratedAtUtc,
             RuntimeRenderAssets = ToFile(model.RuntimeRenderAssets),
             MaskLayer = ToFile(model.MaskLayer),
+            Trays = model.Trays.Select(ToFile).ToArray(),
+            LampEmitters = model.LampEmitters.Select(ToFile).ToArray(),
             SavedAtUtc = DateTime.UtcNow,
             Layers = model.Layers.Select(layer => new FaceLayerFile
             {
@@ -320,6 +324,110 @@ public static class FaceDocumentStorage
             Bounds = ToFile(model.Bounds),
             PixelCount = model.PixelCount
         };
+    }
+
+    private static FaceTrayModel ToModel(FaceTrayFile file)
+    {
+        MachineObjectReference? reference = null;
+        if (MachineObjectReference.TryParse(file.LinkedMachineObjectReference, out var parsedReference))
+        {
+            reference = parsedReference;
+        }
+
+        return new FaceTrayModel
+        {
+            ObjectId = file.ObjectId ?? string.Empty,
+            Name = file.Name ?? string.Empty,
+            IsAutoAuthored = file.IsAutoAuthored,
+            AutoAuthoringSource = file.AutoAuthoringSource,
+            SourceLampWindowObjectId = file.SourceLampWindowObjectId,
+            SourcePanel2DElementId = file.SourcePanel2DElementId,
+            LinkedMachineObjectReference = reference,
+            Bounds = ToModel(file.Bounds),
+            Vertices = (file.Vertices ?? []).Select(ToModel).ToArray()
+        };
+    }
+
+    private static FaceTrayFile ToFile(FaceTrayModel model)
+    {
+        return new FaceTrayFile
+        {
+            ObjectId = model.ObjectId,
+            Name = model.Name,
+            IsAutoAuthored = model.IsAutoAuthored,
+            AutoAuthoringSource = model.AutoAuthoringSource,
+            SourceLampWindowObjectId = model.SourceLampWindowObjectId,
+            SourcePanel2DElementId = model.SourcePanel2DElementId,
+            LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
+            Bounds = ToFile(model.Bounds),
+            Vertices = model.Vertices.Select(ToFile).ToArray()
+        };
+    }
+
+    private static FaceLampEmitterElement ToModel(FaceLampEmitterFile file)
+    {
+        MachineObjectReference? reference = null;
+        if (MachineObjectReference.TryParse(file.LinkedMachineObjectReference, out var parsedReference))
+        {
+            reference = parsedReference;
+        }
+
+        return new FaceLampEmitterElement
+        {
+            ObjectId = file.ObjectId ?? string.Empty,
+            Name = file.Name ?? string.Empty,
+            X = file.X,
+            Y = file.Y,
+            Width = file.Width,
+            Height = file.Height,
+            IsVisible = file.IsVisible,
+            IsLocked = file.IsLocked,
+            LinkedMachineObjectReference = reference,
+            LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+            SourceLampWindowObjectId = file.SourceLampWindowObjectId ?? string.Empty,
+            TrayObjectId = file.TrayObjectId ?? string.Empty,
+            TrayId = file.TrayId,
+            LampId = file.LampId,
+            CenterX = file.CenterX,
+            CenterY = file.CenterY,
+            IsAutoAuthored = file.IsAutoAuthored,
+            AutoAuthoringSource = file.AutoAuthoringSource
+        };
+    }
+
+    private static FaceLampEmitterFile ToFile(FaceLampEmitterElement model)
+    {
+        return new FaceLampEmitterFile
+        {
+            ObjectId = model.ObjectId,
+            Name = model.Name,
+            X = model.X,
+            Y = model.Y,
+            Width = model.Width,
+            Height = model.Height,
+            IsVisible = model.IsVisible,
+            IsLocked = model.IsLocked,
+            LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
+            LinkedPanel2DElementId = model.LinkedPanel2DElementId,
+            SourceLampWindowObjectId = model.SourceLampWindowObjectId,
+            TrayObjectId = model.TrayObjectId,
+            TrayId = model.TrayId,
+            LampId = model.LampId,
+            CenterX = model.CenterX,
+            CenterY = model.CenterY,
+            IsAutoAuthored = model.IsAutoAuthored,
+            AutoAuthoringSource = model.AutoAuthoringSource
+        };
+    }
+
+    private static FacePointModel ToModel(FacePointFile file)
+    {
+        return new FacePointModel { X = file.X, Y = file.Y };
+    }
+
+    private static FacePointFile ToFile(FacePointModel model)
+    {
+        return new FacePointFile { X = model.X, Y = model.Y };
     }
 
     private static FaceSourceRegionModel? ToModel(FaceSourceRegionFile? file)
@@ -596,6 +704,8 @@ public sealed record FaceDocumentFile
     public DateTime? LastRegeneratedAtUtc { get; init; }
     public FaceRuntimeRenderAssetsFile? RuntimeRenderAssets { get; init; }
     public FaceMaskLayerFile? MaskLayer { get; init; }
+    public IReadOnlyList<FaceTrayFile>? Trays { get; init; } = [];
+    public IReadOnlyList<FaceLampEmitterFile>? LampEmitters { get; init; } = [];
     public DateTime SavedAtUtc { get; init; }
     public IReadOnlyList<FaceLayerFile>? Layers { get; init; } = [];
     public IReadOnlyList<FaceElementFile>? Elements { get; init; } = [];
@@ -638,6 +748,47 @@ public sealed record FaceMaskContributionFile
     public string? LinkedMachineObjectReference { get; init; }
     public FaceSourceRegionFile? Bounds { get; init; }
     public int PixelCount { get; init; }
+}
+
+public sealed record FaceTrayFile
+{
+    public string? ObjectId { get; init; }
+    public string? Name { get; init; }
+    public bool IsAutoAuthored { get; init; }
+    public string? AutoAuthoringSource { get; init; }
+    public string? SourceLampWindowObjectId { get; init; }
+    public string? SourcePanel2DElementId { get; init; }
+    public string? LinkedMachineObjectReference { get; init; }
+    public FaceSourceRegionFile? Bounds { get; init; }
+    public IReadOnlyList<FacePointFile>? Vertices { get; init; } = [];
+}
+
+public sealed record FaceLampEmitterFile
+{
+    public string? ObjectId { get; init; }
+    public string? Name { get; init; }
+    public double X { get; init; }
+    public double Y { get; init; }
+    public double Width { get; init; }
+    public double Height { get; init; }
+    public bool IsVisible { get; init; } = true;
+    public bool IsLocked { get; init; }
+    public string? LinkedMachineObjectReference { get; init; }
+    public string? LinkedPanel2DElementId { get; init; }
+    public string? SourceLampWindowObjectId { get; init; }
+    public string? TrayObjectId { get; init; }
+    public int TrayId { get; init; }
+    public int? LampId { get; init; }
+    public double CenterX { get; init; }
+    public double CenterY { get; init; }
+    public bool IsAutoAuthored { get; init; }
+    public string? AutoAuthoringSource { get; init; }
+}
+
+public sealed record FacePointFile
+{
+    public double X { get; init; }
+    public double Y { get; init; }
 }
 
 public sealed record FaceSourceRegionFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -74,6 +74,7 @@ internal sealed class FaceGenerationService
 {
     private readonly IMachineObjectReferenceResolver _machineObjectReferenceResolver;
     private readonly FaceMaskLayerExtractionService _maskLayerExtractionService;
+    private readonly FaceTrayAutoAuthoringService _trayAutoAuthoringService = new();
 
     public FaceGenerationService(IMachineObjectReferenceResolver? machineObjectReferenceResolver = null)
     {
@@ -121,6 +122,8 @@ internal sealed class FaceGenerationService
         var resolvedTitle = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim();
         var faceDocumentId = Guid.NewGuid().ToString("N");
         var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(sourcePanel, region, faceDocumentId, sourcePanel2DDocumentId, projectDirectory, generatedDirectory);
+        var elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(reelDisplays).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray();
+        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { MaskLayer = maskLayer, Elements = elements });
         var document = new FaceDocumentModel
         {
             Id = faceDocumentId,
@@ -130,6 +133,8 @@ internal sealed class FaceGenerationService
             SourceRegion = sourceRegion,
             LastRegeneratedAtUtc = DateTime.UtcNow,
             MaskLayer = maskLayer,
+            Trays = autoAuthored.Trays,
+            LampEmitters = autoAuthored.Emitters,
             Layers =
             [
                 new FaceLayerModel
@@ -163,7 +168,7 @@ internal sealed class FaceGenerationService
                     IsVisible = true
                 }
             ],
-            Elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(reelDisplays).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray()
+            Elements = elements
         };
 
         return new FaceGenerationResult(document, lampWindows.Length, artworkElements.Length, buttons.Length, sevenSegmentDisplays.Length, alphaDisplays.Length, reelDisplays.Length);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -23,6 +23,7 @@ internal sealed class FaceRegenerationResult
 internal sealed class FaceRegenerationService
 {
     private readonly FaceGenerationService _generationService;
+    private readonly FaceTrayAutoAuthoringService _trayAutoAuthoringService = new();
 
     public FaceRegenerationService(FaceGenerationService? generationService = null)
     {
@@ -106,6 +107,7 @@ internal sealed class FaceRegenerationService
         }
 
         mergedElements.AddRange(preservedManualElements);
+        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { MaskLayer = generated.Document.MaskLayer, Elements = mergedElements.ToArray() });
 
         var regeneratedDocument = new FaceDocumentModel
         {
@@ -116,6 +118,8 @@ internal sealed class FaceRegenerationService
             SourceRegion = sourceRegion,
             LastRegeneratedAtUtc = DateTime.UtcNow,
             MaskLayer = generated.Document.MaskLayer,
+            Trays = autoAuthored.Trays,
+            LampEmitters = autoAuthored.Emitters,
             Layers = EnsureFaceMaskLayer(existingFace.Layers.Count > 0 ? existingFace.Layers : generated.Document.Layers),
             Elements = mergedElements.ToArray()
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -86,6 +86,8 @@ public sealed class FaceRuntimeExportService
             LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
             RuntimeRenderAssets = runtimeAssets,
             MaskLayer = faceDocument.MaskLayer,
+            Trays = faceDocument.Trays,
+            LampEmitters = faceDocument.LampEmitters,
             Layers = faceDocument.Layers,
             Elements = faceDocument.Elements
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
@@ -1,0 +1,252 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Windows;
+
+namespace OasisEditor;
+
+internal sealed class FaceTrayAutoAuthoringService
+{
+    public FaceTrayAutoAuthoringResult AutoAuthor(FaceDocumentModel faceDocument)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+
+        var trays = new List<FaceTrayModel>();
+        var emitters = new List<FaceLampEmitterElement>();
+        var nextTrayNumber = 1;
+
+        foreach (var lampWindow in faceDocument.Elements
+            .OfType<FaceLampWindowElement>()
+            .Where(IsValidVisibleLampWindow)
+            .OrderBy(CreateLampStableKey, StringComparer.Ordinal))
+        {
+            var contribution = FindBestContribution(lampWindow, faceDocument.MaskLayer);
+            var bounds = contribution?.Bounds is { IsValid: true } contributionBounds
+                ? contributionBounds
+                : FaceSourceRegionModel.FromRect(new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height));
+            var source = contribution?.Bounds is { IsValid: true } ? "maskContributionBounds" : "lampWindowBounds";
+            var stableKey = CreateLampStableKey(lampWindow);
+            var trayObjectId = CreateStableId("face-tray", stableKey, source, Format(bounds.X), Format(bounds.Y), Format(bounds.Width), Format(bounds.Height));
+            var trayNumber = nextTrayNumber++;
+            var lampId = TryGetLampId(lampWindow.LinkedMachineObjectReference);
+
+            trays.Add(new FaceTrayModel
+            {
+                ObjectId = trayObjectId,
+                Name = string.IsNullOrWhiteSpace(lampWindow.Name)
+                    ? $"Auto Tray {lampId?.ToString() ?? trayNumber.ToString()}"
+                    : $"{lampWindow.Name.Trim()} Tray",
+                IsAutoAuthored = true,
+                AutoAuthoringSource = source,
+                SourceLampWindowObjectId = lampWindow.ObjectId,
+                SourcePanel2DElementId = contribution?.SourcePanel2DElementId ?? lampWindow.LinkedPanel2DElementId,
+                LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
+                Bounds = bounds,
+                Vertices = CreateRectangleVertices(bounds)
+            });
+
+            emitters.Add(new FaceLampEmitterElement
+            {
+                ObjectId = CreateStableId("face-emitter", stableKey),
+                Name = string.IsNullOrWhiteSpace(lampWindow.Name)
+                    ? $"Lamp {lampId?.ToString() ?? trayNumber.ToString()} Emitter"
+                    : $"{lampWindow.Name.Trim()} Emitter",
+                X = Math.Round(lampWindow.X, 2),
+                Y = Math.Round(lampWindow.Y, 2),
+                Width = Math.Round(lampWindow.Width, 2),
+                Height = Math.Round(lampWindow.Height, 2),
+                IsVisible = lampWindow.IsVisible,
+                IsLocked = true,
+                LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
+                LinkedPanel2DElementId = lampWindow.LinkedPanel2DElementId,
+                SourceLampWindowObjectId = lampWindow.ObjectId,
+                TrayObjectId = trayObjectId,
+                TrayId = trayNumber,
+                LampId = lampId,
+                CenterX = Math.Round(lampWindow.X + (lampWindow.Width / 2d), 2),
+                CenterY = Math.Round(lampWindow.Y + (lampWindow.Height / 2d), 2),
+                IsAutoAuthored = true,
+                AutoAuthoringSource = source
+            });
+        }
+
+        return new FaceTrayAutoAuthoringResult(trays, emitters);
+    }
+
+    public IReadOnlyList<FaceValidationDiagnostic> Validate(FaceDocumentModel faceDocument)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+
+        var diagnostics = new List<FaceValidationDiagnostic>();
+        AddDuplicateDiagnostics(faceDocument.Trays.Select(tray => tray.ObjectId), "Face.Tray.DuplicateId", "tray", diagnostics);
+        AddDuplicateDiagnostics(faceDocument.LampEmitters.Select(emitter => emitter.ObjectId), "Face.Emitter.DuplicateId", "emitter", diagnostics);
+
+        var trayIds = faceDocument.Trays
+            .Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId))
+            .Select(tray => tray.ObjectId.Trim())
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var tray in faceDocument.Trays)
+        {
+            if (tray.Bounds is not { IsValid: true })
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.Tray.Bounds.Invalid",
+                    $"Face tray '{DisplayName(tray.ObjectId, tray.Name)}' has invalid bounds."));
+            }
+
+            if (tray.Vertices.Count > 0 && tray.Vertices.Any(vertex => !PanelElementValidation.IsFinite(vertex.X) || !PanelElementValidation.IsFinite(vertex.Y)))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.Tray.Vertices.Invalid",
+                    $"Face tray '{DisplayName(tray.ObjectId, tray.Name)}' has invalid polygon vertices."));
+            }
+        }
+
+        foreach (var emitter in faceDocument.LampEmitters)
+        {
+            if (string.IsNullOrWhiteSpace(emitter.TrayObjectId) || !trayIds.Contains(emitter.TrayObjectId.Trim()))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.Emitter.TrayReference.Missing",
+                    $"Face lamp emitter '{DisplayName(emitter.ObjectId, emitter.Name)}' references missing tray '{emitter.TrayObjectId}'."));
+            }
+
+            if (!PanelElementValidation.IsFinite(emitter.CenterX) || !PanelElementValidation.IsFinite(emitter.CenterY))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.Emitter.Position.Invalid",
+                    $"Face lamp emitter '{DisplayName(emitter.ObjectId, emitter.Name)}' has an invalid position."));
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddDuplicateDiagnostics(IEnumerable<string> ids, string code, string noun, List<FaceValidationDiagnostic> diagnostics)
+    {
+        foreach (var duplicate in ids
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .GroupBy(id => id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key))
+        {
+            diagnostics.Add(new FaceValidationDiagnostic(
+                FaceValidationSeverity.Warning,
+                code,
+                $"Face contains duplicate {noun} ID '{duplicate}'."));
+        }
+    }
+
+    private static FaceMaskContributionModel? FindBestContribution(FaceLampWindowElement lampWindow, FaceMaskLayerModel? maskLayer)
+    {
+        if (maskLayer is null || maskLayer.Contributions.Count == 0)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(lampWindow.LinkedPanel2DElementId))
+        {
+            var linkedPanelElementId = lampWindow.LinkedPanel2DElementId.Trim();
+            var contribution = maskLayer.Contributions
+                .Where(candidate => candidate.Bounds is { IsValid: true })
+                .FirstOrDefault(candidate => string.Equals(candidate.SourcePanel2DElementId, linkedPanelElementId, StringComparison.Ordinal));
+            if (contribution is not null)
+            {
+                return contribution;
+            }
+        }
+
+        var reference = lampWindow.LinkedMachineObjectReference?.ToString();
+        if (!string.IsNullOrWhiteSpace(reference))
+        {
+            var contribution = maskLayer.Contributions
+                .Where(candidate => candidate.Bounds is { IsValid: true })
+                .FirstOrDefault(candidate => string.Equals(candidate.LinkedMachineObjectReference?.ToString(), reference, StringComparison.Ordinal));
+            if (contribution is not null)
+            {
+                return contribution;
+            }
+        }
+
+        var lampBounds = new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height);
+        return maskLayer.Contributions
+            .Where(candidate => candidate.Bounds is { IsValid: true })
+            .OrderByDescending(candidate => OverlapArea(lampBounds, candidate.Bounds!.ToRect()))
+            .ThenByDescending(candidate => candidate.PixelCount)
+            .FirstOrDefault(candidate => OverlapArea(lampBounds, candidate.Bounds!.ToRect()) > 0d);
+    }
+
+    private static IReadOnlyList<FacePointModel> CreateRectangleVertices(FaceSourceRegionModel bounds)
+    {
+        var left = Math.Round(bounds.X, 2);
+        var top = Math.Round(bounds.Y, 2);
+        var right = Math.Round(bounds.X + bounds.Width, 2);
+        var bottom = Math.Round(bounds.Y + bounds.Height, 2);
+        return
+        [
+            new FacePointModel { X = left, Y = top },
+            new FacePointModel { X = right, Y = top },
+            new FacePointModel { X = right, Y = bottom },
+            new FacePointModel { X = left, Y = bottom }
+        ];
+    }
+
+    private static bool IsValidVisibleLampWindow(FaceLampWindowElement element)
+    {
+        return element.IsVisible && element.Width > 0d && element.Height > 0d;
+    }
+
+    private static int? TryGetLampId(MachineObjectReference? reference)
+    {
+        return reference is MachineObjectReference { Kind: MachineObjectKind.Lamp } lampReference
+            && int.TryParse(lampReference.Id, out var id)
+            ? id
+            : null;
+    }
+
+    private static double OverlapArea(Rect left, Rect right)
+    {
+        var intersection = Rect.Intersect(left, right);
+        return intersection.IsEmpty ? 0d : intersection.Width * intersection.Height;
+    }
+
+    private static string CreateLampStableKey(FaceLampWindowElement lampWindow)
+    {
+        if (!string.IsNullOrWhiteSpace(lampWindow.LinkedPanel2DElementId))
+        {
+            return $"panel:{lampWindow.LinkedPanel2DElementId.Trim()}";
+        }
+
+        var reference = lampWindow.LinkedMachineObjectReference?.ToString();
+        if (!string.IsNullOrWhiteSpace(reference))
+        {
+            return $"machine:{reference}";
+        }
+
+        return $"bounds:{Format(lampWindow.X)}:{Format(lampWindow.Y)}:{Format(lampWindow.Width)}:{Format(lampWindow.Height)}:{lampWindow.Name}";
+    }
+
+    private static string CreateStableId(string prefix, params string[] parts)
+    {
+        var input = string.Join("|", parts.Select(part => part.Trim()));
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var hash = Convert.ToHexString(bytes[..8]).ToLowerInvariant();
+        return $"{prefix}-{hash}";
+    }
+
+    private static string DisplayName(string objectId, string name)
+    {
+        return string.IsNullOrWhiteSpace(name) ? objectId : name.Trim();
+    }
+
+    private static string Format(double value) => Math.Round(value, 2).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+}
+
+internal sealed record FaceTrayAutoAuthoringResult(
+    IReadOnlyList<FaceTrayModel> Trays,
+    IReadOnlyList<FaceLampEmitterElement> Emitters);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceValidationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceValidationService.cs
@@ -28,6 +28,7 @@ public sealed class FaceValidationService
         ValidateArtworkAssets(faceDocument, project, diagnostics);
         ValidateMaskLayer(faceDocument, project, diagnostics);
         ValidateMachineReferences(faceDocument, diagnostics);
+        diagnostics.AddRange(new FaceTrayAutoAuthoringService().Validate(faceDocument));
         return diagnostics;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -16,6 +16,7 @@ public sealed class Face2DRenderer : IFace2DRenderer
     private readonly Dictionary<string, SKImage?> _cachedArtworkImages = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, SKImage?> _cachedMaskImages = new(StringComparer.OrdinalIgnoreCase);
     private readonly IFaceTexturePreviewRenderer _texturePreviewRenderer;
+    private readonly FaceTrayDebugOverlayRenderer _trayDebugOverlayRenderer = new();
 
     internal string? LastTexturePreviewFallbackReason { get; private set; }
 
@@ -72,6 +73,8 @@ public sealed class Face2DRenderer : IFace2DRenderer
         {
             DrawButton(canvas, button, viewportTransform);
         }
+
+        _trayDebugOverlayRenderer.Render(canvas, faceDocument, viewportTransform);
     }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTrayDebugOverlayRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTrayDebugOverlayRenderer.cs
@@ -1,0 +1,156 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class FaceTrayDebugOverlayRenderer
+{
+    public int Render(SKCanvas canvas, FaceDocumentModel faceDocument, PanelViewportTransform viewport)
+    {
+        ArgumentNullException.ThrowIfNull(canvas);
+        ArgumentNullException.ThrowIfNull(faceDocument);
+
+        if (faceDocument.Trays.Count == 0 && faceDocument.LampEmitters.Count == 0)
+        {
+            return 0;
+        }
+
+        var drawCount = 0;
+        using var autoTrayPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = new SKColor(0x00, 0xE5, 0xFF, 0xE8),
+            StrokeWidth = (float)Math.Max(1d, 1.5d / viewport.NormalizedZoom),
+            IsAntialias = true
+        };
+        using var manualTrayPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = new SKColor(0xFF, 0xC1, 0x07, 0xF0),
+            StrokeWidth = (float)Math.Max(1d, 1.5d / viewport.NormalizedZoom),
+            IsAntialias = true
+        };
+        using var labelPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Fill,
+            Color = new SKColor(0xFF, 0xFF, 0xFF, 0xF0),
+            TextSize = (float)Math.Max(9d, 11d / Math.Sqrt(viewport.NormalizedZoom)),
+            IsAntialias = true
+        };
+        using var labelShadowPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Fill,
+            Color = new SKColor(0x00, 0x00, 0x00, 0xC8),
+            TextSize = labelPaint.TextSize,
+            IsAntialias = true
+        };
+        using var autoEmitterPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Fill,
+            Color = new SKColor(0xFF, 0x40, 0x81, 0xF0),
+            IsAntialias = true
+        };
+        using var manualEmitterPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Fill,
+            Color = new SKColor(0xFF, 0xC1, 0x07, 0xF0),
+            IsAntialias = true
+        };
+        using var emitterStrokePaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = SKColors.White,
+            StrokeWidth = (float)Math.Max(1d, 1d / viewport.NormalizedZoom),
+            IsAntialias = true
+        };
+
+        foreach (var tray in faceDocument.Trays)
+        {
+            if (!TryGetTrayPath(tray, out var path, out var labelPoint))
+            {
+                continue;
+            }
+
+            using (path)
+            {
+                canvas.DrawPath(path, tray.IsAutoAuthored ? autoTrayPaint : manualTrayPaint);
+            }
+
+            DrawLabel(canvas, ResolveShortId(tray.ObjectId), labelPoint.X, labelPoint.Y - 3f, labelPaint, labelShadowPaint);
+            drawCount++;
+        }
+
+        foreach (var emitter in faceDocument.LampEmitters)
+        {
+            if (!PanelElementValidation.IsFinite(emitter.CenterX) || !PanelElementValidation.IsFinite(emitter.CenterY))
+            {
+                continue;
+            }
+
+            var radius = (float)Math.Max(3d, 4d / viewport.NormalizedZoom);
+            var x = (float)emitter.CenterX;
+            var y = (float)emitter.CenterY;
+            canvas.DrawCircle(x, y, radius, emitter.IsAutoAuthored ? autoEmitterPaint : manualEmitterPaint);
+            canvas.DrawCircle(x, y, radius, emitterStrokePaint);
+            var lampLabel = emitter.LampId is int lampId ? $"L{lampId}" : ResolveShortId(emitter.ObjectId);
+            DrawLabel(canvas, lampLabel, x + radius + 2f, y - radius - 2f, labelPaint, labelShadowPaint);
+            drawCount++;
+        }
+
+        return drawCount;
+    }
+
+    private static bool TryGetTrayPath(FaceTrayModel tray, out SKPath path, out SKPoint labelPoint)
+    {
+        path = new SKPath();
+        labelPoint = default;
+
+        var vertices = tray.Vertices
+            .Where(vertex => PanelElementValidation.IsFinite(vertex.X) && PanelElementValidation.IsFinite(vertex.Y))
+            .ToArray();
+        if (vertices.Length >= 3)
+        {
+            path.MoveTo((float)vertices[0].X, (float)vertices[0].Y);
+            foreach (var vertex in vertices.Skip(1))
+            {
+                path.LineTo((float)vertex.X, (float)vertex.Y);
+            }
+
+            path.Close();
+            labelPoint = new SKPoint((float)vertices.Min(vertex => vertex.X), (float)vertices.Min(vertex => vertex.Y));
+            return true;
+        }
+
+        if (tray.Bounds is not { IsValid: true } bounds)
+        {
+            path.Dispose();
+            return false;
+        }
+
+        var rect = SKRect.Create((float)bounds.X, (float)bounds.Y, (float)bounds.Width, (float)bounds.Height);
+        path.AddRect(rect);
+        labelPoint = new SKPoint(rect.Left, rect.Top);
+        return true;
+    }
+
+    private static void DrawLabel(SKCanvas canvas, string text, float x, float y, SKPaint labelPaint, SKPaint labelShadowPaint)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        canvas.DrawText(text, x + 1f, y + 1f, labelShadowPaint);
+        canvas.DrawText(text, x, y, labelPaint);
+    }
+
+    private static string ResolveShortId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = id.Trim();
+        return trimmed.Length <= 12 ? trimmed : trimmed[^8..];
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -186,6 +186,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             LastRegeneratedAtUtc = _faceDocumentModel.LastRegeneratedAtUtc,
             RuntimeRenderAssets = _faceDocumentModel.RuntimeRenderAssets,
             MaskLayer = _faceDocumentModel.MaskLayer,
+            Trays = _faceDocumentModel.Trays,
+            LampEmitters = _faceDocumentModel.LampEmitters,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()
         }, faceChange);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -600,6 +600,8 @@ public sealed class DocumentWorkspaceViewModel
                 LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
                 RuntimeRenderAssets = faceDocument.RuntimeRenderAssets,
                 MaskLayer = faceDocument.MaskLayer,
+                Trays = faceDocument.Trays,
+                LampEmitters = faceDocument.LampEmitters,
                 Layers = faceDocument.Layers,
                 Elements = faceDocument.Elements
             };


### PR DESCRIPTION
### Motivation

- Provide an immediate first-pass physical tray and emitter representation when a Face is generated or regenerated so lamp ownership and placement can be inspected without opening JSON or the runtime export package.
- Keep the change UI-agnostic and lightweight: persisted tray/emitter models, deterministic IDs, simple rectangular polygons from contribution bounds or lamp-window fallback, minimal validation, and a non-interactive debug overlay for visual verification.

### Description

- Add persisted tray and emitter models and wire them into Face generation/regeneration, producing one auto-authored rectangular `FaceTrayModel` and one `FaceLampEmitterElement` per visible lamp window; deterministic IDs are derived with a stable SHA-256 based hash. (`FaceTrayAutoAuthoringService`, `FaceTrayModel`, `FacePointModel`, updated `FaceLampEmitterElement`).
- Persist the new data in the Face storage schema and bump schema version to `3`, with file-level read/write conversions for `Trays` and `LampEmitters`. (`FaceDocumentStorage` schema bump and serialization/deserialization changes).
- Integrate auto-authoring into the pipeline immediately after mask extraction in `FaceGenerationService` and after merged regeneration in `FaceRegenerationService`, and preserve authored trays/emitters through save/export flows (without changing the existing temporary runtime bridge export behavior). (`FaceGenerationService`, `FaceRegenerationService`, `FaceRuntimeExportService`, `DocumentTabViewModel`, `DocumentWorkspaceViewModel`).
- Add lightweight visual debugging by drawing tray outlines, emitter markers, and short IDs on the Face CPU preview via a small overlay renderer invoked at the end of the Face 2D render pass. (`FaceTrayDebugOverlayRenderer`, `Face2DRenderer`).
- Add validation diagnostics for duplicate IDs, invalid bounds/vertices, invalid emitter positions, and missing emitter->tray references and include them in the existing Face validation pass. (`FaceTrayAutoAuthoringService`, `FaceValidationService`).
- Add unit tests for the auto-authoring and overlay logic (new test file `FaceTrayAutoAuthoringTests.cs`) covering: lamp-window fallback, contribution-bounds preference, deterministic IDs across regenerations, persistence round-trip, basic validation diagnostics, and overlay rendering without a visible WPF window.

Files changed (key):
- `FaceDocumentModel.cs` (new tray/emitter fields, models)
- `FaceDocumentStorage.cs` (schema bump to 3, persistence of trays/emitters/vertices)
- `FaceGenerationService.cs` (invoke auto-authoring after mask extraction)
- `FaceRegenerationService.cs` (invoke auto-authoring after merge)
- `FaceTrayAutoAuthoringService.cs` (new auto-authoring + validation)
- `FaceValidationService.cs` (include tray/emitter diagnostics)
- `Face2DRenderer.cs`, `FaceTrayDebugOverlayRenderer.cs` (overlay rendering)
- `FaceRuntimeExportService.cs` / viewmodel changes to preserve new data through save/export
- `OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs` (new tests)

### Testing

- `git diff --check` was run to ensure there are no whitespace/merge conflicts and returned no errors.
- Added automated unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs` which exercise: tray/emitter generation (fallback and contribution preference), deterministic ID stability across regenerations, serialization round-trip, validation diagnostics, and debug overlay rendering logic; these tests were added but not executed in this environment.
- Per repository guidance the environment cannot build/run the WPF/.NET test runner here; please run the full test suite locally with: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` and verify the new tests and the existing Face tests all pass.

Local checklist for verification (to run locally):
- Run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` and confirm all tests pass including `FaceTrayAutoAuthoringTests`.
- Generate a Face from a Panel2D region with lamp windows and verify the Face document JSON now contains `trays` and `lampEmitters` entries and that IDs are stable when regenerating the same source.
- Verify mask-contribution preference by generating a Face where a contribution exists and confirm the authored tray bounds use the contribution bounds; verify fallback to lamp-window rectangle when no contribution exists.
- Save, close, reopen, and re-save a generated Face and confirm authored trays/emitters persist across the round trip.
- Run runtime export and confirm existing `trayId.png`, `lampIds0.png`, `lampWeights0.png` generation still works (bridge path remains functional).
- Open the Face preview and visually confirm the overlay: auto-authored trays outlined, emitters drawn as markers, short tray IDs and lamp `L#` labels where IDs are available.

Suggested next task
- Phase 4B: improve overlay ergonomics (toggle, label styling, layer visibility) and refine auto-authoring heuristics (merge/group overlapped contributions and simple polygon tracing) based on real machine results from local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2ae10e8968832794514bf19d153df2)