### PR TITLE
Launcher: show modal "Starting Editor" progress and prepare Editor before first show

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/LauncherWindowViewModel.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
 using Microsoft.Win32;
+using OasisEditor.Progress;
 
 namespace OasisEditor;
 
@@ -21,6 +22,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
     private string _projectFilePath = string.Empty;
     private string _statusMessage = "Create or open a project to continue.";
     private string? _selectedRecentProject;
+    private bool _isOpeningEditor;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -120,7 +122,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
         {
             var projectPath = _projectContainerCreationService.CreateProjectContainer(ProjectName, ProjectLocation);
             var projectFilePath = Path.Combine(projectPath, $"{ProjectName.Trim()}.oasisproj");
-            OpenEditor(projectFilePath);
+            BeginOpenEditor(projectFilePath);
         }
         catch (Exception ex)
         {
@@ -131,7 +133,7 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
 
     private bool CanCreateProject()
     {
-        return !string.IsNullOrWhiteSpace(ProjectName) && !string.IsNullOrWhiteSpace(ProjectLocation);
+        return !_isOpeningEditor && !string.IsNullOrWhiteSpace(ProjectName) && !string.IsNullOrWhiteSpace(ProjectLocation);
     }
 
     private void BrowseProjectFile()
@@ -158,12 +160,12 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
 
     private void OpenProject()
     {
-        OpenEditor(ProjectFilePath);
+        BeginOpenEditor(ProjectFilePath);
     }
 
     private bool CanOpenProject()
     {
-        return !string.IsNullOrWhiteSpace(ProjectFilePath);
+        return !_isOpeningEditor && !string.IsNullOrWhiteSpace(ProjectFilePath);
     }
 
     private void OpenSelectedRecentProject()
@@ -173,23 +175,52 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        OpenEditor(SelectedRecentProject);
+        BeginOpenEditor(SelectedRecentProject);
     }
 
     private bool CanOpenSelectedRecentProject()
     {
-        return !string.IsNullOrWhiteSpace(SelectedRecentProject);
+        return !_isOpeningEditor && !string.IsNullOrWhiteSpace(SelectedRecentProject);
     }
 
-    private void OpenEditor(string projectFilePath)
+    private async void BeginOpenEditor(string projectFilePath)
     {
+        if (_isOpeningEditor)
+        {
+            return;
+        }
+
+        _isOpeningEditor = true;
+        NotifyProjectCommands();
+
+        MainWindow? mainWindow = null;
         try
         {
             var trimmed = projectFilePath.Trim();
-            ValidateProjectFile(trimmed);
+            var progressService = new WpfProgressDialogService(() => _launcherWindow, _launcherWindow.Dispatcher);
+            mainWindow = await progressService.RunAsync(
+                new EditorProgressRequest(
+                    "Starting Editor",
+                    "Starting Editor...",
+                    EditorProgressMode.Indeterminate,
+                    CanCancel: false,
+                    ShowDelay: TimeSpan.Zero),
+                async (progress, token) =>
+                {
+                    progress.ReportIndeterminate("Opening project...");
+                    ValidateProjectFile(trimmed);
 
-            var mainWindow = new MainWindow(_applicationThemeService, _preferencesStore, trimmed);
-            _launcherWindow.Hide();
+                    token.ThrowIfCancellationRequested();
+                    progress.ReportIndeterminate("Preparing editor shell...");
+                    var preparedWindow = new MainWindow(_applicationThemeService, _preferencesStore, trimmed);
+
+                    await preparedWindow.PrepareForFirstShowAsync(progress, token).ConfigureAwait(true);
+
+                    progress.ReportIndeterminate("Finalizing editor...");
+                    await _launcherWindow.Dispatcher.InvokeAsync(() => { }, System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+                    return preparedWindow;
+                }).ConfigureAwait(true);
+
             mainWindow.Closed += (_, _) =>
             {
                 if (_launcherWindow.IsVisible)
@@ -199,16 +230,26 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
 
                 _launcherWindow.Close();
             };
+
+            _launcherWindow.Hide();
             mainWindow.Show();
+            StatusMessage = $"Opened project: {trimmed}";
+            mainWindow = null;
         }
         catch (Exception ex)
         {
+            mainWindow?.CloseWithoutSavingPlacement();
             StatusMessage = ex.Message;
             if (!_launcherWindow.IsVisible)
             {
                 _launcherWindow.Show();
             }
             MessageBox.Show(ex.Message, "Open Project Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        finally
+        {
+            _isOpeningEditor = false;
+            NotifyProjectCommands();
         }
     }
 
@@ -237,6 +278,13 @@ public sealed class LauncherWindowViewModel : INotifyPropertyChanged
         {
             throw new InvalidOperationException("Project metadata contains an empty 'name' field.");
         }
+    }
+
+    private void NotifyProjectCommands()
+    {
+        NotifyCreateCommand();
+        NotifyOpenCommand();
+        NotifyOpenRecentCommand();
     }
 
     private void NotifyCreateCommand()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
+using OasisEditor.Progress;
 using OasisEditor.Views;
 
 namespace OasisEditor;
@@ -11,6 +13,7 @@ public partial class MainWindow : Window
     private readonly string _startupProjectFilePath;
     private readonly MainWindowViewModel _viewModel;
     private readonly EditorShellView _editorShell;
+    private bool _suppressWindowPlacementSave;
 
     public MainWindow(
         IApplicationThemeService applicationThemeService,
@@ -57,6 +60,39 @@ public partial class MainWindow : Window
         }));
     }
 
