### PR TITLE
Export runtime textures from authored trays

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -373,6 +373,147 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal(24, tray.LampId);
     }
 
+
+    [Fact]
+    public void CreatePlan_WithAuthoredTraysAndEmitters_UsesAuthoredExportSource()
+    {
+        var document = CreateDocumentWithAuthoredTrayAndEmitter(
+            trayBounds: new FaceSourceRegionModel { X = 0, Y = 0, Width = 2, Height = 2 },
+            trayId: 7,
+            lampId: 42);
+
+        var plan = new FaceRuntimeTextureGenerator().CreatePlan(document, 4, 4);
+
+        Assert.Equal(FaceRuntimeTextureExportSource.Authored, plan.ExportSource);
+        var tray = Assert.Single(plan.Trays);
+        Assert.Equal("authored-tray", tray.ObjectId);
+        Assert.Equal(7, tray.TrayId);
+        Assert.Equal(42, tray.LampId);
+        var emitter = Assert.Single(plan.Emitters);
+        Assert.Equal("authored-emitter", emitter.ObjectId);
+    }
+
+    [Fact]
+    public void CreatePlan_WithoutAuthoredData_UsesLampWindowBridgeFallback()
+    {
+        var document = CreateDocumentWithLampWindows(
+            new FaceLampWindowElement { ObjectId = "fallback-lamp", X = 1, Y = 1, Width = 2, Height = 2, LinkedMachineObjectReference = MachineObjectReference.Lamp(9) });
+
+        var plan = new FaceRuntimeTextureGenerator().CreatePlan(document, 4, 4);
+
+        Assert.Equal(FaceRuntimeTextureExportSource.LampWindowBridge, plan.ExportSource);
+        Assert.Equal("runtime-tray-fallback-lamp", Assert.Single(plan.Trays).ObjectId);
+        Assert.Equal("runtime-emitter-fallback-lamp", Assert.Single(plan.Emitters).ObjectId);
+    }
+
+    [Fact]
+    public void Generate_WithAuthoredTrayAndEmitter_WritesTrayIdsLampIdsAndBinaryWeightsFromAuthoredGeometry()
+    {
+        var outputDirectory = Path.Combine(_generatedDirectory, "authored-texture-test");
+        var document = CreateDocumentWithAuthoredTrayAndEmitter(
+            trayBounds: new FaceSourceRegionModel { X = 1, Y = 1, Width = 2, Height = 2 },
+            trayId: 5,
+            lampId: 77);
+
+        new FaceRuntimeTextureGenerator().Generate(document, 4, 4, outputDirectory);
+
+        using var trayId = SKBitmap.Decode(Path.Combine(outputDirectory, "trayId.png"));
+        using var lampIds0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampIds0.png"));
+        using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
+
+        Assert.Equal(4, trayId.Width);
+        Assert.Equal(4, trayId.Height);
+        Assert.Equal(4, lampIds0.Width);
+        Assert.Equal(4, lampIds0.Height);
+        Assert.Equal(4, lampWeights0.Width);
+        Assert.Equal(4, lampWeights0.Height);
+        Assert.Equal(5, trayId.GetPixel(1, 1).Red);
+        Assert.Equal(77, lampIds0.GetPixel(1, 1).Red);
+        Assert.Equal(255, lampWeights0.GetPixel(1, 1).Red);
+        Assert.Equal(0, trayId.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, lampIds0.GetPixel(0, 0).Alpha);
+        Assert.Equal(0, lampWeights0.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void Generate_WithAuthoredPolygon_LeavesPixelsOutsidePolygonEmptyInsideBounds()
+    {
+        var outputDirectory = Path.Combine(_generatedDirectory, "authored-polygon-texture-test");
+        var document = CreateDocumentWithAuthoredTrayAndEmitter(
+            trayBounds: new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
+            trayId: 3,
+            lampId: 12,
+            vertices:
+            [
+                new FacePointModel { X = 0, Y = 0 },
+                new FacePointModel { X = 4, Y = 0 },
+                new FacePointModel { X = 0, Y = 4 }
+            ]);
+
+        new FaceRuntimeTextureGenerator().Generate(document, 4, 4, outputDirectory);
+
+        using var trayId = SKBitmap.Decode(Path.Combine(outputDirectory, "trayId.png"));
+        using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
+
+        Assert.Equal(3, trayId.GetPixel(0, 0).Red);
+        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Red);
+        Assert.Equal(0, trayId.GetPixel(3, 3).Alpha);
+        Assert.Equal(0, lampWeights0.GetPixel(3, 3).Alpha);
+    }
+
+    [Fact]
+    public void CreateManifest_WithAuthoredExport_IncludesAuthoredTrayAndEmitterMetadata()
+    {
+        var document = CreateDocumentWithAuthoredTrayAndEmitter(
+            trayBounds: new FaceSourceRegionModel { X = 1, Y = 1, Width = 2, Height = 2 },
+            trayId: 6,
+            lampId: 31);
+
+        var manifest = new FaceRuntimeExportService().CreateManifest(document, 4, 4);
+
+        var lamp = Assert.Single(manifest.Lamps);
+        Assert.Equal("authored-emitter", lamp.ObjectId);
+        Assert.Equal(6, lamp.TrayId);
+        Assert.Equal(31, lamp.LampId);
+        var tray = Assert.Single(manifest.Trays);
+        Assert.Equal("authored-tray", tray.ObjectId);
+        Assert.Equal("authored-emitter", tray.LampEmitterObjectId);
+        Assert.Equal(6, tray.TrayId);
+        Assert.Equal(31, tray.LampId);
+    }
+
+    [Fact]
+    public void CreatePlan_WithInvalidAuthoredData_ReportsUsefulDiagnostics()
+    {
+        var document = CreateDocumentWithAuthoredTrayAndEmitter(
+            trayBounds: new FaceSourceRegionModel { X = 0, Y = 0, Width = -1, Height = 1 },
+            trayId: 1,
+            lampId: 10);
+        document = new FaceDocumentModel
+        {
+            Id = document.Id,
+            Title = document.Title,
+            SourceRegion = document.SourceRegion,
+            Trays =
+            [
+                document.Trays[0],
+                new FaceTrayModel { ObjectId = "orphan-tray", Name = "Orphan", Bounds = new FaceSourceRegionModel { X = 2, Y = 2, Width = 1, Height = 1 } }
+            ],
+            LampEmitters =
+            [
+                document.LampEmitters[0],
+                new FaceLampEmitterElement { ObjectId = "authored-emitter", TrayObjectId = "missing-tray", TrayId = 2, LampId = 11 }
+            ]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new FaceRuntimeTextureGenerator().CreatePlan(document, 4, 4));
+
+        Assert.Contains("invalid tray geometry", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("does not have an emitter", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("references missing tray", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("duplicate emitter ID", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_projectDirectory))
@@ -461,6 +602,48 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
             Title = "Runtime Face",
             SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
             Elements = lampWindows
+        };
+    }
+
+    private static FaceDocumentModel CreateDocumentWithAuthoredTrayAndEmitter(
+        FaceSourceRegionModel trayBounds,
+        int trayId,
+        int lampId,
+        IReadOnlyList<FacePointModel>? vertices = null)
+    {
+        return new FaceDocumentModel
+        {
+            Id = "face-runtime",
+            Title = "Runtime Face",
+            SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
+            Trays =
+            [
+                new FaceTrayModel
+                {
+                    ObjectId = "authored-tray",
+                    Name = "Authored Tray",
+                    SourceLampWindowObjectId = "source-lamp-window",
+                    Bounds = trayBounds,
+                    Vertices = vertices ?? []
+                }
+            ],
+            LampEmitters =
+            [
+                new FaceLampEmitterElement
+                {
+                    ObjectId = "authored-emitter",
+                    Name = "Authored Emitter",
+                    SourceLampWindowObjectId = "source-lamp-window",
+                    TrayObjectId = "authored-tray",
+                    TrayId = trayId,
+                    LampId = lampId,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(lampId),
+                    CenterX = trayBounds.X + (trayBounds.Width / 2d),
+                    CenterY = trayBounds.Y + (trayBounds.Height / 2d),
+                    Width = trayBounds.Width,
+                    Height = trayBounds.Height
+                }
+            ]
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -27,20 +27,41 @@ public sealed class FaceRuntimeTextureGenerator
         ArgumentNullException.ThrowIfNull(faceDocument);
         ValidateDimensions(width, height);
 
-        var emitters = CreateTemporaryEmitters(faceDocument).ToArray();
-        ValidateLampIds(emitters);
-        var lampWindowsById = faceDocument.Elements
-            .OfType<FaceLampWindowElement>()
-            .Where(element => IsValidVisibleLampWindow(element) && !string.IsNullOrWhiteSpace(element.ObjectId))
-            .GroupBy(element => element.ObjectId, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
-        var trays = emitters
-            .Select(emitter => CreateTemporaryTray(emitter, lampWindowsById, faceDocument.MaskLayer))
-            .ToArray();
+        FaceRuntimeTrayElement[] trays;
+        FaceLampEmitterElement[] emitters;
+        var exportSource = ResolveExportSource(faceDocument);
+        if (exportSource == FaceRuntimeTextureExportSource.Authored)
+        {
+            ValidateAuthoredExportData(faceDocument);
+            emitters = faceDocument.LampEmitters
+                .OrderBy(emitter => emitter.TrayId)
+                .ThenBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
+                .ToArray();
+            ValidateLampIds(emitters);
+            var emittersByTrayObjectId = emitters.ToDictionary(emitter => emitter.TrayObjectId.Trim(), StringComparer.Ordinal);
+            trays = faceDocument.Trays
+                .OrderBy(tray => emittersByTrayObjectId[tray.ObjectId.Trim()].TrayId)
+                .ThenBy(tray => tray.ObjectId, StringComparer.Ordinal)
+                .Select(tray => CreateAuthoredTray(tray, emittersByTrayObjectId[tray.ObjectId.Trim()]))
+                .ToArray();
+        }
+        else
+        {
+            emitters = CreateTemporaryEmitters(faceDocument).ToArray();
+            ValidateLampIds(emitters);
+            var lampWindowsById = faceDocument.Elements
+                .OfType<FaceLampWindowElement>()
+                .Where(element => IsValidVisibleLampWindow(element) && !string.IsNullOrWhiteSpace(element.ObjectId))
+                .GroupBy(element => element.ObjectId, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+            trays = emitters
+                .Select(emitter => CreateTemporaryTray(emitter, lampWindowsById, faceDocument.MaskLayer))
+                .ToArray();
+        }
 
         var overlaps = DetectTrayOwnershipOverlaps(trays, width, height);
 
-        return new FaceRuntimeTextureGenerationPlan(width, height, trays, emitters, overlaps);
+        return new FaceRuntimeTextureGenerationPlan(width, height, trays, emitters, overlaps, exportSource);
     }
 
     public FaceRuntimeTextureGenerationResult Generate(FaceDocumentModel faceDocument, int width, int height, string outputDirectory)
@@ -73,6 +94,45 @@ public sealed class FaceRuntimeTextureGenerator
     }
 
 
+    private static FaceRuntimeTextureExportSource ResolveExportSource(FaceDocumentModel faceDocument)
+    {
+        var hasAuthoredTrays = faceDocument.Trays.Count > 0;
+        var hasAuthoredEmitters = faceDocument.LampEmitters.Count > 0;
+        return hasAuthoredTrays || hasAuthoredEmitters
+            ? FaceRuntimeTextureExportSource.Authored
+            : FaceRuntimeTextureExportSource.LampWindowBridge;
+    }
+
+    private static FaceRuntimeTrayElement CreateAuthoredTray(FaceTrayModel tray, FaceLampEmitterElement emitter)
+    {
+        var bounds = tray.Bounds!;
+        return new FaceRuntimeTrayElement
+        {
+            TrayId = emitter.TrayId,
+            ObjectId = tray.ObjectId.Trim(),
+            SourceLampWindowObjectId = string.IsNullOrWhiteSpace(tray.SourceLampWindowObjectId) ? emitter.SourceLampWindowObjectId : tray.SourceLampWindowObjectId.Trim(),
+            Name = string.IsNullOrWhiteSpace(tray.Name) ? $"Tray {emitter.TrayId}" : tray.Name,
+            X = bounds.X,
+            Y = bounds.Y,
+            Width = bounds.Width,
+            Height = bounds.Height,
+            Vertices = tray.Vertices.Count > 0 ? tray.Vertices.ToArray() : CreateRectangleVertices(bounds),
+            LampEmitterObjectId = emitter.ObjectId,
+            LampId = emitter.LampId
+        };
+    }
+
+    private static IReadOnlyList<FacePointModel> CreateRectangleVertices(FaceSourceRegionModel bounds)
+    {
+        return
+        [
+            new FacePointModel { X = bounds.X, Y = bounds.Y },
+            new FacePointModel { X = bounds.X + bounds.Width, Y = bounds.Y },
+            new FacePointModel { X = bounds.X + bounds.Width, Y = bounds.Y + bounds.Height },
+            new FacePointModel { X = bounds.X, Y = bounds.Y + bounds.Height }
+        ];
+    }
+
     private static FaceRuntimeTrayElement CreateTemporaryTray(
         FaceLampEmitterElement emitter,
         IReadOnlyDictionary<string, FaceLampWindowElement> lampWindowsById,
@@ -89,6 +149,7 @@ public sealed class FaceRuntimeTextureGenerator
             Y = bounds.Y,
             Width = bounds.Width,
             Height = bounds.Height,
+            Vertices = [],
             LampEmitterObjectId = emitter.ObjectId,
             LampId = emitter.LampId
         };
@@ -185,6 +246,135 @@ public sealed class FaceRuntimeTextureGenerator
         }
     }
 
+    private static void ValidateAuthoredExportData(FaceDocumentModel faceDocument)
+    {
+        var diagnostics = new List<string>();
+        if (faceDocument.Trays.Count == 0)
+        {
+            diagnostics.Add("authored export contains emitters but no trays");
+        }
+
+        if (faceDocument.LampEmitters.Count == 0)
+        {
+            diagnostics.Add("authored export contains trays but no emitters");
+        }
+
+        var trayIds = faceDocument.Trays
+            .Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId))
+            .Select(tray => tray.ObjectId.Trim())
+            .ToArray();
+        var trayIdSet = trayIds.ToHashSet(StringComparer.Ordinal);
+
+        AddDuplicateDiagnostics(trayIds, "duplicate tray ID", diagnostics);
+        AddDuplicateDiagnostics(
+            faceDocument.LampEmitters
+                .Where(emitter => !string.IsNullOrWhiteSpace(emitter.ObjectId))
+                .Select(emitter => emitter.ObjectId.Trim()),
+            "duplicate emitter ID",
+            diagnostics);
+        AddDuplicateDiagnostics(
+            faceDocument.LampEmitters
+                .Where(emitter => emitter.TrayId > 0)
+                .Select(emitter => emitter.TrayId.ToString()),
+            "duplicate numeric tray ID",
+            diagnostics);
+        AddDuplicateDiagnostics(
+            faceDocument.LampEmitters
+                .Where(emitter => !string.IsNullOrWhiteSpace(emitter.TrayObjectId))
+                .Select(emitter => emitter.TrayObjectId.Trim()),
+            "duplicate emitter tray reference",
+            diagnostics);
+
+        foreach (var tray in faceDocument.Trays)
+        {
+            var displayName = DisplayName(tray.ObjectId, tray.Name);
+            if (string.IsNullOrWhiteSpace(tray.ObjectId))
+            {
+                diagnostics.Add($"tray '{displayName}' is missing an ID");
+            }
+
+            if (tray.Bounds is not { IsValid: true } || tray.Bounds.Width <= 0d || tray.Bounds.Height <= 0d)
+            {
+                diagnostics.Add($"tray '{displayName}' has invalid tray geometry bounds");
+            }
+
+            if (tray.Vertices.Count > 0)
+            {
+                if (tray.Vertices.Count < 3
+                    || tray.Vertices.Any(vertex => !PanelElementValidation.IsFinite(vertex.X) || !PanelElementValidation.IsFinite(vertex.Y))
+                    || Math.Abs(PolygonArea(tray.Vertices)) <= double.Epsilon)
+                {
+                    diagnostics.Add($"tray '{displayName}' has invalid tray geometry vertices");
+                }
+            }
+        }
+
+        foreach (var tray in faceDocument.Trays.Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId)))
+        {
+            if (!faceDocument.LampEmitters.Any(emitter => string.Equals(emitter.TrayObjectId?.Trim(), tray.ObjectId.Trim(), StringComparison.Ordinal)))
+            {
+                diagnostics.Add($"tray '{DisplayName(tray.ObjectId, tray.Name)}' does not have an emitter");
+            }
+        }
+
+        foreach (var emitter in faceDocument.LampEmitters)
+        {
+            var displayName = DisplayName(emitter.ObjectId, emitter.Name);
+            if (string.IsNullOrWhiteSpace(emitter.ObjectId))
+            {
+                diagnostics.Add($"emitter '{displayName}' is missing an ID");
+            }
+
+            if (emitter.TrayId <= 0 || emitter.TrayId > byte.MaxValue)
+            {
+                diagnostics.Add($"emitter '{displayName}' has invalid tray ID '{emitter.TrayId}'");
+            }
+
+            if (string.IsNullOrWhiteSpace(emitter.TrayObjectId) || !trayIdSet.Contains(emitter.TrayObjectId.Trim()))
+            {
+                diagnostics.Add($"emitter '{displayName}' references missing tray '{emitter.TrayObjectId}'");
+            }
+        }
+
+        if (diagnostics.Count > 0)
+        {
+            throw new InvalidOperationException("Face authored runtime texture export data is invalid: " + string.Join("; ", diagnostics) + ".");
+        }
+    }
+
+    private static void AddDuplicateDiagnostics(IEnumerable<string> ids, string label, List<string> diagnostics)
+    {
+        foreach (var duplicate in ids
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .GroupBy(id => id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key))
+        {
+            diagnostics.Add($"{label} '{duplicate}'");
+        }
+    }
+
+    private static double PolygonArea(IReadOnlyList<FacePointModel> vertices)
+    {
+        var area = 0d;
+        for (var index = 0; index < vertices.Count; index++)
+        {
+            var current = vertices[index];
+            var next = vertices[(index + 1) % vertices.Count];
+            area += (current.X * next.Y) - (next.X * current.Y);
+        }
+
+        return area / 2d;
+    }
+
+    private static string DisplayName(string objectId, string name)
+    {
+        return string.IsNullOrWhiteSpace(name)
+            ? string.IsNullOrWhiteSpace(objectId) ? "<unnamed>" : objectId.Trim()
+            : name.Trim();
+    }
+
     private static void ValidateLampIds(IReadOnlyList<FaceLampEmitterElement> emitters)
     {
         foreach (var emitter in emitters)
@@ -210,6 +400,11 @@ public sealed class FaceRuntimeTextureGenerator
                 {
                     var index = (y * width) + x;
                     var existing = ownership[index];
+                    if (!RasterGeometry.ContainsPixelCenter(tray, x, y))
+                    {
+                        continue;
+                    }
+
                     if (existing != 0)
                     {
                         if (overlaps.Count < maxRecordedOverlaps)
@@ -280,7 +475,7 @@ public sealed class TrayIdTextureGenerator
                 for (var x = bounds.Left; x < bounds.Right; x++)
                 {
                     var index = (y * width) + x;
-                    if (ownership[index] != 0)
+                    if (ownership[index] != 0 || !RasterGeometry.ContainsPixelCenter(tray, x, y))
                     {
                         continue;
                     }
@@ -353,7 +548,7 @@ public sealed class LampInfluenceTextureGenerator
                 for (var x = bounds.Left; x < bounds.Right; x++)
                 {
                     var index = (y * width) + x;
-                    if (ownership[index] != 0)
+                    if (ownership[index] != 0 || !RasterGeometry.ContainsPixelCenter(tray, x, y))
                     {
                         continue;
                     }
@@ -386,12 +581,19 @@ public sealed class LampInfluenceTextureGenerator
     }
 }
 
+public enum FaceRuntimeTextureExportSource
+{
+    LampWindowBridge,
+    Authored
+}
+
 public sealed record FaceRuntimeTextureGenerationPlan(
     int Width,
     int Height,
     IReadOnlyList<FaceRuntimeTrayElement> Trays,
     IReadOnlyList<FaceLampEmitterElement> Emitters,
-    IReadOnlyList<FaceRuntimeTrayOverlap> Overlaps);
+    IReadOnlyList<FaceRuntimeTrayOverlap> Overlaps,
+    FaceRuntimeTextureExportSource ExportSource);
 
 public sealed record FaceRuntimeTrayOverlap(int X, int Y, int ExistingTrayId, int OverlappingTrayId);
 
@@ -413,11 +615,46 @@ public sealed class FaceRuntimeTrayElement
     public double Y { get; init; }
     public double Width { get; init; }
     public double Height { get; init; }
+    public IReadOnlyList<FacePointModel> Vertices { get; init; } = [];
     public string LampEmitterObjectId { get; init; } = string.Empty;
     public int? LampId { get; init; }
 }
 
 internal readonly record struct RuntimeRect(double X, double Y, double Width, double Height);
+
+
+internal static class RasterGeometry
+{
+    public static bool ContainsPixelCenter(FaceRuntimeTrayElement tray, int x, int y)
+    {
+        if (tray.Vertices.Count == 0)
+        {
+            return true;
+        }
+
+        return ContainsPoint(tray.Vertices, x + 0.5d, y + 0.5d);
+    }
+
+    private static bool ContainsPoint(IReadOnlyList<FacePointModel> vertices, double x, double y)
+    {
+        var inside = false;
+        var previous = vertices.Count - 1;
+        for (var current = 0; current < vertices.Count; current++)
+        {
+            var currentVertex = vertices[current];
+            var previousVertex = vertices[previous];
+            if (((currentVertex.Y > y) != (previousVertex.Y > y))
+                && (x < ((previousVertex.X - currentVertex.X) * (y - currentVertex.Y) / (previousVertex.Y - currentVertex.Y)) + currentVertex.X))
+            {
+                inside = !inside;
+            }
+
+            previous = current;
+        }
+
+        return inside;
+    }
+}
 
 internal readonly record struct RasterBounds(int Left, int Top, int Right, int Bottom)
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
@@ -82,6 +82,11 @@ internal sealed class FaceTrayAutoAuthoringService
         var diagnostics = new List<FaceValidationDiagnostic>();
         AddDuplicateDiagnostics(faceDocument.Trays.Select(tray => tray.ObjectId), "Face.Tray.DuplicateId", "tray", diagnostics);
         AddDuplicateDiagnostics(faceDocument.LampEmitters.Select(emitter => emitter.ObjectId), "Face.Emitter.DuplicateId", "emitter", diagnostics);
+        AddDuplicateDiagnostics(
+            faceDocument.LampEmitters.Where(emitter => emitter.TrayId > 0).Select(emitter => emitter.TrayId.ToString()),
+            "Face.Tray.DuplicateNumericId",
+            "numeric tray",
+            diagnostics);
 
         var trayIds = faceDocument.Trays
             .Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId))
