### PR TITLE
MFME bulb-mask emitter placement (Phase 4F)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceBulbMaskEmitterPlacementTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceBulbMaskEmitterPlacementTests.cs
@@ -1,0 +1,119 @@
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceBulbMaskEmitterPlacementTests
+{
+    [Fact]
+    public void Analyze_UsesAlphaWeightedLuminanceCentroid()
+    {
+        using var bitmap = new SKBitmap(10, 10, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(SKColors.Transparent);
+        bitmap.SetPixel(7, 3, new SKColor(255, 255, 255, 255));
+
+        var result = FaceBulbMaskCentroidAnalyzer.Analyze(bitmap);
+
+        Assert.NotNull(result);
+        Assert.Equal(0.75d, result!.NormalizedX, 2);
+        Assert.Equal(0.35d, result.NormalizedY, 2);
+        Assert.True(result.NormalizedRadius > 0d);
+    }
+
+    [Fact]
+    public void AutoAuthor_MapsBlendMaskCentroidIntoLampWindowCoordinates()
+    {
+        using var temp = new TemporaryDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.Path, "lamps"));
+        var maskPath = Path.Combine(temp.Path, "lamps", "mask.png");
+        WriteMask(maskPath, 10, 10, (7, 3));
+
+        var document = CreateFaceLamp(sourceBlend: true, bulbMaskAssetPath: "lamps/mask.png");
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(document, temp.Path);
+
+        var emitter = Assert.Single(result.Emitters);
+        Assert.Equal("MfmeBulbMaskCentroid", emitter.EmitterPlacementSource);
+        Assert.Equal(175d, emitter.CenterX, 1);
+        Assert.Equal(70d, emitter.CenterY, 1);
+        Assert.NotNull(emitter.Radius);
+    }
+
+    [Fact]
+    public void AutoAuthor_FallsBackWhenBlendIsFalse()
+    {
+        var document = CreateFaceLamp(sourceBlend: false, bulbMaskAssetPath: "lamps/mask.png");
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(document, projectDirectory: null);
+
+        var emitter = Assert.Single(result.Emitters);
+        Assert.Equal("ComponentCentreFallback", emitter.EmitterPlacementSource);
+        Assert.Equal(150d, emitter.CenterX, 1);
+        Assert.Equal(100d, emitter.CenterY, 1);
+        Assert.Empty(emitter.Diagnostics);
+    }
+
+    [Fact]
+    public void AutoAuthor_AddsDiagnosticsWhenBlendMaskMissing()
+    {
+        var document = CreateFaceLamp(sourceBlend: true, bulbMaskAssetPath: "lamps/missing.png");
+        var result = new FaceTrayAutoAuthoringService().AutoAuthor(document, projectDirectory: "/missing-project");
+
+        var emitter = Assert.Single(result.Emitters);
+        Assert.Equal("ComponentCentreFallback", emitter.EmitterPlacementSource);
+        Assert.Contains("bulb-mask-file-missing", emitter.Diagnostics);
+        Assert.Contains("centroid-fallback-used", emitter.Diagnostics);
+    }
+
+    private static FaceDocumentModel CreateFaceLamp(bool sourceBlend, string? bulbMaskAssetPath)
+    {
+        return new FaceDocumentModel
+        {
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "lamp-window-1",
+                    Name = "Lamp 1",
+                    X = 100,
+                    Y = 50,
+                    Width = 100,
+                    Height = 100,
+                    IsVisible = true,
+                    LinkedPanel2DElementId = "panel-lamp-1",
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(1),
+                    SourceBlend = sourceBlend,
+                    BulbMaskAssetPath = bulbMaskAssetPath
+                }
+            ]
+        };
+    }
+
+    private static void WriteMask(string path, int width, int height, (int X, int Y) brightPixel)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(SKColors.Transparent);
+        bitmap.SetPixel(brightPixel.X, brightPixel.Y, new SKColor(255, 255, 255, 255));
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.OpenWrite(path);
+        data.SaveTo(stream);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"oasis-mask-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceBulbMaskEmitterPlacementTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceBulbMaskEmitterPlacementTests.cs
@@ -34,7 +34,7 @@ public sealed class FaceBulbMaskEmitterPlacementTests
         var emitter = Assert.Single(result.Emitters);
         Assert.Equal("MfmeBulbMaskCentroid", emitter.EmitterPlacementSource);
         Assert.Equal(175d, emitter.CenterX, 1);
