### PR TITLE
Fix MFME multi-lamp import

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeExtractReaderTests.cs
@@ -302,6 +302,62 @@ public sealed class MfmeExtractReaderTests
         }
     }
 
+
+    [Fact]
+    public void Read_WithMultipleLampElements_KeepsAllValidAndIgnoresPlaceholders()
+    {
+        var extractDirectory = CreateTempDirectory();
+        var manifestPath = Path.Combine(extractDirectory, "layout.json");
+        Directory.CreateDirectory(Path.Combine(extractDirectory, "lamps"));
+        File.WriteAllText(Path.Combine(extractDirectory, "lamps", "lamp-147.png"), "placeholder");
+        File.WriteAllText(Path.Combine(extractDirectory, "lamps", "lamp-164.png"), "placeholder");
+        File.WriteAllText(manifestPath, """
+        {
+          "ASName": "MultiLampLayout",
+          "Components": [
+            {
+              "$type": "Oasis.MfmeTools.Shared.ExtractComponents.ExtractComponentLamp, MfmeTools",
+              "Position": { "X": 10, "Y": 20 },
+              "Size": { "X": 300, "Y": 80 },
+              "Graphic": true,
+              "LampElements": [
+                { "NumberAsText": "147", "BmpImageFilename": "lamp-147.png" },
+                { "NumberAsText": "", "BmpImageFilename": "", "BmpMaskImageFilename": "" },
+                { "NumberAsText": "164", "BmpImageFilename": "lamp-164.png" }
+              ]
+            }
+          ]
+        }
+        """);
+
+        try
+        {
+            var result = new FileSystemMfmeExtractReader().Read(new MfmeImportContext
+            {
+                SourceExtractPath = extractDirectory,
+                ProjectRootPath = "C:/Project",
+                ProjectAssetsPath = "C:/Project/Assets",
+                CopyAssets = true
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Errors);
+            Assert.Empty(result.Warnings);
+            var lamp = Assert.IsType<MfmeLegacyLampComponent>(Assert.Single(result.Extract!.Components));
+            Assert.Equal(2, lamp.LampElements!.Count);
+            Assert.Equal(147, lamp.LampElements[0].Number);
+            Assert.Equal(0, lamp.LampElements[0].SourceElementIndex);
+            Assert.Equal("lamp-147.png", lamp.LampElements[0].BmpImageFilename);
+            Assert.Equal(164, lamp.LampElements[1].Number);
+            Assert.Equal(2, lamp.LampElements[1].SourceElementIndex);
+            Assert.Equal(0, lamp.SourceComponentIndex);
+        }
+        finally
+        {
+            Directory.Delete(extractDirectory, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"oasis-mfme-tests-{Guid.NewGuid():N}");

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -363,16 +363,18 @@ public sealed class MfmeToOasisComponentMapperTests
             Assert.Equal(200, element.Y);
             Assert.Equal(300, element.Width);
             Assert.Equal(80, element.Height);
-            Assert.Contains("componentIndex=12", element.ImportSource!.Reference);
-            Assert.Contains("sharedLampSetId=mfme-component-12", element.ImportSource.Reference);
-            Assert.Contains("sharedLampSetCount=2", element.ImportSource.Reference);
+            Assert.Equal(12, element.ImportSource!.SourceComponentIndex);
+            Assert.Equal("mfme-component-12", element.ImportSource.SharedLampSetId);
+            Assert.Equal(2, element.ImportSource.SharedLampSetCount);
         });
         Assert.Equal(147, result.Elements[0].DisplayNumber);
         Assert.Equal("lamps/jackpot-147.bmp", result.Elements[0].AssetPath);
-        Assert.Contains("lampElementIndex=0", result.Elements[0].ImportSource!.Reference);
+        Assert.Equal("Lamp:147", result.Elements[0].ImportSource!.Reference);
+        Assert.Equal(0, result.Elements[0].ImportSource.LampElementIndex);
         Assert.Equal(164, result.Elements[1].DisplayNumber);
         Assert.Equal("lamps/jackpot-164.bmp", result.Elements[1].AssetPath);
-        Assert.Contains("lampElementIndex=2", result.Elements[1].ImportSource!.Reference);
+        Assert.Equal("Lamp:164", result.Elements[1].ImportSource!.Reference);
+        Assert.Equal(2, result.Elements[1].ImportSource.LampElementIndex);
     }
 
     private sealed record UnsupportedLegacyComponent()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -313,6 +313,68 @@ public sealed class MfmeToOasisComponentMapperTests
         });
     }
 
