### PR TITLE
Group MFME shared lamp-set trays

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -195,6 +195,49 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal(0, lampWeights0.GetPixel(3, 3).Red);
     }
 
+
+    [Fact]
+    public void Generate_WithSharedAuthoredTray_WritesMultipleEmitterChannels()
+    {
+        var outputDirectory = Path.Combine(_generatedDirectory, "shared-tray-texture-test");
+        var document = new FaceDocumentModel
+        {
+            Trays =
+            [
+                new FaceTrayModel
+                {
+                    ObjectId = "shared-tray",
+                    Bounds = new FaceSourceRegionModel { X = 0, Y = 0, Width = 2, Height = 2 },
+                    Vertices =
+                    [
+                        new FacePointModel { X = 0, Y = 0 },
+                        new FacePointModel { X = 2, Y = 0 },
+                        new FacePointModel { X = 2, Y = 2 },
+                        new FacePointModel { X = 0, Y = 2 }
+                    ]
+                }
+            ],
+            LampEmitters =
+            [
+                new FaceLampEmitterElement { ObjectId = "emitter-a", TrayObjectId = "shared-tray", TrayId = 1, LampId = 11, CenterX = 0.5, CenterY = 0.5 },
+                new FaceLampEmitterElement { ObjectId = "emitter-b", TrayObjectId = "shared-tray", TrayId = 1, LampId = 12, CenterX = 1.5, CenterY = 1.5 }
+            ]
+        };
+
+        var result = new FaceRuntimeTextureGenerator().Generate(document, 2, 2, outputDirectory);
+
+        Assert.Single(result.Plan.Trays);
+        Assert.Equal(2, result.Plan.Emitters.Count);
+        using var trayId = SKBitmap.Decode(Path.Combine(outputDirectory, "trayId.png"));
+        using var lampIds0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampIds0.png"));
+        using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
+        Assert.Equal(1, trayId.GetPixel(0, 0).Red);
+        Assert.Equal(11, lampIds0.GetPixel(0, 0).Red);
+        Assert.Equal(12, lampIds0.GetPixel(0, 0).Green);
+        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Red);
+        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Green);
+    }
+
     [Fact]
     public void Export_WithMissingArtworkAsset_ThrowsFileNotFoundException()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTrayAutoAuthoringTests.cs
@@ -116,6 +116,33 @@ public sealed class FaceTrayAutoAuthoringTests
         Assert.Equal("lamp:3", emitter.LinkedMachineObjectReference?.ToString());
     }
 
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsFaceLampWindowSharedMfmeProvenance()
+    {
+        var json = FaceDocumentStorage.Serialize(new FaceDocumentModel
+        {
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-a",
+                    SharedSourceSetId = "mfme-component-42",
+                    SharedSourceSetCount = 2,
+                    SourceComponentIndex = 42,
+                    SourceBlend = true
+                }
+            ]
+        });
+
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var lamp = Assert.IsType<FaceLampWindowElement>(Assert.Single(FaceDocumentStorage.ToModel(file).Elements));
+        Assert.Equal("mfme-component-42", lamp.SharedSourceSetId);
+        Assert.Equal(2, lamp.SharedSourceSetCount);
+        Assert.Equal(42, lamp.SourceComponentIndex);
+        Assert.True(lamp.SourceBlend);
+    }
+
     [Fact]
     public void Validate_DetectsDuplicateIdsInvalidBoundsAndMissingTrayReferences()
     {
@@ -241,6 +268,44 @@ public sealed class FaceTrayAutoAuthoringTests
         Assert.Contains("isolated-roundish-octagon", Assert.Single(model.Trays).Diagnostics);
     }
 
