### PR TITLE
Optimize Face Play texture preview dirty rendering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Face2DRendererMaskIlluminationTests.cs
@@ -220,6 +220,38 @@ public sealed class Face2DRendererMaskIlluminationTests : IDisposable
         }
     }
 
+
+    [Fact]
+    public void Render_DoesNotDrawTrayDebugOverlayByDefault()
+    {
+        using var textureBitmap = new SKBitmap(20, 20, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        textureBitmap.Erase(SKColors.Black);
+        var renderer = new Face2DRenderer(
+            FaceRuntimeStateResolver.Instance,
+            ResolveTestAssetPath,
+            new StubTexturePreviewRenderer(FaceTexturePreviewRenderResult.FromCachedBitmap(textureBitmap)));
+        var document = new FaceDocumentModel
+        {
+            Trays =
+            [
+                new FaceTrayModel
+                {
+                    ObjectId = "tray-1",
+                    Bounds = new FaceSourceRegionModel { X = 2, Y = 2, Width = 10, Height = 10 }
+                }
+            ]
+        };
+
+        using var surface = SKSurface.Create(new SKImageInfo(20, 20, SKColorType.Bgra8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.White);
+
+        renderer.Render(surface.Canvas, document, new MachineRuntimeState(), new PanelViewportTransform());
+
+        using var snapshot = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(snapshot);
+        Assert.Equal(SKColors.Black, bitmap.GetPixel(2, 2));
+    }
+
     private static FaceDocumentModel CreateDocument(string? artworkPath = null)
     {
         var elements = new List<FaceElementModel>();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceTexturePreviewRendererTests.cs
@@ -384,7 +384,60 @@ public sealed class FaceTexturePreviewRendererTests : IDisposable
         Assert.True(first.Rendered);
         Assert.True(second.Rendered);
         Assert.True(renderer.LastDiagnostics.ReusedComposition);
+        Assert.Equal(0, renderer.LastDiagnostics.DirtyPixelCount);
         Assert.Same(first.Bitmap, second.Bitmap);
+    }
+
+
+    [Fact]
+    public void Render_ChangingOneLampRecomposesOnlyAffectedPixels()
+    {
+        WriteSolidPng("artwork.png", 3, 1, new SKColor(100, 40, 20, 255));
+        WriteSolidPng("mask.png", 3, 1, SKColors.White);
+        WriteSolidPng("trayId.png", 3, 1, new SKColor(1, 0, 0, 255));
+        WriteSolidPng("lampIds0.png", 3, 1, new SKColor(7, 0, 0, 255));
+        WritePixel("lampIds0.png", 1, 0, 3, 1, new SKColor(8, 0, 0, 255));
+        WritePixel("lampIds0.png", 2, 0, 3, 1, new SKColor(9, 0, 0, 255));
+        WriteSolidPng("lampWeights0.png", 3, 1, new SKColor(255, 0, 0, 255));
+        var renderer = CreateRenderer();
+        var runtimeState = new MachineRuntimeState();
+
+        using var first = renderer.Render(CreateDocument(width: 3, height: 1), runtimeState);
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(8), 1d);
+        using var second = renderer.Render(CreateDocument(width: 3, height: 1), runtimeState);
+
+        Assert.True(first.Rendered);
+        Assert.True(second.Rendered);
+        Assert.False(renderer.LastDiagnostics.ReusedComposition);
+        Assert.Equal(1, renderer.LastDiagnostics.DirtyPixelCount);
+        Assert.Equal(25, second.Bitmap!.GetPixel(0, 0).Red);
+        Assert.True(second.Bitmap.GetPixel(1, 0).Red > 25);
+        Assert.Equal(25, second.Bitmap.GetPixel(2, 0).Red);
+    }
+
+    [Fact]
+    public void Render_MultiLampPixelRecomputesWithAllCurrentLampContributions()
+    {
+        WriteSolidPng("artwork.png", 1, 1, new SKColor(100, 40, 20, 255));
+        WriteSolidPng("mask.png", 1, 1, SKColors.White);
+        WriteSolidPng("trayId.png", 1, 1, new SKColor(1, 0, 0, 255));
+        WriteSolidPng("lampIds0.png", 1, 1, new SKColor(7, 8, 0, 255));
+        WriteSolidPng("lampWeights0.png", 1, 1, new SKColor(128, 127, 0, 255));
+        var renderer = new FaceTexturePreviewRenderer(
+            path => string.IsNullOrWhiteSpace(path) ? null : Path.Combine(_testDirectory, path),
+            new FaceTexturePreviewSettings { AmbientStrength = 0.25d, EmissionStrength = 1d, MaskStrength = 1d, LampIds0ChannelCount = 2 });
+        var runtimeState = new MachineRuntimeState();
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(7), 1d);
+        using var first = renderer.Render(CreateDocument(width: 1, height: 1), runtimeState);
+        var firstRed = first.Bitmap!.GetPixel(0, 0).Red;
+
+        runtimeState.SetLampIntensityIfChanged(MachineObjectReference.Lamp(8), 1d);
+        using var second = renderer.Render(CreateDocument(width: 1, height: 1), runtimeState);
+
+        Assert.True(second.Rendered);
+        Assert.Equal(1, renderer.LastDiagnostics.DirtyPixelCount);
+        Assert.True(second.Bitmap!.GetPixel(0, 0).Red > firstRed);
+        Assert.Equal(125, second.Bitmap.GetPixel(0, 0).Red);
     }
 
     public void Dispose()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Face2DRenderer.cs