+
+    [Fact]
+    public void Map_WithMultipleValidLampElements_CreatesIndependentSharedBoundsLamps()
+    {
+        var lampElements = new[]
+        {
+            new MfmeLegacyLampElement("147", 147, new MfmeLegacyColor(1f, 0f, 0f, 1f), "jackpot-147.bmp", "jackpot-147-mask.bmp", Graphic: true, SourceElementIndex: 0),
+            new MfmeLegacyLampElement("", null, null, null, null, Graphic: false, SourceElementIndex: 1),
+            new MfmeLegacyLampElement("164", 164, new MfmeLegacyColor(0f, 1f, 0f, 1f), "jackpot-164.bmp", "jackpot-164-mask.bmp", Graphic: true, SourceElementIndex: 2)
+        };
+        var extract = new MfmeLegacyExtractData
+        {
+            ExtractRootPath = "C:/extract",
+            ManifestPath = "C:/extract/layout.json",
+            LayoutName = "layout",
+            Components =
+            [
+                new MfmeLegacyLampComponent(
+                    new MfmeLegacyPoint(100, 200),
+                    new MfmeLegacyPoint(300, 80),
+                    "JACKPOT",
+                    "Arial",
+                    "Regular",
+                    "12",
+                    lampElements[0],
+                    new MfmeLegacyColor(0f, 0f, 0f, 1f),
+                    new MfmeLegacyColor(1f, 1f, 1f, 1f),
+                    NoOutline: false,
+                    HasButtonInput: false,
+                    HasCoinInput: false,
+                    ButtonNumberAsString: null,
+                    Inverted: false,
+                    Shortcut1: null,
+                    Shortcut2: null,
+                    LampElements: lampElements.Where(element => element.HasUsefulIdentityOrImage).ToArray(),
+                    SourceComponentIndex: 12)
+            ]
+        };
+
+        var result = new MfmeToOasisComponentMapper().Map(extract);
+
+        Assert.Empty(result.Warnings);
+        Assert.Equal(2, result.Elements.Count);
+        Assert.All(result.Elements, element =>
+        {
+            Assert.Equal(PanelElementKind.Lamp, element.Kind);
+            Assert.Equal(100, element.X);
+            Assert.Equal(200, element.Y);
+            Assert.Equal(300, element.Width);
+            Assert.Equal(80, element.Height);
+            Assert.Contains("componentIndex=12", element.ImportSource!.Reference);
+            Assert.Contains("sharedLampSetId=mfme-component-12", element.ImportSource.Reference);
+            Assert.Contains("sharedLampSetCount=2", element.ImportSource.Reference);
+        });
+        Assert.Equal(147, result.Elements[0].DisplayNumber);
+        Assert.Equal("lamps/jackpot-147.bmp", result.Elements[0].AssetPath);
+        Assert.Contains("lampElementIndex=0", result.Elements[0].ImportSource!.Reference);
+        Assert.Equal(164, result.Elements[1].DisplayNumber);
+        Assert.Equal("lamps/jackpot-164.bmp", result.Elements[1].AssetPath);
+        Assert.Contains("lampElementIndex=2", result.Elements[1].ImportSource!.Reference);
+    }
+
     private sealed record UnsupportedLegacyComponent()
         : MfmeLegacyComponentBase(
             "ExtractComponentButton",

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeToOasisComponentMapperTests.cs
@@ -363,18 +363,18 @@ public sealed class MfmeToOasisComponentMapperTests
             Assert.Equal(200, element.Y);
             Assert.Equal(300, element.Width);
             Assert.Equal(80, element.Height);
-            Assert.Equal(12, element.ImportSource!.SourceComponentIndex);
-            Assert.Equal("mfme-component-12", element.ImportSource.SharedLampSetId);
-            Assert.Equal(2, element.ImportSource.SharedLampSetCount);
+            Assert.Equal(12, element.SourceComponentIndex);
+            Assert.Equal("mfme-component-12", element.SharedSourceSetId);
+            Assert.Equal(2, element.SharedSourceSetCount);
         });
         Assert.Equal(147, result.Elements[0].DisplayNumber);
         Assert.Equal("lamps/jackpot-147.bmp", result.Elements[0].AssetPath);
         Assert.Equal("Lamp:147", result.Elements[0].ImportSource!.Reference);
-        Assert.Equal(0, result.Elements[0].ImportSource.LampElementIndex);
+        Assert.Equal(0, result.Elements[0].SourceElementIndex);
         Assert.Equal(164, result.Elements[1].DisplayNumber);
         Assert.Equal("lamps/jackpot-164.bmp", result.Elements[1].AssetPath);
         Assert.Equal("Lamp:164", result.Elements[1].ImportSource!.Reference);
-        Assert.Equal(2, result.Elements[1].ImportSource.LampElementIndex);
+        Assert.Equal(2, result.Elements[1].SourceElementIndex);
     }
 
     private sealed record UnsupportedLegacyComponent()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -165,7 +165,11 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
                 : new PanelElementImportSourceModel
                 {
                     Format = source.ImportSource.Format,
-                    Reference = source.ImportSource.Reference
+                    Reference = source.ImportSource.Reference,
+                    SourceComponentIndex = source.ImportSource.SourceComponentIndex,
+                    LampElementIndex = source.ImportSource.LampElementIndex,
+                    SharedLampSetId = source.ImportSource.SharedLampSetId,
+                    SharedLampSetCount = source.ImportSource.SharedLampSetCount
                 }
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -160,16 +160,16 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
             BandOffset = source.BandOffset,
             IsLocked = source.IsLocked,
             IsVisible = source.IsVisible,
+            SourceComponentIndex = source.SourceComponentIndex,
+            SourceElementIndex = source.SourceElementIndex,
+            SharedSourceSetId = source.SharedSourceSetId,
+            SharedSourceSetCount = source.SharedSourceSetCount,
             ImportSource = source.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel
                 {
                     Format = source.ImportSource.Format,
-                    Reference = source.ImportSource.Reference,
-                    SourceComponentIndex = source.ImportSource.SourceComponentIndex,
-                    LampElementIndex = source.ImportSource.LampElementIndex,
-                    SharedLampSetId = source.ImportSource.SharedLampSetId,
-                    SharedLampSetCount = source.ImportSource.SharedLampSetCount
+                    Reference = source.ImportSource.Reference
                 }
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -75,7 +75,7 @@ internal static class MfmeExtractManifestParser
             }
 
             var sourceType = ReadSourceType(component);
-            if (TryParseSupportedComponent(sourceType, component, out var parsedComponent))
+            if (TryParseSupportedComponent(sourceType, component, index, out var parsedComponent))
             {
                 components.Add(parsedComponent);
                 AddMissingOptionalImageWarnings(parsedComponent, extractDirectory, index, warnings);
@@ -111,20 +111,23 @@ internal static class MfmeExtractManifestParser
                     warnings);
                 break;
             case MfmeLegacyLampComponent lamp:
-                AddMissingImageWarningIfNeeded(
-                    extractDirectory,
-                    "lamps",
-                    lamp.FirstLampElement?.BmpImageFilename,
-                    "Lamp",
-                    componentIndex,
-                    warnings);
-                AddMissingImageWarningIfNeeded(
-                    extractDirectory,
-                    "lamps",
-                    lamp.FirstLampElement?.BmpMaskImageFilename,
-                    "Lamp mask",
-                    componentIndex,
-                    warnings);
+                foreach (var lampElement in lamp.LampElements ?? [])
+                {
+                    AddMissingImageWarningIfNeeded(
+                        extractDirectory,
+                        "lamps",
+                        lampElement.BmpImageFilename,
+                        "Lamp",
+                        componentIndex,
+                        warnings);
+                    AddMissingImageWarningIfNeeded(
+                        extractDirectory,
+                        "lamps",
+                        lampElement.BmpMaskImageFilename,
+                        "Lamp mask",
+                        componentIndex,
+                        warnings);
+                }
                 break;
             case MfmeLegacyReelComponent reel:
                 AddMissingImageWarningIfNeeded(
@@ -195,7 +198,7 @@ internal static class MfmeExtractManifestParser
         return ReadBool(component, "HasCoinInput") || !string.IsNullOrWhiteSpace(ReadString(component, "CoinNote"));
     }
 
