### PR TITLE
Integrate editor emulation backend selection

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -1,0 +1,57 @@
+namespace OasisEditor.Tests;
+
+public sealed class EmulationBackendFactoryTests
+{
+    [Fact]
+    public void CreateBackend_ForNone_ReturnsNull()
+    {
+        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/system6.dll");
+
+        Assert.Null(factory.CreateBackend(FruitMachinePlatformType.None));
+    }
+
+    [Fact]
+    public void CreateBackend_ForImpactWithSystem6Path_ReturnsSystem6Backend()
+    {
+        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/system6.dll");
+
+        Assert.IsType<System6NativeBackend>(factory.CreateBackend(FruitMachinePlatformType.Impact));
+    }
+
+    [Fact]
+    public void CreateBackend_ForImpactWithoutSystem6Path_FallsBackToMameBackend()
+    {
+        var mameBackend = new FakeBackend();
+        var factory = new EmulationBackendFactory(() => mameBackend, () => string.Empty);
+
+        Assert.Same(mameBackend, factory.CreateBackend(FruitMachinePlatformType.Impact));
+    }
+
+    [Fact]
+    public void CreateBackend_ForMpu4_ReturnsMameBackend()
+    {
+        var mameBackend = new FakeBackend();
+        var factory = new EmulationBackendFactory(() => mameBackend, () => "C:/cores/system6.dll");
+
+        Assert.Same(mameBackend, factory.CreateBackend(FruitMachinePlatformType.MPU4));
+    }
+
+    private sealed class FakeBackend : IEmulationBackend
+    {
+        public EmulationBackendState State => EmulationBackendState.Stopped;
+        public EmulationBackendCapabilities Capabilities { get; } = new(false, false, false, false, false, false, false, false);
+        public event EventHandler<EmulationBackendState>? StateChanged;
+        public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
+        public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
+        public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
+        public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
+        public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+        public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -1,3 +1,6 @@
+using OasisEditor;
+using Xunit;
+
 namespace OasisEditor.Tests;
 
 public sealed class EmulationBackendFactoryTests
@@ -40,12 +43,41 @@ public sealed class EmulationBackendFactoryTests
     {
         public EmulationBackendState State => EmulationBackendState.Stopped;
         public EmulationBackendCapabilities Capabilities { get; } = new(false, false, false, false, false, false, false, false);
-        public event EventHandler<EmulationBackendState>? StateChanged;
-        public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
-        public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
-        public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
-        public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
-        public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+        public event EventHandler<EmulationBackendState>? StateChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MachineLampChangedEventArgs>? LampChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MachineReelChangedEventArgs>? ReelChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged
+        {
+            add { }
+            remove { }
+        }
         public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -5,6 +5,7 @@ public sealed class EditorPreferences
     public ThemePreference ThemePreference { get; init; } = ThemePreference.Dark;
 
     public MamePreferences Mame { get; init; } = new();
+    public NativeEmulationPreferences NativeEmulation { get; init; } = new();
     public OutputLogPreferences OutputLog { get; init; } = new();
     public FaceGenerationPreferences FaceGeneration { get; init; } = new();
 
@@ -27,6 +28,11 @@ public sealed class MamePreferences
     public string LocalRomArchiveExtension { get; init; } = ".zip";
 }
 
+
+public sealed class NativeEmulationPreferences
+{
+    public string System6LibraryPath { get; init; } = string.Empty;
+}
 
 public sealed class FaceGenerationPreferences
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -1,0 +1,39 @@
+namespace OasisEditor;
+
+public interface IEmulationBackendFactory
+{
+    IEmulationBackend? CreateBackend(FruitMachinePlatformType platform);
+}
+
+public sealed class EmulationBackendFactory : IEmulationBackendFactory
+{
+    private readonly Func<IEmulationBackend> _mameBackendFactory;
+    private readonly Func<string?> _system6LibraryPathProvider;
+
+    public EmulationBackendFactory(
+        Func<IEmulationBackend> mameBackendFactory,
+        Func<string?> system6LibraryPathProvider)
+    {
+        _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
+        _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
+    }
+
+    public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
+    {
+        return platform switch
+        {
+            FruitMachinePlatformType.None => null,
+            FruitMachinePlatformType.Impact => CreateSystem6BackendOrMameFallback(),
+            FruitMachinePlatformType.Epoch => _mameBackendFactory(),
+            _ => _mameBackendFactory()
+        };
+    }
+
+    private IEmulationBackend CreateSystem6BackendOrMameFallback()
+    {
+        var libraryPath = _system6LibraryPathProvider();
+        return string.IsNullOrWhiteSpace(libraryPath)
+            ? _mameBackendFactory()
+            : new System6NativeBackend(libraryPath);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
@@ -40,11 +40,35 @@ public sealed class MameEmulationBackend : IEmulationBackend
 
     public event EventHandler<EmulationBackendState>? StateChanged;
 
-    public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
-    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
-    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
-    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
-    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+    public event EventHandler<MachineLampChangedEventArgs>? LampChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged
+    {
+        add { }
+        remove { }
+    }
 
     public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -77,9 +77,23 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
     public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
-    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
-    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
-    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged;
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged
+    {
+        add { }
+        remove { }
+    }
+
+    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged
+    {
+        add { }
+        remove { }
+    }
 
     public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -190,7 +190,9 @@ public partial class MainWindow : Window
         {
             ThemePreference = preferences.ThemePreference,
             Mame = preferences.Mame,
+            NativeEmulation = preferences.NativeEmulation,
             OutputLog = preferences.OutputLog,
+            FaceGeneration = preferences.FaceGeneration,
             ProjectWindowStates = states
         });
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -38,6 +38,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameReleaseSource = string.Empty;
     private string _mameLuaPluginPath = string.Empty;
     private string _mameCommandLineOverrides = string.Empty;
+    private string _system6NativeLibraryPath = string.Empty;
     private string _mameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
     private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private string _mameLocalRomSourceDirectory = string.Empty;
@@ -82,6 +83,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool _isLoadingPreferences;
     private readonly IMameEmulationService _mameEmulationService;
     private readonly IMameProcessRunner _mameProcessRunner;
+    private readonly IEmulationBackendFactory _emulationBackendFactory;
+    private readonly IMameLampRuntimeAdapter _lampRuntimeAdapter;
+    private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
+    private IEmulationBackend? _activeEmulationBackend;
     private readonly IMameDebuggerService _mameDebuggerService;
     private readonly MameDebuggerShellViewModel _mameDebuggerShell;
     private MameSetupState _mameSetupState = MameSetupState.NotStarted;
@@ -233,6 +238,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameReleaseSource = preferences.Mame.ReleaseSource;
             _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
             _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
+            _system6NativeLibraryPath = preferences.NativeEmulation.System6LibraryPath;
             _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
             _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
             _mameLocalRomSourceDirectory = preferences.Mame.LocalRomSourceDirectory;
@@ -261,20 +267,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _mameVersionCatalogService = new MameVersionCatalogService(_mameDownloadService);
         var setupValidationService = new MameSetupValidationService(_mamePluginAssetValidator, _mameVersionCatalogService);
         _mameSetupOrchestrator = new MameSetupOrchestrator(setupValidationService);
+        _lampRuntimeAdapter = new MameLampRuntimeAdapter(
+            () => OpenDocuments,
+            () => DebugOutputLamps,
+            message => AddOutputEntry(message, OutputLogStatus.Info),
+            DispatchToUiThread);
+        _reelRuntimeAdapter = new MameReelRuntimeAdapter(
+            () => OpenDocuments,
+            () => SelectedFruitMachinePlatform,
+            () => DebugOutputStdOut,
+            message => AddOutputEntry(message, OutputLogStatus.Info),
+            DispatchToUiThread);
         var mameStdoutParser = new MameStdoutParser(
             new MameLampStateParser(),
-            new MameLampRuntimeAdapter(
-                () => OpenDocuments,
-                () => DebugOutputLamps,
-                message => AddOutputEntry(message, OutputLogStatus.Info),
-                DispatchToUiThread),
+            _lampRuntimeAdapter,
             new MameReelStateParser(),
-            new MameReelRuntimeAdapter(
-                () => OpenDocuments,
-                () => SelectedFruitMachinePlatform,
-                () => DebugOutputStdOut,
-                message => AddOutputEntry(message, OutputLogStatus.Info),
-                DispatchToUiThread),
+            _reelRuntimeAdapter,
             new MameSegmentStateParser(),
             new MameSegmentRuntimeAdapter(
                 () => OpenDocuments,
@@ -314,6 +322,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             new MameProcessStartInfoBuilder(),
             _mameProcessRunner,
             BuildMameLaunchRequest);
+        _emulationBackendFactory = new EmulationBackendFactory(
+            () => new MameEmulationBackend(
+                _mameEmulationService,
+                new MameInputCommandService(new MameInputPortResolver()),
+                _mameProcessRunner,
+                () => SelectedFruitMachinePlatform,
+                input => LoadedProject?.InputDefinitions.FirstOrDefault(definition => string.Equals(definition.Id, input.Id, StringComparison.OrdinalIgnoreCase))),
+            () => System6NativeLibraryPath);
+
         _mameEmulationService.StateChanged += (_, state) =>
         {
             DispatchToUiThread(() =>
@@ -512,7 +529,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
 
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
-    public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME"];
+    public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME", "Native Emulation"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
     public IReadOnlyList<InputDefinitionModel> InputDefinitions => LoadedProject?.InputDefinitions ?? [];
     public IReadOnlyList<InputMapDiagnostic> InputMapDiagnostics
@@ -576,6 +593,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
+    public string System6NativeLibraryPath { get => _system6NativeLibraryPath; set { if (SetProperty(ref _system6NativeLibraryPath, value)) SavePreferences(); } }
     public string MameRomDownloadBaseUrl
     {
         get => _mameRomDownloadBaseUrl;
@@ -1797,7 +1815,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        _playViewInputRouter ??= new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), _mameProcessRunner);
+        _playViewInputRouter ??= _activeEmulationBackend is not null
+            ? new PlayViewInputRouter(_activeEmulationBackend)
+            : new PlayViewInputRouter(new MameInputCommandService(new MameInputPortResolver()), _mameProcessRunner);
         return true;
     }
 
@@ -2159,6 +2179,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 LocalRomSourceDirectory = MameLocalRomSourceDirectory,
                 LocalRomArchiveExtension = MameLocalRomArchiveExtension
             },
+            NativeEmulation = new NativeEmulationPreferences
+            {
+                System6LibraryPath = System6NativeLibraryPath
+            },
             FaceGeneration = FaceGenerationPreferences.FromSettings(
                 _defaultFaceGenerationSettings,
                 _showFaceGenerationSettingsBeforeGenerate,
@@ -2451,12 +2475,79 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry("Emulation start requested.", OutputLogStatus.Info);
         try
         {
-            await _mameEmulationService.StartAsync(CancellationToken.None);
+            await StartBackendEmulationAsync(CancellationToken.None);
         }
         catch (Exception ex)
         {
             AddOutputEntry($"Emulation failed to start: {ex.Message}", OutputLogStatus.Error);
         }
+    }
+
+    private async Task StartBackendEmulationAsync(CancellationToken cancellationToken)
+    {
+        var backend = _emulationBackendFactory.CreateBackend(SelectedFruitMachinePlatform)
+            ?? throw new InvalidOperationException($"No emulation backend is available for platform '{SelectedFruitMachinePlatform}'.");
+
+        _activeEmulationBackend = backend;
+        backend.StateChanged += OnActiveBackendStateChanged;
+        backend.LampChanged += OnActiveBackendLampChanged;
+        backend.ReelChanged += OnActiveBackendReelChanged;
+        try
+        {
+            await backend.StartAsync(BuildEmulationLaunchRequest(), cancellationToken).ConfigureAwait(false);
+            AddOutputEntry($"Started {backend.GetType().Name} for platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Info);
+        }
+        catch
+        {
+            backend.StateChanged -= OnActiveBackendStateChanged;
+            backend.LampChanged -= OnActiveBackendLampChanged;
+            backend.ReelChanged -= OnActiveBackendReelChanged;
+            await backend.DisposeAsync().ConfigureAwait(false);
+            _activeEmulationBackend = null;
+            throw;
+        }
+    }
+
+    private EmulationLaunchRequest BuildEmulationLaunchRequest()
+    {
+        var romRootPath = MameRuntimePaths.EnsureManagedRomRootDirectory();
+        var romPaths = string.IsNullOrWhiteSpace(MameRomName)
+            ? Array.Empty<string>()
+            : new[] { Path.Combine(romRootPath, MameRomName + MameRomArchiveExtension) };
+
+        return new EmulationLaunchRequest(
+            SelectedFruitMachinePlatform,
+            MameRomName,
+            romRootPath,
+            romPaths,
+            MameCommandLineOverrides);
+    }
+
+    private void OnActiveBackendLampChanged(object? sender, MachineLampChangedEventArgs e)
+    {
+        _lampRuntimeAdapter.ApplyLampState(e.LampId, e.Value);
+    }
+
+    private void OnActiveBackendReelChanged(object? sender, MachineReelChangedEventArgs e)
+    {
+        _reelRuntimeAdapter.ApplyReelState(e.ReelId, e.Position);
+    }
+
+    private void OnActiveBackendStateChanged(object? sender, EmulationBackendState state)
+    {
+        DispatchToUiThread(() =>
+        {
+            EmulationState = state switch
+            {
+                EmulationBackendState.Starting => MameEmulationState.Starting,
+                EmulationBackendState.Running => MameEmulationState.Running,
+                EmulationBackendState.Paused => MameEmulationState.Paused,
+                EmulationBackendState.Stopping => MameEmulationState.Stopping,
+                EmulationBackendState.Stopped => MameEmulationState.Stopped,
+                _ => MameEmulationState.Failed
+            };
+            AddOutputEntry($"Emulation backend state changed to {state}.", OutputLogStatus.Info);
+        });
     }
 
     private async void StartDebuggerEmulation()
@@ -2521,7 +2612,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     public void StopEmulationForWindowClose()
     {
-        if (_mameEmulationService.State == MameEmulationState.Stopped)
+        if (_activeEmulationBackend is null && _mameEmulationService.State == MameEmulationState.Stopped)
         {
             return;
         }
@@ -2529,7 +2620,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry("Emulation stop requested.", OutputLogStatus.Info);
         try
         {
-            _mameEmulationService.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+            if (_activeEmulationBackend is not null)
+            {
+                _activeEmulationBackend.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+                _activeEmulationBackend.StateChanged -= OnActiveBackendStateChanged;
+                _activeEmulationBackend.LampChanged -= OnActiveBackendLampChanged;
+                _activeEmulationBackend.ReelChanged -= OnActiveBackendReelChanged;
+                _activeEmulationBackend.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _activeEmulationBackend = null;
+                _playViewInputRouter = null;
+                _playViewInputDispatcher = null;
+                EmulationState = MameEmulationState.Stopped;
+            }
+            else
+            {
+                _mameEmulationService.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
         }
         catch (Exception ex)
         {
@@ -2552,7 +2658,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry("Emulation stop requested.", OutputLogStatus.Info);
         try
         {
-            await _mameEmulationService.StopAsync(CancellationToken.None);
+            if (_activeEmulationBackend is not null)
+            {
+                await _activeEmulationBackend.StopAsync(CancellationToken.None);
+                _activeEmulationBackend.StateChanged -= OnActiveBackendStateChanged;
+                _activeEmulationBackend.LampChanged -= OnActiveBackendLampChanged;
+                _activeEmulationBackend.ReelChanged -= OnActiveBackendReelChanged;
+                await _activeEmulationBackend.DisposeAsync();
+                _activeEmulationBackend = null;
+                _playViewInputRouter = null;
+                _playViewInputDispatcher = null;
+                EmulationState = MameEmulationState.Stopped;
+            }
+            else
+            {
+                await _mameEmulationService.StopAsync(CancellationToken.None);
+            }
         }
         catch (Exception ex)
         {
@@ -2573,7 +2694,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 CanTogglePauseEmulation,
                 "Emulation resume requested.",
                 "Emulation failed to resume",
-                cancellationToken => _mameEmulationService.ResumeAsync(cancellationToken));
+                cancellationToken => _activeEmulationBackend?.ResumeAsync(cancellationToken) ?? _mameEmulationService.ResumeAsync(cancellationToken));
 
             if (!commandSucceeded)
             {
@@ -2587,7 +2708,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             CanTogglePauseEmulation,
             "Emulation pause requested.",
             "Emulation failed to pause",
-            cancellationToken => _mameEmulationService.PauseAsync(cancellationToken));
+            cancellationToken => _activeEmulationBackend?.PauseAsync(cancellationToken) ?? _mameEmulationService.PauseAsync(cancellationToken));
 
         if (!pauseSucceeded)
         {
@@ -2630,7 +2751,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             CanResetEmulation,
             "Emulation soft reset requested.",
             "Emulation failed to soft reset",
-            cancellationToken => _mameEmulationService.SoftResetAsync(cancellationToken));
+            cancellationToken => _activeEmulationBackend?.ResetAsync(EmulationResetKind.Soft, cancellationToken) ?? _mameEmulationService.SoftResetAsync(cancellationToken));
     }
 
     private async void HardResetEmulation()
@@ -2639,7 +2760,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             CanResetEmulation,
             "Emulation hard reset requested.",
             "Emulation failed to hard reset",
-            cancellationToken => _mameEmulationService.HardResetAsync(cancellationToken));
+            cancellationToken => _activeEmulationBackend?.ResetAsync(EmulationResetKind.Hard, cancellationToken) ?? _mameEmulationService.HardResetAsync(cancellationToken));
     }
 
     private bool TrySyncMamePluginsForDebuggerLaunch()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -22,7 +22,7 @@ namespace OasisEditor;
 
 public sealed class MainWindowViewModel : INotifyPropertyChanged
 {
-    private const bool kDebugSkiaPerformanceOutput = false;
+    private static readonly bool kDebugSkiaPerformanceOutput = false;
     private readonly RecentProjectsStore _recentProjectsStore = new();
     private readonly IApplicationThemeService _applicationThemeService;
     private readonly EditorPreferencesStore _preferencesStore;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -2,14 +2,20 @@ namespace OasisEditor;
 
 public sealed class PlayViewInputRouter
 {
-    private readonly IMameInputCommandService _commandService;
-    private readonly IMameProcessRunner _processRunner;
+    private readonly IMameInputCommandService? _commandService;
+    private readonly IMameProcessRunner? _processRunner;
+    private readonly IEmulationBackend? _backend;
     private readonly HashSet<string> _activeInputIds = [];
 
     public PlayViewInputRouter(IMameInputCommandService commandService, IMameProcessRunner processRunner)
     {
         _commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
         _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+    }
+
+    public PlayViewInputRouter(IEmulationBackend backend)
+    {
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
     }
 
     public async Task<bool> TryPressAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken)
@@ -26,7 +32,7 @@ public sealed class PlayViewInputRouter
             return false;
         }
 
