### PR TITLE
Conservative polygonal tray derivation (Phase 4F): deterministic clipping, octagons, and diagnostics

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -155,6 +155,46 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights_debug.png", persisted.RuntimeRenderAssets.LampWeightsDebugPath);
     }
 
+
+    [Fact]
+    public void Generate_UsesDerivedAuthoredPolygonVerticesForTrayAndLampTextures()
+    {
+        var outputDirectory = Path.Combine(_generatedDirectory, "derived-polygon-texture-test");
+        var document = new FaceDocumentModel
+        {
+            Trays =
+            [
+                new FaceTrayModel
+                {
+                    ObjectId = "triangle-tray",
+                    Bounds = new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
+                    Vertices =
+                    [
+                        new FacePointModel { X = 0, Y = 0 },
+                        new FacePointModel { X = 4, Y = 0 },
+                        new FacePointModel { X = 0, Y = 4 }
+                    ]
+                }
+            ],
+            LampEmitters =
+            [
+                new FaceLampEmitterElement { ObjectId = "triangle-emitter", TrayObjectId = "triangle-tray", TrayId = 1, LampId = 24 }
+            ]
+        };
+
+        new FaceRuntimeTextureGenerator().Generate(document, 4, 4, outputDirectory);
+
+        using var trayId = SKBitmap.Decode(Path.Combine(outputDirectory, "trayId.png"));
+        using var lampIds0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampIds0.png"));
+        using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
+        Assert.Equal(1, trayId.GetPixel(0, 0).Red);
+        Assert.Equal(24, lampIds0.GetPixel(0, 0).Red);
+        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Red);
+        Assert.Equal(0, trayId.GetPixel(3, 3).Red);
+        Assert.Equal(0, lampIds0.GetPixel(3, 3).Red);
+        Assert.Equal(0, lampWeights0.GetPixel(3, 3).Red);
+    }
+
     [Fact]
     public void Export_WithMissingArtworkAsset_ThrowsFileNotFoundException()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
@@ -181,6 +181,66 @@ public sealed class FaceTrayAutoAuthoringTests
         Assert.Equal(2, drawCount);
     }
 
+
+    [Fact]
+    public void AutoAuthor_ClipsPartialOverlapsDeterministically()
+    {
+        var document = CreateFaceWithLampWindows(
+            ("left", 1, 0d, 0d, 10d, 10d),
+            ("right", 2, 8d, 0d, 10d, 10d));
+
+        var first = new FaceTrayAutoAuthoringService().AutoAuthor(document);
+        var second = new FaceTrayAutoAuthoringService().AutoAuthor(document);
+
+        Assert.All(first.Trays, tray => Assert.Contains("partial-overlap-clipped", tray.Diagnostics));
+        Assert.Equal(first.Trays.SelectMany(t => t.Vertices.Select(v => (v.X, v.Y))), second.Trays.SelectMany(t => t.Vertices.Select(v => (v.X, v.Y))));
+        Assert.Contains(first.Trays, tray => tray.Vertices.Any(vertex => Math.Abs(vertex.X - 9d) < 0.001d));
+    }
+
+    [Fact]
+    public void AutoAuthor_DerivesOctagonForRoundishIsolatedLamp()
+    {
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampWindows(("round", 4, 0d, 0d, 20d, 20d)));
+
+        var tray = Assert.Single(result.Trays);
+        Assert.Equal(8, tray.Vertices.Count);
+        Assert.Contains("isolated-roundish-octagon", tray.Diagnostics);
+    }
+
+    [Fact]
+    public void AutoAuthor_AddsContainmentDiagnosticWithoutMerging()
+    {
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampWindows(
+            ("large", 5, 0d, 0d, 40d, 40d),
+            ("small", 6, 10d, 10d, 10d, 10d)));
+
+        Assert.Equal(2, result.Trays.Count);
+        Assert.All(result.Trays, tray => Assert.Contains("contained-tray-candidate", tray.Diagnostics));
+    }
+
+    [Fact]
+    public void AutoAuthor_AddsSharedTrayDiagnosticWithoutMerging()
+    {
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampWindows(
+            ("first", 7, 0d, 0d, 20d, 20d),
+            ("second", 8, 2d, 2d, 20d, 20d)));
+
+        Assert.Equal(2, result.Trays.Count);
+        Assert.All(result.Trays, tray => Assert.Contains("possible-shared-tray-candidate", tray.Diagnostics));
+    }
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsTrayDiagnostics()
+    {
+        var authored = new FaceTrayAutoAuthoringService().AutoAuthor(CreateFaceWithLampWindows(("round", 9, 0d, 0d, 20d, 20d)));
+        var json = FaceDocumentStorage.Serialize(new FaceDocumentModel { Trays = authored.Trays, LampEmitters = authored.Emitters });
+
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var model = FaceDocumentStorage.ToModel(file);
+
+        Assert.Contains("isolated-roundish-octagon", Assert.Single(model.Trays).Diagnostics);
+    }
+
     private static FaceDocumentModel CreateFaceWithLampAndContribution()
     {
         return new FaceDocumentModel
@@ -216,6 +276,31 @@ public sealed class FaceTrayAutoAuthoringTests
             ]
         };
     }