-    private static bool TryParseSupportedComponent(string sourceType, JsonElement component, out MfmeLegacyComponentBase parsedComponent)
+    private static bool TryParseSupportedComponent(string sourceType, JsonElement component, int componentIndex, out MfmeLegacyComponentBase parsedComponent)
     {
         var position = ReadPoint(component, "Position");
         var size = ReadPoint(component, "Size");
@@ -212,44 +215,54 @@ internal static class MfmeExtractManifestParser
                 return true;
 
             case "extractcomponentlamp":
-                parsedComponent = new MfmeLegacyLampComponent(
-                    position,
-                    size,
-                    ReadString(component, "TextBoxText"),
-                    ReadString(component, "TextBoxFontName"),
-                    ReadString(component, "TextBoxFontStyle"),
-                    ReadString(component, "TextBoxFontSize"),
-                    ReadFirstLampElement(component, ReadOptionalBool(component, "Graphic")),
-                    ReadColor(component, "OffImageColor"),
-                    ReadColor(component, "TextColor"),
-                    ReadBool(component, "NoOutline"),
-                    HasButtonInput(component),
-                    HasCoinInput(component),
-                    ReadString(component, "ButtonNumberAsString"),
-                    ReadBool(component, "Inverted"),
-                    ReadString(component, "Shortcut1"),
-                    ReadString(component, "Shortcut2"));
-                return true;
+                {
+                    var lampElements = ReadValidLampElements(component, ReadOptionalBool(component, "Graphic"));
+                    parsedComponent = new MfmeLegacyLampComponent(
+                        position,
+                        size,
+                        ReadString(component, "TextBoxText"),
+                        ReadString(component, "TextBoxFontName"),
+                        ReadString(component, "TextBoxFontStyle"),
+                        ReadString(component, "TextBoxFontSize"),
+                        lampElements.FirstOrDefault(),
+                        ReadColor(component, "OffImageColor"),
+                        ReadColor(component, "TextColor"),
+                        ReadBool(component, "NoOutline"),
+                        HasButtonInput(component),
+                        HasCoinInput(component),
+                        ReadString(component, "ButtonNumberAsString"),
+                        ReadBool(component, "Inverted"),
+                        ReadString(component, "Shortcut1"),
+                        ReadString(component, "Shortcut2"),
+                        lampElements,
+                        componentIndex);
+                    return true;
+                }
 
             case "extractcomponentbutton":
-                parsedComponent = new MfmeLegacyButtonComponent(
-                    position,
-                    size,
-                    ReadString(component, "TextBoxText"),
-                    ReadString(component, "TextBoxFontName"),
-                    ReadString(component, "TextBoxFontStyle"),
-                    ReadString(component, "TextBoxFontSize"),
-                    HasButtonInput(component),
-                    HasCoinInput(component),
-                    ReadString(component, "ButtonNumberAsString"),
-                    ReadBool(component, "Inverted"),
-                    ReadString(component, "Shortcut1"),
-                    ReadString(component, "Shortcut2"),
-                    ReadFirstLampElement(component, ReadOptionalBool(component, "Graphic")),
-                    ReadColor(component, "OffImageColor"),
-                    ReadColor(component, "TextColor"),
-                    ReadBool(component, "NoOutline"));
-                return true;
+                {
+                    var lampElements = ReadValidLampElements(component, ReadOptionalBool(component, "Graphic"));
+                    parsedComponent = new MfmeLegacyButtonComponent(
+                        position,
+                        size,
+                        ReadString(component, "TextBoxText"),
+                        ReadString(component, "TextBoxFontName"),
+                        ReadString(component, "TextBoxFontStyle"),
+                        ReadString(component, "TextBoxFontSize"),
+                        HasButtonInput(component),
+                        HasCoinInput(component),
+                        ReadString(component, "ButtonNumberAsString"),
+                        ReadBool(component, "Inverted"),
+                        ReadString(component, "Shortcut1"),
+                        ReadString(component, "Shortcut2"),
+                        lampElements.FirstOrDefault(),
+                        ReadColor(component, "OffImageColor"),
+                        ReadColor(component, "TextColor"),
+                        ReadBool(component, "NoOutline"),
+                        lampElements,
+                        componentIndex);
+                    return true;
+                }
 
             case "extractcomponentreel":
                 parsedComponent = new MfmeLegacyReelComponent(
@@ -305,31 +318,42 @@ internal static class MfmeExtractManifestParser
         }
     }
 