@@ -17,6 +17,7 @@ public sealed class Face2DRenderer : IFace2DRenderer
     private readonly Dictionary<string, SKImage?> _cachedMaskImages = new(StringComparer.OrdinalIgnoreCase);
     private readonly IFaceTexturePreviewRenderer _texturePreviewRenderer;
     private readonly FaceTrayDebugOverlayRenderer _trayDebugOverlayRenderer = new();
+    private readonly bool _renderTrayDebugOverlay;
 
     internal string? LastTexturePreviewFallbackReason { get; private set; }
 
@@ -30,11 +31,12 @@ public sealed class Face2DRenderer : IFace2DRenderer
     {
     }
 
-    internal Face2DRenderer(IFaceRuntimeStateResolver runtimeStateResolver, Func<string?, string?> assetPathResolver, IFaceTexturePreviewRenderer texturePreviewRenderer)
+    internal Face2DRenderer(IFaceRuntimeStateResolver runtimeStateResolver, Func<string?, string?> assetPathResolver, IFaceTexturePreviewRenderer texturePreviewRenderer, bool renderTrayDebugOverlay = false)
     {
         _runtimeStateResolver = runtimeStateResolver ?? throw new ArgumentNullException(nameof(runtimeStateResolver));
         _assetPathResolver = assetPathResolver ?? throw new ArgumentNullException(nameof(assetPathResolver));
         _texturePreviewRenderer = texturePreviewRenderer ?? throw new ArgumentNullException(nameof(texturePreviewRenderer));
+        _renderTrayDebugOverlay = renderTrayDebugOverlay;
     }
 
     public void Render(SKCanvas canvas, FaceDocumentModel faceDocument, MachineRuntimeState runtimeState, PanelViewportTransform viewportTransform)
@@ -74,7 +76,10 @@ public sealed class Face2DRenderer : IFace2DRenderer
             DrawButton(canvas, button, viewportTransform);
         }
 
-        _trayDebugOverlayRenderer.Render(canvas, faceDocument, viewportTransform);
+        if (_renderTrayDebugOverlay)
+        {
+            _trayDebugOverlayRenderer.Render(canvas, faceDocument, viewportTransform);
+        }
     }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/FaceTexturePreviewRenderer.cs
@@ -54,20 +54,29 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
                 return FaceTexturePreviewRenderResult.Fallback(fallbackReason);
             }
 