+    private static FaceDocumentModel CreateFaceWithLampWindows(params (string Id, int LampId, double X, double Y, double Width, double Height)[] lamps)
+    {
+        return new FaceDocumentModel
+        {
+            GenerationSettings = new FaceGenerationSettingsModel
+            {
+                TrayBoundsInflationPercent = 0,
+                TrayBoundsPaddingPixels = 0,
+                ClampTrayBoundsToLampWindow = false
+            },
+            Elements = lamps.Select(lamp => new FaceLampWindowElement
+            {
+                ObjectId = $"face-{lamp.Id}",
+                Name = lamp.Id,
+                X = lamp.X,
+                Y = lamp.Y,
+                Width = lamp.Width,
+                Height = lamp.Height,
+                IsVisible = true,
+                LinkedMachineObjectReference = MachineObjectReference.Lamp(lamp.LampId),
+                LinkedPanel2DElementId = $"panel-{lamp.Id}"
+            }).ToArray()
+        };
+    }
+
 }
 
 internal static class FaceTrayAutoAuthoringTestExtensions

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -96,6 +96,7 @@ public sealed class FaceTrayModel
     public MachineObjectReference? LinkedMachineObjectReference { get; init; }
     public FaceSourceRegionModel? Bounds { get; init; }
     public IReadOnlyList<FacePointModel> Vertices { get; init; } = [];
+    public IReadOnlyList<string> Diagnostics { get; init; } = [];
 }
 
 public sealed class FacePointModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -381,7 +381,8 @@ public static class FaceDocumentStorage
             SourcePanel2DElementId = file.SourcePanel2DElementId,
             LinkedMachineObjectReference = reference,
             Bounds = ToModel(file.Bounds),
-            Vertices = (file.Vertices ?? []).Select(ToModel).ToArray()
+            Vertices = (file.Vertices ?? []).Select(ToModel).ToArray(),
+            Diagnostics = (file.Diagnostics ?? []).Where(diagnostic => !string.IsNullOrWhiteSpace(diagnostic)).Select(diagnostic => diagnostic.Trim()).ToArray()
         };
     }
 
@@ -397,7 +398,8 @@ public static class FaceDocumentStorage
             SourcePanel2DElementId = model.SourcePanel2DElementId,
             LinkedMachineObjectReference = model.LinkedMachineObjectReference?.ToString(),
             Bounds = ToFile(model.Bounds),
-            Vertices = model.Vertices.Select(ToFile).ToArray()
+            Vertices = model.Vertices.Select(ToFile).ToArray(),
+            Diagnostics = model.Diagnostics.ToArray()
         };
     }
 
@@ -808,6 +810,7 @@ public sealed record FaceTrayFile
     public string? LinkedMachineObjectReference { get; init; }
     public FaceSourceRegionFile? Bounds { get; init; }
     public IReadOnlyList<FacePointFile>? Vertices { get; init; } = [];
+    public IReadOnlyList<string>? Diagnostics { get; init; } = [];
 }
 
 public sealed record FaceLampEmitterFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
@@ -72,7 +72,7 @@ internal sealed class FaceTrayAutoAuthoringService
             });
         }
 