-        Assert.Equal(70d, emitter.CenterY, 1);
+        Assert.Equal(85d, emitter.CenterY, 1);
         Assert.NotNull(emitter.Radius);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceBulbMaskCentroidAnalyzer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceBulbMaskCentroidAnalyzer.cs
@@ -1,0 +1,148 @@
+using System.IO;
+using SkiaSharp;
+
+namespace OasisEditor;
+
+internal sealed record FaceBulbMaskCentroidResult(double NormalizedX, double NormalizedY, double NormalizedRadius, int MeaningfulPixelCount, string? Diagnostic);
+
+internal static class FaceBulbMaskCentroidAnalyzer
+{
+    private const double MinimumWeight = 0.0001d;
+    private const double MeaningfulWeightThreshold = 8d;
+
+    public static FaceBulbMaskCentroidResult? Analyze(SKBitmap bitmap)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        if (bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            return null;
+        }
+
+        double totalWeight = 0d;
+        double weightedX = 0d;
+        double weightedY = 0d;
+        var minX = bitmap.Width;
+        var minY = bitmap.Height;
+        var maxX = -1;
+        var maxY = -1;
+        var meaningfulPixels = 0;
+
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                var luminance = (0.2126d * pixel.Red) + (0.7152d * pixel.Green) + (0.0722d * pixel.Blue);
+                var weight = (pixel.Alpha / 255d) * luminance;
+                if (weight <= MinimumWeight)
+                {
+                    continue;
+                }
+
+                totalWeight += weight;
+                weightedX += (x + 0.5d) * weight;
+                weightedY += (y + 0.5d) * weight;
+
+                if (weight >= MeaningfulWeightThreshold)
+                {
+                    meaningfulPixels++;
+                    minX = Math.Min(minX, x);
+                    minY = Math.Min(minY, y);
+                    maxX = Math.Max(maxX, x);
+                    maxY = Math.Max(maxY, y);
+                }
+            }
+        }
+
+        if (totalWeight <= MinimumWeight || !IsFinite(totalWeight))
+        {
+            return null;
+        }
+
+        var centerX = weightedX / totalWeight;
+        var centerY = weightedY / totalWeight;
+        if (!IsFinite(centerX) || !IsFinite(centerY))
+        {
+            return null;
+        }
+
+        double radius;
+        if (meaningfulPixels > 0 && maxX >= minX && maxY >= minY)
+        {
+            radius = Math.Max((maxX - minX) + 1d, (maxY - minY) + 1d) / 2d;
+        }
+        else
+        {
+            meaningfulPixels = Math.Max(1, (int)Math.Round(totalWeight / 255d));
+            radius = Math.Sqrt(meaningfulPixels / Math.PI);
+        }
+
+        var normalizedRadius = radius / Math.Max(bitmap.Width, bitmap.Height);
+        return new FaceBulbMaskCentroidResult(
+            Math.Clamp(centerX / bitmap.Width, 0d, 1d),
+            Math.Clamp(centerY / bitmap.Height, 0d, 1d),
+            Math.Clamp(normalizedRadius, 0d, 1d),
+            meaningfulPixels,
+            null);
+    }
+
+    public static FaceBulbMaskCentroidResult? AnalyzeFile(string? assetPath, string? projectDirectory, out string? diagnostic)
+    {
+        diagnostic = null;
+        if (!TryResolveAssetPath(assetPath, projectDirectory, out var resolvedPath))
+        {
+            diagnostic = "bulb-mask-missing";
+            return null;
+        }
+
+        if (!File.Exists(resolvedPath))
+        {
+            diagnostic = "bulb-mask-file-missing";
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            diagnostic = "bulb-mask-invalid";
+            return null;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        if (bitmap is null)
+        {
+            diagnostic = "bulb-mask-invalid";
+            return null;
+        }
+
+        var result = Analyze(bitmap);
+        diagnostic = result is null ? "bulb-mask-empty" : null;
+        return result;
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, string? projectDirectory, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+        {
+            return false;
+        }
+
+        resolvedPath = Path.GetFullPath(Path.Combine(projectDirectory, candidate.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar)));
+        return true;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -147,6 +147,8 @@ public sealed class FaceArtworkProvenanceModel
 
 public sealed class FaceLampWindowElement : FaceElementModel
 {
+    public string? BulbMaskAssetPath { get; init; }
+    public bool SourceBlend { get; init; }
 }
 
 public sealed class FaceLampEmitterElement : FaceElementModel
@@ -159,6 +161,9 @@ public sealed class FaceLampEmitterElement : FaceElementModel
     public double CenterY { get; init; }
     public bool IsAutoAuthored { get; init; }
     public string? AutoAuthoringSource { get; init; }
+    public string? EmitterPlacementSource { get; init; }
+    public double? Radius { get; init; }
+    public IReadOnlyList<string> Diagnostics { get; init; } = [];
 }
 
 public sealed class FaceReelDisplayElement : FaceElementModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -430,7 +430,10 @@ public static class FaceDocumentStorage
             CenterX = file.CenterX,
             CenterY = file.CenterY,
             IsAutoAuthored = file.IsAutoAuthored,
