### PR TITLE
Add modal progress dialog and progress reporting for document saves

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ConvertMfmeAutomationCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ConvertMfmeAutomationCommandTests.cs
@@ -1,5 +1,6 @@
 using OasisEditor.Automation;
 using OasisEditor.Features.MfmeImport;
+using OasisEditor.Progress;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -101,7 +102,7 @@ public sealed class ConvertMfmeAutomationCommandTests
     {
         public bool WasCalled { get; private set; }
 
-        public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null)
+        public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null, IEditorProgressReporter? progress = null)
         {
             WasCalled = true;
             return current;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/DocumentSaveServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/DocumentSaveServiceTests.cs
@@ -29,4 +29,29 @@ public sealed class DocumentSaveServiceTests
             if (File.Exists(tempPath)) File.Delete(tempPath);
         }
     }
+
+    [Fact]
+    public void SaveDocument_ReportsProgressStages()
+    {
+        var service = new DocumentSaveService();
+        var tempPath = Path.Combine(Path.GetTempPath(), $"oasis-save-progress-{Guid.NewGuid():N}.panel2d");
+
+        try
+        {
+            var current = new DocumentTabViewModel(
+                EditorDocument.CreatePanel2DStub("Panel 1").MarkDirty(),
+                Panel2DDocumentStorage.SerializeLayout([]));
+            var progress = new RecordingEditorProgressReporter();
+
+            service.SaveDocument(current, tempPath, progress: progress);
+
+            Assert.Contains(progress.Reports, report => report.Message == "Preparing document save...");
+            Assert.Contains(progress.Reports, report => report.Message == "Writing document file...");
+            Assert.Contains(progress.Reports, report => report.Message == "Document saved.");
+        }
+        finally
+        {
+            if (File.Exists(tempPath)) File.Delete(tempPath);
+        }
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using OasisEditor.Features.MfmeImport;
+using OasisEditor.Progress;
 
 namespace OasisEditor.Automation;
 
@@ -33,7 +34,7 @@ internal sealed class MfmeExtractImportService : IMfmeExtractImportService
 
 public interface IDocumentSaveService
 {
-    DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null);
+    DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null, IEditorProgressReporter? progress = null);
 }
 
 public sealed class DocumentSaveService : IDocumentSaveService
@@ -45,9 +46,12 @@ public sealed class DocumentSaveService : IDocumentSaveService
         _faceRuntimeExportService = faceRuntimeExportService ?? new FaceRuntimeExportService();
     }
 
-    public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null)
+    public DocumentTabViewModel SaveDocument(DocumentTabViewModel current, string savePath, EditorProject? project = null, IEditorProgressReporter? progress = null)
     {
         ArgumentNullException.ThrowIfNull(current);
+        progress ??= NoOpEditorProgressReporter.Instance;
+        progress.Report(0.0, "Preparing document save...");
+
         if (string.IsNullOrWhiteSpace(savePath))
         {
             throw new ArgumentException("Save path is required.", nameof(savePath));
@@ -55,9 +59,11 @@ public sealed class DocumentSaveService : IDocumentSaveService
 
         var faceDocumentJson = current.FaceDocumentJson;
         var contentSource = current;
+        progress.Report(0.1, "Collecting document content...");
         if (current.Document.DocumentType == EditorDocumentType.Face && project is not null)
         {
-            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project);
+            progress.Report(0.15, "Exporting Face runtime assets...");
+            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, progress.CreateChild(0.15, 0.75));
             faceDocumentJson = FaceDocumentStorage.Serialize(exportResult.Document);
             contentSource = new DocumentTabViewModel(
                 current.Document,
@@ -76,10 +82,13 @@ public sealed class DocumentSaveService : IDocumentSaveService
             };
         }
 
+        progress.Report(0.8, "Serializing document...");
         var content = DocumentWorkspaceViewModel.BuildDocumentContent(contentSource);
+        progress.Report(0.9, "Writing document file...");
         File.WriteAllText(savePath, content);
+        progress.Report(0.95, "Updating document state...");
 
-        return new DocumentTabViewModel(
+        var savedDocument = new DocumentTabViewModel(
             current.Document.SaveAs(savePath, current.ContentSummary).MarkClean(),
             current.PanelLayoutJson,
             current.DocumentId,
@@ -94,5 +103,8 @@ public sealed class DocumentSaveService : IDocumentSaveService
             FacePanX = current.FacePanX,
             FacePanY = current.FacePanY
         };
+
+        progress.Report(1.0, "Document saved.");
+        return savedDocument;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1590,7 +1590,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return _documentWorkspace.CanSaveSelectedDocument();
     }
 
-    private void SaveSelectedDocument()
+    private async void SaveSelectedDocument()
     {
         if (SelectedDocument is null)
         {
@@ -1606,7 +1606,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         try
         {
-            var updatedDocument = _documentSaveService.SaveDocument(current, savePath, LoadedProject);
+            var documentTitle = current.Title;
+            var updatedDocument = await _progressDialogService.RunAsync(
+                new EditorProgressRequest($"Saving {documentTitle}", "Saving document...", EditorProgressMode.Determinate, ShowDelay: TimeSpan.Zero),
+                (progress, _) => Task.Run(() => _documentSaveService.SaveDocument(current, savePath, LoadedProject, progress)));
             _documentWorkspace.ReplaceDocument(current, updatedDocument);
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}", OutputLogStatus.Info);


### PR DESCRIPTION
### Motivation

- Saving documents (especially `.face`) can be slow due to runtime asset export and should surface a progress UI so users know the operation is active and can see coarse stages.
- Reuse the existing modal progress system so save operations share the same UX as other long-running editor operations.

### Description

- Run document saves under the shared progress dialog by converting `SaveSelectedDocument` to an async handler and calling `_progressDialogService.RunAsync(...)` with a determinate `EditorProgressRequest`.
- Extend `IDocumentSaveService.SaveDocument` to accept an optional `IEditorProgressReporter? progress = null` parameter and thread progress through the save path.
- Report coarse save stages (`Preparing document save...`, `Collecting document content...`, `Exporting Face runtime assets...`, `Serializing document...`, `Writing document file...`, `Updating document state...`, `Document saved.`) from `DocumentSaveService`, and nest face runtime export using `progress.CreateChild(0.15, 0.75)` so `.face` export contributes to the same dialog.
- Add and update unit test scaffolding: add `SaveDocument_ReportsProgressStages` to `DocumentSaveServiceTests.cs` and update the fake save implementation signature used in automation tests to accept the new `progress` parameter.

### Testing

- No tests were executed in this environment per repository guidance; the Codex environment lacks the Windows/.NET/WPF toolchain so automated tests were not run here.
- Added unit test `SaveDocument_ReportsProgressStages` in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/DocumentSaveServiceTests.cs` which asserts the new progress messages are emitted during `DocumentSaveService.SaveDocument`.
- Updated `WindowsNetProjects/OasisEditor/OasisEditor.Tests/ConvertMfmeAutomationCommandTests.cs` to match the new `IDocumentSaveService` signature; please run `dotnet test` locally to verify the test suite passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2f1341ff808327b3df01540981bbbd)