-            var lampLookup = BuildLampLookup(runtimeState);
-            var lampSignature = ComputeLampSignature(lampLookup);
-            var reusedComposition = cache.HasComposedFrame && lampSignature == cache.LampSignature;
+            BuildLampLookup(runtimeState, cache.LampLookup);
+            var dirtyPixelCount = ResolveDirtyPixels(cache);
+            var reusedComposition = cache.HasComposedFrame && dirtyPixelCount == 0;
             var composeMilliseconds = 0d;
             if (!reusedComposition)
             {
                 var composeStopwatch = Stopwatch.StartNew();
-                ComposeFrame(cache, lampLookup, lampSignature);
+                if (!cache.HasComposedFrame)
+                {
+                    ComposeFrame(cache);
+                    dirtyPixelCount = cache.PixelCount;
+                }
+                else
+                {
+                    ComposeDirtyPixels(cache);
+                }
+
                 composeStopwatch.Stop();
                 composeMilliseconds = composeStopwatch.Elapsed.TotalMilliseconds;
             }
 
             stopwatch.Stop();
-            _lastDiagnostics = new FaceTexturePreviewDiagnostics(true, cache.WasReusedForLastRequest, reusedComposition, null, loadMilliseconds, precomputeMilliseconds, composeMilliseconds, stopwatch.Elapsed.TotalMilliseconds);
+            _lastDiagnostics = new FaceTexturePreviewDiagnostics(true, cache.WasReusedForLastRequest, reusedComposition, null, loadMilliseconds, precomputeMilliseconds, composeMilliseconds, stopwatch.Elapsed.TotalMilliseconds, dirtyPixelCount);
             TraceDiagnostics(_lastDiagnostics);
             return FaceTexturePreviewRenderResult.FromCachedBitmap(cache.OutputBitmap);
         }
@@ -279,6 +288,7 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
         var maskValues = new byte[pixelCount];
         var lampIds = new byte[pixelCount * cacheKey.LampIds0ChannelCount];
         var lampWeights = new byte[pixelCount * cacheKey.LampIds0ChannelCount];
+        var lampPixelBuilders = new List<int>[256];
 
         for (var y = 0; y < textures.Height; y++)
         {
@@ -301,10 +311,12 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
                 var weights = textures.LampWeights0.GetPixel(x, y);
                 WriteChannels(lampIds, pixelIndex, cacheKey.LampIds0ChannelCount, ids);
                 WriteChannels(lampWeights, pixelIndex, cacheKey.LampIds0ChannelCount, weights);
+                AddLampPixelInfluences(lampPixelBuilders, pixelIndex, cacheKey.LampIds0ChannelCount, ids, weights);
             }
         }
 
-        cache = new FaceTexturePreviewRenderCache(cacheKey, textures.Width, textures.Height, ambientPixels, artworkRgb, maskValues, lampIds, lampWeights);
+        var lampPixelIndex = BuildLampPixelIndex(lampPixelBuilders);
+        cache = new FaceTexturePreviewRenderCache(cacheKey, textures.Width, textures.Height, ambientPixels, artworkRgb, maskValues, lampIds, lampWeights, lampPixelIndex);
         fallbackReason = string.Empty;
         return true;
     }
@@ -329,9 +341,44 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
         }
     }
 