-    private static MfmeLegacyLampElement? ReadFirstLampElement(JsonElement component, bool? componentGraphic)
+    private static IReadOnlyList<MfmeLegacyLampElement> ReadValidLampElements(JsonElement component, bool? componentGraphic)
     {
         if (!component.TryGetProperty("LampElements", out var lampElements) || lampElements.ValueKind != JsonValueKind.Array)
         {
-            return null;
+            return [];
         }
 
+        var validLampElements = new List<MfmeLegacyLampElement>();
+        var lampElementIndex = 0;
         foreach (var lampElement in lampElements.EnumerateArray())
         {
             if (lampElement.ValueKind != JsonValueKind.Object)
             {
+                lampElementIndex++;
                 continue;
             }
 
             var numberAsText = ReadString(lampElement, "NumberAsText");
-            return new MfmeLegacyLampElement(
+            var parsed = new MfmeLegacyLampElement(
                 numberAsText,
                 TryParseNullableInt(numberAsText),
                 ReadColor(lampElement, "OnColor"),
                 ReadString(lampElement, "BmpImageFilename"),
                 ReadString(lampElement, "BmpMaskImageFilename"),
-                ReadOptionalBool(lampElement, "Graphic") ?? componentGraphic ?? false);
+                ReadOptionalBool(lampElement, "Graphic") ?? componentGraphic ?? false,
+                lampElementIndex);
+
+            if (parsed.HasUsefulIdentityOrImage)
+            {
+                validLampElements.Add(parsed);
+            }
+
+            lampElementIndex++;
         }
 
-        return null;
+        return validLampElements;
     }
 
     private static string ReadSourceType(JsonElement component)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -33,7 +33,15 @@ internal sealed record MfmeLegacyLampElement(
     MfmeLegacyColor? OnColor,
     string? BmpImageFilename,
     string? BmpMaskImageFilename,
-    bool Graphic);
+    bool Graphic,
+    int SourceElementIndex = -1)
+{
+    public bool HasUsefulIdentityOrImage => Number.HasValue
+        || !string.IsNullOrWhiteSpace(NumberAsText)
+        || !string.IsNullOrWhiteSpace(BmpImageFilename)
+        || !string.IsNullOrWhiteSpace(BmpMaskImageFilename);
+}
+
 
 internal sealed record MfmeLegacyLampComponent(
     MfmeLegacyPoint Position,
@@ -51,7 +59,9 @@ internal sealed record MfmeLegacyLampComponent(
     string? ButtonNumberAsString,
     bool Inverted,
     string? Shortcut1,
-    string? Shortcut2)
+    string? Shortcut2,
+    IReadOnlyList<MfmeLegacyLampElement>? LampElements = null,
+    int SourceComponentIndex = -1)
     : MfmeLegacyComponentBase(
         "Lamp",
         Position,
@@ -145,7 +155,9 @@ internal sealed record MfmeLegacyButtonComponent(
     MfmeLegacyLampElement? FirstLampElement,
     MfmeLegacyColor? OffImageColor,
     MfmeLegacyColor? TextColor,
-    bool NoOutline)
+    bool NoOutline,
+    IReadOnlyList<MfmeLegacyLampElement>? LampElements = null,
+    int SourceComponentIndex = -1)
     : MfmeLegacyComponentBase(
         "ExtractComponentButton",
         Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -24,9 +24,9 @@ internal sealed class MfmeToOasisComponentMapper
                     break;
                 case MfmeLegacyLampComponent lamp:
                     {
-                        var mappedLamp = MapLamp(lamp, warnings);
-                        elements.Add(mappedLamp);
-                        var input = BuildInputDefinition(lamp, mappedLamp.ObjectId);
+                        var mappedLamps = MapLamps(lamp, warnings);
+                        elements.AddRange(mappedLamps);
+                        var input = BuildInputDefinition(lamp, mappedLamps.FirstOrDefault()?.ObjectId ?? string.Empty);
                         if (input is not null)
                         {
                             inputDefinitions.Add(input);
@@ -35,9 +35,9 @@ internal sealed class MfmeToOasisComponentMapper
                     }
                 case MfmeLegacyButtonComponent button:
                     {
-                        var mappedButtonLamp = MapButtonAsLamp(button, warnings);
-                        elements.Add(mappedButtonLamp);
-                        var input = BuildInputDefinition(button, mappedButtonLamp.ObjectId);
+                        var mappedButtonLamps = MapButtonAsLamps(button, warnings);
+                        elements.AddRange(mappedButtonLamps);
+                        var input = BuildInputDefinition(button, mappedButtonLamps.FirstOrDefault()?.ObjectId ?? string.Empty);
                         if (input is not null)
                         {
                             inputDefinitions.Add(input);
@@ -92,12 +92,37 @@ internal sealed class MfmeToOasisComponentMapper
         };
     }
 
-    private static PanelElementModel MapLamp(MfmeLegacyLampComponent component, ICollection<MfmeImportWarning> warnings)
+    private static IReadOnlyList<PanelElementModel> MapLamps(MfmeLegacyLampComponent component, ICollection<MfmeImportWarning> warnings)
     {
-        var number = component.FirstLampElement?.Number;
-        if (number is null && !string.IsNullOrWhiteSpace(component.FirstLampElement?.NumberAsText))
+        IReadOnlyList<MfmeLegacyLampElement> lampElements = component.LampElements is { Count: > 0 } parsedLampElements
+            ? parsedLampElements
+            : component.FirstLampElement is null ? [] : [component.FirstLampElement];
+
+        if (lampElements.Count == 0)
         {
-            if (int.TryParse(component.FirstLampElement.NumberAsText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            lampElements = [new MfmeLegacyLampElement(null, null, null, null, null, Graphic: false)];
+        }
+
+        var sharedLampSetId = component.SourceComponentIndex >= 0
+            ? $"mfme-component-{component.SourceComponentIndex.ToString(CultureInfo.InvariantCulture)}"
+            : $"mfme-component-{component.Position.X.ToString(CultureInfo.InvariantCulture)}-{component.Position.Y.ToString(CultureInfo.InvariantCulture)}-{component.Size.X.ToString(CultureInfo.InvariantCulture)}-{component.Size.Y.ToString(CultureInfo.InvariantCulture)}";
+
+        return lampElements
+            .Select(lampElement => MapLamp(component, lampElement, lampElements.Count, sharedLampSetId, warnings))
+            .ToArray();
+    }
+
+    private static PanelElementModel MapLamp(
+        MfmeLegacyLampComponent component,
+        MfmeLegacyLampElement? lampElement,
+        int sharedLampSetCount,
+        string sharedLampSetId,
+        ICollection<MfmeImportWarning> warnings)
+    {
+        var number = lampElement?.Number;
+        if (number is null && !string.IsNullOrWhiteSpace(lampElement?.NumberAsText))
+        {
+            if (int.TryParse(lampElement.NumberAsText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
             {
                 number = parsed;
             }
@@ -106,7 +131,7 @@ internal sealed class MfmeToOasisComponentMapper
                 warnings.Add(new MfmeImportWarning(
                     "mfme.import.lamp.number.invalid",
                     "Lamp number could not be parsed; number will be omitted.",
-                    component.FirstLampElement.NumberAsText));
+                    lampElement.NumberAsText));
             }
         }
 
@@ -120,25 +145,25 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             DisplayNumber = number,
-            AssetPath = component.FirstLampElement?.Graphic == true
-                ? BuildExtractRelativePath("lamps", component.FirstLampElement.BmpImageFilename)
+            AssetPath = lampElement?.Graphic == true
+                ? BuildExtractRelativePath("lamps", lampElement.BmpImageFilename)
                 : null,
-            SecondaryAssetPath = component.FirstLampElement?.Graphic == true
-                ? BuildExtractRelativePath("lamps", component.FirstLampElement.BmpMaskImageFilename)
+            SecondaryAssetPath = lampElement?.Graphic == true
+                ? BuildExtractRelativePath("lamps", lampElement.BmpMaskImageFilename)
                 : null,
-            OnColorHex = ToHex(component.FirstLampElement?.OnColor),
+            OnColorHex = ToHex(lampElement?.OnColor),
             OffColorHex = ToHex(component.OffImageColor),
             TextColorHex = ToHex(component.TextColor),
             DisplayText = NormalizeOptional(component.TextBoxText),
             TextBoxFontName = NormalizeLampFontName(component.TextBoxFontName),
             TextBoxFontStyle = NormalizeLampFontStyle(component.TextBoxFontStyle),
             TextBoxFontSize = NormalizeLampFontSize(component.TextBoxFontSize),
-            ImportSource = CreateImportSource(number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType)
+            ImportSource = CreateLampImportSource(component, lampElement, number, sharedLampSetId, sharedLampSetCount)
         };
     }
 
 
-    private static PanelElementModel MapButtonAsLamp(MfmeLegacyButtonComponent component, ICollection<MfmeImportWarning> warnings)
+    private static IReadOnlyList<PanelElementModel> MapButtonAsLamps(MfmeLegacyButtonComponent component, ICollection<MfmeImportWarning> warnings)
     {
         var lampEquivalent = new MfmeLegacyLampComponent(
             component.Position,
@@ -156,9 +181,11 @@ internal sealed class MfmeToOasisComponentMapper
             component.ButtonNumberAsString,
             component.Inverted,
             component.Shortcut1,
-            component.Shortcut2);
+            component.Shortcut2,
+            component.LampElements,
+            component.SourceComponentIndex);
 
-        return MapLamp(lampEquivalent, warnings);
+        return MapLamps(lampEquivalent, warnings);
     }
 
     private static InputDefinitionModel? BuildInputDefinition(MfmeLegacyLampComponent component, string linkedObjectId)
@@ -322,6 +349,17 @@ internal sealed class MfmeToOasisComponentMapper
             TextColorHex = ToHex(component.TextColor),
             ImportSource = CreateImportSource(component.SourceType)
         };