+
+    [Fact]
+    public void AutoAuthor_GroupsMfmeSharedLampSetIntoOneTrayWithMultipleEmitters()
+    {
+        var document = new FaceDocumentModel
+        {
+            GenerationSettings = new FaceGenerationSettingsModel { TrayBoundsInflationPercent = 0, TrayBoundsPaddingPixels = 0 },
+            Elements =
+            [
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-a", Name = "A", X = 10, Y = 20, Width = 30, Height = 40, IsVisible = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(11), LinkedPanel2DElementId = "panel-a",
+                    SourceComponentIndex = 42, SharedSourceSetId = "mfme-component-42", SharedSourceSetCount = 2, SourceBlend = true
+                },
+                new FaceLampWindowElement
+                {
+                    ObjectId = "face-b", Name = "B", X = 10, Y = 20, Width = 30, Height = 40, IsVisible = true,
+                    LinkedMachineObjectReference = MachineObjectReference.Lamp(12), LinkedPanel2DElementId = "panel-b",
+                    SourceComponentIndex = 42, SharedSourceSetId = "mfme-component-42", SharedSourceSetCount = 2, SourceBlend = true
+                }
+            ]
+        };
+
+        var first = new FaceTrayAutoAuthoringService().AutoAuthor(document);
+        var second = new FaceTrayAutoAuthoringService().AutoAuthor(document);
+
+        var tray = Assert.Single(first.Trays);
+        Assert.Equal("shared-tray-from-mfme-component", tray.AutoAuthoringSource);
+        Assert.Contains("mfme-shared-lamp-set-grouped", tray.Diagnostics);
+        Assert.Equal(first.Trays.Single().ObjectId, second.Trays.Single().ObjectId);
+        Assert.Equal(2, first.Emitters.Count);
+        Assert.All(first.Emitters, emitter => Assert.Equal(tray.ObjectId, emitter.TrayObjectId));
+        Assert.Equal(new int?[] { 11, 12 }, first.Emitters.Select(emitter => emitter.LampId).Order().ToArray());
+        Assert.All(first.Emitters, emitter => Assert.Equal(25d, emitter.CenterX));
+        Assert.All(first.Emitters, emitter => Assert.Equal(40d, emitter.CenterY));
+        Assert.Equal(first.Emitters.Select(emitter => emitter.ObjectId), second.Emitters.Select(emitter => emitter.ObjectId));
+    }
     private static FaceDocumentModel CreateFaceWithLampAndContribution()
     {
         return new FaceDocumentModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -148,6 +148,9 @@ public sealed class FaceArtworkProvenanceModel
 public sealed class FaceLampWindowElement : FaceElementModel
 {
     public string? BulbMaskAssetPath { get; init; }
+    public int? SourceComponentIndex { get; init; }
+    public string? SharedSourceSetId { get; init; }
+    public int? SharedSourceSetCount { get; init; }
     public bool SourceBlend { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -640,6 +640,9 @@ public static class FaceDocumentStorage
             LinkedMachineObjectReference = reference,
             LinkedPanel2DElementId = file.LinkedPanel2DElementId,
             BulbMaskAssetPath = file.BulbMaskAssetPath,
+            SourceComponentIndex = file.SourceComponentIndex,
+            SharedSourceSetId = string.IsNullOrWhiteSpace(file.SharedSourceSetId) ? null : file.SharedSourceSetId.Trim(),
+            SharedSourceSetCount = file.SharedSourceSetCount,
             SourceBlend = file.SourceBlend
         };
     }
@@ -719,6 +722,9 @@ public static class FaceDocumentStorage
             SourceRegion = model is FaceArtworkElement artworkRegion ? ToFile(artworkRegion.SourceRegion) : null,
             ArtworkProvenance = model is FaceArtworkElement artworkProvenance ? ToFile(artworkProvenance.Provenance) : null,
             BulbMaskAssetPath = model is FaceLampWindowElement lampWindow ? lampWindow.BulbMaskAssetPath : null,
+            SourceComponentIndex = model is FaceLampWindowElement sourceComponentLampWindow ? sourceComponentLampWindow.SourceComponentIndex : null,
+            SharedSourceSetId = model is FaceLampWindowElement sharedSetLampWindow ? sharedSetLampWindow.SharedSourceSetId : null,
+            SharedSourceSetCount = model is FaceLampWindowElement sharedSetCountLampWindow ? sharedSetCountLampWindow.SharedSourceSetCount : null,
             SourceBlend = model is FaceLampWindowElement sourceLampWindow && sourceLampWindow.SourceBlend
         };
     }
@@ -899,6 +905,9 @@ public sealed record FaceElementFile
     public FaceSourceRegionFile? SourceRegion { get; init; }
     public FaceArtworkProvenanceFile? ArtworkProvenance { get; init; }
     public string? BulbMaskAssetPath { get; init; }