-        return new FaceTrayAutoAuthoringResult(trays, emitters);
+        return new FaceTrayAutoAuthoringResult(DeriveTrayPolygons(trays), emitters);
     }
 
     public IReadOnlyList<FaceValidationDiagnostic> Validate(FaceDocumentModel faceDocument)
@@ -143,6 +143,205 @@ internal sealed class FaceTrayAutoAuthoringService
         }
 
         return diagnostics;
+    }
+
+    private static IReadOnlyList<FaceTrayModel> DeriveTrayPolygons(IReadOnlyList<FaceTrayModel> sourceTrays)
+    {
+        var working = sourceTrays
+            .Select(tray => new TrayPolygonWorkItem(tray, tray.Bounds is { IsValid: true } bounds ? CreateRectangleVertices(bounds).ToList() : tray.Vertices.ToList(), []))
+            .ToArray();
+
+        for (var leftIndex = 0; leftIndex < working.Length; leftIndex++)
+        {
+            for (var rightIndex = leftIndex + 1; rightIndex < working.Length; rightIndex++)
+            {
+                var left = working[leftIndex];
+                var right = working[rightIndex];
+                if (left.Tray.Bounds is not { IsValid: true } leftBounds || right.Tray.Bounds is not { IsValid: true } rightBounds)
+                {
+                    continue;
+                }
+
+                var leftRect = leftBounds.ToRect();
+                var rightRect = rightBounds.ToRect();
+                var overlap = Rect.Intersect(leftRect, rightRect);
+                if (overlap.IsEmpty || overlap.Width <= 0d || overlap.Height <= 0d)
+                {
+                    continue;
+                }
+
+                var smallerArea = Math.Min(leftRect.Width * leftRect.Height, rightRect.Width * rightRect.Height);
+                var largerArea = Math.Max(leftRect.Width * leftRect.Height, rightRect.Width * rightRect.Height);
+                var overlapArea = overlap.Width * overlap.Height;
+                if (smallerArea <= 0d)
+                {
+                    continue;
+                }
+
+                if (overlapArea / smallerArea >= 0.82d && largerArea / smallerArea >= 1.35d)
+                {
+                    left.Diagnostics.Add("contained-tray-candidate");
+                    right.Diagnostics.Add("contained-tray-candidate");
+                    continue;
+                }
+
+                if (overlapArea / smallerArea >= 0.65d)
+                {
+                    left.Diagnostics.Add("possible-shared-tray-candidate");
+                    right.Diagnostics.Add("possible-shared-tray-candidate");
+                    continue;
+                }
+
+                var leftCenter = Center(leftRect);
+                var rightCenter = Center(rightRect);
+                left.Vertices = ClipToNearestSide(left.Vertices, leftCenter, rightCenter);
+                right.Vertices = ClipToNearestSide(right.Vertices, rightCenter, leftCenter);
+                left.Diagnostics.Add("partial-overlap-clipped");
+                right.Diagnostics.Add("partial-overlap-clipped");
+            }
+        }
+
+        return working.Select(item =>
+        {
+            var vertices = item.Vertices.Count >= 3 ? RoundVertices(item.Vertices) : item.Tray.Vertices;
+            if (item.Diagnostics.Count == 0 && string.Equals(item.Tray.AutoAuthoringSource, "lampWindowBounds", StringComparison.Ordinal) && IsRoundishIsolated(item.Tray, sourceTrays))
+            {
+                vertices = CreateOctagonVertices(item.Tray.Bounds!);
+                item.Diagnostics.Add("isolated-roundish-octagon");
+            }
+
+            return new FaceTrayModel
+            {
+                ObjectId = item.Tray.ObjectId,
+                Name = item.Tray.Name,
+                IsAutoAuthored = item.Tray.IsAutoAuthored,
+                AutoAuthoringSource = item.Tray.AutoAuthoringSource,
+                SourceLampWindowObjectId = item.Tray.SourceLampWindowObjectId,
+                SourcePanel2DElementId = item.Tray.SourcePanel2DElementId,
+                LinkedMachineObjectReference = item.Tray.LinkedMachineObjectReference,
+                Bounds = item.Tray.Bounds,
+                Vertices = vertices,
+                Diagnostics = item.Diagnostics.Distinct(StringComparer.Ordinal).OrderBy(diagnostic => diagnostic, StringComparer.Ordinal).ToArray()
+            };
+        }).ToArray();
+    }
+
+    private static List<FacePointModel> ClipToNearestSide(IReadOnlyList<FacePointModel> polygon, Point ownCenter, Point otherCenter)
+    {
+        if (polygon.Count < 3)
+        {
+            return polygon.ToList();
+        }
+
+        var midpoint = new Point((ownCenter.X + otherCenter.X) / 2d, (ownCenter.Y + otherCenter.Y) / 2d);
+        var dx = otherCenter.X - ownCenter.X;
+        var dy = otherCenter.Y - ownCenter.Y;
+        var input = polygon.ToList();
+        var output = new List<FacePointModel>();
+        for (var index = 0; index < input.Count; index++)
+        {
+            var current = input[index];
+            var previous = input[(index + input.Count - 1) % input.Count];
+            var currentInside = IsOwnSide(current, midpoint, dx, dy);
+            var previousInside = IsOwnSide(previous, midpoint, dx, dy);
+            if (currentInside != previousInside)
+            {
+                output.Add(IntersectBisector(previous, current, midpoint, dx, dy));
+            }
+
+            if (currentInside)
+            {
+                output.Add(current);
+            }
+        }
+
+        return output.Count >= 3 ? output : polygon.ToList();
+    }
+
+    private static bool IsOwnSide(FacePointModel point, Point midpoint, double dx, double dy)
+    {
+        return ((point.X - midpoint.X) * dx) + ((point.Y - midpoint.Y) * dy) <= 0.0001d;
+    }
+
+    private static FacePointModel IntersectBisector(FacePointModel start, FacePointModel end, Point midpoint, double dx, double dy)
+    {
+        var sx = start.X - midpoint.X;
+        var sy = start.Y - midpoint.Y;
+        var ex = end.X - start.X;
+        var ey = end.Y - start.Y;
+        var denominator = (ex * dx) + (ey * dy);
+        var t = Math.Abs(denominator) <= double.Epsilon ? 0d : -(((sx * dx) + (sy * dy)) / denominator);
+        t = Math.Clamp(t, 0d, 1d);
+        return new FacePointModel { X = start.X + (ex * t), Y = start.Y + (ey * t) };
+    }
+
+    private static Point Center(Rect rect) => new(rect.X + (rect.Width / 2d), rect.Y + (rect.Height / 2d));
+
+    private static IReadOnlyList<FacePointModel> RoundVertices(IReadOnlyList<FacePointModel> vertices)
+    {
+        return vertices.Select(vertex => new FacePointModel { X = Math.Round(vertex.X, 2), Y = Math.Round(vertex.Y, 2) }).ToArray();
+    }
+
+    private static bool IsRoundishIsolated(FaceTrayModel tray, IReadOnlyList<FaceTrayModel> trays)
+    {
+        if (tray.Bounds is not { IsValid: true } validBounds || validBounds.Width <= 0d || validBounds.Height <= 0d)
+        {
+            return false;
+        }
+
+        var aspect = validBounds.Width / validBounds.Height;
+        if (aspect < 0.9d || aspect > 1.1d)
+        {
+            return false;
+        }
+
+        var rect = validBounds.ToRect();
+        return !trays.Any(otherTray => HasPositiveIntersection(tray, otherTray, rect));
+    }
+
+    private static bool HasPositiveIntersection(FaceTrayModel tray, FaceTrayModel otherTray, Rect rect)
+    {
+        if (string.Equals(otherTray.ObjectId, tray.ObjectId, StringComparison.Ordinal) || otherTray.Bounds is not { IsValid: true } other)
+        {
+            return false;
+        }
+
+        var intersection = Rect.Intersect(rect, other.ToRect());
+        return !intersection.IsEmpty && intersection.Width > 0d && intersection.Height > 0d;
+    }
+
+    private static IReadOnlyList<FacePointModel> CreateOctagonVertices(FaceSourceRegionModel bounds)
+    {
+        var left = bounds.X;
+        var top = bounds.Y;
+        var right = bounds.X + bounds.Width;
+        var bottom = bounds.Y + bounds.Height;
+        var insetX = bounds.Width * 0.2929d;
+        var insetY = bounds.Height * 0.2929d;
+        return RoundVertices([
+            new FacePointModel { X = left + insetX, Y = top },
+            new FacePointModel { X = right - insetX, Y = top },
+            new FacePointModel { X = right, Y = top + insetY },
+            new FacePointModel { X = right, Y = bottom - insetY },
+            new FacePointModel { X = right - insetX, Y = bottom },
+            new FacePointModel { X = left + insetX, Y = bottom },
+            new FacePointModel { X = left, Y = bottom - insetY },
+            new FacePointModel { X = left, Y = top + insetY }
+        ]);
+    }
+
+    private sealed class TrayPolygonWorkItem
+    {
+        public TrayPolygonWorkItem(FaceTrayModel tray, List<FacePointModel> vertices, List<string> diagnostics)
+        {
+            Tray = tray;
+            Vertices = vertices;
+            Diagnostics = diagnostics;
+        }
+
+        public FaceTrayModel Tray { get; }
+        public List<FacePointModel> Vertices { get; set; }
+        public List<string> Diagnostics { get; }
     }
 
     private static void AddDuplicateDiagnostics(IEnumerable<string> ids, string code, string noun, List<FaceValidationDiagnostic> diagnostics)