+    }
+
+    private static PanelElementImportSourceModel CreateLampImportSource(
+        MfmeLegacyLampComponent component,
+        MfmeLegacyLampElement? lampElement,
+        int? number,
+        string sharedLampSetId,
+        int sharedLampSetCount)
+    {
+        var reference = number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType;
+        return CreateImportSource($"{reference};componentIndex={component.SourceComponentIndex.ToString(CultureInfo.InvariantCulture)};lampElementIndex={(lampElement?.SourceElementIndex ?? -1).ToString(CultureInfo.InvariantCulture)};sharedLampSetId={sharedLampSetId};sharedLampSetCount={sharedLampSetCount.ToString(CultureInfo.InvariantCulture)}");
     }
 
     private static PanelElementImportSourceModel CreateImportSource(string reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -158,7 +158,11 @@ internal sealed class MfmeToOasisComponentMapper
             TextBoxFontName = NormalizeLampFontName(component.TextBoxFontName),
             TextBoxFontStyle = NormalizeLampFontStyle(component.TextBoxFontStyle),
             TextBoxFontSize = NormalizeLampFontSize(component.TextBoxFontSize),
-            ImportSource = CreateLampImportSource(component, lampElement, number, sharedLampSetId, sharedLampSetCount)
+            SourceComponentIndex = component.SourceComponentIndex >= 0 ? component.SourceComponentIndex : null,
+            SourceElementIndex = lampElement?.SourceElementIndex >= 0 ? lampElement.SourceElementIndex : null,
+            SharedSourceSetId = sharedLampSetId,
+            SharedSourceSetCount = sharedLampSetCount,
+            ImportSource = CreateLampImportSource(component, number)
         };
     }
 
@@ -353,20 +357,9 @@ internal sealed class MfmeToOasisComponentMapper
 
     private static PanelElementImportSourceModel CreateLampImportSource(
         MfmeLegacyLampComponent component,
-        MfmeLegacyLampElement? lampElement,
-        int? number,
-        string sharedLampSetId,
-        int sharedLampSetCount)
+        int? number)
     {
-        return new PanelElementImportSourceModel
-        {
-            Format = ImportSourceFormat,
-            Reference = number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType,
-            SourceComponentIndex = component.SourceComponentIndex >= 0 ? component.SourceComponentIndex : null,
-            LampElementIndex = lampElement?.SourceElementIndex >= 0 ? lampElement.SourceElementIndex : null,
-            SharedLampSetId = sharedLampSetId,
-            SharedLampSetCount = sharedLampSetCount
-        };
+        return CreateImportSource(number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType);
     }
 
     private static PanelElementImportSourceModel CreateImportSource(string reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -358,8 +358,15 @@ internal sealed class MfmeToOasisComponentMapper
         string sharedLampSetId,
         int sharedLampSetCount)
     {
-        var reference = number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType;
-        return CreateImportSource($"{reference};componentIndex={component.SourceComponentIndex.ToString(CultureInfo.InvariantCulture)};lampElementIndex={(lampElement?.SourceElementIndex ?? -1).ToString(CultureInfo.InvariantCulture)};sharedLampSetId={sharedLampSetId};sharedLampSetCount={sharedLampSetCount.ToString(CultureInfo.InvariantCulture)}");
+        return new PanelElementImportSourceModel
+        {
+            Format = ImportSourceFormat,
+            Reference = number.HasValue ? $"{component.SourceType}:{number.Value}" : component.SourceType,
+            SourceComponentIndex = component.SourceComponentIndex >= 0 ? component.SourceComponentIndex : null,
+            LampElementIndex = lampElement?.SourceElementIndex >= 0 ? lampElement.SourceElementIndex : null,
+            SharedLampSetId = sharedLampSetId,
+            SharedLampSetCount = sharedLampSetCount
+        };
     }
 
     private static PanelElementImportSourceModel CreateImportSource(string reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -35,6 +35,10 @@ internal sealed class PanelElementModel
     public double? BandOffset { get; init; }
     public bool IsLocked { get; init; }
     public bool IsVisible { get; init; } = true;
+    public int? SourceComponentIndex { get; init; }
+    public int? SourceElementIndex { get; init; }
+    public string? SharedSourceSetId { get; init; }
+    public int? SharedSourceSetCount { get; init; }
     public PanelElementImportSourceModel? ImportSource { get; init; }
 }
 