+    public int? SourceComponentIndex { get; init; }
+    public string? SharedSourceSetId { get; init; }
+    public int? SharedSourceSetCount { get; init; }
     public bool SourceBlend { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementServices.cs
@@ -79,6 +79,9 @@ internal static class FaceElementModelUpdater
                 LinkedMachineObjectReference = linkedMachineObjectReference,
                 LinkedPanel2DElementId = update.HasLinkedPanel2DElementId ? update.LinkedPanel2DElementId : existing.LinkedPanel2DElementId,
                 BulbMaskAssetPath = ((FaceLampWindowElement)existing).BulbMaskAssetPath,
+                SourceComponentIndex = ((FaceLampWindowElement)existing).SourceComponentIndex,
+                SharedSourceSetId = ((FaceLampWindowElement)existing).SharedSourceSetId,
+                SharedSourceSetCount = ((FaceLampWindowElement)existing).SharedSourceSetCount,
                 SourceBlend = ((FaceLampWindowElement)existing).SourceBlend
             },
             FaceSevenSegmentDisplayElement sevenSegmentDisplay => new FaceSevenSegmentDisplayElement

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -261,6 +261,9 @@ internal sealed class FaceGenerationService
             LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
             LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
             BulbMaskAssetPath = sourceElement.SecondaryAssetPath,
+            SourceComponentIndex = sourceElement.SourceComponentIndex,
+            SharedSourceSetId = NormalizeOptional(sourceElement.SharedSourceSetId),
+            SharedSourceSetCount = sourceElement.SharedSourceSetCount,
             SourceBlend = sourceElement.SourceBlend
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -259,6 +259,9 @@ internal sealed class FaceRegenerationService
                 LinkedMachineObjectReference = machineReference,
                 LinkedPanel2DElementId = lamp.LinkedPanel2DElementId,
                 BulbMaskAssetPath = lamp.BulbMaskAssetPath,
+                SourceComponentIndex = lamp.SourceComponentIndex,
+                SharedSourceSetId = lamp.SharedSourceSetId,
+                SharedSourceSetCount = lamp.SharedSourceSetCount,
                 SourceBlend = lamp.SourceBlend
             },
             _ => regeneratedElement

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -533,13 +533,13 @@ public sealed class LampInfluenceTextureGenerator
                 throw new InvalidOperationException($"Face runtime tray {tray.TrayId} does not have a valid lamp emitter.");
             }
 
-            if (trayEmitters.Length > 4)
+            if (trayEmitters.Length > 3)
             {
-                throw new InvalidOperationException($"Face runtime tray {tray.TrayId} has {trayEmitters.Length} lamp emitters; the current lampIds0/lampWeights0 format supports up to 4 emitters per tray.");
+                throw new InvalidOperationException($"Face runtime tray {tray.TrayId} has {trayEmitters.Length} lamp emitters; the current lampIds0/lampWeights0 PNG writer preserves RGB data channels plus opaque alpha, so it supports up to 3 emitters per tray.");
             }
 
-            var idChannels = new byte[4];
-            var weightChannels = new byte[4];
+            var idChannels = new byte[3];
+            var weightChannels = new byte[3];
             for (var channel = 0; channel < trayEmitters.Length; channel++)
             {
                 idChannels[channel] = (byte)trayEmitters[channel].LampId!.Value;
@@ -558,8 +558,8 @@ public sealed class LampInfluenceTextureGenerator
                     }
 
                     ownership[index] = tray.TrayId;
-                    idsBitmap.SetPixel(x, y, new SKColor(idChannels[0], idChannels[1], idChannels[2], idChannels[3]));
-                    weightsBitmap.SetPixel(x, y, new SKColor(weightChannels[0], weightChannels[1], weightChannels[2], weightChannels[3]));
+                    idsBitmap.SetPixel(x, y, new SKColor(idChannels[0], idChannels[1], idChannels[2], 255));
+                    weightsBitmap.SetPixel(x, y, new SKColor(weightChannels[0], weightChannels[1], weightChannels[2], 255));
                     debugBitmap.SetPixel(x, y, SKColors.White);
                 }
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -38,11 +38,13 @@ public sealed class FaceRuntimeTextureGenerator
                 .ThenBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
                 .ToArray();
             ValidateLampIds(emitters);
-            var emittersByTrayObjectId = emitters.ToDictionary(emitter => emitter.TrayObjectId.Trim(), StringComparer.Ordinal);
+            var emittersByTrayObjectId = emitters
+                .GroupBy(emitter => emitter.TrayObjectId.Trim(), StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal).ToArray(), StringComparer.Ordinal);
             trays = faceDocument.Trays
