### PR TITLE
Use distance falloff for single-emitter trays

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -189,7 +189,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
         Assert.Equal(1, trayId.GetPixel(0, 0).Red);
         Assert.Equal(24, lampIds0.GetPixel(0, 0).Red);
-        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Red);
+        Assert.True(lampWeights0.GetPixel(0, 0).Red > 0);
         Assert.Equal(0, trayId.GetPixel(3, 3).Red);
         Assert.Equal(0, lampIds0.GetPixel(3, 3).Red);
         Assert.Equal(0, lampWeights0.GetPixel(3, 3).Red);
@@ -295,10 +295,10 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal(1, trayId.GetPixel(1, 1).Red);
         Assert.Equal(24, lampIds0.GetPixel(1, 1).Red);
         Assert.Equal(0, lampIds0.GetPixel(1, 1).Green);
-        Assert.Equal(255, lampWeights0.GetPixel(1, 1).Red);
+        Assert.True(lampWeights0.GetPixel(1, 1).Red > 0);
         Assert.Equal(0, lampWeights0.GetPixel(0, 0).Red);
         Assert.NotEqual(SKColors.Transparent, trayDebug.GetPixel(1, 1));
-        Assert.Equal(255, weightDebug.GetPixel(1, 1).Red);
+        Assert.True(weightDebug.GetPixel(1, 1).Red > 0);
     }
 
 
@@ -490,7 +490,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     }
 
     [Fact]
