### PR TITLE
Add System6 native ROM project settings and multi‑ROM native ABI support

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -33,10 +33,10 @@ public sealed class System6NativeBackendTests
     public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
     {
         var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, _) = CreateNativeFiles(1);
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
         var backend = new System6NativeBackend(dllPath, _ => library);
 
-        await backend.StartAsync(CreateLaunchRequest(rom1), CancellationToken.None);
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
         await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), true, CancellationToken.None);
         await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), false, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
@@ -109,10 +109,10 @@ public sealed class System6NativeBackendTests
 
         public List<int> SwitchesTurnedOff { get; } = new();
 
-        public int Initialise()
+        public byte Initialise()
         {
             InitialiseCalled = true;
-            return 0;
+            return 1;
         }
 
         public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
@@ -131,20 +131,22 @@ public sealed class System6NativeBackendTests
             ResetCalled = true;
         }
 
-        public void Run(int cycles)
+        public int Run(int cycles)
         {
+            return 1;
         }
 
-        public void Shutdown()
+        public byte Shutdown()
         {
             ShutdownCalled = true;
+            return 1;
         }
 
-        public int GetLampsOn() => 0;
+        public bool GetLampsOn(ushort lampIndex) => false;
 
-        public int GetLampBrightness(int lampIndex) => 0;
+        public float GetLampBrightness(ushort lampIndex) => 0f;
 
-        public int GetPosOut(int positionIndex) => 0;
+        public short GetPosOut(sbyte positionIndex) => 0;
 
         public void TurnSwitchOn(int switchIndex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -46,7 +46,7 @@ public sealed class System6NativeBackendTests
     }
 
     [Fact]
-    public async Task StartAsyncWithoutRomPathsFailsBeforeLoadingNativeLibrary()
+    public async Task StartAsyncWithoutRomPathsFailsBeforeLoadingRoms()
     {
         var library = new FakeSystem6NativeLibrary();
         var (dllPath, _, _) = CreateNativeFiles(0);
@@ -55,7 +55,9 @@ public sealed class System6NativeBackendTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
 
-        Assert.False(library.InitialiseCalled);
+        Assert.True(library.InitialiseCalled);
+        Assert.Empty(library.LoadedRoms);
+        Assert.False(library.ResetCalled);
         Assert.Equal(EmulationBackendState.Failed, backend.State);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,14 +14,15 @@ public sealed class System6NativeBackendTests
     public async Task StartAsyncInitialisesLoadsRomsResetsAndStopShutsDown()
     {
         var library = new FakeSystem6NativeLibrary();
-        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
-        var request = CreateLaunchRequest("C:/roms/a.rom", "C:/roms/b.rom");
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var request = CreateLaunchRequest(rom1, rom2);
 
         await backend.StartAsync(request, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
 
         Assert.True(library.InitialiseCalled);
-        Assert.Equal(new[] { "C:/roms/a.rom", "C:/roms/b.rom" }, library.LoadedRoms);
+        Assert.Equal(new[] { rom1, rom2, string.Empty, string.Empty }, library.LoadedRoms);
         Assert.True(library.ResetCalled);
         Assert.True(library.ShutdownCalled);
         Assert.True(library.DisposeCalled);
@@ -31,9 +33,10 @@ public sealed class System6NativeBackendTests
     public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
     {
         var library = new FakeSystem6NativeLibrary();
-        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
+        var (dllPath, rom1, _) = CreateNativeFiles(1);
+        var backend = new System6NativeBackend(dllPath, _ => library);
 
-        await backend.StartAsync(CreateLaunchRequest("C:/roms/a.rom"), CancellationToken.None);
+        await backend.StartAsync(CreateLaunchRequest(rom1), CancellationToken.None);
         await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), true, CancellationToken.None);
         await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), false, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
@@ -46,7 +49,8 @@ public sealed class System6NativeBackendTests
     public async Task StartAsyncWithoutRomPathsFailsBeforeLoadingNativeLibrary()
     {
         var library = new FakeSystem6NativeLibrary();
-        var backend = new System6NativeBackend("C:/cores/system6.dll", _ => library);
+        var (dllPath, _, _) = CreateNativeFiles(0);
+        var backend = new System6NativeBackend(dllPath, _ => library);
         var request = CreateLaunchRequest();
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
@@ -61,8 +65,26 @@ public sealed class System6NativeBackendTests
             FruitMachinePlatformType.None,
             "test-machine",
             "C:/roms",
-            romPaths,
-            string.Empty);
+            [],
+            string.Empty,
+            new System6NativeRomSettings
+            {
+                ProgramRom1Path = romPaths.Length > 0 ? romPaths[0] : string.Empty,
+                ProgramRom2Path = romPaths.Length > 1 ? romPaths[1] : string.Empty
+            });
+    }
+
+    private static (string DllPath, string Rom1, string Rom2) CreateNativeFiles(int romCount)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var dllPath = Path.Combine(directory, "system6.dll");
+        File.WriteAllBytes(dllPath, []);
+        var rom1 = Path.Combine(directory, "a.rom");
+        var rom2 = Path.Combine(directory, "b.rom");
+        if (romCount >= 1) File.WriteAllBytes(rom1, []);
+        if (romCount >= 2) File.WriteAllBytes(rom2, []);
+        return (dllPath, rom1, rom2);
     }
 
     private sealed class FakeSystem6NativeLibrary : ISystem6NativeLibrary
@@ -93,10 +115,15 @@ public sealed class System6NativeBackendTests
             return 0;
         }
 
-        public int LoadRom(string romPath)
+        public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
         {
-            LoadedRoms.Add(romPath);
-            return 0;
+            LoadedRoms.AddRange(programRomPaths);
+            return 1;
+        }
+
+        public int LoadSoundRom(IReadOnlyList<string> soundRomPaths)
+        {
+            return 1;
         }
 
         public void Reset()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -11,5 +11,23 @@ public sealed class EditorProject
     public FruitMachinePlatformType FruitMachinePlatform { get; set; } = FruitMachinePlatformType.None;
     public string MameRomName { get; set; } = string.Empty;
     public bool AutomaticallyDownloadMissingRoms { get; set; } = true;
+    public System6NativeRomSettings System6NativeRoms { get; set; } = new();
     public List<InputDefinitionModel> InputDefinitions { get; } = [];