-            AutoAuthoringSource = file.AutoAuthoringSource
+            AutoAuthoringSource = file.AutoAuthoringSource,
+            EmitterPlacementSource = file.EmitterPlacementSource,
+            Radius = file.Radius,
+            Diagnostics = (file.Diagnostics ?? []).Where(diagnostic => !string.IsNullOrWhiteSpace(diagnostic)).Select(diagnostic => diagnostic.Trim()).ToArray()
         };
     }
 
@@ -455,7 +458,10 @@ public static class FaceDocumentStorage
             CenterX = model.CenterX,
             CenterY = model.CenterY,
             IsAutoAuthored = model.IsAutoAuthored,
-            AutoAuthoringSource = model.AutoAuthoringSource
+            AutoAuthoringSource = model.AutoAuthoringSource,
+            EmitterPlacementSource = model.EmitterPlacementSource,
+            Radius = model.Radius,
+            Diagnostics = model.Diagnostics.ToArray()
         };
     }
 
@@ -632,7 +638,9 @@ public static class FaceDocumentStorage
             IsVisible = file.IsVisible,
             IsLocked = file.IsLocked,
             LinkedMachineObjectReference = reference,
-            LinkedPanel2DElementId = file.LinkedPanel2DElementId
+            LinkedPanel2DElementId = file.LinkedPanel2DElementId,
+            BulbMaskAssetPath = file.BulbMaskAssetPath,
+            SourceBlend = file.SourceBlend
         };
     }
 
@@ -709,7 +717,9 @@ public static class FaceDocumentStorage
             AssetPath = model switch { FaceArtworkElement artwork => artwork.AssetPath, FaceReelDisplayElement reel => reel.AssetPath, _ => null },
             SourcePanel2DDocumentId = model is FaceArtworkElement artworkSource ? artworkSource.SourcePanel2DDocumentId : null,
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
-            ArtworkProvenance = model is FaceArtworkElement artworkProvenance ? ToFile(artworkProvenance.Provenance) : null
+            ArtworkProvenance = model is FaceArtworkElement artworkProvenance ? ToFile(artworkProvenance.Provenance) : null,
+            BulbMaskAssetPath = model is FaceLampWindowElement lampWindow ? lampWindow.BulbMaskAssetPath : null,
+            SourceBlend = model is FaceLampWindowElement sourceLampWindow && sourceLampWindow.SourceBlend
         };
     }
 
@@ -833,6 +843,9 @@ public sealed record FaceLampEmitterFile
     public double CenterY { get; init; }
     public bool IsAutoAuthored { get; init; }
     public string? AutoAuthoringSource { get; init; }
+    public string? EmitterPlacementSource { get; init; }
+    public double? Radius { get; init; }
+    public IReadOnlyList<string>? Diagnostics { get; init; } = [];
 }
 
 public sealed record FacePointFile
@@ -885,6 +898,8 @@ public sealed record FaceElementFile
     public string? SourcePanel2DDocumentId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }
     public FaceArtworkProvenanceFile? ArtworkProvenance { get; init; }