-                .OrderBy(tray => emittersByTrayObjectId[tray.ObjectId.Trim()].TrayId)
+                .OrderBy(tray => emittersByTrayObjectId[tray.ObjectId.Trim()][0].TrayId)
                 .ThenBy(tray => tray.ObjectId, StringComparer.Ordinal)
-                .Select(tray => CreateAuthoredTray(tray, emittersByTrayObjectId[tray.ObjectId.Trim()]))
+                .Select(tray => CreateAuthoredTray(tray, emittersByTrayObjectId[tray.ObjectId.Trim()][0]))
                 .ToArray();
         }
         else
@@ -272,19 +274,6 @@ public sealed class FaceRuntimeTextureGenerator
                 .Select(emitter => emitter.ObjectId.Trim()),
             "duplicate emitter ID",
             diagnostics);
-        AddDuplicateDiagnostics(
-            faceDocument.LampEmitters
-                .Where(emitter => emitter.TrayId > 0)
-                .Select(emitter => emitter.TrayId.ToString()),
-            "duplicate numeric tray ID",
-            diagnostics);
-        AddDuplicateDiagnostics(
-            faceDocument.LampEmitters
-                .Where(emitter => !string.IsNullOrWhiteSpace(emitter.TrayObjectId))
-                .Select(emitter => emitter.TrayObjectId.Trim()),
-            "duplicate emitter tray reference",
-            diagnostics);
-
         foreach (var tray in faceDocument.Trays)
         {
             var displayName = DisplayName(tray.ObjectId, tray.Name);
@@ -525,7 +514,9 @@ public sealed class LampInfluenceTextureGenerator
     {
         ArgumentNullException.ThrowIfNull(trays);
         ArgumentNullException.ThrowIfNull(emitters);
-        var emittersByTray = emitters.ToDictionary(emitter => emitter.TrayId);
+        var emittersByTray = emitters
+            .GroupBy(emitter => emitter.TrayId)
+            .ToDictionary(group => group.Key, group => group.OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal).ToArray());
 
         using var idsBitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
         using var weightsBitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
@@ -537,9 +528,22 @@ public sealed class LampInfluenceTextureGenerator
         var ownership = new int[width * height];
         foreach (var tray in trays)
         {
-            if (!emittersByTray.TryGetValue(tray.TrayId, out var emitter) || emitter.LampId is not int lampId)
+            if (!emittersByTray.TryGetValue(tray.TrayId, out var trayEmitters) || trayEmitters.Length == 0 || trayEmitters.Any(emitter => emitter.LampId is not int))
             {
                 throw new InvalidOperationException($"Face runtime tray {tray.TrayId} does not have a valid lamp emitter.");
+            }
+
+            if (trayEmitters.Length > 4)
+            {
+                throw new InvalidOperationException($"Face runtime tray {tray.TrayId} has {trayEmitters.Length} lamp emitters; the current lampIds0/lampWeights0 format supports up to 4 emitters per tray.");
+            }
+
+            var idChannels = new byte[4];
+            var weightChannels = new byte[4];
+            for (var channel = 0; channel < trayEmitters.Length; channel++)
+            {
+                idChannels[channel] = (byte)trayEmitters[channel].LampId!.Value;
+                weightChannels[channel] = 255;
             }
 
             var bounds = RasterBounds.FromElement(tray, width, height);
@@ -554,8 +558,8 @@ public sealed class LampInfluenceTextureGenerator
                     }
 
                     ownership[index] = tray.TrayId;
-                    idsBitmap.SetPixel(x, y, new SKColor((byte)lampId, 0, 0, 255));
-                    weightsBitmap.SetPixel(x, y, new SKColor(255, 0, 0, 255));
+                    idsBitmap.SetPixel(x, y, new SKColor(idChannels[0], idChannels[1], idChannels[2], idChannels[3]));
+                    weightsBitmap.SetPixel(x, y, new SKColor(weightChannels[0], weightChannels[1], weightChannels[2], weightChannels[3]));
                     debugBitmap.SetPixel(x, y, SKColors.White);
                 }
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceTrayAutoAuthoringService.cs
@@ -14,67 +14,74 @@ internal sealed class FaceTrayAutoAuthoringService
         var trays = new List<FaceTrayModel>();
         var emitters = new List<FaceLampEmitterElement>();
         var nextTrayNumber = 1;