+}
+
+
+public sealed class System6NativeRomSettings
+{
+    public string ProgramRom1Path { get; set; } = string.Empty;
+    public string ProgramRom2Path { get; set; } = string.Empty;
+    public string ProgramRom3Path { get; set; } = string.Empty;
+    public string ProgramRom4Path { get; set; } = string.Empty;
+    public string SoundRom1Path { get; set; } = string.Empty;
+    public string SoundRom2Path { get; set; } = string.Empty;
+    public string SoundRom3Path { get; set; } = string.Empty;
+    public string SoundRom4Path { get; set; } = string.Empty;
+    public bool FlashSwitch { get; set; }
+
+    public IReadOnlyList<string> ProgramRomPaths => [ProgramRom1Path, ProgramRom2Path, ProgramRom3Path, ProgramRom4Path];
+    public IReadOnlyList<string> SoundRomPaths => [SoundRom1Path, SoundRom2Path, SoundRom3Path, SoundRom4Path];
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -56,7 +56,8 @@ public sealed record EmulationLaunchRequest(
     string MachineName,
     string RomRootPath,
     IReadOnlyList<string> RomPaths,
-    string AdditionalArguments);
+    string AdditionalArguments,
+    System6NativeRomSettings? System6NativeRoms = null);
 
 public sealed class MachineLampChangedEventArgs : EventArgs
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -2,7 +2,7 @@ namespace OasisEditor;
 
 public interface ISystem6NativeLibrary : INativeCoreLibrary
 {
-    int Initialise();
+    byte Initialise();
 
     int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch);
 
@@ -10,15 +10,15 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 
     void Reset();
 
-    void Run(int cycles);
+    int Run(int cycles);
 
-    void Shutdown();
+    byte Shutdown();
 
-    int GetLampsOn();
+    bool GetLampsOn(ushort lampIndex);
 
-    int GetLampBrightness(int lampIndex);
+    float GetLampBrightness(ushort lampIndex);
 
-    int GetPosOut(int positionIndex);
+    short GetPosOut(sbyte positionIndex);
 
     void TurnSwitchOn(int switchIndex);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -4,7 +4,9 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 {
     int Initialise();
 
-    int LoadRom(string romPath);
+    int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch);
+
+    int LoadSoundRom(IReadOnlyList<string> soundRomPaths);
 
     void Reset();
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 
 namespace OasisEditor;
@@ -8,6 +9,8 @@ public sealed class System6NativeBackend : IEmulationBackend
     private const int System6ClockHz = 8000000;
     private const int LampCount = 32;
     private const int ReelCount = 16;
+    private static readonly TimeSpan SlowRunWarningThreshold = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan RunWarningThrottleInterval = TimeSpan.FromSeconds(10);
 
     private static readonly EmulationBackendCapabilities System6Capabilities = new(
         SupportsPause: true,
@@ -31,6 +34,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private CancellationTokenSource? _runLoopCancellation;
     private Task? _runLoopTask;
     private EmulationBackendState _state = EmulationBackendState.Stopped;
+    private DateTime _lastRunWarningUtc = DateTime.MinValue;
 
     public System6NativeBackend(string libraryPath)
         : this(libraryPath, static path => new System6NativeLibrary(path))
@@ -109,10 +113,15 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         try
         {
-            if (request.RomPaths.Count == 0)
+            if (string.IsNullOrWhiteSpace(_libraryPath) || !File.Exists(_libraryPath))
             {
-                throw new InvalidOperationException($"System6 native backend requires at least one ROM path before starting core '{_libraryPath}'.");
+                throw new InvalidOperationException($"System6 native backend DLL path is missing or does not exist: '{_libraryPath}'.");
             }
+
+            var nativeRoms = request.System6NativeRoms
+                ?? throw new InvalidOperationException("System6 native backend requires native DLL ROM settings.");
+            var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
+            var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
 
             _library = _libraryFactory(_libraryPath);
             try
@@ -124,17 +133,27 @@ public sealed class System6NativeBackend : IEmulationBackend
                 throw new InvalidOperationException($"System6 native backend failed to initialise core '{_libraryPath}'.", ex);
             }
 
-            foreach (var romPath in request.RomPaths)
+            cancellationToken.ThrowIfCancellationRequested();
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                try
+                var loadRomResult = _library.LoadRom(programRomPaths, nativeRoms.FlashSwitch);
+                if (loadRomResult == 0)
                 {
-                    _library.LoadRom(romPath);
+                    throw new InvalidOperationException("SYSTEM6LoadROM returned failure.");
                 }
-                catch (Exception ex)
+
+                if (soundRomPaths.Any(path => !string.IsNullOrWhiteSpace(path)))
                 {
-                    throw new InvalidOperationException($"System6 native backend failed to load ROM '{romPath}' with core '{_libraryPath}'.", ex);
+                    var loadSoundRomResult = _library.LoadSoundRom(soundRomPaths);
+                    if (loadSoundRomResult == 0)
+                    {
+                        throw new InvalidOperationException("SYSTEM6LoadSoundROM returned failure.");
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"System6 native backend failed to load native ROMs with core '{_libraryPath}'.", ex);
             }
 
             try
@@ -272,7 +291,10 @@ public sealed class System6NativeBackend : IEmulationBackend
                     var library = _library;
                     if (library is not null)
                     {
+                        var stopwatch = Stopwatch.StartNew();
                         library.Run(_cyclesPerFrame);
+                        stopwatch.Stop();
+                        WarnIfRunCallIsSlow(stopwatch.Elapsed);
                         PollOutputs(library);
                     }
                 }
@@ -288,6 +310,44 @@ public sealed class System6NativeBackend : IEmulationBackend
             SetState(EmulationBackendState.Failed);
             throw;
         }
+    }
+
+    private static IReadOnlyList<string> ValidateNativeRomPaths(IReadOnlyList<string> romPaths, bool requireFirst, string romKind)
+    {
+        if (requireFirst && (romPaths.Count == 0 || string.IsNullOrWhiteSpace(romPaths[0])))
+        {
+            throw new InvalidOperationException("System6 native backend requires Program ROM 1 before starting.");
+        }
+
+        var validated = new[] { string.Empty, string.Empty, string.Empty, string.Empty };
+        for (var i = 0; i < Math.Min(validated.Length, romPaths.Count); i++)
+        {
+            var path = romPaths[i];
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                continue;
+            }
+
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"System6 native {romKind} ROM {i + 1} was not found.", path);
+            }
+
+            validated[i] = path;
+        }
+
+        return validated;
+    }
+
+    private void WarnIfRunCallIsSlow(TimeSpan elapsed)
+    {
+        if (elapsed <= SlowRunWarningThreshold || DateTime.UtcNow - _lastRunWarningUtc < RunWarningThrottleInterval)
+        {
+            return;
+        }
+
+        _lastRunWarningUtc = DateTime.UtcNow;
+        Debug.WriteLine($"System6 native backend Run({_cyclesPerFrame}) took {elapsed.TotalMilliseconds:0.0} ms; native core may be pegging a CPU core.");
     }
 
     private void PollOutputs(ISystem6NativeLibrary library)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -10,6 +10,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private const int System6ClockHz = 8000000;
     private const int LampCount = 32;
     private const int ReelCount = 16;