@@ -104,6 +109,17 @@ internal sealed class FaceTrayAutoAuthoringService
                     FaceValidationSeverity.Warning,
                     "Face.Tray.Vertices.Invalid",
                     $"Face tray '{DisplayName(tray.ObjectId, tray.Name)}' has invalid polygon vertices."));
+            }
+        }
+
+        foreach (var tray in faceDocument.Trays.Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId)))
+        {
+            if (!faceDocument.LampEmitters.Any(emitter => string.Equals(emitter.TrayObjectId?.Trim(), tray.ObjectId.Trim(), StringComparison.Ordinal)))
+            {
+                diagnostics.Add(new FaceValidationDiagnostic(
+                    FaceValidationSeverity.Warning,
+                    "Face.Tray.Emitter.Missing",
+                    $"Face tray '{DisplayName(tray.ObjectId, tray.Name)}' does not have a lamp emitter."));
             }
         }
 


### PR DESCRIPTION
### Motivation

- Make authored Face trays and emitters the authoritative source for runtime texture generation when present while preserving the existing lamp-window bridge fallback.
- Ensure runtime textures and manifest reflect authored geometry deterministically and enable authored-tray diagnostics early in the pipeline.

### Description

- Add export-source selection in `FaceRuntimeTextureGenerator.CreatePlan(...)` to choose authored export when authored `Trays` or `LampEmitters` exist, otherwise fall back to the lamp-window bridge. 
- Produce runtime tray elements from authored `FaceTrayModel` + `FaceLampEmitterElement`, rasterise authored polygon vertices (point-in-polygon test) when present, and generate `trayId.png`, `lampIds0.png`, and `lampWeights0.png` from that authored plan; preserve dimensions and deterministic ownership semantics. 
- Implement authored-export validation that detects tray-without-emitter, emitter-without-tray, duplicate tray/emitter IDs, duplicate numeric tray IDs, and invalid tray geometry and surface useful diagnostics. 
- Keep manifest shape and CPU preview contract unchanged so preview and Unity-import contract continue to consume `trayId.png`, `lampIds0.png`, and `lampWeights0.png`; add tests exercising authored path, bridge fallback, generated textures, manifest entries, polygon clipping, and invalid authored data.

### Testing

- Performed patch hygiene check with `git diff --check` (no issues found). 
- Added unit tests in `FaceRuntimeExportServiceTests` covering authored export selection, bridge fallback, authored texture generation, polygon raster clipping, manifest metadata, and invalid authored-data diagnostics, but tests were not executed here because the Codex environment does not have the Windows/.NET/WPF toolchain. 
- No `dotnet test` or full test run was executed in this environment; local CI or developer machine run is required to validate the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b125fbcc483279a2cc9642e0c9fa8)