+    public string? BulbMaskAssetPath { get; init; }
+    public bool SourceBlend { get; init; }
 }
 
 public sealed record FaceArtworkProvenanceFile

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -77,7 +77,9 @@ internal static class FaceElementModelUpdater
                 IsVisible = update.IsVisible ?? existing.IsVisible,
                 IsLocked = update.IsLocked ?? existing.IsLocked,
                 LinkedMachineObjectReference = linkedMachineObjectReference,
-                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId
+                LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
+                BulbMaskAssetPath = ((FaceLampWindowElement)existing).BulbMaskAssetPath,
+                SourceBlend = ((FaceLampWindowElement)existing).SourceBlend
             },
             FaceSevenSegmentDisplayElement sevenSegmentDisplay => new FaceSevenSegmentDisplayElement
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -125,7 +125,7 @@ internal sealed class FaceGenerationService
         var faceDocumentId = Guid.NewGuid().ToString("N");
         var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(sourcePanel, region, faceDocumentId, sourcePanel2DDocumentId, projectDirectory, generatedDirectory, settings.MaskExtractionThreshold);
         var elements = artworkElements.Cast<FaceElementModel>().Concat(lampWindows).Concat(reelDisplays).Concat(sevenSegmentDisplays).Concat(alphaDisplays).Concat(buttons).ToArray();
-        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { GenerationSettings = settings, MaskLayer = maskLayer, Elements = elements });
+        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { GenerationSettings = settings, MaskLayer = maskLayer, Elements = elements }, projectDirectory);
         var document = new FaceDocumentModel
         {
             Id = faceDocumentId,
@@ -259,7 +259,9 @@ internal sealed class FaceGenerationService
             IsVisible = sourceElement.IsVisible,
             IsLocked = sourceElement.IsLocked,
             LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
-            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            BulbMaskAssetPath = sourceElement.SecondaryAssetPath,
+            SourceBlend = sourceElement.SourceBlend
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -111,7 +111,7 @@ internal sealed class FaceRegenerationService
         }
 
         mergedElements.AddRange(preservedManualElements);
-        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { GenerationSettings = settings, MaskLayer = generated.Document.MaskLayer, Elements = mergedElements.ToArray() });
+        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { GenerationSettings = settings, MaskLayer = generated.Document.MaskLayer, Elements = mergedElements.ToArray() }, projectDirectory);
 
         var regeneratedDocument = new FaceDocumentModel
         {
@@ -257,7 +257,9 @@ internal sealed class FaceRegenerationService
                 IsVisible = lamp.IsVisible,
                 IsLocked = lamp.IsLocked,
                 LinkedMachineObjectReference = machineReference,
-                LinkedPanel2DElementId = lamp.LinkedPanel2DElementId
+                LinkedPanel2DElementId = lamp.LinkedPanel2DElementId,
+                BulbMaskAssetPath = lamp.BulbMaskAssetPath,
+                SourceBlend = lamp.SourceBlend
             },
             _ => regeneratedElement
         };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
@@ -6,7 +6,7 @@ namespace OasisEditor;
 
 internal sealed class FaceTrayAutoAuthoringService
 {
-    public FaceTrayAutoAuthoringResult AutoAuthor(FaceDocumentModel faceDocument)
+    public FaceTrayAutoAuthoringResult AutoAuthor(FaceDocumentModel faceDocument, string? projectDirectory = null)
     {
         ArgumentNullException.ThrowIfNull(faceDocument);
 
@@ -47,6 +47,8 @@ internal sealed class FaceTrayAutoAuthoringService
                 Vertices = CreateRectangleVertices(bounds)
             });
 
+            var placement = ResolveEmitterPlacement(lampWindow, projectDirectory);
+
             emitters.Add(new FaceLampEmitterElement
             {
                 ObjectId = CreateStableId("face-emitter", stableKey),
@@ -65,10 +67,13 @@ internal sealed class FaceTrayAutoAuthoringService
                 TrayObjectId = trayObjectId,
                 TrayId = trayNumber,
                 LampId = lampId,
-                CenterX = Math.Round(lampWindow.X + (lampWindow.Width / 2d), 2),
-                CenterY = Math.Round(lampWindow.Y + (lampWindow.Height / 2d), 2),
+                CenterX = Math.Round(placement.CenterX, 2),
+                CenterY = Math.Round(placement.CenterY, 2),
                 IsAutoAuthored = true,
-                AutoAuthoringSource = source
+                AutoAuthoringSource = source,
+                EmitterPlacementSource = placement.Source,
+                Radius = placement.Radius is double radius ? Math.Round(radius, 2) : null,
+                Diagnostics = placement.Diagnostics
             });
         }
 
