### PR TITLE
Add raw emitter influence debug textures

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -11,7 +11,6 @@ public sealed class FaceRuntimeTextureGenerator
     public const string LampWeights0FileName = "lampWeights0.png";
     public const string TrayIdDebugFileName = "trayId_debug.png";
     public const string LampWeightsDebugFileName = "lampWeights_debug.png";
-    public const string RawEmitterDebugFileNamePrefix = "debug_raw_emitter_";
 
     private readonly TrayIdTextureGenerator _trayIdTextureGenerator;
     private readonly LampInfluenceTextureGenerator _lampInfluenceTextureGenerator;
@@ -92,7 +91,7 @@ public sealed class FaceRuntimeTextureGenerator
         progress.Report(0.35, "Generating texture files...");
         _trayIdTextureGenerator.Generate(plan.Trays, width, height, trayIdPath, trayIdDebugPath);
         progress.Report(0.65, "Generating texture files...");
-        _lampInfluenceTextureGenerator.Generate(plan.Trays, plan.Emitters, width, height, lampIds0Path, lampWeights0Path, lampWeightsDebugPath, outputDirectory);
+        _lampInfluenceTextureGenerator.Generate(plan.Trays, plan.Emitters, width, height, lampIds0Path, lampWeights0Path, lampWeightsDebugPath);
 
         progress.Report(1.0, "Texture file generation complete.");
         return new FaceRuntimeTextureGenerationResult(
@@ -522,8 +521,7 @@ public sealed class LampInfluenceTextureGenerator
         int height,
         string lampIds0Path,
         string lampWeights0Path,
-        string lampWeightsDebugPath,
-        string? rawEmitterDebugOutputDirectory = null)
+        string lampWeightsDebugPath)
     {
         ArgumentNullException.ThrowIfNull(trays);
         ArgumentNullException.ThrowIfNull(emitters);
@@ -575,11 +573,6 @@ public sealed class LampInfluenceTextureGenerator
         WritePng(idsBitmap, lampIds0Path, "lamp ID texture");
         WritePng(weightsBitmap, lampWeights0Path, "lamp weight texture");
         WritePng(debugBitmap, lampWeightsDebugPath, "lamp weight debug texture");
-
-        if (!string.IsNullOrWhiteSpace(rawEmitterDebugOutputDirectory))
-        {
-            GenerateRawEmitterDebugTextures(emittersByTray, width, height, rawEmitterDebugOutputDirectory);
-        }
     }
 
     private static IReadOnlyList<LampInfluence> CreateInfluences(IReadOnlyList<FaceLampEmitterElement> emitters)
@@ -588,43 +581,6 @@ public sealed class LampInfluenceTextureGenerator
             .OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
             .Select((emitter, index) => CreateRawInfluence(emitter, index))
             .ToArray();
-    }
-
-    private static void GenerateRawEmitterDebugTextures(
-        IReadOnlyDictionary<int, FaceLampEmitterElement[]> emittersByTray,
-        int width,
-        int height,
-        string outputDirectory)
-    {
-        var influences = emittersByTray
-            .OrderByDescending(group => group.Value.Length)
-            .ThenBy(group => group.Key)
-            .Select(group => group.Value)
-            .FirstOrDefault()?
-            .OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
-            .Take(SupportedChannelCount)
-            .Select((emitter, index) => CreateRawInfluence(emitter, index))
-            .ToArray()
-            ?? [];
-
-        for (var index = 0; index < influences.Length; index++)
-        {
-            using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-            bitmap.Erase(SKColors.Transparent);
-            var influence = influences[index];
-            for (var y = 0; y < height; y++)
-            {
-                for (var x = 0; x < width; x++)
-                {
-                    var rawWeight = CalculateRawWeight(influence, x + 0.5d, y + 0.5d);
-                    var weight = ToWeightByte(rawWeight);
-                    bitmap.SetPixel(x, y, new SKColor(weight, weight, weight, 255));
-                }
-            }
-
-            var path = Path.Combine(outputDirectory, $"{FaceRuntimeTextureGenerator.RawEmitterDebugFileNamePrefix}{index}.png");
-            WritePng(bitmap, path, $"raw emitter {index} debug texture");
-        }
     }
 
     private static LampInfluence CreateRawInfluence(FaceLampEmitterElement emitter, int order)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -552,7 +552,7 @@ public sealed class LampInfluenceTextureGenerator
             }
 
             var bounds = RasterBounds.FromElement(tray, width, height);
-            var influences = CreateInfluences(tray, trayEmitters);
+            var influences = CreateInfluences(trayEmitters);
             for (var y = bounds.Top; y < bounds.Bottom; y++)
             {
                 for (var x = bounds.Left; x < bounds.Right; x++)
@@ -582,23 +582,11 @@ public sealed class LampInfluenceTextureGenerator
         }
     }
 