-        var wrote = await _commandService.TrySendInputStateAsync(_processRunner, platform, inputDefinition, isPressed: true, cancellationToken).ConfigureAwait(false);
+        var wrote = await TrySendInputStateAsync(platform, inputDefinition, isPressed: true, cancellationToken).ConfigureAwait(false);
         if (!wrote)
         {
             _activeInputIds.Remove(inputDefinition.Id);
@@ -44,7 +50,7 @@ public sealed class PlayViewInputRouter
             return false;
         }
 
-        return await _commandService.TrySendInputStateAsync(_processRunner, platform, inputDefinition, isPressed: false, cancellationToken).ConfigureAwait(false);
+        return await TrySendInputStateAsync(platform, inputDefinition, isPressed: false, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> ReleaseAllAsync(FruitMachinePlatformType platform, IReadOnlyDictionary<string, InputDefinitionModel> inputDefinitionsById, CancellationToken cancellationToken)
@@ -66,7 +72,7 @@ public sealed class PlayViewInputRouter
             }
 
             _activeInputIds.Remove(inputId);
-            var wrote = await _commandService.TrySendInputStateAsync(_processRunner, platform, definition, isPressed: false, cancellationToken).ConfigureAwait(false);
+            var wrote = await TrySendInputStateAsync(platform, definition, isPressed: false, cancellationToken).ConfigureAwait(false);
             if (wrote)
             {
                 released++;
@@ -74,5 +80,24 @@ public sealed class PlayViewInputRouter
         }
 
         return released;