@@ -143,6 +148,43 @@ internal sealed class FaceTrayAutoAuthoringService
         }
 
         return diagnostics;
+    }
+
+
+    private static EmitterPlacement ResolveEmitterPlacement(FaceLampWindowElement lampWindow, string? projectDirectory)
+    {
+        var fallbackSource = lampWindow.Width > 0d && lampWindow.Height > 0d
+            ? "ComponentCentreFallback"
+            : "LampWindowCentreFallback";
+        var fallback = new EmitterPlacement(
+            lampWindow.X + (lampWindow.Width / 2d),
+            lampWindow.Y + (lampWindow.Height / 2d),
+            fallbackSource,
+            null,
+            []);
+
+        if (!lampWindow.SourceBlend)
+        {
+            return fallback;
+        }
+
+        if (string.IsNullOrWhiteSpace(lampWindow.BulbMaskAssetPath))
+        {
+            return fallback with { Diagnostics = ["bulb-mask-missing", "centroid-fallback-used"] };
+        }
+
+        var centroid = FaceBulbMaskCentroidAnalyzer.AnalyzeFile(lampWindow.BulbMaskAssetPath, projectDirectory, out var diagnostic);
+        if (centroid is null)
+        {
+            return fallback with { Diagnostics = string.IsNullOrWhiteSpace(diagnostic) ? ["centroid-fallback-used"] : [diagnostic, "centroid-fallback-used"] };
+        }
+
+        return new EmitterPlacement(
+            lampWindow.X + (centroid.NormalizedX * lampWindow.Width),
+            lampWindow.Y + (centroid.NormalizedY * lampWindow.Height),
+            "MfmeBulbMaskCentroid",
+            centroid.NormalizedRadius * Math.Max(lampWindow.Width, lampWindow.Height),
+            []);
     }
 
     private static IReadOnlyList<FaceTrayModel> DeriveTrayPolygons(IReadOnlyList<FaceTrayModel> sourceTrays)
@@ -493,3 +535,5 @@ internal sealed class FaceTrayAutoAuthoringService
 internal sealed record FaceTrayAutoAuthoringResult(
     IReadOnlyList<FaceTrayModel> Trays,
     IReadOnlyList<FaceLampEmitterElement> Emitters);
+
+internal sealed record EmitterPlacement(double CenterX, double CenterY, string Source, double? Radius, IReadOnlyList<string> Diagnostics);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/ImportMfmeExtractCommand.cs
@@ -164,6 +164,7 @@ internal sealed class ImportMfmeExtractCommand : IDocumentCommand, IExecutionTra
             SourceElementIndex = source.SourceElementIndex,
             SharedSourceSetId = source.SharedSourceSetId,
             SharedSourceSetCount = source.SharedSourceSetCount,
+            SourceBlend = source.SourceBlend,
             ImportSource = source.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -235,7 +235,8 @@ internal static class MfmeExtractManifestParser
                         ReadString(component, "Shortcut1"),
                         ReadString(component, "Shortcut2"),
                         lampElements,
-                        componentIndex);
+                        componentIndex,
+                        ReadBool(component, "Blend"));
                     return true;
                 }
 
@@ -260,7 +261,8 @@ internal static class MfmeExtractManifestParser
                         ReadColor(component, "TextColor"),
                         ReadBool(component, "NoOutline"),
                         lampElements,
-                        componentIndex);
+                        componentIndex,
+                        ReadBool(component, "Blend"));
                     return true;
                 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
@@ -149,6 +149,11 @@ internal sealed class MfmeImportAssetCopier
             BandOffset = element.BandOffset,
             IsLocked = element.IsLocked,
             IsVisible = element.IsVisible,
