### PR TITLE
Fix modal progress dialog rendering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Progress/WpfProgressDialogService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Progress/WpfProgressDialogService.cs
@@ -76,10 +76,15 @@ public sealed class WpfProgressDialogService : IProgressDialogService
             if (_dispatcher.CheckAccess())
             {
                 viewModel.UpdateState(state);
+                PumpPendingProgressRender();
             }
             else
             {
-                _dispatcher.BeginInvoke(() => viewModel.UpdateState(state), DispatcherPriority.Normal);
+                _dispatcher.BeginInvoke(() =>
+                {
+                    viewModel.UpdateState(state);
+                    PumpPendingProgressRender();
+                }, DispatcherPriority.Normal);
             }
         });
 
@@ -131,6 +136,20 @@ public sealed class WpfProgressDialogService : IProgressDialogService
 
         await Task.CompletedTask;
         return result!;
+    }
+
+    private void PumpPendingProgressRender()
+    {
+        if (!_dispatcher.CheckAccess())
+        {
+            return;
+        }
+
+        var frame = new DispatcherFrame();
+        _dispatcher.BeginInvoke(
+            DispatcherPriority.ContextIdle,
+            new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
     }
 
     private Window? ResolveOwnerWindow()


### PR DESCRIPTION
### Motivation
- Modal progress dialogs sometimes remained visually stuck at 0% (or showed no indeterminate animation) while long-running synchronous work executed on the UI thread, making the editor appear unresponsive.
- Progress updates marshalled back from background threads also needed to ensure the UI had a chance to repaint immediately after state changes.

### Description
- Call a small dispatcher render pump after `EditorProgressDialogViewModel.UpdateState` so progress state changes are immediately rendered when on the UI thread.
- Apply the same pump when progress updates are marshalled back via `_dispatcher.BeginInvoke` so background-thread reports also force a repaint.
- Add `PumpPendingProgressRender()` which uses a `DispatcherFrame`/`Dispatcher.PushFrame` with `DispatcherPriority.ContextIdle` to process pending UI work before returning.
- All other modal progress dialog behavior is preserved.

### Testing
- Ran `git diff --check` to validate whitespace and trivial diff issues and it passed.
- Could not run `dotnet build` / unit tests / WPF runtime verification in this environment due to the repository's stated Windows/.NET/WPF constraints, so no runtime tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2ee57773f083279e7023edf15b960c)