+    private const string DiagnosticStageEnvironmentVariable = "OASIS_SYSTEM6_STARTUP_STAGE";
     private static readonly TimeSpan SlowRunWarningThreshold = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan RunWarningThrottleInterval = TimeSpan.FromSeconds(10);
 
@@ -119,25 +120,44 @@ public sealed class System6NativeBackend : IEmulationBackend
                 throw new InvalidOperationException($"System6 native backend DLL path is missing or does not exist: '{_libraryPath}'.");
             }
 
-            var nativeRoms = request.System6NativeRoms
-                ?? throw new InvalidOperationException("System6 native backend requires native DLL ROM settings.");
-            var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
-            var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
+            var startupStage = ResolveStartupStage();
+            LogStartupStage($"startup diagnostic stage = {startupStage}");
 
             _library = _libraryFactory(_libraryPath);
+            LogStartupStage("native DLL loaded and exports bound");
+            if (startupStage is System6StartupStage.LoadBindOnly)
+            {
+                return CompleteStagedStartup();
+            }
+
             try
             {
-                _library.Initialise();
+                var initialiseResult = _library.Initialise();
+                LogStartupStage($"Initialise returned {initialiseResult}");
+                if (initialiseResult == 0)
+                {
+                    throw new InvalidOperationException("SYSTEM6Initialise returned failure.");
+                }
             }
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"System6 native backend failed to initialise core '{_libraryPath}'.", ex);
             }
+            if (startupStage is System6StartupStage.InitialiseOnly)
+            {
+                return CompleteStagedStartup();
+            }
+
+            var nativeRoms = request.System6NativeRoms
+                ?? throw new InvalidOperationException("System6 native backend requires native DLL ROM settings.");
+            var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
+            var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
 
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
                 var loadRomResult = _library.LoadRom(programRomPaths, nativeRoms.FlashSwitch);
+                LogStartupStage($"LoadROM returned {loadRomResult}");
                 if (loadRomResult == 0)
                 {
                     throw new InvalidOperationException("SYSTEM6LoadROM returned failure.");
@@ -146,27 +166,50 @@ public sealed class System6NativeBackend : IEmulationBackend
                 if (soundRomPaths.Any(path => !string.IsNullOrWhiteSpace(path)))
                 {
                     var loadSoundRomResult = _library.LoadSoundRom(soundRomPaths);
+                    LogStartupStage($"LoadSoundROM returned {loadSoundRomResult}");
                     if (loadSoundRomResult == 0)
                     {
                         throw new InvalidOperationException("SYSTEM6LoadSoundROM returned failure.");
                     }
+                }
+                else
+                {
+                    LogStartupStage("LoadSoundROM skipped");
                 }
             }
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"System6 native backend failed to load native ROMs with core '{_libraryPath}'.", ex);
             }
+            if (startupStage is System6StartupStage.LoadRomOnly)
+            {
+                return CompleteStagedStartup();
+            }
 
             try
             {
                 _library.Reset();
+                LogStartupStage("Reset completed");
             }
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"System6 native backend failed to reset core '{_libraryPath}' during startup.", ex);
             }
             ResetCachedOutputState();
+            if (startupStage is System6StartupStage.ResetOnly)
+            {
+                LogStartupStage("first Run skipped / pending");
+                return CompleteStagedStartup();
+            }
 