-    private static IReadOnlyList<LampInfluence> CreateInfluences(FaceRuntimeTrayElement tray, IReadOnlyList<FaceLampEmitterElement> emitters)
+    private static IReadOnlyList<LampInfluence> CreateInfluences(IReadOnlyList<FaceLampEmitterElement> emitters)
     {
-        var fallbackRadius = ResolveFallbackRadius(tray, emitters);
         return emitters
             .OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
-            .Select((emitter, index) =>
-            {
-                var radius = emitter.Radius is double emitterRadius && emitterRadius > 0d && IsFinite(emitterRadius)
-                    ? emitterRadius
-                    : fallbackRadius;
-                return new LampInfluence(
-                    (byte)emitter.LampId!.Value,
-                    emitter.CenterX,
-                    emitter.CenterY,
-                    Math.Max(MinimumRadius, radius),
-                    index);
-            })
+            .Select((emitter, index) => CreateRawInfluence(emitter, index))
             .ToArray();
     }
 
@@ -615,7 +603,7 @@ public sealed class LampInfluenceTextureGenerator
             .FirstOrDefault()?
             .OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
             .Take(SupportedChannelCount)
-            .Select(CreateRawInfluence)
+            .Select((emitter, index) => CreateRawInfluence(emitter, index))
             .ToArray()
             ?? [];
 
@@ -629,7 +617,7 @@ public sealed class LampInfluenceTextureGenerator
                 for (var x = 0; x < width; x++)
                 {
                     var rawWeight = CalculateRawWeight(influence, x + 0.5d, y + 0.5d);
-                    var weight = (byte)Math.Clamp(Math.Round(rawWeight * 255d, MidpointRounding.AwayFromZero), 0d, 255d);
+                    var weight = ToWeightByte(rawWeight);
                     bitmap.SetPixel(x, y, new SKColor(weight, weight, weight, 255));
                 }
             }
@@ -639,7 +627,7 @@ public sealed class LampInfluenceTextureGenerator
         }
     }
 
-    private static LampInfluence CreateRawInfluence(FaceLampEmitterElement emitter)
+    private static LampInfluence CreateRawInfluence(FaceLampEmitterElement emitter, int order)
     {
         var fallbackRadius = Math.Max(MinimumRadius, Math.Max(emitter.Width, emitter.Height) * 0.65d);
         var radius = emitter.Radius is double emitterRadius && emitterRadius > 0d && IsFinite(emitterRadius)
@@ -650,7 +638,7 @@ public sealed class LampInfluenceTextureGenerator
             emitter.CenterX,
             emitter.CenterY,
             Math.Max(MinimumRadius, radius),
-            0);
+            order);
     }
 
     private static double CalculateRawWeight(LampInfluence influence, double pixelX, double pixelY)
@@ -676,67 +664,20 @@ public sealed class LampInfluenceTextureGenerator
             .Take(SupportedChannelCount)
             .ToArray();
 
-        var rawByteWeights = retained
-            .Select(influence => Math.Clamp(influence.RawWeight * 255d, 0d, 255d))
-            .ToArray();
-        var totalByteWeight = rawByteWeights.Sum();
-        if (totalByteWeight <= 0d || !IsFinite(totalByteWeight))
-        {
-            return (idChannels, weightChannels);
-        }
-
-        var scale = totalByteWeight > 255d ? 255d / totalByteWeight : 1d;
         for (var channel = 0; channel < retained.Length; channel++)
         {
             idChannels[channel] = retained[channel].Influence.LampId;
-            weightChannels[channel] = (byte)Math.Clamp(Math.Round(rawByteWeights[channel] * scale, MidpointRounding.AwayFromZero), 0d, 255d);
+            weightChannels[channel] = ToWeightByte(retained[channel].RawWeight);
         }
 
-        ClampTotalWeight(weightChannels);
         return (idChannels, weightChannels);
     }
 