-    public void Generate_WithAuthoredTrayAndEmitter_WritesTrayIdsLampIdsAndFullSingleEmitterWeightsFromAuthoredGeometry()
+    public void Generate_WithAuthoredTrayAndEmitter_WritesTrayIdsLampIdsAndFalloffSingleEmitterWeightsFromAuthoredGeometry()
     {
         var outputDirectory = Path.Combine(_generatedDirectory, "authored-texture-test");
         var document = CreateDocumentWithAuthoredTrayAndEmitter(
@@ -512,10 +512,47 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal(4, lampWeights0.Height);
         Assert.Equal(5, trayId.GetPixel(1, 1).Red);
         Assert.Equal(77, lampIds0.GetPixel(1, 1).Red);
-        Assert.Equal(255, lampWeights0.GetPixel(1, 1).Red);
+        Assert.True(lampWeights0.GetPixel(1, 1).Red > 0);
+        Assert.Equal(0, lampIds0.GetPixel(1, 1).Green);
+        Assert.Equal(0, lampWeights0.GetPixel(1, 1).Green);
+        Assert.Equal(0, lampIds0.GetPixel(1, 1).Blue);
+        Assert.Equal(0, lampWeights0.GetPixel(1, 1).Blue);
         Assert.Equal(0, trayId.GetPixel(0, 0).Alpha);
         Assert.Equal(0, lampIds0.GetPixel(0, 0).Alpha);
         Assert.Equal(0, lampWeights0.GetPixel(0, 0).Alpha);
+    }
+
+    [Fact]
+    public void Generate_WithSingleAuthoredEmitter_UsesDistanceFalloffAndDebugIsNotSolidRed()
+    {
+        var firstOutputDirectory = Path.Combine(_generatedDirectory, "single-emitter-falloff-test-a");
+        var secondOutputDirectory = Path.Combine(_generatedDirectory, "single-emitter-falloff-test-b");
+        var document = CreateDocumentWithAuthoredTrayAndEmitters(
+            new FaceSourceRegionModel { X = 0, Y = 0, Width = 6, Height = 6 },
+            new TestEmitter("center-emitter", 19, 3, 3));
+
+        var generator = new FaceRuntimeTextureGenerator();
+        generator.Generate(document, 6, 6, firstOutputDirectory);
+        generator.Generate(document, 6, 6, secondOutputDirectory);
+
+        using var firstIds = SKBitmap.Decode(Path.Combine(firstOutputDirectory, "lampIds0.png"));
+        using var firstWeights = SKBitmap.Decode(Path.Combine(firstOutputDirectory, "lampWeights0.png"));
+        using var firstDebug = SKBitmap.Decode(Path.Combine(firstOutputDirectory, "lampWeights_debug.png"));
+        using var secondWeights = SKBitmap.Decode(Path.Combine(secondOutputDirectory, "lampWeights0.png"));
+
+        var nearCenter = firstWeights.GetPixel(2, 2);
+        var trayEdge = firstWeights.GetPixel(0, 0);
+
+        Assert.Equal(new SKColor(19, 0, 0, 255), firstIds.GetPixel(2, 2));
+        Assert.True(nearCenter.Red > 160);
+        Assert.True(trayEdge.Red > 0);
+        Assert.True(trayEdge.Red < nearCenter.Red);
+        Assert.Equal(0, nearCenter.Green);
+        Assert.Equal(0, nearCenter.Blue);
+        Assert.NotEqual(new SKColor(255, 0, 0, 255), firstDebug.GetPixel(0, 0));
+        Assert.Equal(firstWeights.GetPixel(0, 0), firstDebug.GetPixel(0, 0));
+        Assert.Equal(firstWeights.GetPixel(0, 0), secondWeights.GetPixel(0, 0));
+        Assert.Equal(firstWeights.GetPixel(2, 2), secondWeights.GetPixel(2, 2));
     }
 
     [Fact]
@@ -601,7 +638,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         using var lampWeights0 = SKBitmap.Decode(Path.Combine(outputDirectory, "lampWeights0.png"));
 
         Assert.Equal(3, trayId.GetPixel(0, 0).Red);
-        Assert.Equal(255, lampWeights0.GetPixel(0, 0).Red);
+        Assert.True(lampWeights0.GetPixel(0, 0).Red > 0);
         Assert.Equal(0, trayId.GetPixel(3, 3).Alpha);
         Assert.Equal(0, lampWeights0.GetPixel(3, 3).Alpha);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -591,13 +591,6 @@ public sealed class LampInfluenceTextureGenerator
     {
         var idChannels = new byte[SupportedChannelCount];
         var weightChannels = new byte[SupportedChannelCount];
-        if (influences.Count == 1)
-        {
-            idChannels[0] = influences[0].LampId;
-            weightChannels[0] = 255;
-            return (idChannels, weightChannels);
-        }
-
         var retained = influences
             .Select(influence =>
             {
@@ -645,12 +638,16 @@ public sealed class LampInfluenceTextureGenerator
 
     private static double ResolveFallbackRadius(FaceRuntimeTrayElement tray, IReadOnlyList<FaceLampEmitterElement> emitters)
     {
-        var trayRadius = Math.Max(1d, Math.Max(tray.Width, tray.Height) / Math.Max(1d, emitters.Count));
+        var trayDiameter = Math.Max(tray.Width, tray.Height);
         if (emitters.Count < 2)
         {
-            return trayRadius;
+            // Single-emitter trays still use physical distance falloff. When no authored
+            // radius exists, use a deterministic tray-relative radius that lights most
+            // of the tray while preserving visible edge falloff in lampWeights_debug.png.
+            return Math.Max(1d, trayDiameter * 0.65d);
         }
 
+        var trayRadius = Math.Max(1d, trayDiameter / Math.Max(1d, emitters.Count));
         var nearestSpacing = double.PositiveInfinity;
         for (var left = 0; left < emitters.Count; left++)
         {


### PR DESCRIPTION
### Motivation
- Single-emitter trays were using a binary full-strength special case that wrote a constant `255` red weight across the tray, producing solid `FF0000` regions in `lampWeights_debug.png` and differing from the multi-emitter physical falloff model.
- The goal is to make single-emitter trays use the same distance/radius falloff as multi-emitter trays while keeping the existing `lampIds0`/`lampWeights0` RGB layout and total-weight clamping.

### Description
- Removed the early `influences.Count == 1` branch in `CreateEmitterChannels` so channel generation always computes a distance/radius falloff and then selects up to three emitter channels; the `lampIds0`/`lampWeights0` channel packing and `ClampTotalWeight` behavior are preserved. (`WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs`).
- Added and documented a deterministic single-emitter fallback radius in `ResolveFallbackRadius` that returns `Math.Max(1d, Math.Max(tray.Width, tray.Height) * 0.65d)` when no authored `Radius` is available so single-emitter trays light most of the tray but still show edge falloff. (`FaceRuntimeTextureGenerator.cs`).
- Kept the existing scaling and clamping logic so overlapping emitters remain deterministic and the total byte-weight is capped to `255` after scaling. (`FaceRuntimeTextureGenerator.cs`).
- Updated unit tests to remove expectations of binary `255` weights and added a new test `Generate_WithSingleAuthoredEmitter_UsesDistanceFalloffAndDebugIsNotSolidRed` that checks near-emitter high red intensity, falloff toward edges, green/blue remain zero for single-emitter trays, debug image is not solid red, and generation is deterministic; edits are in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs`.

### Testing
- No automated .NET tests were executed in this environment due to the repository's AGENTS.md constraint against running the Windows/.NET/WPF toolchain here. 
- Unit tests were updated/added in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs`, specifically the renamed/adjusted single-emitter assertions and the new `Generate_WithSingleAuthoredEmitter_UsesDistanceFalloffAndDebugIsNotSolidRed` test. 
- Recommended local automated steps: run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and expect the updated test suite to pass and produce non-solid-red `lampWeights_debug.png` for single-emitter trays.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d752a0a4483278e60cbd862f23358)