+            SourceComponentIndex = element.SourceComponentIndex,
+            SourceElementIndex = element.SourceElementIndex,
+            SharedSourceSetId = element.SharedSourceSetId,
+            SharedSourceSetCount = element.SharedSourceSetCount,
+            SourceBlend = element.SourceBlend,
             ImportSource = element.ImportSource
         };
     }
@@ -243,6 +248,11 @@ internal sealed class MfmeImportAssetCopier
             BandOffset = element.BandOffset,
             IsLocked = element.IsLocked,
             IsVisible = element.IsVisible,
+            SourceComponentIndex = element.SourceComponentIndex,
+            SourceElementIndex = element.SourceElementIndex,
+            SharedSourceSetId = element.SharedSourceSetId,
+            SharedSourceSetCount = element.SharedSourceSetCount,
+            SourceBlend = element.SourceBlend,
             ImportSource = element.ImportSource
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -61,7 +61,8 @@ internal sealed record MfmeLegacyLampComponent(
     string? Shortcut1,
     string? Shortcut2,
     IReadOnlyList<MfmeLegacyLampElement>? LampElements = null,
-    int SourceComponentIndex = -1)
+    int SourceComponentIndex = -1,
+    bool Blend = false)
     : MfmeLegacyComponentBase(
         "Lamp",
         Position,
@@ -157,7 +158,8 @@ internal sealed record MfmeLegacyButtonComponent(
     MfmeLegacyColor? TextColor,
     bool NoOutline,
     IReadOnlyList<MfmeLegacyLampElement>? LampElements = null,
-    int SourceComponentIndex = -1)
+    int SourceComponentIndex = -1,
+    bool Blend = false)
     : MfmeLegacyComponentBase(
         "ExtractComponentButton",
         Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -162,6 +162,7 @@ internal sealed class MfmeToOasisComponentMapper
             SourceElementIndex = lampElement?.SourceElementIndex >= 0 ? lampElement.SourceElementIndex : null,
             SharedSourceSetId = sharedLampSetId,
             SharedSourceSetCount = sharedLampSetCount,
+            SourceBlend = component.Blend,
             ImportSource = CreateLampImportSource(component, number)
         };
     }
@@ -187,7 +188,8 @@ internal sealed class MfmeToOasisComponentMapper
             component.Shortcut1,
             component.Shortcut2,
             component.LampElements,
-            component.SourceComponentIndex);
+            component.SourceComponentIndex,
+            component.Blend);
 
         return MapLamps(lampEquivalent, warnings);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -39,6 +39,7 @@ internal sealed class PanelElementModel
     public int? SourceElementIndex { get; init; }
     public string? SharedSourceSetId { get; init; }
     public int? SharedSourceSetCount { get; init; }
