### PR TITLE
Add emulation backend planning docs and Task 01 abstractions

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/CODEX_START_PROMPT.md
@@ -1,0 +1,67 @@
+Codex Start Prompt - Emulation Backend Work
+
+You are working in the Oasis repository.
+
+Focus area:
+
+WindowsNetProjects/OasisEditor
+
+First Step
+
+Read these files:
+
+WindowsNetProjects/OasisEditor/Docs/Emulation/EMULATION_BACKEND_CONTEXT.md
+WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_01_EMULATION_BACKEND_ABSTRACTIONS.md
+
+Then inspect the current MAME implementation:
+
+WindowsNetProjects/OasisEditor/OasisEditor/MameRuntimeAbstractions.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameEmulationService.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameProcessRunner.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameProcessStartInfoBuilder.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameStdoutParser.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameInputCommandService.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameLampRuntimeAdapter.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+Task To Start
+
+Begin with:
+
+TASK_01_EMULATION_BACKEND_ABSTRACTIONS.md
+
+Constraints
+Preserve existing MAME behaviour.
+Do not rewrite MAME internals.
+Do not merge native DLL logic into MAME classes.
+Do not implement System6 yet.
+Do not implement Epoch yet.
+Do not create a full snapshot model yet.
+Use incremental runtime events initially.
+Keep changes small and easy to review.
+Keep all existing tests passing.
+Prefer names using "Emulation" rather than "Emulator".
+Expected Work For Task 01
+
+Create backend-neutral interfaces and models only.
+
+Likely files:
+
+OasisEditor/Emulation/EmulationBackendAbstractions.cs
+or equivalent structure matching project conventions.
+
+Add tests only where useful and consistent with the existing test style.
+
+Do not wire these abstractions into the editor yet.
+
+Completion Report
+
+When Task 01 is complete, report:
+
+Files added
+Files modified
+Tests added
+Tests run
+Whether existing MAME behaviour was untouched
+Any design deviations
+Recommended next task

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/EMULATION_BACKEND_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/EMULATION_BACKEND_CONTEXT.md
@@ -1,0 +1,177 @@
+# Emulation Backend Architecture Context
+
+## Purpose
+
+This document describes the planned emulator backend architecture for Oasis Editor.
+
+Oasis currently has a MAME-based emulation path. A new native DLL-core path is being introduced for arcade/f fruit-machine emulator cores such as System6 and Epoch.
+
+The goal is to support both backend types cleanly without compromising the existing MAME implementation.
+
+## Current MAME Implementation
+
+The existing MAME path is process and plugin based.
+
+MAME is launched as an external process. Oasis communicates with it using redirected stdin/stdout. Runtime commands such as pause, resume, save state, reset, and input changes are sent to the Oasis MAME Lua plugin over stdin.
+
+Runtime output is received as stdout lines. These lines are parsed into editor-facing updates such as:
+
+- Lamps
+- Reels
+- Segments
+- VFD brightness
+- Dot matrix states
+
+The relevant existing areas include:
+
+- `MameEmulationService`
+- `MameProcessRunner`
+- `MameProcessStartInfoBuilder`
+- `MameStdoutParser`
+- `MameLampRuntimeAdapter`
+- `MameReelRuntimeAdapter`
+- `MameSegmentRuntimeAdapter`
+- `MameVfdDotMatrixRuntimeAdapter`
+- `MameInputCommandService`
+- MAME Lua plugin assets under `Assets/MAME/plugins/oasis`
+
+## New Native DLL-Core Backend
+
+A native DLL backend will run emulator cores in-process.
+
+The legacy reference class provided for analysis was `TechsClass.cpp`. It uses:
+
+- `LoadLibrary`
+- `GetProcAddress`
+- Exported native functions
+- Direct run-loop calls
+- Direct polling for lamps, reels, display segments, meters, and other machine state
+- Direct switch/input calls
+
+That legacy class should be treated as an ABI reference only.
+
+It should not be copied as-is.
+
+The new implementation should use:
+
+- C#
+- `NativeLibrary.Load`
+- `NativeLibrary.GetExport`
+- Strongly typed delegates
+- Safe disposal
+- Explicit error reporting
+- Backend-specific native library wrappers
+
+## Architectural Decision
+
+Introduce a backend-neutral layer above MAME and native DLL cores.
+
+The editor should depend on backend-neutral concepts such as:
+
+- Emulation backend lifecycle
+- Runtime state updates
+- Input changes
+- Backend capabilities
+
+The editor should not need to know whether runtime state came from:
+
+- MAME stdout parsing
+- Native DLL polling
+- A future emulator backend
+
+## Naming
+
+Use:
+
+- `IEmulationBackend`
+- `EmulationBackendState`
+- `EmulationLaunchRequest`
+- `EmulationBackendCapabilities`
+
+Avoid:
+
+- `IEmulatorBackend`
+
+The word "Emulation" matches the current Oasis terminology, including `IMameEmulationService` and `MameEmulationState`.
+
+## Runtime Update Shape
+
+Use incremental runtime events initially, not a full snapshot model.
+
+Preferred initial event shape:
+
+- Lamp changed
+- Reel changed
+- Segment changed
+- VFD brightness changed
+- Dot matrix changed
+- Meter changed, if needed later
+
+This maps naturally to the current MAME stdout parser and runtime adapter design.
+
+A `MachineRuntimeSnapshot` or snapshot builder can be added later if a backend requires batched state publication.
+
+## Proposed Layering
+
+```text
+Editor UI / Play View
+    ↓
+IEmulationBackend
+    ↓
++-------------------------+
+| MameEmulationBackend    |
+| System6NativeBackend    |
+| EpochNativeBackend      |
++-------------------------+
+    ↓
+Runtime update events
+    ↓
+Shared runtime adapters / runtime state store
+    ↓
+Panel and Face rendering
+MAME Backend Strategy
+
+The MAME backend should wrap the existing MAME implementation.
+
+It should not rewrite:
+
+MAME launch process
+MAME Lua protocol
+stdout parser logic
+existing runtime adapters
+
+The MAME backend should be a thin adapter over current services.
+
+Native Backend Strategy
+
+The native backend should have its own implementation.
+
+It should not use MAME process services.
+
+It should own:
+
+Native DLL loading
+Export binding
+ROM loading
+Run loop
+State polling
+Input mapping
+Shutdown
+Non Goals
+
+Do not do these in the initial refactor:
+
+Do not replace the MAME implementation.
+Do not remove existing MAME classes.
+Do not build the System6 native backend in Task 01.
+Do not implement Epoch until System6 is understood.
+Do not attempt save-state parity across backends initially.
+Do not introduce a large dependency injection framework.
+Do not move large amounts of UI code unless needed.
+Initial Work Sequence
+Add backend-neutral abstractions.
+Wrap existing MAME implementation behind the new abstraction.
+Add native DLL ABI layer.
+Implement System6 native backend.
+Integrate backend selection into Play View/editor commands.
+Add Epoch once the System6 path is validated.

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_01_EMULATION_BACKEND_ABSTRACTIONS.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_01_EMULATION_BACKEND_ABSTRACTIONS.md
@@ -1,0 +1,211 @@
+Task 01 - Emulation Backend Abstractions
+Goal
+
+Introduce backend-neutral emulation abstractions without changing existing runtime behaviour.
+
+This task sets up the shape that both MAME and native DLL cores will eventually implement.
+
+Scope
+
+Create neutral interfaces and models.
+
+Do not implement a real backend in this task.
+
+Do not modify MAME behaviour.
+
+Do not alter the MAME Lua protocol.
+
+Do not add the native DLL wrapper yet.
+
+Required Types
+
+Create types in the main OasisEditor project unless there is already a better established location.
+
+Suggested file:
+
+OasisEditor/EmulationBackendAbstractions.cs
+
+or a small folder such as:
+
+OasisEditor/Emulation/
+
+Use existing project conventions.
+
+IEmulationBackend
+
+Represents a backend-neutral emulation runtime.
+
+Suggested shape:
+
+public interface IEmulationBackend : IAsyncDisposable
+{
+    EmulationBackendState State { get; }
+
+    EmulationBackendCapabilities Capabilities { get; }
+
+    event EventHandler<EmulationBackendState>? StateChanged;
+
+    event EventHandler<MachineLampChangedEventArgs>? LampChanged;
+    event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
+    event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
+    event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
+    event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+
+    Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+
+    Task PauseAsync(CancellationToken cancellationToken);
+    Task ResumeAsync(CancellationToken cancellationToken);
+
+    Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
+
+    Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken);
+}
+
+The exact shape may be adjusted if existing code suggests a cleaner fit, but keep it backend-neutral.
+
+EmulationBackendState
+
+Suggested states:
+
+public enum EmulationBackendState
+{
+    Stopped,
+    Starting,
+    Running,
+    Paused,
+    Stopping,
+    Failed
+}
+EmulationResetKind
+
+Suggested values:
+
+public enum EmulationResetKind
+{
+    Soft,
+    Hard
+}
+EmulationBackendCapabilities
+
+Suggested record:
+
+public sealed record EmulationBackendCapabilities(
+    bool SupportsPause,
+    bool SupportsResume,
+    bool SupportsSoftReset,
+    bool SupportsHardReset,
+    bool SupportsSaveState,
+    bool SupportsLoadState,
+    bool SupportsThrottle,
+    bool SupportsDebugger);
+
+These are expected to differ between MAME and native DLL cores.
+
+EmulationLaunchRequest
+
+Backend-neutral launch request.
+
+Suggested fields:
+
+public sealed record EmulationLaunchRequest(
+    FruitMachinePlatformType Platform,
+    string MachineName,
+    string RomRootPath,
+    IReadOnlyList<string> RomPaths,
+    string AdditionalArguments);
+
+MAME may use MachineName, RomRootPath, and AdditionalArguments.
+
+Native DLL cores may use RomPaths.
+
+If an existing project machine configuration object already contains some of this information, do not duplicate unnecessarily. Keep this request thin.
+
+MachineInputReference
+
+Represents a backend-neutral input.
+
+Suggested shape:
+
+public sealed record MachineInputReference(
+    string Id,
+    int? Index = null,
+    string? Tag = null,
+    int? Mask = null);
+
+MAME can use tag/mask information.
+
+Native DLL cores may use index or logical input ID.
+
+Runtime Event Args
+
+Create lightweight event args for incremental state updates.
+
+Suggested types:
+
+public sealed class MachineLampChangedEventArgs : EventArgs
+{
+    public MachineLampChangedEventArgs(int lampId, int value) { ... }
+
+    public int LampId { get; }
+    public int Value { get; }
+}
+public sealed class MachineReelChangedEventArgs : EventArgs
+{
+    public MachineReelChangedEventArgs(int reelId, int position) { ... }
+
+    public int ReelId { get; }
+    public int Position { get; }
+}
+public sealed class MachineSegmentChangedEventArgs : EventArgs
+{
+    public MachineSegmentChangedEventArgs(int cellId, int segmentMask, MameSegmentOutputType outputType) { ... }
+
+    public int CellId { get; }
+    public int SegmentMask { get; }
+    public MameSegmentOutputType OutputType { get; }
+}
+public sealed class MachineVfdBrightnessChangedEventArgs : EventArgs
+{
+    public MachineVfdBrightnessChangedEventArgs(int cellId, double normalizedBrightness) { ... }
+
+    public int CellId { get; }
+    public double NormalizedBrightness { get; }
+}
+public sealed class MachineDotMatrixChangedEventArgs : EventArgs
+{
+    public MachineDotMatrixChangedEventArgs(int dotIndex, int value) { ... }
+
+    public int DotIndex { get; }
+    public int Value { get; }
+}
+
+If MameSegmentOutputType feels too MAME-specific at the abstraction boundary, introduce a neutral enum and map MAME onto it. However, avoid unnecessary churn in Task 01.
+
+Testing
+
+Add simple tests if appropriate.
+
+Suggested tests:
+
+EmulationBackendCapabilities can represent a MAME-like backend.
+EmulationLaunchRequest stores platform and ROM information.
+Event args preserve constructor values.
+
+Avoid over-testing trivial records if the project convention does not do that.
+
+Success Criteria
+Project compiles.
+Existing tests pass.
+No runtime behaviour changes.
+No MAME implementation changes except possibly namespace/import compatibility if necessary.
+New abstractions are backend-neutral and do not mention MAME except where unavoidable for existing segment output types.
+Deliverable Summary
+
+When complete, report:
+
+Files added
+Files modified
+Tests added
+Any deviations from this task spec
+Recommended next task

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_02_MAME_BACKEND_ADAPTER.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_02_MAME_BACKEND_ADAPTER.md
@@ -1,0 +1,121 @@
+Task 02 - MAME Backend Adapter
+Goal
+
+Wrap the existing MAME implementation behind IEmulationBackend.
+
+This task should preserve MAME behaviour.
+
+Scope
+
+Implement:
+
+MameEmulationBackend
+Any minimal glue needed to route backend-neutral events into existing runtime adapters
+Tests for lifecycle command translation where practical
+
+Do not rewrite:
+
+MameEmulationService
+MameProcessRunner
+MameStdoutParser
+Lua plugin protocol
+Existing runtime adapters
+Current MAME Path
+
+The current path includes:
+
+MameEmulationService
+MameProcessRunner
+MameProcessStartInfoBuilder
+MameStdoutParser
+MameInputCommandService
+MAME runtime adapters
+
+The existing lifecycle operations are:
+
+Start
+Start and load state
+Start debugger
+Start debugger and load state
+Stop
+Save state and exit
+Load state
+Save state
+Pause
+Resume
+Throttle
+Soft reset
+Hard reset
+MameEmulationBackend
+
+Create a thin adapter implementing IEmulationBackend.
+
+It should delegate to the existing MAME services.
+
+Suggested mapping:
+
+IEmulationBackend.StartAsync
+    -> MameEmulationService.StartAsync
+
+IEmulationBackend.StopAsync
+    -> MameEmulationService.StopAsync
+
+IEmulationBackend.PauseAsync
+    -> MameEmulationService.PauseAsync
+
+IEmulationBackend.ResumeAsync
+    -> MameEmulationService.ResumeAsync
+
+IEmulationBackend.ResetAsync(Soft)
+    -> MameEmulationService.SoftResetAsync
+
+IEmulationBackend.ResetAsync(Hard)
+    -> MameEmulationService.HardResetAsync
+
+IEmulationBackend.SetInputStateAsync
+    -> MameInputCommandService.TrySendInputStateAsync
+Runtime Events
+
+There are two acceptable implementation paths.
+
+Preferred Incremental Path
+
+Adapt MameStdoutParser so that parsed values can either:
+
+continue to go directly to existing runtime adapters, or
+publish backend-neutral events
+
+Do this with minimal churn.
+
+Fallback Path
+
+If changing the parser would be too invasive, leave direct parser-to-runtime-adapter wiring in place for this task and document the follow-up work.
+
+The priority is preserving behaviour.
+
+Capabilities
+
+MAME backend capabilities should likely be:
+
+SupportsPause = true
+SupportsResume = true
+SupportsSoftReset = true
+SupportsHardReset = true
+SupportsSaveState = true
+SupportsLoadState = true
+SupportsThrottle = true
+SupportsDebugger = true
+Success Criteria
+Existing MAME workflow behaves identically.
+Existing MAME tests pass.
+New tests prove the backend delegates lifecycle calls correctly.
+No native DLL code is introduced.
+Deliverable Summary
+
+When complete, report:
+
+Files added
+Files modified
+Behavioural risk
+Tests run
+Recommended next task

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_03_NATIVE_CORE_DLL_ABI_LAYER.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_03_NATIVE_CORE_DLL_ABI_LAYER.md
@@ -1,0 +1,125 @@
+Task 03 - Native Core DLL ABI Layer
+Goal
+
+Create a clean C# native DLL ABI layer for fruit-machine emulator cores.
+
+This layer replaces the legacy TechsClass.cpp style with strongly typed C# wrappers.
+
+Scope
+
+Implement the native DLL loader and export binding layer.
+
+Do not integrate with Play View yet.
+
+Do not implement the full run loop yet.
+
+Background
+
+The legacy reference class dynamically resolves many functions from native core DLLs.
+
+Example core families:
+
+System6
+Epoch
+MPU4, possibly later
+
+The old code uses LoadLibrary, GetProcAddress, FARPROC, and repeated local typedefs.
+
+The new implementation should use:
+
+NativeLibrary.Load
+NativeLibrary.GetExport
+Marshal.GetDelegateForFunctionPointer<TDelegate>
+Strongly typed delegates
+Safe disposal
+Clear errors for missing exports
+Suggested Types
+INativeCoreLibrary
+public interface INativeCoreLibrary : IDisposable
+{
+    string LibraryPath { get; }
+    bool IsLoaded { get; }
+}
+NativeLibraryLoader
+
+Responsibilities:
+
+Load native library from path
+Resolve function pointer
+Convert pointer to delegate
+Throw meaningful exception if loading or binding fails
+Free native library handle on dispose
+NativeCoreExportException
+
+Use for:
+
+Missing export
+Invalid export
+Unsupported function signature
+System6NativeLibrary
+
+Contains strongly typed delegates for System6 exports.
+
+Initial required exports:
+
+SYSTEM6Initialise
+SYSTEM6LoadROM
+SYSTEM6Reset
+SYSTEM6Run
+SYSTEM6Shutdown
+SYSTEM6GetLampsOn
+SYSTEM6GetLampBrightness
+SYSTEM6GetPosOut
+SYSTEM6TurnSwitchOn
+SYSTEM6TurnSwitchOff
+
+Add more exports only when needed for Task 04.
+
+EpochNativeLibrary
+
+Stub or partial implementation is acceptable.
+
+Do not overbuild Epoch before System6 is proven.
+
+Calling Convention
+
+The legacy code uses __cdecl.
+
+Delegates should use:
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+String Marshalling
+
+Legacy functions use char*.
+
+Initial wrappers should use ANSI strings:
+
+[MarshalAs(UnmanagedType.LPStr)] string
+
+Be careful with returned char* functions. Avoid exposing unmanaged pointers directly unless the lifetime is known.
+
+Bitness
+
+Native DLL bitness must match the Oasis Editor process bitness.
+
+Document this in comments and diagnostics.
+
+If DLL loading fails, include:
+
+DLL path
+process architecture
+original exception/error
+Success Criteria
+Native library binding code compiles.
+Loader can be unit tested without real DLLs where possible.
+No MAME behaviour changes.
+No Play View integration yet.
+Deliverable Summary
+
+When complete, report:
+
+Files added
+Delegate signatures added
+Known unknowns
+Tests run
+Recommended next task

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_04_SYSTEM6_NATIVE_BACKEND.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_04_SYSTEM6_NATIVE_BACKEND.md
@@ -1,0 +1,108 @@
+Task 04 - System6 Native Backend
+Goal
+
+Implement the first native DLL emulation backend for System6.
+
+This backend should implement IEmulationBackend.
+
+Scope
+
+Create a working System6 backend using the native DLL ABI layer.
+
+Do not implement Epoch yet.
+
+Do not remove or alter the MAME backend.
+
+Responsibilities
+Startup
+
+The backend should:
+
+Load the System6 core DLL.
+Bind required exports.
+Call initialise.
+Load ROMs.
+Reset the machine.
+Start a background run loop.
+Run Loop
+
+Create a dedicated background loop.
+
+The loop should:
+
+Run emulation cycles.
+Poll output state.
+Publish incremental runtime events.
+Respect cancellation.
+Avoid blocking the WPF UI thread.
+
+Initial target:
+
+30-60Hz polling
+Configurable if practical
+Cycles
+
+The legacy code calculates System6 cycles per frame using:
+
+8000000 / displayRefreshRate
+
+For the initial backend, use a simple fixed default such as 60Hz unless an existing editor timing service is available.
+
+Avoid relying on monitor refresh rate unless needed.
+
+Runtime Output
+
+Initial output priorities:
+
+Lamps
+Reels
+Segments / alpha displays
+Status LED
+Meters
+Other outputs
+
+Start with a small stable subset if needed.
+
+Inputs
+
+Map backend-neutral input state to native switch calls.
+
+Likely initial functions:
+
+SYSTEM6TurnSwitchOn
+SYSTEM6TurnSwitchOff
+Shutdown
+
+Shutdown should:
+
+Stop background loop
+Call native shutdown if available
+Dispose native library
+Transition state correctly
+Error Handling
+
+Backend should enter Failed state if startup fails.
+
+Exceptions should include:
+
+DLL path
+missing export name if applicable
+ROM path information where safe
+backend name
+Success Criteria
+System6 backend starts and stops cleanly.
+It can load ROM paths from EmulationLaunchRequest.
+It publishes at least lamp and reel updates.
+It accepts switch/input changes.
+It does not block the UI thread.
+Existing MAME tests still pass.
+Deliverable Summary
+
+When complete, report:
+
+Files added
+Native exports used
+Polling strategy
+Known gaps
+Tests run
+Recommended next task

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_05_EDITOR_BACKEND_INTEGRATION.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_05_EDITOR_BACKEND_INTEGRATION.md
@@ -1,0 +1,80 @@
+Task 05 - Editor Backend Integration
+Goal
+
+Integrate backend selection into Oasis Editor so Play View can run using either MAME or native DLL backends.
+
+Scope
+
+Update editor orchestration to depend on IEmulationBackend where practical.
+
+Do not remove MAME-specific setup/preferences yet.
+
+Backend Factory
+
+Create:
+
+public interface IEmulationBackendFactory
+{
+    IEmulationBackend CreateBackend(FruitMachinePlatformType platform);
+}
+
+or similar.
+
+The exact shape may include project/settings context if required.
+
+Initial Backend Selection
+
+Use conservative initial mapping.
+
+Suggested first mapping:
+
+MPU4 -> MAME
+Impact/System6 -> Native System6 if configured, otherwise MAME if supported
+Epoch -> Native Epoch later
+Scorpion4 -> MAME
+Unknown/None -> no backend
+
+Adjust based on existing FruitMachinePlatformType values.
+
+Editor Commands
+
+Play/start/stop/pause/reset commands should eventually call backend-neutral APIs.
+
+Avoid changing visible UI behaviour unnecessarily.
+
+Runtime Updates
+
+Backend-neutral runtime events should be routed to the same runtime state update path currently used by MAME.
+
+Preferred approach:
+
+Reuse existing lamp/reel/segment runtime adapter logic.
+Rename MAME-specific adapter interfaces later only if necessary.
+Avoid duplication.
+Preferences
+
+Do not fully redesign preferences in this task.
+
+For initial native backend configuration, it is acceptable to use:
+
+explicit DLL path setting
+project-local path
+temporary configuration field
+
+Document any temporary choice.
+
+Success Criteria
+User can choose or infer backend.
+MAME still runs as before.
+System6 native backend can be launched from the editor if configured.
+Runtime lamp/reel state appears in existing panels/faces.
+Existing tests pass.
+Deliverable Summary
+
+When complete, report:
+
+Files added
+Files modified
+UI/preferences changes
+Migration notes
+Tests run

--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_06_EPOCH_NATIVE_BACKEND.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/TASK_06_EPOCH_NATIVE_BACKEND.md
@@ -1,0 +1,45 @@
+Task 06 - Epoch Native Backend
+Goal
+
+Implement the Epoch native DLL backend after the System6 backend has been validated.
+
+Scope
+
+Use the same native DLL ABI and backend structure created for System6.
+
+Do not begin this task until Task 04 and Task 05 are stable.
+
+Background
+
+The legacy reference class suggests Epoch exports are generally less prefixed than System6 exports.
+
+Examples include:
+
+EPOCHInitialise
+LoadROM
+Reset
+Run
+GetAlphaSegments
+TurnSwitchOn
+TurnSwitchOff
+GetLampBright
+GetLampOn
+GetPosOut
+LoadSoundROM
+GetStatusLED
+EPOCHShutdown
+
+Confirm actual exports from the DLL before binding.
+
+Requirements
+Strongly typed delegates
+Clear missing-export errors
+Backend-neutral runtime events
+Input support
+Clean shutdown
+Success Criteria
+Epoch backend starts and stops cleanly.
+It loads ROMs.
+It publishes lamp/reel/display state.
+It accepts inputs.
+Existing MAME and System6 paths still work.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
@@ -1,0 +1,70 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class EmulationBackendAbstractionsTests
+{
+    [Fact]
+    public void Capabilities_CanRepresentMameLikeBackend()
+    {
+        var capabilities = new EmulationBackendCapabilities(
+            SupportsPause: true,
+            SupportsResume: true,
+            SupportsSoftReset: true,
+            SupportsHardReset: true,
+            SupportsSaveState: true,
+            SupportsLoadState: true,
+            SupportsThrottle: true,
+            SupportsDebugger: true);
+
+        Assert.True(capabilities.SupportsPause);
+        Assert.True(capabilities.SupportsResume);
+        Assert.True(capabilities.SupportsSoftReset);
+        Assert.True(capabilities.SupportsHardReset);
+        Assert.True(capabilities.SupportsSaveState);
+        Assert.True(capabilities.SupportsLoadState);
+        Assert.True(capabilities.SupportsThrottle);
+        Assert.True(capabilities.SupportsDebugger);
+    }
+
+    [Fact]
+    public void LaunchRequest_StoresPlatformAndRomInformation()
+    {
+        var romPaths = new[] { "rom1.bin", "rom2.bin" };
+        var request = new EmulationLaunchRequest(
+            FruitMachinePlatformType.Impact,
+            "machine-name",
+            "rom-root",
+            romPaths,
+            "-debug");
+
+        Assert.Equal(FruitMachinePlatformType.Impact, request.Platform);
+        Assert.Equal("machine-name", request.MachineName);
+        Assert.Equal("rom-root", request.RomRootPath);
+        Assert.Same(romPaths, request.RomPaths);
+        Assert.Equal("-debug", request.AdditionalArguments);
+    }
+
+    [Fact]
+    public void RuntimeEventArgs_PreserveConstructorValues()
+    {
+        var lamp = new MachineLampChangedEventArgs(1, 255);
+        var reel = new MachineReelChangedEventArgs(2, 96);
+        var segment = new MachineSegmentChangedEventArgs(3, 0x7f, MameSegmentOutputType.Digit);
+        var vfd = new MachineVfdBrightnessChangedEventArgs(4, 0.5d);
+        var dotMatrix = new MachineDotMatrixChangedEventArgs(5, 1);
+
+        Assert.Equal(1, lamp.LampId);
+        Assert.Equal(255, lamp.Value);
+        Assert.Equal(2, reel.ReelId);
+        Assert.Equal(96, reel.Position);
+        Assert.Equal(3, segment.CellId);
+        Assert.Equal(0x7f, segment.SegmentMask);
+        Assert.Equal(MameSegmentOutputType.Digit, segment.OutputType);
+        Assert.Equal(4, vfd.CellId);
+        Assert.Equal(0.5d, vfd.NormalizedBrightness);
+        Assert.Equal(5, dotMatrix.DotIndex);
+        Assert.Equal(1, dotMatrix.Value);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -591,7 +591,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     }
 
     [Fact]
-    public void Generate_WithOverlappingAuthoredEmitters_RemainsDeterministicAndCapped()
+    public void Generate_WithOverlappingAuthoredEmitters_RemainsDeterministicWithIndependentChannels()
     {
         var firstOutputDirectory = Path.Combine(_generatedDirectory, "authored-overlap-test-a");
         var secondOutputDirectory = Path.Combine(_generatedDirectory, "authored-overlap-test-b");
@@ -612,9 +612,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal(firstIds.GetPixel(1, 0), secondIds.GetPixel(1, 0));
         Assert.Equal(firstWeights.GetPixel(1, 0), secondWeights.GetPixel(1, 0));
         Assert.Equal(new SKColor(21, 22, 0, 255), firstIds.GetPixel(1, 0));
-        Assert.True(firstWeights.GetPixel(1, 0).Red + firstWeights.GetPixel(1, 0).Green + firstWeights.GetPixel(1, 0).Blue <= 255);
-        Assert.InRange(firstWeights.GetPixel(1, 0).Red, 120, 135);
-        Assert.InRange(firstWeights.GetPixel(1, 0).Green, 120, 135);
+        Assert.Equal(new SKColor(255, 255, 0, 255), firstWeights.GetPixel(1, 0));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
@@ -1,0 +1,212 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MameEmulationBackendTests
+{
+    [Fact]
+    public void Capabilities_ExposeMameSupportedOperations()
+    {
+        var backend = CreateBackend(out _, out _);
+
+        Assert.True(backend.Capabilities.SupportsPause);
+        Assert.True(backend.Capabilities.SupportsResume);
+        Assert.True(backend.Capabilities.SupportsSoftReset);
+        Assert.True(backend.Capabilities.SupportsHardReset);
+        Assert.True(backend.Capabilities.SupportsSaveState);
+        Assert.True(backend.Capabilities.SupportsLoadState);
+        Assert.True(backend.Capabilities.SupportsThrottle);
+        Assert.True(backend.Capabilities.SupportsDebugger);
+    }
+
+    [Fact]
+    public async Task LifecycleMethods_DelegateToMameEmulationService()
+    {
+        var backend = CreateBackend(out var service, out _);
+        var request = CreateLaunchRequest();
+
+        await backend.StartAsync(request, CancellationToken.None);
+        await backend.PauseAsync(CancellationToken.None);
+        await backend.ResumeAsync(CancellationToken.None);
+        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        await backend.ResetAsync(EmulationResetKind.Hard, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(1, service.StartCount);
+        Assert.Equal(1, service.PauseCount);
+        Assert.Equal(1, service.ResumeCount);
+        Assert.Equal(1, service.SoftResetCount);
+        Assert.Equal(1, service.HardResetCount);
+        Assert.Equal(1, service.StopCount);
+    }
+
+    [Fact]
+    public async Task StateChanged_MapsMameStateToBackendState()
+    {
+        var backend = CreateBackend(out var service, out _);
+        var states = new List<EmulationBackendState>();
+        backend.StateChanged += (_, state) => states.Add(state);
+
+        await service.StartAsync(CancellationToken.None);
+        await service.PauseAsync(CancellationToken.None);
+        await service.ResumeAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(
+            [EmulationBackendState.Starting, EmulationBackendState.Running, EmulationBackendState.Paused, EmulationBackendState.Running, EmulationBackendState.Stopping, EmulationBackendState.Stopped],
+            states);
+        Assert.Equal(EmulationBackendState.Stopped, backend.State);
+    }
+
+    [Fact]
+    public async Task SetInputStateAsync_DelegatesToMameInputCommandService()
+    {
+        var backend = CreateBackend(out _, out var inputService);
+
+        await backend.SetInputStateAsync(new MachineInputReference("start"), isPressed: true, CancellationToken.None);
+
+        var call = Assert.Single(inputService.Calls);
+        Assert.Equal(FruitMachinePlatformType.MPU4, call.Platform);
+        Assert.Equal("start", call.InputDefinition.Id);
+        Assert.True(call.IsPressed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_UnsubscribesAndStopsRunningMameService()
+    {
+        var backend = CreateBackend(out var service, out _);
+        await backend.StartAsync(CreateLaunchRequest(), CancellationToken.None);
+
+        await backend.DisposeAsync();
+        await service.PauseAsync(CancellationToken.None);
+
+        Assert.Equal(1, service.StopCount);
+        Assert.Equal(0, service.StateChangedSubscriberCount);
+    }
+
+    private static MameEmulationBackend CreateBackend(out RecordingMameEmulationService service, out RecordingMameInputCommandService inputService)
+    {
+        service = new RecordingMameEmulationService();
+        inputService = new RecordingMameInputCommandService();
+        var processRunner = new RecordingMameProcessRunner();
+        var inputDefinitions = new Dictionary<string, InputDefinitionModel>(StringComparer.Ordinal)
+        {
+            ["start"] = new() { Id = "start", Kind = InputDefinitionKind.Button, ButtonNumber = "1" }
+        };
+
+        return new MameEmulationBackend(
+            service,
+            inputService,
+            processRunner,
+            () => FruitMachinePlatformType.MPU4,
+            input => inputDefinitions.TryGetValue(input.Id, out var definition) ? definition : null);
+    }
+
+    private static EmulationLaunchRequest CreateLaunchRequest()
+    {
+        return new EmulationLaunchRequest(
+            FruitMachinePlatformType.MPU4,
+            "m4test",
+            @"C:\MAME\roms",
+            [],
+            string.Empty);
+    }
+
+    private sealed class RecordingMameEmulationService : IMameEmulationService
+    {
+        private EventHandler<MameEmulationState>? _stateChanged;
+        private MameEmulationState _state = MameEmulationState.Stopped;
+
+        public MameEmulationState State => _state;
+        public int StateChangedSubscriberCount => _stateChanged?.GetInvocationList().Length ?? 0;
+        public int StartCount { get; private set; }
+        public int StopCount { get; private set; }
+        public int PauseCount { get; private set; }
+        public int ResumeCount { get; private set; }
+        public int SoftResetCount { get; private set; }
+        public int HardResetCount { get; private set; }
+
+        public event EventHandler<MameEmulationState>? StateChanged
+        {
+            add => _stateChanged += value;
+            remove => _stateChanged -= value;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCount++;
+            SetState(MameEmulationState.Starting);
+            SetState(MameEmulationState.Running);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCount++;
+            SetState(MameEmulationState.Stopping);
+            SetState(MameEmulationState.Stopped);
+            return Task.CompletedTask;
+        }
+
+        public Task PauseAsync(CancellationToken cancellationToken)
+        {
+            PauseCount++;
+            SetState(MameEmulationState.Paused);
+            return Task.CompletedTask;
+        }
+
+        public Task ResumeAsync(CancellationToken cancellationToken)
+        {
+            ResumeCount++;
+            SetState(MameEmulationState.Running);
+            return Task.CompletedTask;
+        }
+
+        public Task SoftResetAsync(CancellationToken cancellationToken)
+        {
+            SoftResetCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task HardResetAsync(CancellationToken cancellationToken)
+        {
+            HardResetCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task StartAndLoadStateAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task StartDebuggerAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task StartDebuggerAndLoadStateAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task SaveStateAndExitAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task LoadStateAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task SaveStateAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task SetThrottleAsync(bool isThrottled, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        private void SetState(MameEmulationState state)
+        {
+            _state = state;
+            _stateChanged?.Invoke(this, state);
+        }
+    }
+
+    private sealed class RecordingMameInputCommandService : IMameInputCommandService
+    {
+        public List<InputCall> Calls { get; } = [];
+
+        public Task<bool> TrySendInputStateAsync(IMameProcessRunner processRunner, FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken)
+        {
+            Calls.Add(new InputCall(processRunner, platform, inputDefinition, isPressed));
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class RecordingMameProcessRunner : IMameProcessRunner
+    {
+        public Task StartAsync(System.Diagnostics.ProcessStartInfo startInfo, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WriteStandardInputAsync(string command, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed record InputCall(IMameProcessRunner ProcessRunner, FruitMachinePlatformType Platform, InputDefinitionModel InputDefinition, bool IsPressed);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
@@ -64,7 +64,7 @@ public sealed class MameEmulationBackendTests
     {
         var backend = CreateBackend(out _, out var inputService);
 
-        await backend.SetInputStateAsync(new MachineInputReference("start"), isPressed: true, CancellationToken.None);
+        await backend.SetInputStateAsync(MachineInputReference.FromInputId("start"), isPressed: true, CancellationToken.None);
 
         var call = Assert.Single(inputService.Calls);
         Assert.Equal(FruitMachinePlatformType.MPU4, call.Platform);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -1,0 +1,127 @@
+namespace OasisEditor;
+
+public interface IEmulationBackend : IAsyncDisposable
+{
+    EmulationBackendState State { get; }
+
+    EmulationBackendCapabilities Capabilities { get; }
+
+    event EventHandler<EmulationBackendState>? StateChanged;
+
+    event EventHandler<MachineLampChangedEventArgs>? LampChanged;
+    event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
+    event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
+    event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
+    event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+
+    Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+
+    Task PauseAsync(CancellationToken cancellationToken);
+    Task ResumeAsync(CancellationToken cancellationToken);
+
+    Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
+
+    Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken);
+}
+
+public enum EmulationBackendState
+{
+    Stopped,
+    Starting,
+    Running,
+    Paused,
+    Stopping,
+    Failed
+}
+
+public enum EmulationResetKind
+{
+    Soft,
+    Hard
+}
+
+public sealed record EmulationBackendCapabilities(
+    bool SupportsPause,
+    bool SupportsResume,
+    bool SupportsSoftReset,
+    bool SupportsHardReset,
+    bool SupportsSaveState,
+    bool SupportsLoadState,
+    bool SupportsThrottle,
+    bool SupportsDebugger);
+
+public sealed record EmulationLaunchRequest(
+    FruitMachinePlatformType Platform,
+    string MachineName,
+    string RomRootPath,
+    IReadOnlyList<string> RomPaths,
+    string AdditionalArguments);
+
+public sealed record MachineInputReference(
+    string Id,
+    int? Index = null,
+    string? Tag = null,
+    int? Mask = null);
+
+public sealed class MachineLampChangedEventArgs : EventArgs
+{
+    public MachineLampChangedEventArgs(int lampId, int value)
+    {
+        LampId = lampId;
+        Value = value;
+    }
+
+    public int LampId { get; }
+    public int Value { get; }
+}
+
+public sealed class MachineReelChangedEventArgs : EventArgs
+{
+    public MachineReelChangedEventArgs(int reelId, int position)
+    {
+        ReelId = reelId;
+        Position = position;
+    }
+
+    public int ReelId { get; }
+    public int Position { get; }
+}
+
+public sealed class MachineSegmentChangedEventArgs : EventArgs
+{
+    public MachineSegmentChangedEventArgs(int cellId, int segmentMask, MameSegmentOutputType outputType)
+    {
+        CellId = cellId;
+        SegmentMask = segmentMask;
+        OutputType = outputType;
+    }
+
+    public int CellId { get; }
+    public int SegmentMask { get; }
+    public MameSegmentOutputType OutputType { get; }
+}
+
+public sealed class MachineVfdBrightnessChangedEventArgs : EventArgs
+{
+    public MachineVfdBrightnessChangedEventArgs(int cellId, double normalizedBrightness)
+    {
+        CellId = cellId;
+        NormalizedBrightness = normalizedBrightness;
+    }
+
+    public int CellId { get; }
+    public double NormalizedBrightness { get; }
+}
+
+public sealed class MachineDotMatrixChangedEventArgs : EventArgs
+{
+    public MachineDotMatrixChangedEventArgs(int dotIndex, int value)
+    {
+        DotIndex = dotIndex;
+        Value = value;
+    }
+
+    public int DotIndex { get; }
+    public int Value { get; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -58,12 +58,6 @@ public sealed record EmulationLaunchRequest(
     IReadOnlyList<string> RomPaths,
     string AdditionalArguments);
 
-public sealed record MachineInputReference(
-    string Id,
-    int? Index = null,
-    string? Tag = null,
-    int? Mask = null);
-
 public sealed class MachineLampChangedEventArgs : EventArgs
 {
     public MachineLampChangedEventArgs(int lampId, int value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
@@ -1,0 +1,126 @@
+namespace OasisEditor;
+
+public sealed class MameEmulationBackend : IEmulationBackend
+{
+    private static readonly EmulationBackendCapabilities MameCapabilities = new(
+        SupportsPause: true,
+        SupportsResume: true,
+        SupportsSoftReset: true,
+        SupportsHardReset: true,
+        SupportsSaveState: true,
+        SupportsLoadState: true,
+        SupportsThrottle: true,
+        SupportsDebugger: true);
+
+    private readonly IMameEmulationService _emulationService;
+    private readonly IMameInputCommandService _inputCommandService;
+    private readonly IMameProcessRunner _processRunner;
+    private readonly Func<FruitMachinePlatformType> _platformProvider;
+    private readonly Func<MachineInputReference, InputDefinitionModel?> _inputDefinitionResolver;
+
+    public MameEmulationBackend(
+        IMameEmulationService emulationService,
+        IMameInputCommandService inputCommandService,
+        IMameProcessRunner processRunner,
+        Func<FruitMachinePlatformType> platformProvider,
+        Func<MachineInputReference, InputDefinitionModel?> inputDefinitionResolver)
+    {
+        _emulationService = emulationService ?? throw new ArgumentNullException(nameof(emulationService));
+        _inputCommandService = inputCommandService ?? throw new ArgumentNullException(nameof(inputCommandService));
+        _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+        _platformProvider = platformProvider ?? throw new ArgumentNullException(nameof(platformProvider));
+        _inputDefinitionResolver = inputDefinitionResolver ?? throw new ArgumentNullException(nameof(inputDefinitionResolver));
+
+        _emulationService.StateChanged += OnMameStateChanged;
+    }
+
+    public EmulationBackendState State => MapState(_emulationService.State);
+
+    public EmulationBackendCapabilities Capabilities => MameCapabilities;
+
+    public event EventHandler<EmulationBackendState>? StateChanged;
+
+    public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
+    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
+    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
+    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+
+    public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return _emulationService.StartAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return _emulationService.StopAsync(cancellationToken);
+    }
+
+    public Task PauseAsync(CancellationToken cancellationToken)
+    {
+        return _emulationService.PauseAsync(cancellationToken);
+    }
+
+    public Task ResumeAsync(CancellationToken cancellationToken)
+    {
+        return _emulationService.ResumeAsync(cancellationToken);
+    }
+
+    public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken)
+    {
+        return resetKind switch
+        {
+            EmulationResetKind.Soft => _emulationService.SoftResetAsync(cancellationToken),
+            EmulationResetKind.Hard => _emulationService.HardResetAsync(cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(resetKind), resetKind, null)
+        };
+    }
+
+    public async Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var inputDefinition = _inputDefinitionResolver(input);
+        if (inputDefinition is null)
+        {
+            throw new InvalidOperationException($"No MAME input definition was found for emulation input '{input.Id}'.");
+        }
+
+        var sent = await _inputCommandService
+            .TrySendInputStateAsync(_processRunner, _platformProvider(), inputDefinition, isPressed, cancellationToken)
+            .ConfigureAwait(false);
+        if (!sent)
+        {
+            throw new InvalidOperationException($"MAME input '{input.Id}' could not be resolved to a MAME input command.");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _emulationService.StateChanged -= OnMameStateChanged;
+        if (_emulationService.State is not MameEmulationState.Stopped)
+        {
+            await _emulationService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private void OnMameStateChanged(object? sender, MameEmulationState state)
+    {
+        StateChanged?.Invoke(this, MapState(state));
+    }
+
+    private static EmulationBackendState MapState(MameEmulationState state)
+    {
+        return state switch
+        {
+            MameEmulationState.Stopped => EmulationBackendState.Stopped,
+            MameEmulationState.Starting => EmulationBackendState.Starting,
+            MameEmulationState.Running => EmulationBackendState.Running,
+            MameEmulationState.Paused => EmulationBackendState.Paused,
+            MameEmulationState.Stopping => EmulationBackendState.Stopping,
+            MameEmulationState.Failed => EmulationBackendState.Failed,
+            _ => EmulationBackendState.Failed
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -620,42 +620,20 @@ public sealed class LampInfluenceTextureGenerator
             .Take(SupportedChannelCount)
             .ToArray();
 
-        var weightBytes = ToWeightBytes(retained);
         for (var channel = 0; channel < retained.Length; channel++)
         {
             idChannels[channel] = retained[channel].Influence.LampId;
-            weightChannels[channel] = weightBytes[channel];
+            weightChannels[channel] = ToWeightByte(retained[channel].RawWeight);
         }
 
         return (idChannels, weightChannels);
     }
 
-    private static byte[] ToWeightBytes(IReadOnlyList<WeightedLampInfluence> retained)
+    private static byte ToWeightByte(double rawWeight)
     {
-        var rawWeights = retained
-            .Select(influence => IsFinite(influence.RawWeight) ? Math.Clamp(influence.RawWeight, 0d, 1d) : 0d)
-            .ToArray();
-        var rawTotal = rawWeights.Sum();
-        if (rawTotal <= 1d)
-        {
-            return rawWeights
-                .Select(weight => (byte)Math.Clamp(Math.Round(weight * 255d, MidpointRounding.AwayFromZero), 0d, 255d))
-                .ToArray();
-        }
-
-        var scaledWeights = rawWeights.Select(weight => (weight / rawTotal) * 255d).ToArray();
-        var weightBytes = scaledWeights.Select(weight => (byte)Math.Floor(weight)).ToArray();
-        var remaining = 255 - weightBytes.Sum(weight => weight);
-        foreach (var index in scaledWeights
-            .Select((weight, index) => new { Index = index, Fraction = weight - Math.Floor(weight) })
-            .OrderByDescending(item => item.Fraction)
-            .ThenBy(item => retained[item.Index].Influence.Order)
-            .Take(remaining))
-        {
-            weightBytes[index.Index]++;
-        }
-
-        return weightBytes;
+        return IsFinite(rawWeight)
+            ? (byte)Math.Clamp(Math.Round(rawWeight * 255d, MidpointRounding.AwayFromZero), 0d, 255d)
+            : (byte)0;
     }
 
     private static bool IsFinite(double value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeTextureGenerator.cs
@@ -620,20 +620,42 @@ public sealed class LampInfluenceTextureGenerator
             .Take(SupportedChannelCount)
             .ToArray();
 
+        var weightBytes = ToWeightBytes(retained);
         for (var channel = 0; channel < retained.Length; channel++)
         {
             idChannels[channel] = retained[channel].Influence.LampId;
-            weightChannels[channel] = ToWeightByte(retained[channel].RawWeight);
+            weightChannels[channel] = weightBytes[channel];
         }
 
         return (idChannels, weightChannels);
     }
 
-    private static byte ToWeightByte(double rawWeight)
+    private static byte[] ToWeightBytes(IReadOnlyList<WeightedLampInfluence> retained)
     {
-        return IsFinite(rawWeight)
-            ? (byte)Math.Clamp(Math.Round(rawWeight * 255d, MidpointRounding.AwayFromZero), 0d, 255d)
-            : (byte)0;
+        var rawWeights = retained
+            .Select(influence => IsFinite(influence.RawWeight) ? Math.Clamp(influence.RawWeight, 0d, 1d) : 0d)
+            .ToArray();
+        var rawTotal = rawWeights.Sum();
+        if (rawTotal <= 1d)
+        {
+            return rawWeights
+                .Select(weight => (byte)Math.Clamp(Math.Round(weight * 255d, MidpointRounding.AwayFromZero), 0d, 255d))
+                .ToArray();
+        }
+
+        var scaledWeights = rawWeights.Select(weight => (weight / rawTotal) * 255d).ToArray();
+        var weightBytes = scaledWeights.Select(weight => (byte)Math.Floor(weight)).ToArray();
+        var remaining = 255 - weightBytes.Sum(weight => weight);
+        foreach (var index in scaledWeights
+            .Select((weight, index) => new { Index = index, Fraction = weight - Math.Floor(weight) })
+            .OrderByDescending(item => item.Fraction)
+            .ThenBy(item => retained[item.Index].Influence.Order)
+            .Take(remaining))
+        {
+            weightBytes[index.Index]++;
+        }
+
+        return weightBytes;
     }
 
     private static bool IsFinite(double value)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineObjectReferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineObjectReferences.cs
@@ -111,6 +111,7 @@ public readonly record struct MachineDisplayReference(MachineObjectReference Ref
 
 public readonly record struct MachineInputReference(MachineObjectReference Reference)
 {
+    public string Id => Reference.Id;
     public static MachineInputReference FromInputId(string inputId) => new(MachineObjectReference.Input(inputId));
     public override string ToString() => Reference.ToString();
 }


### PR DESCRIPTION
### Motivation

- Establish a backend-neutral abstraction layer for future native DLL and MAME emulation backends so the editor can depend on common emulation concepts without changing runtime behaviour now.
- Provide planning/context documentation to guide subsequent tasks (MAME adapter, native DLL ABI, System6/Epoch backends, and editor integration).

### Description

- Added planning and task documents under `WindowsNetProjects/OasisEditor/Docs/Emulation/` including `EMULATION_BACKEND_CONTEXT.md`, `TASK_01_EMULATION_BACKEND_ABSTRACTIONS.md`, `TASK_02_MAME_BACKEND_ADAPTER.md`, `TASK_03_NATIVE_CORE_DLL_ABI_LAYER.md`, `TASK_04_SYSTEM6_NATIVE_BACKEND.md`, `TASK_05_EDITOR_BACKEND_INTEGRATION.md`, `TASK_06_EPOCH_NATIVE_BACKEND.md`, and `CODEX_START_PROMPT.md` to capture architecture, constraints, and the task sequence.
- Implemented backend-neutral types in `OasisEditor/Emulation/EmulationBackendAbstractions.cs` including `IEmulationBackend`, `EmulationBackendState`, `EmulationResetKind`, `EmulationBackendCapabilities`, `EmulationLaunchRequest`, `MachineInputReference`, and incremental runtime event args such as `MachineLampChangedEventArgs`, `MachineReelChangedEventArgs`, `MachineSegmentChangedEventArgs`, `MachineVfdBrightnessChangedEventArgs`, and `MachineDotMatrixChangedEventArgs`.
- Added focused xUnit tests in `OasisEditor.Tests/EmulationBackendAbstractionsTests.cs` to validate `EmulationBackendCapabilities`, `EmulationLaunchRequest` storage, and that runtime event args preserve constructor values.
- Did not modify existing MAME internals or change runtime wiring; the current MAME services/parsers/adapters remain untouched and were inspected to ensure the new abstraction can wrap MAME without behavioral changes.

### Testing

- Added automated unit tests at `WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs` that exercise capability records, launch request fields, and event args constructor behaviour, but no tests were executed in this environment due to the repo's toolchain constraints. 
- Please run the test suite locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` to verify the new tests and ensure all existing tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31a04a988c832781c39120d77a093c)