@@ -42,8 +46,4 @@ internal sealed class PanelElementImportSourceModel
 {
     public string Format { get; init; } = string.Empty;
     public string? Reference { get; init; }
-    public int? SourceComponentIndex { get; init; }
-    public int? LampElementIndex { get; init; }
-    public string? SharedLampSetId { get; init; }
-    public int? SharedLampSetCount { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -42,4 +42,8 @@ internal sealed class PanelElementImportSourceModel
 {
     public string Format { get; init; } = string.Empty;
     public string? Reference { get; init; }
+    public int? SourceComponentIndex { get; init; }
+    public int? LampElementIndex { get; init; }
+    public string? SharedLampSetId { get; init; }
+    public int? SharedLampSetCount { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -350,7 +350,11 @@ internal static class Panel2DDocumentStorage
                 : new PanelElementImportSourceModel
                 {
                     Format = normalized.ImportSource.Format,
-                    Reference = normalized.ImportSource.Reference
+                    Reference = normalized.ImportSource.Reference,
+                    SourceComponentIndex = normalized.ImportSource.SourceComponentIndex,
+                    LampElementIndex = normalized.ImportSource.LampElementIndex,
+                    SharedLampSetId = normalized.ImportSource.SharedLampSetId,
+                    SharedLampSetCount = normalized.ImportSource.SharedLampSetCount
                 }
         };
     }
@@ -362,7 +366,11 @@ internal static class Panel2DDocumentStorage
             : new PanelElementImportSourceFile
             {
                 Format = element.ImportSource.Format,
-                Reference = element.ImportSource.Reference
+                Reference = element.ImportSource.Reference,
+                SourceComponentIndex = element.ImportSource.SourceComponentIndex,
+                LampElementIndex = element.ImportSource.LampElementIndex,
+                SharedLampSetId = element.ImportSource.SharedLampSetId,
+                SharedLampSetCount = element.ImportSource.SharedLampSetCount
             };
 
         return NormalizeElement(new PanelElementFile
@@ -637,7 +645,11 @@ internal static class Panel2DDocumentStorage
         return new PanelElementImportSourceFile
         {
             Format = format ?? string.Empty,
-            Reference = reference
+            Reference = reference,
+            SourceComponentIndex = importSource.SourceComponentIndex,
+            LampElementIndex = importSource.LampElementIndex,
+            SharedLampSetId = NormalizeOptionalString(importSource.SharedLampSetId),
+            SharedLampSetCount = importSource.SharedLampSetCount
         };
     }
 
@@ -820,4 +832,8 @@ internal sealed record PanelElementImportSourceFile
 {
     public string Format { get; init; } = string.Empty;
     public string? Reference { get; init; }
+    public int? SourceComponentIndex { get; init; }
+    public int? LampElementIndex { get; init; }
+    public string? SharedLampSetId { get; init; }
+    public int? SharedLampSetCount { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -345,16 +345,16 @@ internal static class Panel2DDocumentStorage
             BandOffset = normalized.BandOffset,
             IsLocked = normalized.IsLocked,
             IsVisible = normalized.IsVisible ?? true,
+            SourceComponentIndex = normalized.SourceComponentIndex,
+            SourceElementIndex = normalized.SourceElementIndex,
+            SharedSourceSetId = normalized.SharedSourceSetId,
+            SharedSourceSetCount = normalized.SharedSourceSetCount,
             ImportSource = normalized.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel
                 {
                     Format = normalized.ImportSource.Format,
-                    Reference = normalized.ImportSource.Reference,
-                    SourceComponentIndex = normalized.ImportSource.SourceComponentIndex,
-                    LampElementIndex = normalized.ImportSource.LampElementIndex,
-                    SharedLampSetId = normalized.ImportSource.SharedLampSetId,
-                    SharedLampSetCount = normalized.ImportSource.SharedLampSetCount
+                    Reference = normalized.ImportSource.Reference
                 }
         };
     }
@@ -366,11 +366,7 @@ internal static class Panel2DDocumentStorage
             : new PanelElementImportSourceFile
             {
                 Format = element.ImportSource.Format,
-                Reference = element.ImportSource.Reference,
-                SourceComponentIndex = element.ImportSource.SourceComponentIndex,
-                LampElementIndex = element.ImportSource.LampElementIndex,
-                SharedLampSetId = element.ImportSource.SharedLampSetId,
-                SharedLampSetCount = element.ImportSource.SharedLampSetCount
+                Reference = element.ImportSource.Reference
             };
 
         return NormalizeElement(new PanelElementFile
@@ -401,6 +397,10 @@ internal static class Panel2DDocumentStorage
             BandOffset = element.BandOffset,
             IsLocked = element.IsLocked,
             IsVisible = element.IsVisible,
+            SourceComponentIndex = element.SourceComponentIndex,
+            SourceElementIndex = element.SourceElementIndex,
+            SharedSourceSetId = element.SharedSourceSetId,
+            SharedSourceSetCount = element.SharedSourceSetCount,
             ImportSource = importSource,
             Native = CreateNativeFromLegacyFields(
                 assetPath: element.AssetPath,
@@ -476,6 +476,10 @@ internal static class Panel2DDocumentStorage
         var normalizedBandOffset = normalizedNative?.BandOffset ?? element.BandOffset;
         var normalizedIsLocked = element.IsLocked;
         var normalizedIsVisible = element.IsVisible ?? true;
+        var normalizedSourceComponentIndex = element.SourceComponentIndex;
+        var normalizedSourceElementIndex = element.SourceElementIndex;
+        var normalizedSharedSourceSetId = NormalizeOptionalString(element.SharedSourceSetId);
+        var normalizedSharedSourceSetCount = element.SharedSourceSetCount;
 
         var mergedNative = normalizedNative is null
             ? CreateNativeFromLegacyFields(
@@ -541,6 +545,10 @@ internal static class Panel2DDocumentStorage
             BandOffset = normalizedBandOffset,
             IsLocked = normalizedIsLocked,
             IsVisible = normalizedIsVisible,
+            SourceComponentIndex = normalizedSourceComponentIndex,
+            SourceElementIndex = normalizedSourceElementIndex,
+            SharedSourceSetId = normalizedSharedSourceSetId,
+            SharedSourceSetCount = normalizedSharedSourceSetCount,
             ImportSource = normalizedImportSource,
             Native = mergedNative
         };
@@ -645,11 +653,7 @@ internal static class Panel2DDocumentStorage
         return new PanelElementImportSourceFile
         {
             Format = format ?? string.Empty,
-            Reference = reference,
-            SourceComponentIndex = importSource.SourceComponentIndex,
-            LampElementIndex = importSource.LampElementIndex,
-            SharedLampSetId = NormalizeOptionalString(importSource.SharedLampSetId),
-            SharedLampSetCount = importSource.SharedLampSetCount
+            Reference = reference
         };
     }
 
@@ -797,6 +801,10 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public double? BandOffset { get; init; }
     public bool IsLocked { get; init; }
     public bool? IsVisible { get; init; }
+    public int? SourceComponentIndex { get; init; }
+    public int? SourceElementIndex { get; init; }
+    public string? SharedSourceSetId { get; init; }
+    public int? SharedSourceSetCount { get; init; }
     public PanelElementImportSourceFile? ImportSource { get; init; }
     public PanelElementNativeFile? Native { get; init; }
 
@@ -832,8 +840,4 @@ internal sealed record PanelElementImportSourceFile
 {
     public string Format { get; init; } = string.Empty;
     public string? Reference { get; init; }
-    public int? SourceComponentIndex { get; init; }
-    public int? LampElementIndex { get; init; }
-    public string? SharedLampSetId { get; init; }
-    public int? SharedLampSetCount { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -57,7 +57,11 @@ internal static class PanelElementModelCloner
         return new PanelElementImportSourceModel
         {
             Format = source.Format,
-            Reference = source.Reference
+            Reference = source.Reference,
+            SourceComponentIndex = source.SourceComponentIndex,
+            LampElementIndex = source.LampElementIndex,
+            SharedLampSetId = source.SharedLampSetId,
+            SharedLampSetCount = source.SharedLampSetCount
         };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -43,6 +43,10 @@ internal static class PanelElementModelCloner
             BandOffset = source.BandOffset,
             IsLocked = isLocked ?? source.IsLocked,
             IsVisible = isVisible ?? source.IsVisible,
+            SourceComponentIndex = source.SourceComponentIndex,
+            SourceElementIndex = source.SourceElementIndex,
+            SharedSourceSetId = source.SharedSourceSetId,
+            SharedSourceSetCount = source.SharedSourceSetCount,
             ImportSource = CloneImportSource(source.ImportSource)
         };
     }
@@ -57,11 +61,7 @@ internal static class PanelElementModelCloner
         return new PanelElementImportSourceModel
         {
             Format = source.Format,
-            Reference = source.Reference,
-            SourceComponentIndex = source.SourceComponentIndex,
-            LampElementIndex = source.LampElementIndex,
-            SharedLampSetId = source.SharedLampSetId,
-            SharedLampSetCount = source.SharedLampSetCount
+            Reference = source.Reference
         };
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -85,16 +85,16 @@ internal static class PanelElementModelUpdater
             BandOffset = update.BandOffset.HasValue ? update.BandOffset.Value : source.BandOffset,
             IsLocked = update.IsLocked.HasValue ? update.IsLocked.Value : source.IsLocked,
             IsVisible = update.IsVisible.HasValue ? update.IsVisible.Value : source.IsVisible,
+            SourceComponentIndex = source.SourceComponentIndex,
+            SourceElementIndex = source.SourceElementIndex,
+            SharedSourceSetId = source.SharedSourceSetId,
+            SharedSourceSetCount = source.SharedSourceSetCount,
             ImportSource = source.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel
                 {
                     Format = source.ImportSource.Format,
-                    Reference = source.ImportSource.Reference,
-                    SourceComponentIndex = source.ImportSource.SourceComponentIndex,
-                    LampElementIndex = source.ImportSource.LampElementIndex,
-                    SharedLampSetId = source.ImportSource.SharedLampSetId,
-                    SharedLampSetCount = source.ImportSource.SharedLampSetCount
+                    Reference = source.ImportSource.Reference
                 }
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -90,7 +90,11 @@ internal static class PanelElementModelUpdater
                 : new PanelElementImportSourceModel
                 {
                     Format = source.ImportSource.Format,
-                    Reference = source.ImportSource.Reference
+                    Reference = source.ImportSource.Reference,
+                    SourceComponentIndex = source.ImportSource.SourceComponentIndex,
+                    LampElementIndex = source.ImportSource.LampElementIndex,
+                    SharedLampSetId = source.ImportSource.SharedLampSetId,
+                    SharedLampSetCount = source.ImportSource.SharedLampSetCount
                 }
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -61,6 +61,10 @@ internal static class PanelElementModelComparer
                && left.BandOffset == right.BandOffset
                && left.IsLocked == right.IsLocked
                && left.IsVisible == right.IsVisible
+               && left.SourceComponentIndex == right.SourceComponentIndex
+               && left.SourceElementIndex == right.SourceElementIndex
+               && string.Equals(left.SharedSourceSetId, right.SharedSourceSetId, StringComparison.Ordinal)
+               && left.SharedSourceSetCount == right.SharedSourceSetCount
                && AreEquivalent(left.ImportSource, right.ImportSource);
     }
 
@@ -72,10 +76,6 @@ internal static class PanelElementModelComparer
         }
 
         return string.Equals(left.Format, right.Format, StringComparison.Ordinal)
-               && string.Equals(left.Reference, right.Reference, StringComparison.Ordinal)
-               && left.SourceComponentIndex == right.SourceComponentIndex
-               && left.LampElementIndex == right.LampElementIndex
-               && string.Equals(left.SharedLampSetId, right.SharedLampSetId, StringComparison.Ordinal)
-               && left.SharedLampSetCount == right.SharedLampSetCount;
+               && string.Equals(left.Reference, right.Reference, StringComparison.Ordinal);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -72,6 +72,10 @@ internal static class PanelElementModelComparer
         }
 
         return string.Equals(left.Format, right.Format, StringComparison.Ordinal)
