### PR TITLE
Add native core DLL ABI layer (System6 ABI, loader, and diagnostics)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NativeCoreExportExceptionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NativeCoreExportExceptionTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class NativeCoreExportExceptionTests
+{
+    [Fact]
+    public void CreateLoadFailureIncludesPathArchitectureAndOriginalError()
+    {
+        var inner = new DllNotFoundException("native dependency missing");
+
+        var exception = NativeCoreExportException.CreateLoadFailure("C:/cores/system6.dll", Architecture.X64, inner);
+
+        Assert.Contains("C:/cores/system6.dll", exception.Message);
+        Assert.Contains("X64", exception.Message);
+        Assert.Contains("native dependency missing", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void CreateMissingExportIncludesExportPathAndArchitecture()
+    {
+        var inner = new EntryPointNotFoundException("export missing");
+
+        var exception = NativeCoreExportException.CreateMissingExport("C:/cores/system6.dll", Architecture.X86, "SYSTEM6Run", inner);
+
+        Assert.Contains("SYSTEM6Run", exception.Message);
+        Assert.Contains("C:/cores/system6.dll", exception.Message);
+        Assert.Contains("X86", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+
+    [Fact]
+    public void CreateInvalidExportBindingIncludesDelegateType()
+    {
+        var inner = new ArgumentException("invalid pointer");
+
+        var exception = NativeCoreExportException.CreateInvalidExportBinding(
+            "C:/cores/system6.dll",
+            Architecture.X64,
+            "SYSTEM6LoadROM",
+            typeof(System6NativeLibrary.System6LoadRomDelegate),
+            inner);
+
+        Assert.Contains("SYSTEM6LoadROM", exception.Message);
+        Assert.Contains(nameof(System6NativeLibrary.System6LoadRomDelegate), exception.Message);
+        Assert.Contains("X64", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class System6NativeBackendTests
+{
+    [Fact]
+    public async Task StartAsyncInitialisesLoadsRomsResetsAndStopShutsDown()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
+        var request = CreateLaunchRequest("C:/roms/a.rom", "C:/roms/b.rom");
+
+        await backend.StartAsync(request, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.True(library.InitialiseCalled);
+        Assert.Equal(new[] { "C:/roms/a.rom", "C:/roms/b.rom" }, library.LoadedRoms);
+        Assert.True(library.ResetCalled);
+        Assert.True(library.ShutdownCalled);
+        Assert.True(library.DisposeCalled);
+        Assert.Equal(EmulationBackendState.Stopped, backend.State);
+    }
+
+    [Fact]
+    public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
+
+        await backend.StartAsync(CreateLaunchRequest("C:/roms/a.rom"), CancellationToken.None);
+        await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), true, CancellationToken.None);
+        await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), false, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { 12 }, library.SwitchesTurnedOn);
+        Assert.Equal(new[] { 12 }, library.SwitchesTurnedOff);
+    }
+
+    [Fact]
+    public async Task StartAsyncWithoutRomPathsFailsBeforeLoadingNativeLibrary()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
+        var request = CreateLaunchRequest();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
+
+        Assert.False(library.InitialiseCalled);
+        Assert.Equal(EmulationBackendState.Failed, backend.State);
+    }
+
+    private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)
+    {
+        return new EmulationLaunchRequest(
+            FruitMachinePlatformType.None,
+            "test-machine",
+            "C:/roms",
+            romPaths,
+            string.Empty);
+    }
+
+    private sealed class FakeSystem6NativeLibrary : ISystem6NativeLibrary
+    {
+        public string LibraryPath => "C:/cores/system6.dll";
+
+        public Architecture ProcessArchitecture => Architecture.X64;
+
+        public bool IsLoaded => !DisposeCalled;
+
+        public bool InitialiseCalled { get; private set; }
+
+        public bool ResetCalled { get; private set; }
+
+        public bool ShutdownCalled { get; private set; }
+
+        public bool DisposeCalled { get; private set; }
+
+        public List<string> LoadedRoms { get; } = new();
+
+        public List<int> SwitchesTurnedOn { get; } = new();
+
+        public List<int> SwitchesTurnedOff { get; } = new();
+
+        public int Initialise()
+        {
+            InitialiseCalled = true;
+            return 0;
+        }
+
+        public int LoadRom(string romPath)
+        {
+            LoadedRoms.Add(romPath);
+            return 0;
+        }
+
+        public void Reset()
+        {
+            ResetCalled = true;
+        }
+
+        public void Run(int cycles)
+        {
+        }
+
+        public void Shutdown()
+        {
+            ShutdownCalled = true;
+        }
+
+        public int GetLampsOn() => 0;
+
+        public int GetLampBrightness(int lampIndex) => 0;
+
+        public int GetPosOut(int positionIndex) => 0;
+
+        public void TurnSwitchOn(int switchIndex)
+        {
+            SwitchesTurnedOn.Add(switchIndex);
+        }
+
+        public void TurnSwitchOff(int switchIndex)
+        {
+            SwitchesTurnedOff.Add(switchIndex);
+        }
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/EpochNativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/EpochNativeLibrary.cs
@@ -1,0 +1,24 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+public sealed class EpochNativeLibrary : INativeCoreLibrary
+{
+    private readonly NativeLibraryLoader _loader;
+
+    public EpochNativeLibrary(string libraryPath)
+    {
+        _loader = new NativeLibraryLoader(libraryPath);
+    }
+
+    public string LibraryPath => _loader.LibraryPath;
+
+    public Architecture ProcessArchitecture => _loader.ProcessArchitecture;
+
+    public bool IsLoaded => _loader.IsLoaded;
+
+    public void Dispose()
+    {
+        _loader.Dispose();
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/INativeCoreLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/INativeCoreLibrary.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+public interface INativeCoreLibrary : IDisposable
+{
+    string LibraryPath { get; }
+
+    Architecture ProcessArchitecture { get; }
+
+    bool IsLoaded { get; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -1,0 +1,24 @@
+namespace OasisEditor;
+
+public interface ISystem6NativeLibrary : INativeCoreLibrary
+{
+    int Initialise();
+
+    int LoadRom(string romPath);
+
+    void Reset();
+
+    void Run(int cycles);
+
+    void Shutdown();
+
+    int GetLampsOn();
+
+    int GetLampBrightness(int lampIndex);
+
+    int GetPosOut(int positionIndex);
+
+    void TurnSwitchOn(int switchIndex);
+
+    void TurnSwitchOff(int switchIndex);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeCoreExportException.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeCoreExportException.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+public sealed class NativeCoreExportException : Exception
+{
+    public NativeCoreExportException(string message)
+        : base(message)
+    {
+    }
+
+    public NativeCoreExportException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public static NativeCoreExportException CreateLoadFailure(string libraryPath, Architecture processArchitecture, Exception innerException)
+    {
+        return new NativeCoreExportException(
+            $"Failed to load native core library '{libraryPath}'. Process architecture is {processArchitecture}; the native DLL must match the Oasis Editor process bitness. {innerException.Message}",
+            innerException);
+    }
+
+    public static NativeCoreExportException CreateMissingExport(string libraryPath, Architecture processArchitecture, string exportName, Exception innerException)
+    {
+        return new NativeCoreExportException(
+            $"Failed to bind native core export '{exportName}' from '{libraryPath}'. Process architecture is {processArchitecture}; verify the DLL is the expected core version and bitness. {innerException.Message}",
+            innerException);
+    }
+
+    public static NativeCoreExportException CreateInvalidExportBinding(string libraryPath, Architecture processArchitecture, string exportName, Type delegateType, Exception innerException)
+    {
+        return new NativeCoreExportException(
+            $"Failed to bind native core export '{exportName}' from '{libraryPath}' to delegate '{delegateType.FullName}'. Process architecture is {processArchitecture}; verify the managed delegate signature and native calling convention match. {innerException.Message}",
+            innerException);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs
@@ -1,0 +1,81 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+public sealed class NativeLibraryLoader : INativeCoreLibrary
+{
+    private IntPtr _libraryHandle;
+    private bool _disposed;
+
+    public NativeLibraryLoader(string libraryPath)
+    {
+        if (string.IsNullOrWhiteSpace(libraryPath))
+        {
+            throw new ArgumentException("Native core library path must not be empty.", nameof(libraryPath));
+        }
+
+        LibraryPath = libraryPath;
+        ProcessArchitecture = RuntimeInformation.ProcessArchitecture;
+
+        try
+        {
+            _libraryHandle = NativeLibrary.Load(libraryPath);
+        }
+        catch (Exception ex) when (ex is DllNotFoundException or BadImageFormatException or FileLoadException or ArgumentException)
+        {
+            throw NativeCoreExportException.CreateLoadFailure(libraryPath, ProcessArchitecture, ex);
+        }
+    }
+
+    public string LibraryPath { get; }
+
+    public Architecture ProcessArchitecture { get; }
+
+    public bool IsLoaded => _libraryHandle != IntPtr.Zero;
+
+    public TDelegate BindExport<TDelegate>(string exportName)
+        where TDelegate : Delegate
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(exportName))
+        {
+            throw new ArgumentException("Native core export name must not be empty.", nameof(exportName));
+        }
+
+        IntPtr exportAddress;
+        try
+        {
+            exportAddress = NativeLibrary.GetExport(_libraryHandle, exportName);
+        }
+        catch (Exception ex) when (ex is EntryPointNotFoundException or ArgumentNullException)
+        {
+            throw NativeCoreExportException.CreateMissingExport(LibraryPath, ProcessArchitecture, exportName, ex);
+        }
+
+        try
+        {
+            return Marshal.GetDelegateForFunctionPointer<TDelegate>(exportAddress);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidCastException or MarshalDirectiveException)
+        {
+            throw NativeCoreExportException.CreateInvalidExportBinding(LibraryPath, ProcessArchitecture, exportName, typeof(TDelegate), ex);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_libraryHandle != IntPtr.Zero)
+        {
+            NativeLibrary.Free(_libraryHandle);
+            _libraryHandle = IntPtr.Zero;
+        }
+
+        _disposed = true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,0 +1,354 @@
+using System.Globalization;
+
+namespace OasisEditor;
+
+public sealed class System6NativeBackend : IEmulationBackend
+{
+    private const int DefaultFramesPerSecond = 60;
+    private const int System6ClockHz = 8000000;
+    private const int LampCount = 32;
+    private const int ReelCount = 16;
+
+    private static readonly EmulationBackendCapabilities System6Capabilities = new(
+        SupportsPause: true,
+        SupportsResume: true,
+        SupportsSoftReset: true,
+        SupportsHardReset: true,
+        SupportsSaveState: false,
+        SupportsLoadState: false,
+        SupportsThrottle: false,
+        SupportsDebugger: false);
+
+    private readonly string _libraryPath;
+    private readonly Func<string, ISystem6NativeLibrary> _libraryFactory;
+    private readonly TimeSpan _pollInterval;
+    private readonly int _cyclesPerFrame;
+    private readonly object _stateGate = new();
+    private readonly int[] _lastLampValues = Enumerable.Repeat(-1, LampCount).ToArray();
+    private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
+
+    private ISystem6NativeLibrary? _library;
+    private CancellationTokenSource? _runLoopCancellation;
+    private Task? _runLoopTask;
+    private EmulationBackendState _state = EmulationBackendState.Stopped;
+
+    public System6NativeBackend(string libraryPath)
+        : this(libraryPath, static path => new System6NativeLibrary(path))
+    {
+    }
+
+    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory)
+        : this(libraryPath, libraryFactory, DefaultFramesPerSecond)
+    {
+    }
+
+    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory, int framesPerSecond)
+    {
+        if (string.IsNullOrWhiteSpace(libraryPath))
+        {
+            throw new ArgumentException("System6 native core library path must not be empty.", nameof(libraryPath));
+        }
+
+        if (framesPerSecond <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(framesPerSecond), framesPerSecond, "System6 polling rate must be greater than zero.");
+        }
+
+        _libraryPath = libraryPath;
+        _libraryFactory = libraryFactory ?? throw new ArgumentNullException(nameof(libraryFactory));
+        _pollInterval = TimeSpan.FromMilliseconds(1000.0 / framesPerSecond);
+        _cyclesPerFrame = System6ClockHz / framesPerSecond;
+    }
+
+    public EmulationBackendState State
+    {
+        get
+        {
+            lock (_stateGate)
+            {
+                return _state;
+            }
+        }
+    }
+
+    public EmulationBackendCapabilities Capabilities => System6Capabilities;
+
+    public event EventHandler<EmulationBackendState>? StateChanged;
+
+    public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
+    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
+    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
+    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+
+    public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (State is not EmulationBackendState.Stopped)
+        {
+            throw new InvalidOperationException($"System6 native backend cannot start while it is {State}.");
+        }
+
+        SetState(EmulationBackendState.Starting);
+
+        try
+        {
+            if (request.RomPaths.Count == 0)
+            {
+                throw new InvalidOperationException($"System6 native backend requires at least one ROM path before starting core '{_libraryPath}'.");
+            }
+
+            _library = _libraryFactory(_libraryPath);
+            try
+            {
+                _library.Initialise();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"System6 native backend failed to initialise core '{_libraryPath}'.", ex);
+            }
+
+            foreach (var romPath in request.RomPaths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    _library.LoadRom(romPath);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"System6 native backend failed to load ROM '{romPath}' with core '{_libraryPath}'.", ex);
+                }
+            }
+
+            try
+            {
+                _library.Reset();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"System6 native backend failed to reset core '{_libraryPath}' during startup.", ex);
+            }
+            ResetCachedOutputState();
+
+            _runLoopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _runLoopTask = Task.Run(() => RunLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
+            SetState(EmulationBackendState.Running);
+            return Task.CompletedTask;
+        }
+        catch
+        {
+            CleanupLibraryAfterFailedStart();
+            SetState(EmulationBackendState.Failed);
+            throw;
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (State is EmulationBackendState.Stopped)
+        {
+            return;
+        }
+
+        SetState(EmulationBackendState.Stopping);
+
+        var runLoopCancellation = _runLoopCancellation;
+        if (runLoopCancellation is not null)
+        {
+            await runLoopCancellation.CancelAsync().ConfigureAwait(false);
+        }
+
+        if (_runLoopTask is not null)
+        {
+            try
+            {
+                await _runLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (runLoopCancellation?.IsCancellationRequested == true)
+            {
+            }
+            catch
+            {
+                // The run loop moves the backend to Failed before faulting. Stop should still
+                // release the native core and return the backend to a clean stopped state.
+            }
+        }
+
+        ShutdownAndDisposeLibrary();
+        _runLoopCancellation?.Dispose();
+        _runLoopCancellation = null;
+        _runLoopTask = null;
+        SetState(EmulationBackendState.Stopped);
+    }
+
+    public Task PauseAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (State is EmulationBackendState.Running)
+        {
+            SetState(EmulationBackendState.Paused);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task ResumeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (State is EmulationBackendState.Paused)
+        {
+            SetState(EmulationBackendState.Running);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (resetKind is not EmulationResetKind.Soft and not EmulationResetKind.Hard)
+        {
+            throw new ArgumentOutOfRangeException(nameof(resetKind), resetKind, null);
+        }
+
+        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot reset before it has started.");
+        library.Reset();
+        ResetCachedOutputState();
+        return Task.CompletedTask;
+    }
+
+    public Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot set input state before it has started.");
+        if (!int.TryParse(input.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var switchIndex))
+        {
+            throw new InvalidOperationException($"System6 native backend input '{input.Id}' is not a numeric switch index.");
+        }
+
+        if (isPressed)
+        {
+            library.TurnSwitchOn(switchIndex);
+        }
+        else
+        {
+            library.TurnSwitchOff(switchIndex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (State is EmulationBackendState.Running)
+                {
+                    var library = _library;
+                    if (library is not null)
+                    {
+                        library.Run(_cyclesPerFrame);
+                        PollOutputs(library);
+                    }
+                }
+
+                await Task.Delay(_pollInterval, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch
+        {
+            SetState(EmulationBackendState.Failed);
+            throw;
+        }
+    }
+
+    private void PollOutputs(ISystem6NativeLibrary library)
+    {
+        var lampsOn = library.GetLampsOn();
+        for (var lampIndex = 0; lampIndex < LampCount; lampIndex++)
+        {
+            var isOn = (lampsOn & (1 << lampIndex)) != 0;
+            var value = isOn ? library.GetLampBrightness(lampIndex) : 0;
+            if (_lastLampValues[lampIndex] != value)
+            {
+                _lastLampValues[lampIndex] = value;
+                LampChanged?.Invoke(this, new MachineLampChangedEventArgs(lampIndex, value));
+            }
+        }
+
+        for (var reelIndex = 0; reelIndex < ReelCount; reelIndex++)
+        {
+            var position = library.GetPosOut(reelIndex);
+            if (_lastReelPositions[reelIndex] != position)
+            {
+                _lastReelPositions[reelIndex] = position;
+                ReelChanged?.Invoke(this, new MachineReelChangedEventArgs(reelIndex, position));
+            }
+        }
+    }
+
+    private void ResetCachedOutputState()
+    {
+        Array.Fill(_lastLampValues, -1);
+        Array.Fill(_lastReelPositions, int.MinValue);
+    }
+
+    private void CleanupLibraryAfterFailedStart()
+    {
+        ShutdownAndDisposeLibrary();
+        _runLoopCancellation?.Dispose();
+        _runLoopCancellation = null;
+        _runLoopTask = null;
+    }
+
+    private void ShutdownAndDisposeLibrary()
+    {
+        var library = _library;
+        _library = null;
+        if (library is null)
+        {
+            return;
+        }
+
+        try
+        {
+            library.Shutdown();
+        }
+        finally
+        {
+            library.Dispose();
+        }
+    }
+
+    private void SetState(EmulationBackendState state)
+    {
+        var changed = false;
+        lock (_stateGate)
+        {
+            if (_state != state)
+            {
+                _state = state;
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            StateChanged?.Invoke(this, state);
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -2,9 +2,19 @@ using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
-public sealed class System6NativeLibrary : INativeCoreLibrary
+public sealed class System6NativeLibrary : ISystem6NativeLibrary
 {
     private readonly NativeLibraryLoader _loader;
+    private readonly System6InitialiseDelegate _initialise;
+    private readonly System6LoadRomDelegate _loadRom;
+    private readonly System6ResetDelegate _reset;
+    private readonly System6RunDelegate _run;
+    private readonly System6ShutdownDelegate _shutdown;
+    private readonly System6GetLampsOnDelegate _getLampsOn;
+    private readonly System6GetLampBrightnessDelegate _getLampBrightness;
+    private readonly System6GetPosOutDelegate _getPosOut;
+    private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
+    private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
 
     public System6NativeLibrary(string libraryPath)
         : this(new NativeLibraryLoader(libraryPath))
@@ -15,16 +25,16 @@ public sealed class System6NativeLibrary : INativeCoreLibrary
     {
         _loader = loader ?? throw new ArgumentNullException(nameof(loader));
 
-        Initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
-        LoadROM = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
-        Reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
-        Run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
-        Shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
-        GetLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
-        GetLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
-        GetPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
-        TurnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
-        TurnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
+        _initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
+        _loadRom = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
+        _reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
+        _run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
+        _shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
+        _getLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
+        _getLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
+        _getPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
+        _turnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
+        _turnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
     }
 
     public string LibraryPath => _loader.LibraryPath;
@@ -33,25 +43,25 @@ public sealed class System6NativeLibrary : INativeCoreLibrary
 
     public bool IsLoaded => _loader.IsLoaded;
 
-    public System6InitialiseDelegate Initialise { get; }
+    public int Initialise() => _initialise();
 
-    public System6LoadRomDelegate LoadROM { get; }
+    public int LoadRom(string romPath) => _loadRom(romPath);
 
-    public System6ResetDelegate Reset { get; }
+    public void Reset() => _reset();
 
-    public System6RunDelegate Run { get; }
+    public void Run(int cycles) => _run(cycles);
 
-    public System6ShutdownDelegate Shutdown { get; }
+    public void Shutdown() => _shutdown();
 
-    public System6GetLampsOnDelegate GetLampsOn { get; }
+    public int GetLampsOn() => _getLampsOn();
 
-    public System6GetLampBrightnessDelegate GetLampBrightness { get; }
+    public int GetLampBrightness(int lampIndex) => _getLampBrightness(lampIndex);
 
-    public System6GetPosOutDelegate GetPosOut { get; }
+    public int GetPosOut(int positionIndex) => _getPosOut(positionIndex);
 
-    public System6TurnSwitchOnDelegate TurnSwitchOn { get; }
+    public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
 
-    public System6TurnSwitchOffDelegate TurnSwitchOff { get; }
+    public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(switchIndex);
 
     public void Dispose()
     {
@@ -68,7 +78,7 @@ public sealed class System6NativeLibrary : INativeCoreLibrary
     public delegate void System6ResetDelegate();
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6RunDelegate();
+    public delegate void System6RunDelegate(int cycles);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6ShutdownDelegate();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -1,0 +1,90 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+public sealed class System6NativeLibrary : INativeCoreLibrary
+{
+    private readonly NativeLibraryLoader _loader;
+
+    public System6NativeLibrary(string libraryPath)
+        : this(new NativeLibraryLoader(libraryPath))
+    {
+    }
+
+    public System6NativeLibrary(NativeLibraryLoader loader)
+    {
+        _loader = loader ?? throw new ArgumentNullException(nameof(loader));
+
+        Initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
+        LoadROM = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
+        Reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
+        Run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
+        Shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
+        GetLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
+        GetLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
+        GetPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
+        TurnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
+        TurnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
+    }
+
+    public string LibraryPath => _loader.LibraryPath;
+
+    public Architecture ProcessArchitecture => _loader.ProcessArchitecture;
+
+    public bool IsLoaded => _loader.IsLoaded;
+
+    public System6InitialiseDelegate Initialise { get; }
+
+    public System6LoadRomDelegate LoadROM { get; }
+
+    public System6ResetDelegate Reset { get; }
+
+    public System6RunDelegate Run { get; }
+
+    public System6ShutdownDelegate Shutdown { get; }
+
+    public System6GetLampsOnDelegate GetLampsOn { get; }
+
+    public System6GetLampBrightnessDelegate GetLampBrightness { get; }
+
+    public System6GetPosOutDelegate GetPosOut { get; }
+
+    public System6TurnSwitchOnDelegate TurnSwitchOn { get; }
+
+    public System6TurnSwitchOffDelegate TurnSwitchOff { get; }
+
+    public void Dispose()
+    {
+        _loader.Dispose();
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6InitialiseDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6LoadRomDelegate([MarshalAs(UnmanagedType.LPStr)] string romPath);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6ResetDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6RunDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6ShutdownDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6GetLampsOnDelegate();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6GetLampBrightnessDelegate(int lampIndex);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6GetPosOutDelegate(int positionIndex);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6TurnSwitchOnDelegate(int switchIndex);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6TurnSwitchOffDelegate(int switchIndex);
+}


### PR DESCRIPTION
### Motivation
- Provide a small, well-typed C# ABI layer for in-process native emulator cores (System6/Epoch) to enable future native backend implementations. 
- Replace the legacy `LoadLibrary`/`GetProcAddress` style with `NativeLibrary.Load`/`GetExport` and strongly typed delegates for safer binding and diagnostics. 
- Keep the change surface minimal and avoid touching or altering existing MAME behavior or Play View integration. 

### Description
- Added the native core contract `INativeCoreLibrary` at `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/INativeCoreLibrary.cs`. 
- Implemented `NativeLibraryLoader` which loads DLLs with `NativeLibrary.Load`, binds exports with `NativeLibrary.GetExport` and `Marshal.GetDelegateForFunctionPointer<TDelegate>`, and frees handles on `Dispose`; file: `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs`. 
- Added `NativeCoreExportException` with helpers that construct clear diagnostics including DLL path and process architecture for load failures, missing exports, and invalid bindings; file: `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeCoreExportException.cs`. 
- Added `System6NativeLibrary` exposing strongly typed cdecl delegates for the initial System6 ABI exports (`SYSTEM6Initialise`, `SYSTEM6LoadROM`, `SYSTEM6Reset`, `SYSTEM6Run`, `SYSTEM6Shutdown`, `SYSTEM6GetLampsOn`, `SYSTEM6GetLampBrightness`, `SYSTEM6GetPosOut`, `SYSTEM6TurnSwitchOn`, `SYSTEM6TurnSwitchOff`) with ANSI string marshalling for ROM paths; file: `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs`. 
- Added a minimal `EpochNativeLibrary` stub that uses the same loader/disposal pattern without implementing epoch-specific behavior; file: `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/EpochNativeLibrary.cs`. 
- Added focused unit tests that validate the diagnostic message construction for `NativeCoreExportException` without requiring real native DLLs; file: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/NativeCoreExportExceptionTests.cs`. 
- No changes were made to MAME-related code or runtime behaviour and no System6 run loop, backend selection, Play View wiring, or editor UI integration was implemented. 

### Testing
- ⚠️ To build the editor project locally run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj` on the Windows development machine because the Codex environment lacks the required Windows/.NET/WPF toolchain. 
- ⚠️ To run the new unit tests locally run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` on the Windows development machine and expect the added tests to pass. 
- ⚠️ The Codex environment did not run the tests due to the environment constraint described in `WindowsNetProjects/OasisEditor/AGENTS.md`, so CI/local verification is required to confirm integration with the rest of the test suite. 

Files added
- `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/INativeCoreLibrary.cs` 
- `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeCoreExportException.cs` 
- `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/NativeLibraryLoader.cs` 
- `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs` 
- `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/EpochNativeLibrary.cs` 
- `WindowsNetProjects/OasisEditor/OasisEditor.Tests/NativeCoreExportExceptionTests.cs` 

Notes
- MAME behavior was not changed. 
- No System6 backend run loop, Play View integration, or editor/backend selection wiring was started. 
- Recommended next task: Task 04 — implement the System6 native backend run loop and runtime polling on top of this ABI wrapper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31aa154ff88327aeb4b314b9d86a18)