### PR DESCRIPTION
### Motivation

- Reduce obvious rectangular overlap artifacts in authored tray overlays and the CPU preview by deriving conservative polygonal tray shapes from the existing rectangular bounds while preserving deterministic behaviour. 
- Treat partial overlaps and feature-trail corners conservatively without automatically merging or altering authored tray records. 
- Surface containment and shared-tray candidates as diagnostics to inform later manual/shared-tray workflows rather than performing destructive merges.

### Description

- Added a post-processing polygon derivation stage `DeriveTrayPolygons` that runs after existing rectangular tray bounds generation and produces `Vertices` for trained authored trays while leaving `Bounds` as the rectangular fallback. 
- Implemented deterministic partial-overlap handling using a conservative half-plane split between tray centers (`ClipToNearestSide`), containment and possible-shared-tray heuristics, and a small-behaviour octagon generator for isolated round-ish trays (`CreateOctagonVertices`). 
- Persisted per-tray diagnostic metadata via `FaceTrayModel.Diagnostics` and extended `FaceDocumentStorage` to read/write `Diagnostics` in the `.face` file format. 
- Kept export compatibility: runtime texture generation already consumes `Vertices` when present, so authored polygons are used for `trayId.png`, `lampIds0.png`, and `lampWeights0.png` with no runtime format change. 
- Added unit tests covering deterministic clipping, octagon derivation for isolated lamps, containment/shared-tray diagnostics, diagnostic round-trip persistence, and a runtime texture test that verifies authored polygon vertices affect the generated textures. 