-    private static void ClampTotalWeight(byte[] weightChannels)
+    private static byte ToWeightByte(double rawWeight)
     {
-        var overflow = weightChannels.Sum(weight => weight) - 255;
-        for (var channel = weightChannels.Length - 1; channel >= 0 && overflow > 0; channel--)
-        {
-            var reduction = Math.Min(weightChannels[channel], overflow);
-            weightChannels[channel] -= (byte)reduction;
-            overflow -= reduction;
-        }
-    }
-
-    private static double ResolveFallbackRadius(FaceRuntimeTrayElement tray, IReadOnlyList<FaceLampEmitterElement> emitters)
-    {
-        var trayDiameter = Math.Max(tray.Width, tray.Height);
-        if (emitters.Count < 2)
-        {
-            // Single-emitter trays still use physical distance falloff. When no authored
-            // radius exists, use a deterministic tray-relative radius that lights most
-            // of the tray while preserving visible edge falloff in lampWeights_debug.png.
-            return Math.Max(1d, trayDiameter * 0.65d);
-        }
-
-        var trayRadius = Math.Max(1d, trayDiameter / Math.Max(1d, emitters.Count));
-        var nearestSpacing = double.PositiveInfinity;
-        for (var left = 0; left < emitters.Count; left++)
-        {
-            for (var right = left + 1; right < emitters.Count; right++)
-            {
-                var dx = emitters[left].CenterX - emitters[right].CenterX;
-                var dy = emitters[left].CenterY - emitters[right].CenterY;
-                var spacing = Math.Sqrt((dx * dx) + (dy * dy));
-                if (spacing > 0d && spacing < nearestSpacing)
-                {
-                    nearestSpacing = spacing;
-                }
-            }
-        }
-
-        return IsFinite(nearestSpacing)
-            ? Math.Max(1d, Math.Min(trayRadius, nearestSpacing))
-            : trayRadius;
+        return IsFinite(rawWeight)
+            ? (byte)Math.Clamp(Math.Round(rawWeight * 255d, MidpointRounding.AwayFromZero), 0d, 255d)
+            : (byte)0;
     }
 
     private static bool IsFinite(double value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -11,6 +11,7 @@ public sealed class FaceRuntimeTextureGenerator
     public const string LampWeights0FileName = "lampWeights0.png";
     public const string TrayIdDebugFileName = "trayId_debug.png";
     public const string LampWeightsDebugFileName = "lampWeights_debug.png";
+    public const string RawEmitterDebugFileNamePrefix = "debug_raw_emitter_";
 
     private readonly TrayIdTextureGenerator _trayIdTextureGenerator;
     private readonly LampInfluenceTextureGenerator _lampInfluenceTextureGenerator;
@@ -91,7 +92,7 @@ public sealed class FaceRuntimeTextureGenerator
         progress.Report(0.35, "Generating texture files...");
         _trayIdTextureGenerator.Generate(plan.Trays, width, height, trayIdPath, trayIdDebugPath);
         progress.Report(0.65, "Generating texture files...");
-        _lampInfluenceTextureGenerator.Generate(plan.Trays, plan.Emitters, width, height, lampIds0Path, lampWeights0Path, lampWeightsDebugPath);
+        _lampInfluenceTextureGenerator.Generate(plan.Trays, plan.Emitters, width, height, lampIds0Path, lampWeights0Path, lampWeightsDebugPath, outputDirectory);
 
         progress.Report(1.0, "Texture file generation complete.");
         return new FaceRuntimeTextureGenerationResult(
@@ -521,7 +522,8 @@ public sealed class LampInfluenceTextureGenerator
         int height,
         string lampIds0Path,
         string lampWeights0Path,
-        string lampWeightsDebugPath)
+        string lampWeightsDebugPath,
+        string? rawEmitterDebugOutputDirectory = null)
     {
         ArgumentNullException.ThrowIfNull(trays);
         ArgumentNullException.ThrowIfNull(emitters);
@@ -573,6 +575,11 @@ public sealed class LampInfluenceTextureGenerator
         WritePng(idsBitmap, lampIds0Path, "lamp ID texture");
         WritePng(weightsBitmap, lampWeights0Path, "lamp weight texture");
         WritePng(debugBitmap, lampWeightsDebugPath, "lamp weight debug texture");
+
+        if (!string.IsNullOrWhiteSpace(rawEmitterDebugOutputDirectory))
+        {
+            GenerateRawEmitterDebugTextures(emittersByTray, width, height, rawEmitterDebugOutputDirectory);
+        }
     }
 
     private static IReadOnlyList<LampInfluence> CreateInfluences(FaceRuntimeTrayElement tray, IReadOnlyList<FaceLampEmitterElement> emitters)
@@ -595,6 +602,66 @@ public sealed class LampInfluenceTextureGenerator
             .ToArray();
     }
 