+    public async Task PrepareForFirstShowAsync(IEditorProgressReporter progress, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        if (!Dispatcher.CheckAccess())
+        {
+            await Dispatcher.InvokeAsync(
+                () => PrepareForFirstShowAsync(progress, cancellationToken),
+                DispatcherPriority.Normal).Task.Unwrap().ConfigureAwait(true);
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        progress.ReportIndeterminate("Preparing editor shell...");
+        ApplyWindowPlacement();
+        UpdateLayout();
+
+        cancellationToken.ThrowIfCancellationRequested();
+        progress.ReportIndeterminate("Loading startup documents...");
+        await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Loaded);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        progress.ReportIndeterminate("Finalizing editor...");
+        await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.Render);
+        await Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
+    }
+
+    public void CloseWithoutSavingPlacement()
+    {
+        _suppressWindowPlacementSave = true;
+        Close();
+    }
+
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         ApplyWindowPlacement();
@@ -75,7 +111,10 @@ public partial class MainWindow : Window
     private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
         _viewModel.StopEmulationForWindowClose();
-        SaveWindowPlacement();
+        if (!_suppressWindowPlacementSave)
+        {
+            SaveWindowPlacement();
+        }
     }
 
     private void OnAssetsWindowMenuItemClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- Prevent the partially-initialized Editor window with white/blank regions from appearing when opening a project from the Launcher.  
- Reuse the existing modal progress UI so the Launcher startup flow matches in-editor progress styling.  
- Ensure startup failure returns cleanly to the Launcher without leaving hidden/partially-initialized windows.

### Description
- Route Launcher project create/open/recent-open through `WpfProgressDialogService.RunAsync(...)` with indeterminate step messages such as `Starting Editor`, `Opening project...`, `Preparing editor shell...`, and `Finalizing editor...`.  
- Add `LauncherWindowViewModel.BeginOpenEditor(...)` which shows the shared modal progress, validates the project, constructs `MainWindow` while the Launcher (and progress dialog) remain visible, and only hides the Launcher and calls `MainWindow.Show()` after preparation completes.  
- Add a minimal readiness hook `MainWindow.PrepareForFirstShowAsync(IEditorProgressReporter, CancellationToken)` that applies window placement, yields through dispatcher priorities (`Loaded`, `Render`, `ApplicationIdle`), and reports progress text to the shared reporter.  
- Add cleanup for startup failures by calling `MainWindow.CloseWithoutSavingPlacement()` when needed and gating Launcher commands with `_isOpeningEditor` to avoid concurrent opens.  

### Testing
- No automated tests were executed in this environment because the Windows/.NET/WPF toolchain is not available here (`dotnet` not found); please run `dotnet test` locally to execute unit tests and validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2efff8daa08327b7004ba285505677)