Files changed (key):
- `WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs` (derive polygons, clipping, diagnostics)
- `WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs` (added `Diagnostics` to `FaceTrayModel`)
- `WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs` (persist tray diagnostics)
- `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs` (new tests for clipping, octagon, diagnostics)
- `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs` (test verifying export uses authored polygons)

### Testing

- No `.NET` unit tests were executed in this Codex environment per `AGENTS.md` constraints; the change includes new tests that must be run locally by the developer. 
- Added tests: `AutoAuthor_ClipsPartialOverlapsDeterministically`, `AutoAuthor_DerivesOctagonForRoundishIsolatedLamp`, `AutoAuthor_AddsContainmentDiagnosticWithoutMerging`, `AutoAuthor_AddsSharedTrayDiagnosticWithoutMerging`, `Serialize_AndRead_RoundTripsTrayDiagnostics`, and `Generate_UsesDerivedAuthoredPolygonVerticesForTrayAndLampTextures` (all located with existing Face tests). 
- Recommend running `dotnet test` for the `OasisEditor.Tests` project locally and exercising end-to-end flows: `Generate/Regenerate Face` overlays, save/reopen `.face`, `FaceRuntimeExportService.Export`, and CPU preview to confirm visual improvements and diagnostic propagation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d2ba1db3c83278ec061ab9ebd976c)