-    private static double[] BuildLampLookup(MachineRuntimeState runtimeState)
+    private static void AddLampPixelInfluences(List<int>[] lampPixelBuilders, int pixelIndex, int channelCount, SKColor ids, SKColor weights)
     {
-        var lookup = new double[256];
+        Span<byte> idChannels = stackalloc byte[] { ids.Red, ids.Green, ids.Blue, ids.Alpha };
+        Span<byte> weightChannels = stackalloc byte[] { weights.Red, weights.Green, weights.Blue, weights.Alpha };
+        Span<byte> addedLampIds = stackalloc byte[4];
+        var addedCount = 0;
+        for (var channel = 0; channel < channelCount; channel++)
+        {
+            var lampId = idChannels[channel];
+            if (lampId == 0 || weightChannels[channel] == 0)
+            {
+                continue;
+            }
+
+            if (addedLampIds[..addedCount].Contains(lampId))
+            {
+                continue;
+            }
+
+            addedLampIds[addedCount++] = lampId;
+            (lampPixelBuilders[lampId] ??= []).Add(pixelIndex);
+        }
+    }
+
+    private static int[][] BuildLampPixelIndex(List<int>[] lampPixelBuilders)
+    {
+        var index = new int[256][];
+        for (var lampId = 0; lampId < index.Length; lampId++)
+        {
+            index[lampId] = lampPixelBuilders[lampId]?.ToArray() ?? [];
+        }
+
+        return index;
+    }
+
+    private static void BuildLampLookup(MachineRuntimeState runtimeState, double[] lookup)
+    {
+        Array.Clear(lookup, 0, lookup.Length);
         foreach (var entry in runtimeState.LampIntensityByMachineObjectId)
         {
             if (!MachineObjectReference.TryParse(entry.Key, out var reference)
@@ -346,25 +393,59 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
             lookup[lampId] = Math.Clamp(entry.Value, 0d, 1d);
         }
 
-        return lookup;
     }
 
-    private static long ComputeLampSignature(double[] lampLookup)
+    private static int ResolveDirtyPixels(FaceTexturePreviewRenderCache cache)
     {
-        const long fnvOffsetBasis = unchecked((long)1469598103934665603UL);
-        const long fnvPrime = 1099511628211L;
-        var hash = fnvOffsetBasis;
-        for (var lampId = 1; lampId < lampLookup.Length; lampId++)
+        cache.DirtyPixelCount = 0;
+        BeginDirtyMark(cache);
+        for (var lampId = 1; lampId < cache.LampLookup.Length; lampId++)
         {
-            var quantized = (byte)Math.Clamp(Math.Round(lampLookup[lampId] * 255d, MidpointRounding.AwayFromZero), 0d, 255d);
-            hash ^= ((long)lampId << 8) | quantized;
-            hash *= fnvPrime;
+            var quantized = (byte)Math.Clamp(Math.Round(cache.LampLookup[lampId] * 255d, MidpointRounding.AwayFromZero), 0d, 255d);
+            cache.CurrentQuantizedLampIntensities[lampId] = quantized;
+            if (cache.HasComposedFrame && quantized == cache.PreviousQuantizedLampIntensities[lampId])
+            {
+                continue;
+            }
+
+            MarkDirtyPixels(cache, cache.LampPixelIndex[lampId]);
         }
 
-        return hash;
+        return cache.HasComposedFrame ? cache.DirtyPixelCount : cache.PixelCount;
     }
 
-    private static unsafe void ComposeFrame(FaceTexturePreviewRenderCache cache, double[] lampLookup, long lampSignature)
+    private static void BeginDirtyMark(FaceTexturePreviewRenderCache cache)
+    {
+        if (cache.DirtyMark == int.MaxValue)
+        {
+            Array.Clear(cache.DirtyPixelMarks, 0, cache.DirtyPixelMarks.Length);
+            cache.DirtyMark = 0;
+        }
+
+        cache.DirtyMark++;
+    }
+
+    private static void MarkDirtyPixels(FaceTexturePreviewRenderCache cache, int[] pixelIndices)
+    {
+        if (pixelIndices.Length == 0)
+        {
+            return;
+        }
+
+        var mark = cache.DirtyMark;
+        foreach (var pixelIndex in pixelIndices)
+        {
+            if (cache.DirtyPixelMarks[pixelIndex] == mark)
+            {
+                continue;
+            }
+
+            cache.DirtyPixelMarks[pixelIndex] = mark;
+            cache.DirtyPixels[cache.DirtyPixelCount++] = pixelIndex;
+        }
+    }
+
+    private static unsafe void ComposeFrame(FaceTexturePreviewRenderCache cache)
     {
         var output = cache.OutputBitmap;
         var pixels = (byte*)output.GetPixels().ToPointer();
@@ -389,7 +470,7 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
                         continue;
                     }
 
-                    visibleLight += lampLookup[lampId] * (weight / 255d);
+                    visibleLight += cache.LampLookup[lampId] * (weight / 255d);
                 }
 
                 var light = (cache.MaskValues[pixelIndex] / 255d) * visibleLight * cache.Key.EmissionStrength;
@@ -411,8 +492,58 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
             }
         }
 
-        cache.LampSignature = lampSignature;
+        Array.Copy(cache.CurrentQuantizedLampIntensities, cache.PreviousQuantizedLampIntensities, cache.CurrentQuantizedLampIntensities.Length);
         cache.HasComposedFrame = true;