+            if (startupStage is System6StartupStage.OneRunOnly)
+            {
+                var runResult = _library.Run(_cyclesPerFrame);
+                LogStartupStage($"first Run({_cyclesPerFrame}) returned {runResult}");
+                return CompleteStagedStartup();
+            }
+
+            LogStartupStage("first Run skipped / pending");
             _runLoopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _runLoopTask = Task.Run(() => RunLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
             SetState(EmulationBackendState.Running);
@@ -281,6 +324,41 @@ public sealed class System6NativeBackend : IEmulationBackend
         await StopAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
+    private Task CompleteStagedStartup()
+    {
+        LogStartupStage("staged startup complete; run loop not started");
+        SetState(EmulationBackendState.Running);
+        return Task.CompletedTask;
+    }
+
+    private static System6StartupStage ResolveStartupStage()
+    {
+        var raw = Environment.GetEnvironmentVariable(DiagnosticStageEnvironmentVariable);
+        return Enum.TryParse<System6StartupStage>(raw, ignoreCase: true, out var stage)
+            ? stage
+            : System6StartupStage.FullRunLoop;
+    }
+
+    private static int ToLampBrightnessValue(float brightness)
+    {
+        if (float.IsNaN(brightness) || brightness <= 0f)
+        {
+            return 0;
+        }
+
+        if (brightness <= 1f)
+        {
+            return (int)MathF.Round(brightness * 255f);
+        }
+
+        return (int)MathF.Round(Math.Min(brightness, 255f));
+    }
+
+    private static void LogStartupStage(string message)
+    {
+        Debug.WriteLine($"System6 native startup: {message}");
+    }
+
     private async Task RunLoopAsync(CancellationToken cancellationToken)
     {
         try
@@ -293,8 +371,12 @@ public sealed class System6NativeBackend : IEmulationBackend
                     if (library is not null)
                     {
                         var stopwatch = Stopwatch.StartNew();
-                        library.Run(_cyclesPerFrame);
+                        var runResult = library.Run(_cyclesPerFrame);
                         stopwatch.Stop();
+                        if (runResult == 0)
+                        {
+                            Debug.WriteLine($"System6 native backend Run({_cyclesPerFrame}) returned 0.");
+                        }
                         WarnIfRunCallIsSlow(stopwatch.Elapsed);
                         PollOutputs(library);
                     }
@@ -315,9 +397,9 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private static IReadOnlyList<string> ValidateNativeRomPaths(IReadOnlyList<string> romPaths, bool requireFirst, string romKind)
     {
-        if (requireFirst && (romPaths.Count == 0 || string.IsNullOrWhiteSpace(romPaths[0])))
+        if (requireFirst && (romPaths.Count < 2 || string.IsNullOrWhiteSpace(romPaths[0]) || string.IsNullOrWhiteSpace(romPaths[1])))
         {
-            throw new InvalidOperationException("System6 native backend requires Program ROM 1 before starting.");
+            throw new InvalidOperationException("System6 native backend requires Program ROM 1 and Program ROM 2 before starting.");
         }
 
         var validated = new[] { string.Empty, string.Empty, string.Empty, string.Empty };
@@ -353,11 +435,11 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private void PollOutputs(ISystem6NativeLibrary library)
     {
-        var lampsOn = library.GetLampsOn();
         for (var lampIndex = 0; lampIndex < LampCount; lampIndex++)
         {
-            var isOn = (lampsOn & (1 << lampIndex)) != 0;
-            var value = isOn ? library.GetLampBrightness(lampIndex) : 0;
+            var nativeLampIndex = checked((ushort)lampIndex);
+            var isOn = library.GetLampsOn(nativeLampIndex);
+            var value = isOn ? ToLampBrightnessValue(library.GetLampBrightness(nativeLampIndex)) : 0;
             if (_lastLampValues[lampIndex] != value)
             {
                 _lastLampValues[lampIndex] = value;
@@ -367,7 +449,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         for (var reelIndex = 0; reelIndex < ReelCount; reelIndex++)
         {
-            var position = library.GetPosOut(reelIndex);
+            var position = library.GetPosOut(checked((sbyte)reelIndex));
             if (_lastReelPositions[reelIndex] != position)
             {
                 _lastReelPositions[reelIndex] = position;
@@ -401,7 +483,8 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         try
         {
-            library.Shutdown();
+            var shutdownResult = library.Shutdown();
+            LogStartupStage($"Shutdown returned {shutdownResult}");
         }
         finally
         {
@@ -426,4 +509,15 @@ public sealed class System6NativeBackend : IEmulationBackend
             StateChanged?.Invoke(this, state);
         }
     }
+}
+
+
+internal enum System6StartupStage
+{
+    LoadBindOnly,
+    InitialiseOnly,
+    LoadRomOnly,
+    ResetOnly,
+    OneRunOnly,
+    FullRunLoop
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 
 namespace OasisEditor;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -16,6 +16,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6GetPosOutDelegate _getPosOut;
     private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
     private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
+    private readonly List<IntPtr> _romPathBuffers = [];
 
     public System6NativeLibrary(string libraryPath)
         : this(new NativeLibraryLoader(libraryPath))
@@ -49,13 +50,13 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
     {
-        var paths = NormalizeRomSlots(programRomPaths);
+        var paths = AllocateRomPathSlots(programRomPaths);
         return _loadRom(paths[0], paths[1], paths[2], paths[3], flashSwitch ? (byte)1 : (byte)0);
     }
 
     public int LoadSoundRom(IReadOnlyList<string> soundRomPaths)
     {
-        var paths = NormalizeRomSlots(soundRomPaths);
+        var paths = AllocateRomPathSlots(soundRomPaths);
         return _loadSoundRom(paths[0], paths[1], paths[2], paths[3]);
     }
 
@@ -77,37 +78,57 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public void Dispose()
     {
+        FreeRomPathBuffers();
         _loader.Dispose();
     }
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6InitialiseDelegate();
 
-    private static string[] NormalizeRomSlots(IReadOnlyList<string> romPaths)
+    private IntPtr[] AllocateRomPathSlots(IReadOnlyList<string> romPaths)
     {
-        var paths = new[] { string.Empty, string.Empty, string.Empty, string.Empty };
-        for (var i = 0; i < Math.Min(paths.Length, romPaths.Count); i++)
+        // Keep ANSI path buffers alive for the lifetime of the native core.
+        // Some legacy System6 DLLs retain the char* values passed to LoadROM
+        // and read them later during Reset/Run rather than copying immediately.
+
+        var paths = new[] { IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero };
+        for (var i = 0; i < paths.Length; i++)
         {
-            paths[i] = romPaths[i] ?? string.Empty;
+            var path = i < romPaths.Count ? romPaths[i] ?? string.Empty : string.Empty;
+            paths[i] = Marshal.StringToHGlobalAnsi(path);
+            _romPathBuffers.Add(paths[i]);
         }
 
         return paths;
     }
 
+    private void FreeRomPathBuffers()
+    {
+        foreach (var buffer in _romPathBuffers)
+        {
+            if (buffer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        _romPathBuffers.Clear();
+    }
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6LoadRomDelegate(
-        [MarshalAs(UnmanagedType.LPStr)] string romPath1,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath2,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath3,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath4,
+        IntPtr romPath1,
+        IntPtr romPath2,
+        IntPtr romPath3,
+        IntPtr romPath4,
         byte flashSwitch);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6LoadSoundRomDelegate(
-        [MarshalAs(UnmanagedType.LPStr)] string romPath1,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath2,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath3,
-        [MarshalAs(UnmanagedType.LPStr)] string romPath4);
+        IntPtr romPath1,
+        IntPtr romPath2,
+        IntPtr romPath3,
+        IntPtr romPath4);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6ResetDelegate();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -82,7 +82,9 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _loader.Dispose();
     }
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    // System6 DLL exports are Windows native callbacks. Use StdCall explicitly so
+    // 32-bit cores do not corrupt the stack when called from managed code.
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6InitialiseDelegate();
 
     private IntPtr[] AllocateRomPathSlots(IReadOnlyList<string> romPaths)
@@ -115,7 +117,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _romPathBuffers.Clear();
     }
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6LoadRomDelegate(
         IntPtr romPath1,
         IntPtr romPath2,
@@ -123,34 +125,34 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         IntPtr romPath4,
         byte flashSwitch);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6LoadSoundRomDelegate(
         IntPtr romPath1,
         IntPtr romPath2,
         IntPtr romPath3,
         IntPtr romPath4);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void System6ResetDelegate();
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void System6RunDelegate(int cycles);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void System6ShutdownDelegate();
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6GetLampsOnDelegate();
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6GetLampBrightnessDelegate(int lampIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate int System6GetPosOutDelegate(int positionIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void System6TurnSwitchOnDelegate(int switchIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void System6TurnSwitchOffDelegate(int switchIndex);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -7,6 +7,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly NativeLibraryLoader _loader;
     private readonly System6InitialiseDelegate _initialise;
     private readonly System6LoadRomDelegate _loadRom;
+    private readonly System6LoadSoundRomDelegate _loadSoundRom;
     private readonly System6ResetDelegate _reset;
     private readonly System6RunDelegate _run;
     private readonly System6ShutdownDelegate _shutdown;
@@ -27,6 +28,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
         _initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
         _loadRom = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
+        _loadSoundRom = _loader.BindExport<System6LoadSoundRomDelegate>("SYSTEM6LoadSoundROM");
         _reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
         _run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
         _shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
@@ -45,7 +47,17 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public int Initialise() => _initialise();
 
-    public int LoadRom(string romPath) => _loadRom(romPath);
+    public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
+    {
+        var paths = NormalizeRomSlots(programRomPaths);
+        return _loadRom(paths[0], paths[1], paths[2], paths[3], flashSwitch ? (byte)1 : (byte)0);
+    }
+
+    public int LoadSoundRom(IReadOnlyList<string> soundRomPaths)
+    {
+        var paths = NormalizeRomSlots(soundRomPaths);
+        return _loadSoundRom(paths[0], paths[1], paths[2], paths[3]);
+    }
 
     public void Reset() => _reset();
 
@@ -71,8 +83,31 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6InitialiseDelegate();
 
+    private static string[] NormalizeRomSlots(IReadOnlyList<string> romPaths)
+    {
+        var paths = new[] { string.Empty, string.Empty, string.Empty, string.Empty };
+        for (var i = 0; i < Math.Min(paths.Length, romPaths.Count); i++)
+        {
+            paths[i] = romPaths[i] ?? string.Empty;
+        }
+
+        return paths;
+    }
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6LoadRomDelegate([MarshalAs(UnmanagedType.LPStr)] string romPath);
+    public delegate int System6LoadRomDelegate(
+        [MarshalAs(UnmanagedType.LPStr)] string romPath1,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath2,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath3,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath4,
+        byte flashSwitch);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6LoadSoundRomDelegate(
+        [MarshalAs(UnmanagedType.LPStr)] string romPath1,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath2,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath3,
+        [MarshalAs(UnmanagedType.LPStr)] string romPath4);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6ResetDelegate();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -46,7 +46,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public bool IsLoaded => _loader.IsLoaded;
 
-    public int Initialise() => _initialise();
+    public byte Initialise() => _initialise();
 
     public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
     {
@@ -62,15 +62,15 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public void Reset() => _reset();
 
-    public void Run(int cycles) => _run(cycles);
+    public int Run(int cycles) => _run(cycles);
 
-    public void Shutdown() => _shutdown();
+    public byte Shutdown() => _shutdown();
 
-    public int GetLampsOn() => _getLampsOn();
+    public bool GetLampsOn(ushort lampIndex) => _getLampsOn(lampIndex);
 
-    public int GetLampBrightness(int lampIndex) => _getLampBrightness(lampIndex);
+    public float GetLampBrightness(ushort lampIndex) => _getLampBrightness(lampIndex);
 
-    public int GetPosOut(int positionIndex) => _getPosOut(positionIndex);
+    public short GetPosOut(sbyte positionIndex) => _getPosOut(positionIndex);
 
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
 
@@ -82,10 +82,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _loader.Dispose();
     }
 
-    // System6 DLL exports are Windows native callbacks. Use StdCall explicitly so
-    // 32-bit cores do not corrupt the stack when called from managed code.
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate int System6InitialiseDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte System6InitialiseDelegate();
 
     private IntPtr[] AllocateRomPathSlots(IReadOnlyList<string> romPaths)
     {
@@ -96,7 +94,13 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         var paths = new[] { IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero };
         for (var i = 0; i < paths.Length; i++)
         {
-            var path = i < romPaths.Count ? romPaths[i] ?? string.Empty : string.Empty;
+            var path = i < romPaths.Count ? romPaths[i] : string.Empty;
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                paths[i] = IntPtr.Zero;
+                continue;
+            }
+
             paths[i] = Marshal.StringToHGlobalAnsi(path);
             _romPathBuffers.Add(paths[i]);
         }
@@ -117,7 +121,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _romPathBuffers.Clear();
     }
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6LoadRomDelegate(
         IntPtr romPath1,
         IntPtr romPath2,
@@ -125,34 +129,35 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         IntPtr romPath4,
         byte flashSwitch);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int System6LoadSoundRomDelegate(
         IntPtr romPath1,
         IntPtr romPath2,
         IntPtr romPath3,
         IntPtr romPath4);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6ResetDelegate();
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate void System6RunDelegate(int cycles);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate int System6RunDelegate(int cycles);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate void System6ShutdownDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte System6ShutdownDelegate();
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate int System6GetLampsOnDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public delegate bool System6GetLampsOnDelegate(ushort lampIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate int System6GetLampBrightnessDelegate(int lampIndex);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate float System6GetLampBrightnessDelegate(ushort lampIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate int System6GetPosOutDelegate(int positionIndex);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate short System6GetPosOutDelegate(sbyte positionIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6TurnSwitchOnDelegate(int switchIndex);
 
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6TurnSwitchOffDelegate(int switchIndex);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -64,7 +64,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _system6SoundRom3Path = string.Empty;
     private string _system6SoundRom4Path = string.Empty;
     private bool _system6FlashSwitch;
-    private string _system6NativeRomStatus = "Program ROM 1 is required for native DLL launch.";
+    private string _system6NativeRomStatus = "Program ROM 1 and 2 are required for native DLL launch.";
     private string _mameRomStatus = "Unknown";
     private bool _isMameRomDownloadInProgress;
     private bool _isMfmeImportInProgress;
@@ -2625,8 +2625,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void RefreshSystem6NativeRomStatus()
     {
-        System6NativeRomStatus = string.IsNullOrWhiteSpace(System6ProgramRom1Path)
-            ? "Program ROM 1 is required for native DLL launch."
+        System6NativeRomStatus = string.IsNullOrWhiteSpace(System6ProgramRom1Path) || string.IsNullOrWhiteSpace(System6ProgramRom2Path)
+            ? "Program ROM 1 and 2 are required for native DLL launch."
             : "Configured; paths are validated when native emulation starts.";
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -55,6 +55,16 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
     private string _mameRomName = string.Empty;
     private bool _automaticallyDownloadMissingRoms = true;
+    private string _system6ProgramRom1Path = string.Empty;
+    private string _system6ProgramRom2Path = string.Empty;
+    private string _system6ProgramRom3Path = string.Empty;
+    private string _system6ProgramRom4Path = string.Empty;
+    private string _system6SoundRom1Path = string.Empty;
+    private string _system6SoundRom2Path = string.Empty;
+    private string _system6SoundRom3Path = string.Empty;
+    private string _system6SoundRom4Path = string.Empty;
+    private bool _system6FlashSwitch;
+    private string _system6NativeRomStatus = "Program ROM 1 is required for native DLL launch.";
     private string _mameRomStatus = "Unknown";
     private bool _isMameRomDownloadInProgress;
     private bool _isMfmeImportInProgress;
@@ -167,6 +177,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ResyncMamePluginsCommand = new RelayCommand(ResyncMamePlugins);
         RemoveCachedMameVersionCommand = new RelayCommand(RemoveCachedMameVersion);
         DownloadMameRomCommand = new RelayCommand(DownloadMameRom, CanDownloadMameRom);
+        BrowseSystem6ProgramRom1Command = new RelayCommand(() => BrowseSystem6RomPath(1, true));
+        BrowseSystem6ProgramRom2Command = new RelayCommand(() => BrowseSystem6RomPath(2, true));
+        BrowseSystem6ProgramRom3Command = new RelayCommand(() => BrowseSystem6RomPath(3, true));
+        BrowseSystem6ProgramRom4Command = new RelayCommand(() => BrowseSystem6RomPath(4, true));
+        BrowseSystem6SoundRom1Command = new RelayCommand(() => BrowseSystem6RomPath(1, false));
+        BrowseSystem6SoundRom2Command = new RelayCommand(() => BrowseSystem6RomPath(2, false));
+        BrowseSystem6SoundRom3Command = new RelayCommand(() => BrowseSystem6RomPath(3, false));
+        BrowseSystem6SoundRom4Command = new RelayCommand(() => BrowseSystem6RomPath(4, false));
         ResetMameRomSourceDefaultsCommand = new RelayCommand(ResetMameRomSourceDefaults);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
@@ -492,6 +510,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ResyncMamePluginsCommand { get; }
     public ICommand RemoveCachedMameVersionCommand { get; }
     public ICommand DownloadMameRomCommand { get; }
+    public ICommand BrowseSystem6ProgramRom1Command { get; }
+    public ICommand BrowseSystem6ProgramRom2Command { get; }
+    public ICommand BrowseSystem6ProgramRom3Command { get; }
+    public ICommand BrowseSystem6ProgramRom4Command { get; }
+    public ICommand BrowseSystem6SoundRom1Command { get; }
+    public ICommand BrowseSystem6SoundRom2Command { get; }
+    public ICommand BrowseSystem6SoundRom3Command { get; }
+    public ICommand BrowseSystem6SoundRom4Command { get; }
     public ICommand CloseProjectSettingsCommand { get; }
     public ICommand ResetMameRomSourceDefaultsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
@@ -746,6 +772,27 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         get => _mameRomStatus;
         private set => SetProperty(ref _mameRomStatus, value);
     }
+
+    public string System6ProgramRom1Path { get => _system6ProgramRom1Path; set => SetSystem6RomPath(ref _system6ProgramRom1Path, value, nameof(System6ProgramRom1Path)); }
+    public string System6ProgramRom2Path { get => _system6ProgramRom2Path; set => SetSystem6RomPath(ref _system6ProgramRom2Path, value, nameof(System6ProgramRom2Path)); }
+    public string System6ProgramRom3Path { get => _system6ProgramRom3Path; set => SetSystem6RomPath(ref _system6ProgramRom3Path, value, nameof(System6ProgramRom3Path)); }
+    public string System6ProgramRom4Path { get => _system6ProgramRom4Path; set => SetSystem6RomPath(ref _system6ProgramRom4Path, value, nameof(System6ProgramRom4Path)); }
+    public string System6SoundRom1Path { get => _system6SoundRom1Path; set => SetSystem6RomPath(ref _system6SoundRom1Path, value, nameof(System6SoundRom1Path)); }
+    public string System6SoundRom2Path { get => _system6SoundRom2Path; set => SetSystem6RomPath(ref _system6SoundRom2Path, value, nameof(System6SoundRom2Path)); }
+    public string System6SoundRom3Path { get => _system6SoundRom3Path; set => SetSystem6RomPath(ref _system6SoundRom3Path, value, nameof(System6SoundRom3Path)); }
+    public string System6SoundRom4Path { get => _system6SoundRom4Path; set => SetSystem6RomPath(ref _system6SoundRom4Path, value, nameof(System6SoundRom4Path)); }
+    public bool System6FlashSwitch
+    {
+        get => _system6FlashSwitch;
+        set
+        {
+            if (SetProperty(ref _system6FlashSwitch, value))
+            {
+                SaveSystem6NativeRomSettings();
+            }
+        }
+    }
+    public string System6NativeRomStatus { get => _system6NativeRomStatus; private set => SetProperty(ref _system6NativeRomStatus, value); }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -2520,7 +2567,119 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             MameRomName,
             romRootPath,
             romPaths,
-            MameCommandLineOverrides);
+            MameCommandLineOverrides,
+            BuildSystem6NativeRomSettingsForLaunch());
+    }
+
+    private bool SetSystem6RomPath(ref string field, string value, string propertyName)
+    {
+        if (!SetProperty(ref field, value, propertyName))
+        {
+            return false;
+        }
+
+        SaveSystem6NativeRomSettings();
+        RefreshSystem6NativeRomStatus();
+        return true;
+    }
+
+    private void SaveSystem6NativeRomSettings()
+    {
+        if (LoadedProject is null)
+        {
+            return;
+        }
+
+        LoadedProject.System6NativeRoms = new System6NativeRomSettings
+        {
+            ProgramRom1Path = System6ProgramRom1Path,
+            ProgramRom2Path = System6ProgramRom2Path,
+            ProgramRom3Path = System6ProgramRom3Path,
+            ProgramRom4Path = System6ProgramRom4Path,
+            SoundRom1Path = System6SoundRom1Path,
+            SoundRom2Path = System6SoundRom2Path,
+            SoundRom3Path = System6SoundRom3Path,
+            SoundRom4Path = System6SoundRom4Path,
+            FlashSwitch = System6FlashSwitch
+        };
+        SaveLoadedProjectMetadata();
+    }
+
+    private void ApplySystem6NativeRomSettingsToViewModel(System6NativeRomSettings settings)
+    {
+        _system6ProgramRom1Path = settings.ProgramRom1Path;
+        _system6ProgramRom2Path = settings.ProgramRom2Path;
+        _system6ProgramRom3Path = settings.ProgramRom3Path;
+        _system6ProgramRom4Path = settings.ProgramRom4Path;
+        _system6SoundRom1Path = settings.SoundRom1Path;
+        _system6SoundRom2Path = settings.SoundRom2Path;
+        _system6SoundRom3Path = settings.SoundRom3Path;
+        _system6SoundRom4Path = settings.SoundRom4Path;
+        _system6FlashSwitch = settings.FlashSwitch;
+        OnPropertyChanged(nameof(System6ProgramRom1Path)); OnPropertyChanged(nameof(System6ProgramRom2Path));
+        OnPropertyChanged(nameof(System6ProgramRom3Path)); OnPropertyChanged(nameof(System6ProgramRom4Path));
+        OnPropertyChanged(nameof(System6SoundRom1Path)); OnPropertyChanged(nameof(System6SoundRom2Path));
+        OnPropertyChanged(nameof(System6SoundRom3Path)); OnPropertyChanged(nameof(System6SoundRom4Path));
+        OnPropertyChanged(nameof(System6FlashSwitch));
+    }
+
+    private void RefreshSystem6NativeRomStatus()
+    {
+        System6NativeRomStatus = string.IsNullOrWhiteSpace(System6ProgramRom1Path)
+            ? "Program ROM 1 is required for native DLL launch."
+            : "Configured; paths are validated when native emulation starts.";
+    }
+
+    private void BrowseSystem6RomPath(int slot, bool isProgramRom)
+    {
+        if (LoadedProject is null) return;
+        var dialog = new OpenFileDialog { Title = $"Select System6 {(isProgramRom ? "Program" : "Sound")} ROM {slot}", Filter = "ROM files|*.bin;*.rom;*.p1;*.p2;*.p3;*.p4;*.snd|All files|*.*", InitialDirectory = LoadedProject.ProjectDirectory, CheckFileExists = true };
+        if (dialog.ShowDialog() != true) return;
+        var value = MakeProjectRelativePath(dialog.FileName, LoadedProject.ProjectDirectory);
+        if (isProgramRom)
+        {
+            if (slot == 1) System6ProgramRom1Path = value; else if (slot == 2) System6ProgramRom2Path = value; else if (slot == 3) System6ProgramRom3Path = value; else System6ProgramRom4Path = value;
+        }
+        else
+        {
+            if (slot == 1) System6SoundRom1Path = value; else if (slot == 2) System6SoundRom2Path = value; else if (slot == 3) System6SoundRom3Path = value; else System6SoundRom4Path = value;
+        }
+    }
+
+    private System6NativeRomSettings BuildSystem6NativeRomSettingsForLaunch()
+    {
+        var settings = LoadedProject?.System6NativeRoms ?? new System6NativeRomSettings();
+        if (LoadedProject is null) return settings;
+        return new System6NativeRomSettings
+        {
+            ProgramRom1Path = ResolveProjectRelativePath(settings.ProgramRom1Path, LoadedProject.ProjectDirectory),
+            ProgramRom2Path = ResolveProjectRelativePath(settings.ProgramRom2Path, LoadedProject.ProjectDirectory),
+            ProgramRom3Path = ResolveProjectRelativePath(settings.ProgramRom3Path, LoadedProject.ProjectDirectory),
+            ProgramRom4Path = ResolveProjectRelativePath(settings.ProgramRom4Path, LoadedProject.ProjectDirectory),
+            SoundRom1Path = ResolveProjectRelativePath(settings.SoundRom1Path, LoadedProject.ProjectDirectory),
+            SoundRom2Path = ResolveProjectRelativePath(settings.SoundRom2Path, LoadedProject.ProjectDirectory),
+            SoundRom3Path = ResolveProjectRelativePath(settings.SoundRom3Path, LoadedProject.ProjectDirectory),
+            SoundRom4Path = ResolveProjectRelativePath(settings.SoundRom4Path, LoadedProject.ProjectDirectory),
+            FlashSwitch = settings.FlashSwitch
+        };
+    }
+
+    private static string ResolveProjectRelativePath(string path, string projectDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path)) return path;
+        return Path.GetFullPath(Path.Combine(projectDirectory, path));
+    }
+
+    private static string MakeProjectRelativePath(string path, string projectDirectory)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var fullProjectDirectory = Path.GetFullPath(projectDirectory);
+        var relativePath = Path.GetRelativePath(fullProjectDirectory, fullPath);
+        return !relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+               && !relativePath.Equals("..", StringComparison.Ordinal)
+               && !Path.IsPathRooted(relativePath)
+            ? relativePath
+            : fullPath;
     }
 
     private void OnActiveBackendLampChanged(object? sender, MachineLampChangedEventArgs e)
@@ -3040,7 +3199,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         SelectedFruitMachinePlatform = project.FruitMachinePlatform;
         MameRomName = project.MameRomName;
         AutomaticallyDownloadMissingRoms = project.AutomaticallyDownloadMissingRoms;
+        ApplySystem6NativeRomSettingsToViewModel(project.System6NativeRoms);
         RefreshMameRomStatus();
+        RefreshSystem6NativeRomStatus();
         PanelElementFactory.ProjectDirectoryPath = project.ProjectDirectory;
         ProjectFilePath = project.ProjectFilePath;
         UpdateRecentProjects(project.ProjectFilePath);
@@ -3109,6 +3270,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         var fruitMachinePlatform = ResolveFruitMachinePlatform(projectDocument.RootElement);
         var mameRomName = ResolveMameRomName(projectDocument.RootElement);
         var automaticallyDownloadMissingRoms = ResolveAutomaticallyDownloadMissingRoms(projectDocument.RootElement);
+        var system6NativeRoms = ResolveSystem6NativeRomSettings(projectDocument.RootElement);
         var inputDefinitions = ResolveInputDefinitions(projectDocument.RootElement);
 
         return new EditorProject
@@ -3121,7 +3283,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             GeneratedDirectory = generatedDirectory,
             FruitMachinePlatform = fruitMachinePlatform,
             MameRomName = mameRomName,
-            AutomaticallyDownloadMissingRoms = automaticallyDownloadMissingRoms
+            AutomaticallyDownloadMissingRoms = automaticallyDownloadMissingRoms,
+            System6NativeRoms = system6NativeRoms
         }.WithInputDefinitions(inputDefinitions);
     }
 
@@ -3266,7 +3429,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     {
                         wroteProjectSettings = true;
                         writer.WritePropertyName("project_settings");
-                        WriteProjectSettings(writer, property.Value, LoadedProject.FruitMachinePlatform, LoadedProject.MameRomName, LoadedProject.AutomaticallyDownloadMissingRoms);
+                        WriteProjectSettings(writer, property.Value, LoadedProject.FruitMachinePlatform, LoadedProject.MameRomName, LoadedProject.AutomaticallyDownloadMissingRoms, LoadedProject.System6NativeRoms);
                         continue;
                     }
 
@@ -3288,6 +3451,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                     writer.WriteString("FruitMachine_Platform", LoadedProject.FruitMachinePlatform.ToString());
                     writer.WriteString("MameRomName", LoadedProject.MameRomName);
                     writer.WriteBoolean("AutomaticallyDownloadMissingRoms", LoadedProject.AutomaticallyDownloadMissingRoms);
+                    WriteSystem6NativeRomSettings(writer, LoadedProject.System6NativeRoms);
                     writer.WriteEndObject();
                 }
 
@@ -3308,12 +3472,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private static void WriteProjectSettings(Utf8JsonWriter writer, JsonElement existingProjectSettings, FruitMachinePlatformType platform, string mameRomName, bool automaticallyDownloadMissingRoms)
+    private static void WriteProjectSettings(Utf8JsonWriter writer, JsonElement existingProjectSettings, FruitMachinePlatformType platform, string mameRomName, bool automaticallyDownloadMissingRoms, System6NativeRomSettings system6NativeRoms)
     {
         writer.WriteStartObject();
         var wrotePlatform = false;
         var wroteMameRomName = false;
         var wroteAutomaticallyDownloadMissingRoms = false;
+        var wroteSystem6NativeRoms = false;
 
         foreach (var settingProperty in existingProjectSettings.EnumerateObject())
         {
@@ -3335,6 +3500,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 wroteAutomaticallyDownloadMissingRoms = true;
                 continue;
             }
+            if (settingProperty.NameEquals("System6NativeRoms"))
+            {
+                WriteSystem6NativeRomSettings(writer, system6NativeRoms);
+                wroteSystem6NativeRoms = true;
+                continue;
+            }
 
             settingProperty.WriteTo(writer);
         }
@@ -3351,8 +3522,55 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             writer.WriteBoolean("AutomaticallyDownloadMissingRoms", automaticallyDownloadMissingRoms);
         }
+        if (!wroteSystem6NativeRoms)
+        {
+            WriteSystem6NativeRomSettings(writer, system6NativeRoms);
+        }
 
         writer.WriteEndObject();
+    }
+
+    private static void WriteSystem6NativeRomSettings(Utf8JsonWriter writer, System6NativeRomSettings settings)
+    {
+        writer.WritePropertyName("System6NativeRoms");
+        writer.WriteStartObject();
+        writer.WriteString("ProgramRom1Path", settings.ProgramRom1Path);
+        writer.WriteString("ProgramRom2Path", settings.ProgramRom2Path);
+        writer.WriteString("ProgramRom3Path", settings.ProgramRom3Path);
+        writer.WriteString("ProgramRom4Path", settings.ProgramRom4Path);
+        writer.WriteString("SoundRom1Path", settings.SoundRom1Path);
+        writer.WriteString("SoundRom2Path", settings.SoundRom2Path);
+        writer.WriteString("SoundRom3Path", settings.SoundRom3Path);
+        writer.WriteString("SoundRom4Path", settings.SoundRom4Path);
+        writer.WriteBoolean("FlashSwitch", settings.FlashSwitch);
+        writer.WriteEndObject();
+    }
+
+    private static System6NativeRomSettings ResolveSystem6NativeRomSettings(JsonElement root)
+    {
+        if (!root.TryGetProperty("project_settings", out var projectSettingsElement)
+            || !projectSettingsElement.TryGetProperty("System6NativeRoms", out var romsElement))
+        {
+            return new System6NativeRomSettings();
+        }
+
+        return new System6NativeRomSettings
+        {
+            ProgramRom1Path = GetOptionalString(romsElement, "ProgramRom1Path"),
+            ProgramRom2Path = GetOptionalString(romsElement, "ProgramRom2Path"),
+            ProgramRom3Path = GetOptionalString(romsElement, "ProgramRom3Path"),
+            ProgramRom4Path = GetOptionalString(romsElement, "ProgramRom4Path"),
+            SoundRom1Path = GetOptionalString(romsElement, "SoundRom1Path"),
+            SoundRom2Path = GetOptionalString(romsElement, "SoundRom2Path"),
+            SoundRom3Path = GetOptionalString(romsElement, "SoundRom3Path"),
+            SoundRom4Path = GetOptionalString(romsElement, "SoundRom4Path"),
+            FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True
+        };
+    }
+
+    private static string GetOptionalString(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var value) ? value.GetString() ?? string.Empty : string.Empty;
     }
 
     private FruitMachinePlatformType ResolveFruitMachinePlatform(JsonElement root)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -4,10 +4,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             d:DesignHeight="340"