+    }
+
+    private async Task<bool> TrySendInputStateAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken)
+    {
+        if (_backend is not null)
+        {
+            try
+            {
+                await _backend.SetInputStateAsync(MachineInputReference.FromInputId(inputDefinition.Id), isPressed, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        return _commandService is not null && _processRunner is not null
+            && await _commandService.TrySendInputStateAsync(_processRunner, platform, inputDefinition, isPressed, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -122,6 +122,26 @@
                     <Button Padding="10,4" Content="Remove Cached Version" Command="{Binding RemoveCachedMameVersionCommand}" />
                 </StackPanel>
             </StackPanel>
+
+            <StackPanel>
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedPreferencesCategory}" Value="Native Emulation">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock FontSize="18" FontWeight="SemiBold" Text="Native Emulation" />
+                <TextBlock Margin="0,16,0,4" Text="System6 native core DLL path" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBox Text="{Binding System6NativeLibraryPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <TextBlock Margin="0,8,0,0"
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="Temporary Task 05 setting: Impact projects use this System6 DLL path when provided; otherwise they fall back to MAME." />
+            </StackPanel>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation

- Provide a small, conservative backend-selection layer so Play View can run either the existing MAME adapter or the new System6 native backend without changing MAME internals or behavior.【F:WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs†L1-L38】【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L2486-L2551】

### Description

- Added `IEmulationBackendFactory` and `EmulationBackendFactory` which map platforms to a backend; Impact maps to System6 when a DLL path is configured and falls back to MAME otherwise.【F:WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs†L1-L38】
- Wired Play View start/stop/pause/reset flows to use an active `IEmulationBackend` where present, including launch request creation and state mapping into the existing `MameEmulationState` view-model plumbing.【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L2486-L2551】【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L2526-L2548】
- Routed backend-neutral lamp/reel events from an active backend into the existing runtime adapters (`MameLampRuntimeAdapter` / `MameReelRuntimeAdapter`) so native backends update Play View visuals via the same path MAME uses.【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L2511-L2534】【F:WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs†L1-L102】
- Extended `PlayViewInputRouter` to send inputs via an active `IEmulationBackend` when present while preserving the existing MAME stdin/stdout input command path as a fallback.【F:WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs†L16-L35】【F:WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs†L85-L102】
- Added a temporary preferences section and persisted `System6LibraryPath` so users can point the editor at a System6 DLL for Impact projects during Task 05 evaluation.【F:WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs†L31-L36】【F:WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml†L126-L144】
- Added focused unit tests for the backend factory behaviors (None, Impact→System6, Impact→fallback-to-MAME, MPU4→MAME) as an automated verification of selection logic.【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs†L1-L57】

### Testing

- No build or test was executed in this Codex environment per `WindowsNetProjects/OasisEditor/AGENTS.md`; verified repository consistency and added focused unit tests only (tests must be run locally).【F:WindowsNetProjects/OasisEditor/AGENTS.md†L1-L10】

- Recommended automated checks John should run locally:
  - ⚠️ `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` — build the solution on Windows with the proper .NET/WPF toolchain.
  - ⚠️ `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` — run the full test suite locally to validate no regressions and to execute the new `EmulationBackendFactoryTests`.
  - ⚠️ `dotnet test --filter FullyQualifiedName~EmulationBackendFactoryTests` — run only the new factory tests for quick verification.
  - ⚠️ Start the editor and open Preferences to set the System6 native DLL path, select an Impact project platform, open Play View, and exercise Start/Stop/Pause/Reset and inputs to confirm the System6 backend is chosen when configured and MAME is used otherwise.

- Quick sanity checks already performed in the workspace:
  - ✅ `git diff --check` to validate no whitespace/indexing errors.
  - ✅ `git status --short` to confirm the intended files are staged/committed.

Notes:
- MAME behavior was preserved; the MAME path (process launch, Lua stdin/stdout protocol, stdout parsing, runtime adapters, debugger and save/load state flows) remains unchanged and is used as the fallback/default backend.【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L321-L332】【F:WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs†L311-L324】
- System6 native backend run-loop and polling code were not modified here; this change only wires backend selection and event/input routing so System6 can be launched from the editor when configured.【F:WindowsNetProjects/OasisEditor/OasisEditor/Emulation/System6NativeBackend.cs†L1-L40】

Recommended next task

- Expand backend-neutral event publication to include segment updates, VFD brightness, and dot matrix events, and add small adapter seams for any System6 assumptions (lamp/reel counts, input index parsing) before adding Epoch or more platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31af0750f48327b251afbfc7b8b95a)