+    private static void GenerateRawEmitterDebugTextures(
+        IReadOnlyDictionary<int, FaceLampEmitterElement[]> emittersByTray,
+        int width,
+        int height,
+        string outputDirectory)
+    {
+        var influences = emittersByTray
+            .OrderByDescending(group => group.Value.Length)
+            .ThenBy(group => group.Key)
+            .Select(group => group.Value)
+            .FirstOrDefault()?
+            .OrderBy(emitter => emitter.ObjectId, StringComparer.Ordinal)
+            .Take(SupportedChannelCount)
+            .Select(CreateRawInfluence)
+            .ToArray()
+            ?? [];
+
+        for (var index = 0; index < influences.Length; index++)
+        {
+            using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+            bitmap.Erase(SKColors.Transparent);
+            var influence = influences[index];
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var rawWeight = CalculateRawWeight(influence, x + 0.5d, y + 0.5d);
+                    var weight = (byte)Math.Clamp(Math.Round(rawWeight * 255d, MidpointRounding.AwayFromZero), 0d, 255d);
+                    bitmap.SetPixel(x, y, new SKColor(weight, weight, weight, 255));
+                }
+            }
+
+            var path = Path.Combine(outputDirectory, $"{FaceRuntimeTextureGenerator.RawEmitterDebugFileNamePrefix}{index}.png");
+            WritePng(bitmap, path, $"raw emitter {index} debug texture");
+        }
+    }
+
+    private static LampInfluence CreateRawInfluence(FaceLampEmitterElement emitter)
+    {
+        var fallbackRadius = Math.Max(MinimumRadius, Math.Max(emitter.Width, emitter.Height) * 0.65d);
+        var radius = emitter.Radius is double emitterRadius && emitterRadius > 0d && IsFinite(emitterRadius)
+            ? emitterRadius
+            : fallbackRadius;
+        return new LampInfluence(
+            (byte)emitter.LampId!.Value,
+            emitter.CenterX,
+            emitter.CenterY,
+            Math.Max(MinimumRadius, radius),
+            0);
+    }
+
+    private static double CalculateRawWeight(LampInfluence influence, double pixelX, double pixelY)
+    {
+        var dx = pixelX - influence.CenterX;
+        var dy = pixelY - influence.CenterY;
+        var distance = Math.Sqrt((dx * dx) + (dy * dy));
+        var normalizedDistance = Math.Clamp(distance / influence.Radius, 0d, 1d);
+        return Math.Pow(1d - normalizedDistance, 2d);
+    }
+
     private static (byte[] IdChannels, byte[] WeightChannels) CreateEmitterChannels(IReadOnlyList<LampInfluence> influences, double pixelX, double pixelY)
     {
         var idChannels = new byte[SupportedChannelCount];
@@ -602,11 +669,7 @@ public sealed class LampInfluenceTextureGenerator
         var retained = influences
             .Select(influence =>
             {
-                var dx = pixelX - influence.CenterX;
-                var dy = pixelY - influence.CenterY;
-                var distance = Math.Sqrt((dx * dx) + (dy * dy));
-                var normalizedDistance = Math.Clamp(distance / influence.Radius, 0d, 1d);
-                var rawWeight = Math.Pow(1d - normalizedDistance, 2d);
+                var rawWeight = CalculateRawWeight(influence, pixelX, pixelY);
                 return new WeightedLampInfluence(influence, rawWeight);
             })
             .OrderBy(influence => influence.Influence.Order)


### PR DESCRIPTION
### Motivation
- Debugging showed incorrect shapes for 3-emitter trays and we need a way to inspect each emitter's raw distance falloff independently of normalization, channel packing, and ownership logic. 
- The goal is to export per-emitter raw influence maps so any crescent-shaped artifacts can be attributed to either distance/radius maths or later packing/normalization steps.

### Description
- Added `RawEmitterDebugFileNamePrefix` and threaded the export `outputDirectory` into the lamp influence generation call so raw debug images are written alongside existing textures. 
- Extended `LampInfluenceTextureGenerator.Generate(...)` with an optional `rawEmitterDebugOutputDirectory` parameter and invoked `GenerateRawEmitterDebugTextures(...)` when provided. 
- Implemented `GenerateRawEmitterDebugTextures(...)` which selects the tray with the most emitters and writes up to three files named `debug_raw_emitter_0.png`, `debug_raw_emitter_1.png`, and `debug_raw_emitter_2.png`, each containing the emitter's raw falloff (`rawWeight = falloff(distanceToThisEmitter)`) without reference to other emitters. 
- Extracted the raw falloff computation into `CalculateRawWeight(...)` and reused it in the packed-channel path so the raw debug images isolate per-emitter distance behavior from subsequent normalization/packing/ownership logic.

### Testing
- No automated unit/integration tests were executed in this environment because the container lacks the required Windows/.NET/WPF toolchain per `AGENTS.md` (no runtime build/test performed). 
- Repository checks: `git diff --check` completed without errors and the change was committed. 
- Recommended local automated validations to run: execute `dotnet build` and `dotnet test`, then run the runtime texture export that invokes `FaceRuntimeTextureGenerator.Generate(...)` and assert that `debug_raw_emitter_*.png` files are produced and that each file contains a single circular/elliptical blob centred on its emitter (this verifies raw falloff independent of packing/normalization).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2f1af34f588327ad4fe57ebfa91d26)