-
-        foreach (var lampWindow in faceDocument.Elements
+        var lampWindows = faceDocument.Elements
             .OfType<FaceLampWindowElement>()
             .Where(IsValidVisibleLampWindow)
-            .OrderBy(CreateLampStableKey, StringComparer.Ordinal))
-        {
-            var contribution = FindBestContribution(lampWindow, faceDocument.MaskLayer);
-            var baseBounds = contribution?.Bounds is { IsValid: true } contributionBounds
-                ? contributionBounds
-                : FaceSourceRegionModel.FromRect(new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height));
-            var lampBounds = FaceSourceRegionModel.FromRect(new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height));
-            var bounds = ExpandBounds(baseBounds, lampBounds, settings);
-            var source = contribution?.Bounds is { IsValid: true } ? "maskContributionBounds" : "lampWindowBounds";
-            var stableKey = CreateLampStableKey(lampWindow);
-            var trayObjectId = CreateStableId("face-tray", stableKey, source, Format(bounds.X), Format(bounds.Y), Format(bounds.Width), Format(bounds.Height));
-            var trayNumber = nextTrayNumber++;
-            var lampId = TryGetLampId(lampWindow.LinkedMachineObjectReference);
+            .OrderBy(CreateLampStableKey, StringComparer.Ordinal)
+            .Select(lampWindow => CreateLampWorkItem(lampWindow, faceDocument.MaskLayer, settings))
+            .ToArray();
 
+        var groupedLampObjectIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var group in lampWindows
+            .Where(item => HasValidSharedSetProvenance(item.LampWindow))
+            .GroupBy(item => item.LampWindow.SharedSourceSetId!.Trim(), StringComparer.Ordinal)
+            .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            var members = group.OrderBy(item => item.StableKey, StringComparer.Ordinal).ToArray();
+            if (members.Length < 2 || !members.Any(item => item.LampWindow.SourceBlend || (item.LampWindow.SharedSourceSetCount ?? 0) > 1) || !HaveEquivalentSourceBounds(members))
+            {
+                continue;
+            }
+
+            var bounds = UnionBounds(members.Select(item => item.Bounds));
+            var trayNumber = nextTrayNumber++;
+            var trayObjectId = CreateStableId("face-tray", "mfme-shared-set", group.Key, Format(bounds.X), Format(bounds.Y), Format(bounds.Width), Format(bounds.Height));
+            var first = members[0].LampWindow;
             trays.Add(new FaceTrayModel
             {
                 ObjectId = trayObjectId,
-                Name = string.IsNullOrWhiteSpace(lampWindow.Name)
-                    ? $"Auto Tray {lampId?.ToString() ?? trayNumber.ToString()}"
-                    : $"{lampWindow.Name.Trim()} Tray",
+                Name = $"MFME Shared Lamp Set {group.Key} Tray",
                 IsAutoAuthored = true,
-                AutoAuthoringSource = source,
-                SourceLampWindowObjectId = lampWindow.ObjectId,
-                SourcePanel2DElementId = contribution?.SourcePanel2DElementId ?? lampWindow.LinkedPanel2DElementId,
-                LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
+                AutoAuthoringSource = "shared-tray-from-mfme-component",
+                SourceLampWindowObjectId = string.Join(",", members.Select(item => item.LampWindow.ObjectId).Where(id => !string.IsNullOrWhiteSpace(id)).OrderBy(id => id, StringComparer.Ordinal)),
+                SourcePanel2DElementId = string.Join(",", members.Select(item => item.Contribution?.SourcePanel2DElementId ?? item.LampWindow.LinkedPanel2DElementId).Where(id => !string.IsNullOrWhiteSpace(id)).OrderBy(id => id, StringComparer.Ordinal)),
+                LinkedMachineObjectReference = first.LinkedMachineObjectReference,
                 Bounds = bounds,
-                Vertices = CreateRectangleVertices(bounds)
+                Vertices = CreateRectangleVertices(bounds),
+                Diagnostics = ["mfme-shared-lamp-set-grouped"]
             });
 