-               && string.Equals(left.Reference, right.Reference, StringComparison.Ordinal);
+               && string.Equals(left.Reference, right.Reference, StringComparison.Ordinal)
+               && left.SourceComponentIndex == right.SourceComponentIndex
+               && left.LampElementIndex == right.LampElementIndex
+               && string.Equals(left.SharedLampSetId, right.SharedLampSetId, StringComparison.Ordinal)
+               && left.SharedLampSetCount == right.SharedLampSetCount;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
@@ -591,6 +592,22 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference ?? string.Empty));
+            if (selectedElement.ImportSource.SourceComponentIndex.HasValue)
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Component Index", "Metadata", selectedElement.ImportSource.SourceComponentIndex.Value.ToString(CultureInfo.InvariantCulture)));
+            }
+            if (selectedElement.ImportSource.LampElementIndex.HasValue)
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Lamp Element Index", "Metadata", selectedElement.ImportSource.LampElementIndex.Value.ToString(CultureInfo.InvariantCulture)));
+            }
+            if (!string.IsNullOrWhiteSpace(selectedElement.ImportSource.SharedLampSetId))
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Lamp Set", "Metadata", selectedElement.ImportSource.SharedLampSetId));
+            }
+            if (selectedElement.ImportSource.SharedLampSetCount.HasValue)
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Lamp Count", "Metadata", selectedElement.ImportSource.SharedLampSetCount.Value.ToString(CultureInfo.InvariantCulture)));
+            }
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -592,21 +592,21 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         {
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Format", "Metadata", selectedElement.ImportSource.Format));
             _propertyRows.Add(new InspectorInfoPropertyViewModel("Import Reference", "Metadata", selectedElement.ImportSource.Reference ?? string.Empty));
-            if (selectedElement.ImportSource.SourceComponentIndex.HasValue)
+            if (selectedElement.SourceComponentIndex.HasValue)
             {
-                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Component Index", "Metadata", selectedElement.ImportSource.SourceComponentIndex.Value.ToString(CultureInfo.InvariantCulture)));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Component Index", "Metadata", selectedElement.SourceComponentIndex.Value.ToString(CultureInfo.InvariantCulture)));
             }