+    }
+
+    private static unsafe void ComposeDirtyPixels(FaceTexturePreviewRenderCache cache)
+    {
+        var output = cache.OutputBitmap;
+        var pixels = (byte*)output.GetPixels().ToPointer();
+        var rowBytes = output.RowBytes;
+        for (var i = 0; i < cache.DirtyPixelCount; i++)
+        {
+            ComposePixel(cache, pixels, rowBytes, cache.DirtyPixels[i]);
+        }
+
+        Array.Copy(cache.CurrentQuantizedLampIntensities, cache.PreviousQuantizedLampIntensities, cache.CurrentQuantizedLampIntensities.Length);
+    }
+
+    private static unsafe void ComposePixel(FaceTexturePreviewRenderCache cache, byte* pixels, int rowBytes, int pixelIndex)
+    {
+        var channelCount = cache.Key.LampIds0ChannelCount;
+        var rgbaIndex = pixelIndex * 4;
+        var rgbIndex = pixelIndex * 3;
+        var visibleLight = 0d;
+        var lampOffset = pixelIndex * channelCount;
+        for (var channel = 0; channel < channelCount; channel++)
+        {
+            var lampId = cache.LampIds[lampOffset + channel];
+            var weight = cache.LampWeights[lampOffset + channel];
+            if (lampId == 0 || weight == 0)
+            {
+                continue;
+            }
+
+            visibleLight += cache.LampLookup[lampId] * (weight / 255d);
+        }
+
+        var light = (cache.MaskValues[pixelIndex] / 255d) * visibleLight * cache.Key.EmissionStrength;
+        var target = pixels + ((pixelIndex / cache.Width) * rowBytes) + ((pixelIndex % cache.Width) * 4);
+        if (light <= 0.000001d)
+        {
+            target[0] = cache.AmbientPixels[rgbaIndex];
+            target[1] = cache.AmbientPixels[rgbaIndex + 1];
+            target[2] = cache.AmbientPixels[rgbaIndex + 2];
+            target[3] = cache.AmbientPixels[rgbaIndex + 3];
+            return;
+        }
+
+        var multiplier = cache.Key.AmbientStrength + light;
+        target[0] = ScaleChannel(cache.ArtworkRgb[rgbIndex], multiplier);
+        target[1] = ScaleChannel(cache.ArtworkRgb[rgbIndex + 1], multiplier);
+        target[2] = ScaleChannel(cache.ArtworkRgb[rgbIndex + 2], multiplier);
+        target[3] = cache.AmbientPixels[rgbaIndex + 3];
     }
 
     private static byte ResolveMaskByte(SKColor maskPixel, double maskStrength)
@@ -462,6 +593,7 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
             $"Face texture preview timings: textureCacheLoad={diagnostics.TextureCacheLoadMilliseconds:0.00} ms, "
             + $"precompute={diagnostics.PrecomputeMilliseconds:0.00} ms, "
             + $"compose={diagnostics.ComposeMilliseconds:0.00} ms, "
+            + $"dirtyPixels={diagnostics.DirtyPixelCount}, "
             + $"drawCachedImage=pending-canvas-draw, "
             + $"reusedTextures={diagnostics.ReusedTextureCache}, "
             + $"reusedComposition={diagnostics.ReusedComposition}");