-            var placement = ResolveEmitterPlacement(lampWindow, projectDirectory);
-
-            emitters.Add(new FaceLampEmitterElement
+            foreach (var item in members)
             {
-                ObjectId = CreateStableId("face-emitter", stableKey),
-                Name = string.IsNullOrWhiteSpace(lampWindow.Name)
-                    ? $"Lamp {lampId?.ToString() ?? trayNumber.ToString()} Emitter"
-                    : $"{lampWindow.Name.Trim()} Emitter",
-                X = Math.Round(lampWindow.X, 2),
-                Y = Math.Round(lampWindow.Y, 2),
-                Width = Math.Round(lampWindow.Width, 2),
-                Height = Math.Round(lampWindow.Height, 2),
-                IsVisible = lampWindow.IsVisible,
-                IsLocked = true,
-                LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
-                LinkedPanel2DElementId = lampWindow.LinkedPanel2DElementId,
-                SourceLampWindowObjectId = lampWindow.ObjectId,
-                TrayObjectId = trayObjectId,
-                TrayId = trayNumber,
-                LampId = lampId,
-                CenterX = Math.Round(placement.CenterX, 2),
-                CenterY = Math.Round(placement.CenterY, 2),
+                emitters.Add(CreateEmitter(item, trayObjectId, trayNumber, "shared-tray-from-mfme-component", projectDirectory, ["mfme-shared-lamp-set-grouped"]));
+                if (!string.IsNullOrWhiteSpace(item.LampWindow.ObjectId))
+                {
+                    groupedLampObjectIds.Add(item.LampWindow.ObjectId.Trim());
+                }
+            }
+        }
+
+        foreach (var item in lampWindows.Where(item => string.IsNullOrWhiteSpace(item.LampWindow.ObjectId) || !groupedLampObjectIds.Contains(item.LampWindow.ObjectId.Trim())))
+        {
+            var trayNumber = nextTrayNumber++;
+            var trayObjectId = CreateStableId("face-tray", item.StableKey, item.Source, Format(item.Bounds.X), Format(item.Bounds.Y), Format(item.Bounds.Width), Format(item.Bounds.Height));
+            var lampId = TryGetLampId(item.LampWindow.LinkedMachineObjectReference);
+            trays.Add(new FaceTrayModel
+            {
+                ObjectId = trayObjectId,
+                Name = string.IsNullOrWhiteSpace(item.LampWindow.Name)
+                    ? $"Auto Tray {lampId?.ToString() ?? trayNumber.ToString()}"
+                    : $"{item.LampWindow.Name.Trim()} Tray",
                 IsAutoAuthored = true,
-                AutoAuthoringSource = source,
-                EmitterPlacementSource = placement.Source,
-                Radius = placement.Radius is double radius ? Math.Round(radius, 2) : null,
-                Diagnostics = placement.Diagnostics
+                AutoAuthoringSource = item.Source,
+                SourceLampWindowObjectId = item.LampWindow.ObjectId,
+                SourcePanel2DElementId = item.Contribution?.SourcePanel2DElementId ?? item.LampWindow.LinkedPanel2DElementId,
+                LinkedMachineObjectReference = item.LampWindow.LinkedMachineObjectReference,
+                Bounds = item.Bounds,
+                Vertices = CreateRectangleVertices(item.Bounds)
             });
+
+            emitters.Add(CreateEmitter(item, trayObjectId, trayNumber, item.Source, projectDirectory, []));
         }
 
         return new FaceTrayAutoAuthoringResult(DeriveTrayPolygons(trays), emitters);
@@ -87,12 +94,6 @@ internal sealed class FaceTrayAutoAuthoringService
         var diagnostics = new List<FaceValidationDiagnostic>();
         AddDuplicateDiagnostics(faceDocument.Trays.Select(tray => tray.ObjectId), "Face.Tray.DuplicateId", "tray", diagnostics);
         AddDuplicateDiagnostics(faceDocument.LampEmitters.Select(emitter => emitter.ObjectId), "Face.Emitter.DuplicateId", "emitter", diagnostics);
-        AddDuplicateDiagnostics(
-            faceDocument.LampEmitters.Where(emitter => emitter.TrayId > 0).Select(emitter => emitter.TrayId.ToString()),
-            "Face.Tray.DuplicateNumericId",
-            "numeric tray",
-            diagnostics);
-
         var trayIds = faceDocument.Trays
             .Where(tray => !string.IsNullOrWhiteSpace(tray.ObjectId))
             .Select(tray => tray.ObjectId.Trim())
@@ -150,6 +151,92 @@ internal sealed class FaceTrayAutoAuthoringService
         return diagnostics;
     }
 