+             d:DesignHeight="640"
              d:DesignWidth="560">
-    <Grid Margin="16">
+    <ScrollViewer VerticalScrollBarVisibility="Auto"><Grid Margin="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -60,5 +62,24 @@
                       Content="Automatically download missing ROMs"
                       IsChecked="{Binding AutomaticallyDownloadMissingRoms}" />
         </StackPanel>
-    </Grid>
+            <TextBlock Grid.Row="11" Margin="0,20,0,4" Text="Native DLL ROMs / System6 ROMs" Foreground="{DynamicResource TextSecondaryBrush}" />
+            <Grid Grid.Row="12">
+                <Grid.ColumnDefinitions><ColumnDefinition Width="120" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 1" /><TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="0" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom1Command}" Content="Browse" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 2" /><TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="1" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom2Command}" Content="Browse" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 3" /><TextBox Grid.Row="2" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="2" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom3Command}" Content="Browse" />
+                <TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 4" /><TextBox Grid.Row="3" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="3" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom4Command}" Content="Browse" />
+                <TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 1" /><TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="4" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom1Command}" Content="Browse" />
+                <TextBlock Grid.Row="5" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 2" /><TextBox Grid.Row="5" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="5" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom2Command}" Content="Browse" />
+                <TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 3" /><TextBox Grid.Row="6" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="6" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom3Command}" Content="Browse" />
+                <TextBlock Grid.Row="7" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 4" /><TextBox Grid.Row="7" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="7" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom4Command}" Content="Browse" />
+                <CheckBox Grid.Row="8" Grid.Column="1" Margin="0,2,0,6" Content="Flash switch" IsChecked="{Binding System6FlashSwitch}" />
+                <TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
+            </Grid>
+    </Grid></ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Enable System6 native DLL cores to receive uncompressed program and sound ROM paths and a flash‑switch value at project level instead of reusing the MAME archive workflow. 
- Fail fast on missing/invalid native DLL or ROM configuration so the native backend never starts with invalid settings. 
- Surface native ROM configuration in Project Settings so users can edit and persist native ROM paths per project.