-            if (selectedElement.ImportSource.LampElementIndex.HasValue)
+            if (selectedElement.SourceElementIndex.HasValue)
             {
-                _propertyRows.Add(new InspectorInfoPropertyViewModel("Lamp Element Index", "Metadata", selectedElement.ImportSource.LampElementIndex.Value.ToString(CultureInfo.InvariantCulture)));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Source Element Index", "Metadata", selectedElement.SourceElementIndex.Value.ToString(CultureInfo.InvariantCulture)));
             }
-            if (!string.IsNullOrWhiteSpace(selectedElement.ImportSource.SharedLampSetId))
+            if (!string.IsNullOrWhiteSpace(selectedElement.SharedSourceSetId))
             {
-                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Lamp Set", "Metadata", selectedElement.ImportSource.SharedLampSetId));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Source Set", "Metadata", selectedElement.SharedSourceSetId));
             }
-            if (selectedElement.ImportSource.SharedLampSetCount.HasValue)
+            if (selectedElement.SharedSourceSetCount.HasValue)
             {
-                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Lamp Count", "Metadata", selectedElement.ImportSource.SharedLampSetCount.Value.ToString(CultureInfo.InvariantCulture)));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Shared Source Count", "Metadata", selectedElement.SharedSourceSetCount.Value.ToString(CultureInfo.InvariantCulture)));
             }
         }
     }


### PR DESCRIPTION
### Motivation
- MFME `ExtractComponentLamp` can include multiple `LampElements` that represent independent lamps in the same component, but the parser formerly used `ReadFirstLampElement` and imported only the first entry. 
- Missing lamp elements caused panel imports to drop lamps (e.g. jackpot values) and lose provenance needed for later tray/ emitter workflows. 
- The change must import all valid lamp elements while preserving shared-set provenance and avoiding importing empty placeholder entries.

### Description
- Replace first-only parsing with `ReadValidLampElements(...)` that enumerates `LampElements`, filters out placeholders, preserves source `LampElements` index, and returns all valid entries. 
- Extend `MfmeLegacyLampElement` with `SourceElementIndex` and `HasUsefulIdentityOrImage` and allow lamp/button component DTOs to carry the full `LampElements` list and `SourceComponentIndex`. 
- Fan out MFME lamp components into multiple Panel2D lamp elements in `MfmeToOasisComponentMapper` by adding `MapLamps(...)` which creates one `PanelElementModel` per valid `LampElement` while keeping the component bounds and per-element number/image/mask. 
- Preserve shared-set provenance by encoding `componentIndex`, `lampElementIndex`, `sharedLampSetId`, and `sharedLampSetCount` into the `ImportSource.Reference` for each imported lamp. 
- Update missing-image warnings to iterate valid lamp elements instead of only the first element. 
- Add unit tests that cover parsing multiple `LampElements`, ignoring placeholders, importing multiple Panel2D lamps with shared bounds, and preservation of provenance metadata.

### Testing
- Added tests: `MfmeExtractReaderTests.Read_WithMultipleLampElements_KeepsAllValidAndIgnoresPlaceholders` and `MfmeToOasisComponentMapperTests.Map_WithMultipleValidLampElements_CreatesIndependentSharedBoundsLamps`. 
- Verified repository formatting/patch checks with `git diff --check` which reported no issues. 
- Did not run `dotnet test` or full CI locally per repository guidance and environment constraints, so unit tests were not executed here and should be run locally/CI by the maintainer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d23c0060c83278bde257cde48d444)