@@ -512,7 +644,7 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
 
     private sealed class FaceTexturePreviewRenderCache : IDisposable
     {
-        public FaceTexturePreviewRenderCache(FaceTexturePreviewCacheKey key, int width, int height, byte[] ambientPixels, byte[] artworkRgb, byte[] maskValues, byte[] lampIds, byte[] lampWeights)
+        public FaceTexturePreviewRenderCache(FaceTexturePreviewCacheKey key, int width, int height, byte[] ambientPixels, byte[] artworkRgb, byte[] maskValues, byte[] lampIds, byte[] lampWeights, int[][] lampPixelIndex)
         {
             Key = key;
             Width = width;
@@ -522,6 +654,13 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
             MaskValues = maskValues;
             LampIds = lampIds;
             LampWeights = lampWeights;
+            LampPixelIndex = lampPixelIndex;
+            PixelCount = width * height;
+            LampLookup = new double[256];
+            CurrentQuantizedLampIntensities = new byte[256];
+            PreviousQuantizedLampIntensities = new byte[256];
+            DirtyPixelMarks = new int[PixelCount];
+            DirtyPixels = new int[PixelCount];
             OutputBitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
         }
 
@@ -533,11 +672,18 @@ public sealed class FaceTexturePreviewRenderer : IFaceTexturePreviewRenderer, ID
         public byte[] MaskValues { get; }
         public byte[] LampIds { get; }
         public byte[] LampWeights { get; }
+        public int[][] LampPixelIndex { get; }
+        public int PixelCount { get; }
+        public double[] LampLookup { get; }
+        public byte[] CurrentQuantizedLampIntensities { get; }
+        public byte[] PreviousQuantizedLampIntensities { get; }
+        public int[] DirtyPixelMarks { get; }
+        public int[] DirtyPixels { get; }
+        public int DirtyPixelCount { get; set; }
+        public int DirtyMark { get; set; }
         public SKBitmap OutputBitmap { get; }
         public bool WasReusedForLastRequest { get; set; }
         public bool HasComposedFrame { get; set; }
-        public long LampSignature { get; set; }
-
         public void Dispose()
         {
             OutputBitmap.Dispose();
@@ -606,7 +752,8 @@ public readonly record struct FaceTexturePreviewDiagnostics(
     double TextureCacheLoadMilliseconds,
     double PrecomputeMilliseconds,
     double ComposeMilliseconds,
-    double TotalMilliseconds)
+    double TotalMilliseconds,
+    int DirtyPixelCount = 0)
 {
     public static FaceTexturePreviewDiagnostics Empty { get; } = new(false, false, false, null, 0d, 0d, 0d, 0d);
 }


### PR DESCRIPTION
### Motivation

- The Face texture preview path recomposed the entire face bitmap whenever any lamp signature changed, causing a single CPU core to be pegged during rapid lamp changes.
- The intent is to avoid full-frame recomposition when only a subset of lamps change so Face Play remains responsive while preserving pixel-accurate lighting.

### Description

- Precompute a lamp-to-pixel influence index during `TryPrecompute` from `lampIds0.png`/`lampWeights0.png` and store it in the cache (`lampPixelIndex`) via `AddLampPixelInfluences` and `BuildLampPixelIndex`.
- Replace per-frame `double[256]` allocations with reusable arrays stored on `FaceTexturePreviewRenderCache` (`LampLookup`, `CurrentQuantizedLampIntensities`, `PreviousQuantizedLampIntensities`, and dirty pixel buffers) and fill `LampLookup` via `BuildLampLookup(runtimeState, cache.LampLookup)`.
- On each render compute dirty work with `ResolveDirtyPixels(cache)`, reuse the composed bitmap when `dirtyPixelCount == 0`, otherwise call `ComposeFrame(cache)` for first composition or `ComposeDirtyPixels(cache)` to recompute only the union of affected pixels while still accounting for all lamp channels per pixel.
- Add lightweight diagnostics (`DirtyPixelCount`) to `FaceTexturePreviewDiagnostics`, make the tray debug overlay opt-in via a `Face2DRenderer` constructor flag, and add unit tests to cover composition reuse, dirty recomposition, multi-lamp-pixel correctness, and default-off tray overlay.

### Testing

- Added unit tests in `FaceTexturePreviewRendererTests.cs` and `Face2DRendererMaskIlluminationTests.cs` covering unchanged-state reuse, single-lamp dirty recomposition, multi-lamp pixel correctness, and that tray debug overlays are off by default.
- Could not run `dotnet test` in this execution environment per `WindowsNetProjects/OasisEditor/AGENTS.md`, so tests were not executed here and must be run locally on Windows/.NET; please run `dotnet test ./WindowsNetProjects/OasisEditor/OasisEditor.Tests` locally.
- Performed a repository whitespace/format check with `git diff --check`, which reported no issues.
- Recommended local performance checklist: open Face Play with runtime textures, run emulation with many fast-changing lamps, verify CPU usage reduced and `DirtyPixelCount` (enable `FaceTexturePreviewSettings.EnableDiagnostics`) reflects much smaller work than full pixel count.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2f045933ec8327bb25ef39aa91e9f9)