### Description
- Added a `System6NativeRomSettings` model and `EditorProject.System6NativeRoms` to store four program ROM slots, four sound ROM slots, and a `FlashSwitch` boolean, persisted to `.oasisproj` via existing project settings read/write code and `WriteSystem6NativeRomSettings`/`ResolveSystem6NativeRomSettings` helpers. 
- Extended `EmulationLaunchRequest` with an optional `System6NativeRoms` payload so native ROM settings travel separately from the existing MAME `RomPaths`. 
- Updated `ISystem6NativeLibrary` and `System6NativeLibrary` to match a multi‑ROM ABI: `SYSTEM6LoadROM(rom1,rom2,rom3,rom4,flash)` and `SYSTEM6LoadSoundROM(rom1,rom2,rom3,rom4)`, normalising missing slots to empty strings. 
- Changed `System6NativeBackend` startup to validate the native DLL path, require `Program ROM 1`, validate each configured ROM file exists, call the new `LoadRom`/`LoadSoundRom` delegates and treat return values as success/failure, and refuse to start the run loop on errors. 
- Added lightweight run‑loop diagnostics that measure each `Run(cycles)` call and emit a throttled warning if a call takes suspiciously long. 
- Added Project Settings UI fields and browse commands for Program ROM 1–4, Sound ROM 1–4, and `FlashSwitch`, with project‑relative path storage and launch‑time resolution to absolute paths. The existing MAME ROM UI and workflow were left unchanged. 
- Updated `System6NativeBackend` unit tests to exercise the new multi‑ROM loading behaviour and to create temporary native files for validation.

### Testing
- Updated unit tests in `System6NativeBackendTests` to reflect the multi‑ROM ABI and temporary file creation, but tests were not executed in this environment due to the repository's tooling constraints. 
- Ran `git diff --check` to validate patch formatting and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32f05773248327bdab3ac15386681d)