### PR TITLE
Add modal progress dialog when opening Face Play View

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -97,6 +97,20 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
     public event Action<EditorToolWindowId>? ToolWindowCloseRequested;
 
+    public Task RunEditorProgressAsync(
+        EditorProgressRequest request,
+        Func<IEditorProgressReporter, CancellationToken, Task> operation,
+        CancellationToken cancellationToken = default)
+    {
+        return _progressDialogService.RunAsync(request, operation, cancellationToken);
+    }
+
+    public void ReportEditorOperationError(string message, OutputLogStatus status)
+    {
+        StatusMessage = message;
+        AddOutputEntry(message, status);
+    }
+
     public MainWindowViewModel(
         IApplicationThemeService applicationThemeService,
         EditorPreferencesStore preferencesStore,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -97,6 +97,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public event Action<EditorToolWindowId>? ToolWindowOpenRequested;
     public event Action<EditorToolWindowId>? ToolWindowCloseRequested;
 
+    public bool IsEditorProgressOperationActive => _progressDialogService.IsOperationActive;
+
     public Task RunEditorProgressAsync(
         EditorProgressRequest request,
         Func<IEditorProgressReporter, CancellationToken, Task> operation,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -36,7 +36,6 @@ public partial class PlayView : UserControl
     private Guid? _preparedFaceDocumentId;
     private string? _preparedFaceDocumentJson;
     private Guid? _preparingFaceDocumentId;
-    private string? _preparingFaceDocumentJson;
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
@@ -119,6 +118,12 @@ public partial class PlayView : UserControl
         RequestRender();
     }
 
+    private bool IsFacePlayViewPrepared(DocumentTabViewModel selected)
+    {
+        return _preparedFaceDocumentId == selected.DocumentId
+            && string.Equals(_preparedFaceDocumentJson, selected.FaceDocumentJson, StringComparison.Ordinal);
+    }
+
     private async Task PrepareFacePlayViewAsync(DocumentTabViewModel selected, int refreshVersion)
     {
         if (ViewModel is not { } viewModel)
@@ -126,32 +131,36 @@ public partial class PlayView : UserControl
             return;
         }
 
-        if (_preparedFaceDocumentId == selected.DocumentId
-            && string.Equals(_preparedFaceDocumentJson, selected.FaceDocumentJson, StringComparison.Ordinal))
+        if (IsFacePlayViewPrepared(selected))
         {
             RequestRender();
             return;
         }
 
-        if (_preparingFaceDocumentId == selected.DocumentId
-            && string.Equals(_preparingFaceDocumentJson, selected.FaceDocumentJson, StringComparison.Ordinal))
+        if (_preparingFaceDocumentId == selected.DocumentId)
         {
             return;
         }
 
         _preparingFaceDocumentId = selected.DocumentId;
-        _preparingFaceDocumentJson = selected.FaceDocumentJson;
         try
         {
+            await WaitForActiveProgressOperationAsync(viewModel);
+            if (refreshVersion != _selectionRefreshVersion || !ReferenceEquals(ViewModel?.SelectedDocument, selected))
+            {
+                return;
+            }
+
             await viewModel.RunEditorProgressAsync(
-                new EditorProgressRequest("Opening Face Play View", "Preparing Face Play View...", EditorProgressMode.Indeterminate),
-                (progress, token) =>
+                new EditorProgressRequest("Opening Face Play View", "Preparing Face Play View...", EditorProgressMode.Indeterminate, ShowDelay: TimeSpan.Zero),
+                async (progress, token) =>
                 {
                     token.ThrowIfCancellationRequested();
                     progress.ReportIndeterminate("Loading Face render assets...");
+                    await Dispatcher.Yield(DispatcherPriority.ApplicationIdle);
+                    token.ThrowIfCancellationRequested();
                     WarmFacePlayViewRenderCache(selected);
                     progress.ReportIndeterminate("Finalizing Face Play View...");
-                    return Task.CompletedTask;
                 });
 
             _preparedFaceDocumentId = selected.DocumentId;
@@ -167,12 +176,19 @@ public partial class PlayView : UserControl
         finally
         {
             _preparingFaceDocumentId = null;
-            _preparingFaceDocumentJson = null;
         }
 
         if (refreshVersion == _selectionRefreshVersion)
         {
             RequestRender();
+        }
+    }
+
+    private static async Task WaitForActiveProgressOperationAsync(MainWindowViewModel viewModel)
+    {
+        while (viewModel.IsEditorProgressOperationActive)
+        {
+            await Task.Delay(50);
         }
     }
 
@@ -209,6 +225,11 @@ public partial class PlayView : UserControl
         canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
         if (selected.Document.DocumentType == EditorDocumentType.Face)
         {
+            if (!IsFacePlayViewPrepared(selected))
+            {
+                return;
+            }
+
             _faceRenderer.Render(canvas, selected.GetFaceDocument(), selected.RuntimeState, viewport);
         }
         else
@@ -783,7 +804,7 @@ public partial class PlayView : UserControl
             return;
         }
 