+    public bool SourceBlend { get; init; }
     public PanelElementImportSourceModel? ImportSource { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -284,6 +284,7 @@ internal static class Panel2DDocumentStorage
                 || element.BandOffset.HasValue
                 || element.IsLocked
                 || element.IsVisible is false
+                || element.SourceBlend
                 || element.ImportSource is not null)
             {
                 return CurrentSchemaVersion;
@@ -349,6 +350,7 @@ internal static class Panel2DDocumentStorage
             SourceElementIndex = normalized.SourceElementIndex,
             SharedSourceSetId = normalized.SharedSourceSetId,
             SharedSourceSetCount = normalized.SharedSourceSetCount,
+            SourceBlend = normalized.SourceBlend,
             ImportSource = normalized.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel
@@ -401,6 +403,7 @@ internal static class Panel2DDocumentStorage
             SourceElementIndex = element.SourceElementIndex,
             SharedSourceSetId = element.SharedSourceSetId,
             SharedSourceSetCount = element.SharedSourceSetCount,
+            SourceBlend = element.SourceBlend,
             ImportSource = importSource,
             Native = CreateNativeFromLegacyFields(
                 assetPath: element.AssetPath,
@@ -549,6 +552,7 @@ internal static class Panel2DDocumentStorage
             SourceElementIndex = normalizedSourceElementIndex,
             SharedSourceSetId = normalizedSharedSourceSetId,
             SharedSourceSetCount = normalizedSharedSourceSetCount,
+            SourceBlend = element.SourceBlend,
             ImportSource = normalizedImportSource,
             Native = mergedNative
         };
@@ -805,6 +809,7 @@ internal sealed record PanelElementFile : IPanelSelectableObject
     public int? SourceElementIndex { get; init; }
     public string? SharedSourceSetId { get; init; }
     public int? SharedSourceSetCount { get; init; }
+    public bool SourceBlend { get; init; }
     public PanelElementImportSourceFile? ImportSource { get; init; }
     public PanelElementNativeFile? Native { get; init; }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -47,6 +47,7 @@ internal static class PanelElementModelCloner
             SourceElementIndex = source.SourceElementIndex,
             SharedSourceSetId = source.SharedSourceSetId,
             SharedSourceSetCount = source.SharedSourceSetCount,
+            SourceBlend = source.SourceBlend,
             ImportSource = CloneImportSource(source.ImportSource)
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelUpdate.cs
@@ -89,6 +89,7 @@ internal static class PanelElementModelUpdater
             SourceElementIndex = source.SourceElementIndex,
             SharedSourceSetId = source.SharedSourceSetId,
             SharedSourceSetCount = source.SharedSourceSetCount,
+            SourceBlend = source.SourceBlend,
             ImportSource = source.ImportSource is null
                 ? null
                 : new PanelElementImportSourceModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementValidation.cs
@@ -65,6 +65,7 @@ internal static class PanelElementModelComparer
                && left.SourceElementIndex == right.SourceElementIndex
                && string.Equals(left.SharedSourceSetId, right.SharedSourceSetId, StringComparison.Ordinal)
                && left.SharedSourceSetCount == right.SharedSourceSetCount
+               && left.SourceBlend == right.SourceBlend
                && AreEquivalent(left.ImportSource, right.ImportSource);
     }
 


### PR DESCRIPTION
### Motivation

- Improve emitter placement for MFME multi-lamp components by using per-lamp MFME bulb-mask images when available instead of always centering in the shared component bounds.  
- Preserve existing fallback behaviour for non-Blend components and missing/invalid masks.  
- Record placement provenance and diagnostics to support later phases (radius/influence maps, shared-tray analysis, manual editing).

### Description

- Propagate MFME `Blend` and per-lamp mask paths from import through Panel2D into Face generation by reading `Blend` from manifests and storing mask filenames as `SecondaryAssetPath`/`BulbMaskAssetPath`.  
- Add `FaceBulbMaskCentroidAnalyzer` which loads mask images (SkiaSharp) and computes an alpha-weighted luminance centroid and a normalized radius estimate using `weight = alpha * luminance` and the suggested centroid formula; it also returns diagnostics for missing/invalid/empty masks.  
- Use mask centroid when auto-authoring emitters: if `SourceBlend == true` and a valid mask loads then map the mask-space normalized centroid into the lamp-window / Face coordinate space to set `CenterX`/`CenterY` and store `EmitterPlacementSource = MfmeBulbMaskCentroid` and an estimated `Radius`; otherwise keep `ComponentCentreFallback` / `LampWindowCentreFallback` semantics and add diagnostics.  
- Persist new metadata and diagnostics on models and storage (`BulbMaskAssetPath`, `SourceBlend`, `EmitterPlacementSource`, `Radius`, `Diagnostics`) and thread `projectDirectory` through generation so relative mask paths resolve correctly; updated Face auto-authoring and generation calls to accept `projectDirectory`.  
- Added unit tests (`FaceBulbMaskEmitterPlacementTests`) covering centroid calculation, coordinate mapping, fallback selection, and diagnostics (tests are added but not executed in this environment).  

### Testing

- Ran repository static checks: `git diff --check` and `git diff --cached --check` (no whitespace/patch issues).  
- Added automated unit tests: `FaceBulbMaskEmitterPlacementTests` (covers `FaceBulbMaskCentroidAnalyzer` and `FaceTrayAutoAuthoringService` placement choices) but `dotnet build` / `dotnet test` were not executed in this environment per project constraints.  
- Local test recommendations: run solution build and test suite, especially `FaceBulbMaskEmitterPlacementTests`, `FaceTrayAutoAuthoringTests`, `MfmeToOasisComponentMapperTests`, and `FaceRuntimeExportServiceTests` to validate end-to-end import → generate → overlay/export behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d3562389083278b346e76363618a5)