+    private static LampWorkItem CreateLampWorkItem(FaceLampWindowElement lampWindow, FaceMaskLayerModel? maskLayer, FaceGenerationSettingsModel settings)
+    {
+        var contribution = FindBestContribution(lampWindow, maskLayer);
+        var baseBounds = contribution?.Bounds is { IsValid: true } contributionBounds
+            ? contributionBounds
+            : FaceSourceRegionModel.FromRect(new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height));
+        var lampBounds = FaceSourceRegionModel.FromRect(new Rect(lampWindow.X, lampWindow.Y, lampWindow.Width, lampWindow.Height));
+        var bounds = ExpandBounds(baseBounds, lampBounds, settings);
+        var source = contribution?.Bounds is { IsValid: true } ? "maskContributionBounds" : "lampWindowBounds";
+        return new LampWorkItem(lampWindow, contribution, bounds, source, CreateLampStableKey(lampWindow));
+    }
+
+    private static FaceLampEmitterElement CreateEmitter(
+        LampWorkItem item,
+        string trayObjectId,
+        int trayNumber,
+        string source,
+        string? projectDirectory,
+        IReadOnlyList<string> additionalDiagnostics)
+    {
+        var lampWindow = item.LampWindow;
+        var lampId = TryGetLampId(lampWindow.LinkedMachineObjectReference);
+        var placement = ResolveEmitterPlacement(lampWindow, projectDirectory);
+        var diagnostics = placement.Diagnostics
+            .Concat(additionalDiagnostics)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(diagnostic => diagnostic, StringComparer.Ordinal)
+            .ToArray();
+
+        return new FaceLampEmitterElement
+        {
+            ObjectId = CreateStableId("face-emitter", item.StableKey),
+            Name = string.IsNullOrWhiteSpace(lampWindow.Name)
+                ? $"Lamp {lampId?.ToString() ?? trayNumber.ToString()} Emitter"
+                : $"{lampWindow.Name.Trim()} Emitter",
+            X = Math.Round(lampWindow.X, 2),
+            Y = Math.Round(lampWindow.Y, 2),
+            Width = Math.Round(lampWindow.Width, 2),
+            Height = Math.Round(lampWindow.Height, 2),
+            IsVisible = lampWindow.IsVisible,
+            IsLocked = true,
+            LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
+            LinkedPanel2DElementId = lampWindow.LinkedPanel2DElementId,
+            SourceLampWindowObjectId = lampWindow.ObjectId,
+            TrayObjectId = trayObjectId,
+            TrayId = trayNumber,
+            LampId = lampId,
+            CenterX = Math.Round(placement.CenterX, 2),
+            CenterY = Math.Round(placement.CenterY, 2),
+            IsAutoAuthored = true,
+            AutoAuthoringSource = source,
+            EmitterPlacementSource = placement.Source,
+            Radius = placement.Radius is double radius ? Math.Round(radius, 2) : null,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static bool HasValidSharedSetProvenance(FaceLampWindowElement lampWindow)
+    {
+        return !string.IsNullOrWhiteSpace(lampWindow.SharedSourceSetId)
+            && (lampWindow.SourceComponentIndex.HasValue || (lampWindow.SharedSourceSetCount ?? 0) > 1 || lampWindow.SourceBlend);
+    }
+
+    private static bool HaveEquivalentSourceBounds(IReadOnlyList<LampWorkItem> items)
+    {
+        var first = items[0].LampWindow;
+        return items.All(item =>
+            NearlyEqual(item.LampWindow.X, first.X)
+            && NearlyEqual(item.LampWindow.Y, first.Y)
+            && NearlyEqual(item.LampWindow.Width, first.Width)
+            && NearlyEqual(item.LampWindow.Height, first.Height));
+    }
+
+    private static bool NearlyEqual(double left, double right) => Math.Abs(left - right) <= 0.01d;
+
+    private static FaceSourceRegionModel UnionBounds(IEnumerable<FaceSourceRegionModel> bounds)
+    {
+        Rect? union = null;
+        foreach (var bound in bounds.Where(bound => bound.IsValid))
+        {
+            var rect = bound.ToRect();
+            union = union is Rect existing ? Rect.Union(existing, rect) : rect;
+        }
+
+        return FaceSourceRegionModel.FromRect(union ?? Rect.Empty);
+    }
 
     private static EmitterPlacement ResolveEmitterPlacement(FaceLampWindowElement lampWindow, string? projectDirectory)
     {
@@ -190,7 +277,10 @@ internal sealed class FaceTrayAutoAuthoringService
     private static IReadOnlyList<FaceTrayModel> DeriveTrayPolygons(IReadOnlyList<FaceTrayModel> sourceTrays)
     {
         var working = sourceTrays
-            .Select(tray => new TrayPolygonWorkItem(tray, tray.Bounds is { IsValid: true } bounds ? CreateRectangleVertices(bounds).ToList() : tray.Vertices.ToList(), []))
+            .Select(tray => new TrayPolygonWorkItem(
+                tray,
+                tray.Bounds is { IsValid: true } bounds ? CreateRectangleVertices(bounds).ToList() : tray.Vertices.ToList(),
+                tray.Diagnostics.Where(diagnostic => !string.IsNullOrWhiteSpace(diagnostic)).Select(diagnostic => diagnostic.Trim()).ToList()))
             .ToArray();
 
         for (var leftIndex = 0; leftIndex < working.Length; leftIndex++)
@@ -535,5 +625,12 @@ internal sealed class FaceTrayAutoAuthoringService
 internal sealed record FaceTrayAutoAuthoringResult(
     IReadOnlyList<FaceTrayModel> Trays,
     IReadOnlyList<FaceLampEmitterElement> Emitters);
+
+internal sealed record LampWorkItem(
+    FaceLampWindowElement LampWindow,
+    FaceMaskContributionModel? Contribution,
+    FaceSourceRegionModel Bounds,
+    string Source,
+    string StableKey);
 
 internal sealed record EmitterPlacement(double CenterX, double CenterY, string Source, double? Radius, IReadOnlyList<string> Diagnostics);


### PR DESCRIPTION
### Motivation

- MFME-imported lamp components that include multiple overlapping lamp elements from the same source were producing multiple fully-overlapping authored trays, which is noisy and incorrect for known shared lamp sets.
- Use MFME shared-set provenance to group intentional multi-lamp components into a single authored tray while preserving deterministic output and existing constraints (no generic merging, no falloff, no new formats).
- Ensure the authored model and runtime export reflect one tray with multiple emitters and preserve lamp IDs, machine references, emitter positions, and diagnostics.

### Description

- Preserve MFME provenance on Face lamp windows by adding `SourceComponentIndex`, `SharedSourceSetId`, and `SharedSourceSetCount`, and propagate them through generation/regeneration/cloning and Face JSON storage so Face documents retain shared-set metadata.
- Implement grouping in `FaceTrayAutoAuthoringService.AutoAuthor` that: groups visible `FaceLampWindowElement` instances sharing a non-empty `SharedSourceSetId` (and meeting simple equivalence/checks), derives tray bounds (union of contribution/source bounds), creates one authored `FaceTrayModel` for the group, and creates one authored `FaceLampEmitterElement` per lamp window referencing the shared tray while retaining deterministic IDs, lamp IDs, and bulb-mask-derived centres; grouped trays are annotated with diagnostics (`mfme-shared-lamp-set-grouped`, `shared-tray-from-mfme-component`).
- Preserve fallback behavior: lamps without valid shared-set provenance still auto-author as one tray + one emitter each, and no generic overlap-merging logic was added.
- Update runtime export to support multiple emitters per authored tray without introducing new texture formats by packing up to four emitter lamp IDs and weights into the RGBA channels of `lampIds0.png` and `lampWeights0.png`, and add validation to error if a tray contains more than 4 emitters under the current format.
- Added/updated unit tests to cover provenance persistence, grouping behavior (one tray, multiple emitters), deterministic IDs/positions/lamp IDs, and authored runtime texture generation for a shared tray.

### Testing

- No automated tests were executed in this Codex environment because the required Windows/.NET/WPF toolchain is not available here; the repository policy explicitly forbids building/tests in this environment.
- Unit tests added (to run locally): `FaceTrayAutoAuthoringTests.AutoAuthor_GroupsMfmeSharedLampSetIntoOneTrayWithMultipleEmitters`, `FaceTrayAutoAuthoringTests.Serialize_AndRead_RoundTripsFaceLampWindowSharedMfmeProvenance`, and `FaceRuntimeExportServiceTests.Generate_WithSharedAuthoredTray_WritesMultipleEmitterChannels` (plus minor test updates to existing suites).
- Expected local verification checklist: run the full test suite (or at least the two test classes above) and confirm they pass; generate a Face from an MFME import with a known shared multi-lamp component and verify overlays show one tray outline and multiple emitter markers; export runtime textures and confirm `trayId.png` contains one tray ID for the shared area and `lampIds0.png`/`lampWeights0.png` carry multiple emitter channels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d5622fa70832787bcc9e627b48d05)