-        Dispatcher.Invoke(() => RequestRender());
+        Dispatcher.Invoke(RefreshCanvasFromSelection);
     }
 
     private void OnSelectedDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -152,7 +152,7 @@ public partial class PlayView : UserControl
             }
 
             await viewModel.RunEditorProgressAsync(
-                new EditorProgressRequest("Opening Face Play View", "Preparing Face Play View...", EditorProgressMode.Indeterminate, ShowDelay: TimeSpan.Zero),
+                new EditorProgressRequest("Generating Face Play View", "Generating Face Play View...", EditorProgressMode.Indeterminate, ShowDelay: TimeSpan.Zero),
                 async (progress, token) =>
                 {
                     token.ThrowIfCancellationRequested();
@@ -168,7 +168,7 @@ public partial class PlayView : UserControl
         }
         catch (Exception ex)
         {
-            viewModel.ReportEditorOperationError($"Open Face Play View failed: {ex.Message}", OutputLogStatus.Error);
+            viewModel.ReportEditorOperationError($"Generate Face Play View failed: {ex.Message}", OutputLogStatus.Error);
             EmptyStateText.Text = ex.Message;
             EmptyStateText.Visibility = Visibility.Visible;
             return;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -11,6 +11,7 @@ using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using SkiaSharp.Views.WPF;
 using OasisEditor.Rendering;
+using OasisEditor.Progress;
 
 namespace OasisEditor.Views;
 
@@ -31,6 +32,11 @@ public partial class PlayView : UserControl
     private double _reelDragStartTemporaryOffset;
     private bool _isRenderQueued;
     private bool _isRenderDirty;
+    private int _selectionRefreshVersion;
+    private Guid? _preparedFaceDocumentId;
+    private string? _preparedFaceDocumentJson;
+    private Guid? _preparingFaceDocumentId;
+    private string? _preparingFaceDocumentJson;
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
@@ -102,9 +108,88 @@ public partial class PlayView : UserControl
         }
 
         EmptyStateText.Visibility = Visibility.Collapsed;
+
+        if (selected.Document.DocumentType == EditorDocumentType.Face)
+        {
+            _ = PrepareFacePlayViewAsync(selected, ++_selectionRefreshVersion);
+            return;
+        }
+
+        _selectionRefreshVersion++;
         RequestRender();
     }
 
+    private async Task PrepareFacePlayViewAsync(DocumentTabViewModel selected, int refreshVersion)
+    {
+        if (ViewModel is not { } viewModel)
+        {
+            return;
+        }
+
+        if (_preparedFaceDocumentId == selected.DocumentId
+            && string.Equals(_preparedFaceDocumentJson, selected.FaceDocumentJson, StringComparison.Ordinal))
+        {
+            RequestRender();
+            return;
+        }
+
+        if (_preparingFaceDocumentId == selected.DocumentId
+            && string.Equals(_preparingFaceDocumentJson, selected.FaceDocumentJson, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _preparingFaceDocumentId = selected.DocumentId;
+        _preparingFaceDocumentJson = selected.FaceDocumentJson;
+        try
+        {
+            await viewModel.RunEditorProgressAsync(
+                new EditorProgressRequest("Opening Face Play View", "Preparing Face Play View...", EditorProgressMode.Indeterminate),
+                (progress, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    progress.ReportIndeterminate("Loading Face render assets...");
+                    WarmFacePlayViewRenderCache(selected);
+                    progress.ReportIndeterminate("Finalizing Face Play View...");
+                    return Task.CompletedTask;
+                });
+
+            _preparedFaceDocumentId = selected.DocumentId;
+            _preparedFaceDocumentJson = selected.FaceDocumentJson;
+        }
+        catch (Exception ex)
+        {
+            viewModel.ReportEditorOperationError($"Open Face Play View failed: {ex.Message}", OutputLogStatus.Error);
+            EmptyStateText.Text = ex.Message;
+            EmptyStateText.Visibility = Visibility.Visible;
+            return;
+        }
+        finally
+        {
+            _preparingFaceDocumentId = null;
+            _preparingFaceDocumentJson = null;
+        }
+
+        if (refreshVersion == _selectionRefreshVersion)
+        {
+            RequestRender();
+        }
+    }
+
+    private void WarmFacePlayViewRenderCache(DocumentTabViewModel selected)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(1, 1));
+        if (surface is null)
+        {
+            return;
+        }
+
+        _faceRenderer.Render(
+            surface.Canvas,
+            selected.GetFaceDocument(),
+            selected.RuntimeState,
+            new PanelViewportTransform(_skiaZoom, _skiaPan.X, _skiaPan.Y));
+    }
 
     private void OnPlaySkiaSurfacePaintSurface(object? sender, SKPaintSurfaceEventArgs eventArgs)
     {


### PR DESCRIPTION
### Motivation
- Opening a Face into Play View can perform expensive first-load work (texture/cache warm-up) and currently gives no modal feedback to the user. 
- Reuse the existing shared modal progress system so the Play View shows the same indeterminate/determinate dialog used by Face generation and imports.

### Description
- Exposed the shared progress runner via `MainWindowViewModel.RunEditorProgressAsync` and added `ReportEditorOperationError` to centralize error reporting to the status/output log.
- Updated `PlayView.RefreshCanvasFromSelection` to detect Face document selection and kick off a preparation flow instead of immediately rendering.
- Added `PrepareFacePlayViewAsync` which calls the shared progress service with an `EditorProgressRequest` titled "Opening Face Play View" and reports indeterminate stage messages while warming the Face renderer cache.
- Implemented preparation tracking (`_preparedFaceDocumentId`, `_preparingFaceDocumentId`, and JSON fingerprint) and guarded against duplicate or repeated preparations so the modal dialog is not shown repeatedly for the same unchanged Face.

### Testing
- Ran repository checks including `git diff --check` which reported no issues and committed the changes successfully.  
- No build or unit tests were executed in this environment per `AGENTS.md` constraints because the Windows/.NET/WPF toolchain is not available here, so local build and validation are required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2ee7545c5483278b5d178e9deaf091)