### PR TITLE
Add System6 reel opto configuration, UI, persistence, and native bindings

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ public sealed class System6NativeBackendTests
         Assert.True(library.InitialiseCalled);
         Assert.Equal(new[] { rom1, rom2, string.Empty, string.Empty }, library.LoadedRoms);
         Assert.True(library.ResetCalled);
+        Assert.Equal(8 * 4, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
+        Assert.True(library.Calls.IndexOf("SetOptoInvert:7:0") < library.Calls.IndexOf("Reset"));
         Assert.True(library.ShutdownCalled);
         Assert.True(library.DisposeCalled);
         Assert.Equal(EmulationBackendState.Stopped, backend.State);
@@ -59,6 +62,22 @@ public sealed class System6NativeBackendTests
         Assert.Empty(library.LoadedRoms);
         Assert.False(library.ResetCalled);
         Assert.Equal(EmulationBackendState.Failed, backend.State);
+    }
+
+    [Fact]
+    public async Task StartAsyncInvalidReelOptosFailsBeforeResetAndRun()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var request = CreateLaunchRequest(rom1, rom2);
+        request.System6NativeRoms!.ReelOptos[0].Steps = 0;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
+
+        Assert.Contains("steps must be between 1 and 255", ex.Message);
+        Assert.False(library.ResetCalled);
+        Assert.Empty(library.Calls.Where(call => call.StartsWith("Run", StringComparison.Ordinal)));
     }
 
     private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)
@@ -111,14 +130,18 @@ public sealed class System6NativeBackendTests
 
         public List<int> SwitchesTurnedOff { get; } = new();
 
+        public List<string> Calls { get; } = new();
+
         public byte Initialise()
         {
+            Calls.Add("Initialise");
             InitialiseCalled = true;
             return 1;
         }
 
         public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
         {
+            Calls.Add("LoadRom");
             LoadedRoms.AddRange(programRomPaths);
             return 1;
         }
@@ -128,13 +151,23 @@ public sealed class System6NativeBackendTests
             return 1;
         }
 
+        public void SetSteps(byte reelNum, byte steps) => Calls.Add($"SetSteps:{reelNum}:{steps}");
+
+        public void SetOptoStart(byte reelNum, byte start) => Calls.Add($"SetOptoStart:{reelNum}:{start}");
+
+        public void SetOptoEnd(byte reelNum, byte end) => Calls.Add($"SetOptoEnd:{reelNum}:{end}");
+
+        public void SetOptoInvert(byte reelNum, byte state) => Calls.Add($"SetOptoInvert:{reelNum}:{state}");
+
         public void Reset()
         {
+            Calls.Add("Reset");
             ResetCalled = true;
         }
 
         public int Run(int cycles)
         {
+            Calls.Add($"Run:{cycles}");
             return 1;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -18,6 +18,9 @@ public sealed class EditorProject
 
 public sealed class System6NativeRomSettings
 {
+    public const int DefaultReelOptoSlotCount = 8;
+    public List<System6ReelOptoSettings> ReelOptos { get; set; } = CreateDefaultReelOptos();
+
     public string ProgramRom1Path { get; set; } = string.Empty;
     public string ProgramRom2Path { get; set; } = string.Empty;
     public string ProgramRom3Path { get; set; } = string.Empty;
@@ -30,4 +33,38 @@ public sealed class System6NativeRomSettings
 
     public IReadOnlyList<string> ProgramRomPaths => [ProgramRom1Path, ProgramRom2Path, ProgramRom3Path, ProgramRom4Path];
     public IReadOnlyList<string> SoundRomPaths => [SoundRom1Path, SoundRom2Path, SoundRom3Path, SoundRom4Path];
+
+    public static List<System6ReelOptoSettings> CreateDefaultReelOptos()
+    {
+        var reelOptos = new List<System6ReelOptoSettings>(DefaultReelOptoSlotCount);
+        for (var reelIndex = 0; reelIndex < DefaultReelOptoSlotCount; reelIndex++)
+        {
+            reelOptos.Add(System6ReelOptoSettings.CreateDefault(reelIndex));
+        }
+
+        return reelOptos;
+    }
+}
+
+public sealed class System6ReelOptoSettings
+{
+    public const int DefaultSteps = 96;
+    public const int DefaultOptoStart = 5;
+    public const int DefaultOptoEnd = 7;
+    public const bool DefaultOptoInvert = false;
+
+    public int ReelIndex { get; set; }
+    public int Steps { get; set; } = DefaultSteps;
+    public int OptoStart { get; set; } = DefaultOptoStart;
+    public int OptoEnd { get; set; } = DefaultOptoEnd;
+    public bool OptoInvert { get; set; } = DefaultOptoInvert;
+
+    public static System6ReelOptoSettings CreateDefault(int reelIndex) => new()
+    {
+        ReelIndex = reelIndex,
+        Steps = DefaultSteps,
+        OptoStart = DefaultOptoStart,
+        OptoEnd = DefaultOptoEnd,
+        OptoInvert = DefaultOptoInvert
+    };
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -8,6 +8,14 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 
     int LoadSoundRom(IReadOnlyList<string> soundRomPaths);
 
+    void SetSteps(byte reelNum, byte steps);
+
+    void SetOptoStart(byte reelNum, byte start);
+
+    void SetOptoEnd(byte reelNum, byte end);
+
+    void SetOptoInvert(byte reelNum, byte state);
+
     void Reset();
 
     int Run(int cycles);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -10,6 +10,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private const int System6ClockHz = 8000000;
     private const int LampCount = 32;
     private const int ReelCount = 16;
+    private const int SupportedReelOptoCount = 8;
     private const string DiagnosticStageEnvironmentVariable = "OASIS_SYSTEM6_STARTUP_STAGE";
     private static readonly TimeSpan SlowRunWarningThreshold = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan RunWarningThrottleInterval = TimeSpan.FromSeconds(10);
@@ -152,6 +153,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                 ?? throw new InvalidOperationException("System6 native backend requires native DLL ROM settings.");
             var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
             var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
+            var reelOptos = ValidateReelOptos(nativeRoms.ReelOptos);
 
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -176,6 +178,8 @@ public sealed class System6NativeBackend : IEmulationBackend
                 {
                     LogStartupStage("LoadSoundROM skipped");
                 }
+
+                ApplyReelOptos(_library, reelOptos);
             }
             catch (Exception ex)
             {
@@ -392,6 +396,49 @@ public sealed class System6NativeBackend : IEmulationBackend
         {
             SetState(EmulationBackendState.Failed);
             throw;
+        }
+    }
+
+    private static IReadOnlyList<System6ReelOptoSettings> ValidateReelOptos(IReadOnlyList<System6ReelOptoSettings>? reelOptos)
+    {
+        var settings = reelOptos is { Count: > 0 } ? reelOptos : System6NativeRomSettings.CreateDefaultReelOptos();
+        foreach (var reel in settings)
+        {
+            if (reel.ReelIndex is < 0 or >= SupportedReelOptoCount)
+            {
+                throw new InvalidOperationException($"System6 reel opto setting has invalid reel index {reel.ReelIndex}; supported range is 0-{SupportedReelOptoCount - 1}.");
+            }
+            if (reel.Steps is < 1 or > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto steps must be between 1 and 255.");
+            }
+            if (reel.OptoStart is < 0 or > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto start must be between 0 and 255.");
+            }
+            if (reel.OptoEnd is < 0 or > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto end must be between 0 and 255.");
+            }
+            if (reel.OptoStart >= reel.OptoEnd)
+            {
+                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto start must be less than opto end.");
+            }
+        }
+
+        return settings;
+    }
+
+    private static void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
+    {
+        foreach (var reel in reelOptos)
+        {
+            var reelNum = checked((byte)reel.ReelIndex);
+            library.SetSteps(reelNum, checked((byte)reel.Steps));
+            library.SetOptoStart(reelNum, checked((byte)reel.OptoStart));
+            library.SetOptoEnd(reelNum, checked((byte)reel.OptoEnd));
+            library.SetOptoInvert(reelNum, reel.OptoInvert ? (byte)1 : (byte)0);
+            LogStartupStage($"System6 reel {reel.ReelIndex + 1} opto: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -8,6 +8,10 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6InitialiseDelegate _initialise;
     private readonly System6LoadRomDelegate _loadRom;
     private readonly System6LoadSoundRomDelegate _loadSoundRom;
+    private readonly System6SetStepsDelegate _setSteps;
+    private readonly System6SetOptoStartDelegate _setOptoStart;
+    private readonly System6SetOptoEndDelegate _setOptoEnd;
+    private readonly System6SetOptoInvertDelegate _setOptoInvert;
     private readonly System6ResetDelegate _reset;
     private readonly System6RunDelegate _run;
     private readonly System6ShutdownDelegate _shutdown;
@@ -30,6 +34,10 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
         _loadRom = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
         _loadSoundRom = _loader.BindExport<System6LoadSoundRomDelegate>("SYSTEM6LoadSoundROM");
+        _setSteps = _loader.BindExport<System6SetStepsDelegate>("SetSteps");
+        _setOptoStart = _loader.BindExport<System6SetOptoStartDelegate>("SetOptoStart");
+        _setOptoEnd = _loader.BindExport<System6SetOptoEndDelegate>("SetOptoEnd");
+        _setOptoInvert = _loader.BindExport<System6SetOptoInvertDelegate>("SetOptoInvert");
         _reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
         _run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
         _shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
@@ -59,6 +67,14 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         var paths = AllocateRomPathSlots(soundRomPaths);
         return _loadSoundRom(paths[0], paths[1], paths[2], paths[3]);
     }
+
+    public void SetSteps(byte reelNum, byte steps) => _setSteps(reelNum, steps);
+
+    public void SetOptoStart(byte reelNum, byte start) => _setOptoStart(reelNum, start);
+
+    public void SetOptoEnd(byte reelNum, byte end) => _setOptoEnd(reelNum, end);
+
+    public void SetOptoInvert(byte reelNum, byte state) => _setOptoInvert(reelNum, state);
 
     public void Reset() => _reset();
 
@@ -135,6 +151,18 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         IntPtr romPath2,
         IntPtr romPath3,
         IntPtr romPath4);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetStepsDelegate(byte reelNum, byte steps);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetOptoStartDelegate(byte reelNum, byte start);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetOptoEndDelegate(byte reelNum, byte end);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetOptoInvertDelegate(byte reelNum, byte state);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6ResetDelegate();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -65,6 +65,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _system6SoundRom4Path = string.Empty;
     private bool _system6FlashSwitch;
     private string _system6NativeRomStatus = "Program ROM 1 and 2 are required for native DLL launch.";
+    private ObservableCollection<System6ReelOptoSettingsViewModel> _system6ReelOptos = [];
     private string _mameRomStatus = "Unknown";
     private bool _isMameRomDownloadInProgress;
     private bool _isMfmeImportInProgress;
@@ -185,6 +186,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         BrowseSystem6SoundRom2Command = new RelayCommand(() => BrowseSystem6RomPath(2, false));
         BrowseSystem6SoundRom3Command = new RelayCommand(() => BrowseSystem6RomPath(3, false));
         BrowseSystem6SoundRom4Command = new RelayCommand(() => BrowseSystem6RomPath(4, false));
+        ResetSystem6ReelOptosCommand = new RelayCommand(ResetSystem6ReelOptosToDefaults);
         ResetMameRomSourceDefaultsCommand = new RelayCommand(ResetMameRomSourceDefaults);
         CloseProjectSettingsCommand = new RelayCommand(CloseProjectSettings);
         CloseProjectCommand = new RelayCommand(CloseProject, CanCloseProject);
@@ -519,6 +521,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand BrowseSystem6SoundRom3Command { get; }
     public ICommand BrowseSystem6SoundRom4Command { get; }
     public ICommand CloseProjectSettingsCommand { get; }
+    public ICommand ResetSystem6ReelOptosCommand { get; }
     public ICommand ResetMameRomSourceDefaultsCommand { get; }
     public ICommand ApplyInspectorSummaryCommand { get; }
     public ICommand CloseProjectCommand { get; }
@@ -793,6 +796,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
     public string System6NativeRomStatus { get => _system6NativeRomStatus; private set => SetProperty(ref _system6NativeRomStatus, value); }
+    public ObservableCollection<System6ReelOptoSettingsViewModel> System6ReelOptos { get => _system6ReelOptos; private set => SetProperty(ref _system6ReelOptos, value); }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -2600,7 +2604,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom2Path = System6SoundRom2Path,
             SoundRom3Path = System6SoundRom3Path,
             SoundRom4Path = System6SoundRom4Path,
-            FlashSwitch = System6FlashSwitch
+            FlashSwitch = System6FlashSwitch,
+            ReelOptos = System6ReelOptos.Select(reel => reel.ToModel()).ToList()
         };
         SaveLoadedProjectMetadata();
     }
@@ -2616,6 +2621,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _system6SoundRom3Path = settings.SoundRom3Path;
         _system6SoundRom4Path = settings.SoundRom4Path;
         _system6FlashSwitch = settings.FlashSwitch;
+        System6ReelOptos = new ObservableCollection<System6ReelOptoSettingsViewModel>((settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos()).Select(reel => new System6ReelOptoSettingsViewModel(reel, SaveSystem6NativeRomSettings)));
         OnPropertyChanged(nameof(System6ProgramRom1Path)); OnPropertyChanged(nameof(System6ProgramRom2Path));
         OnPropertyChanged(nameof(System6ProgramRom3Path)); OnPropertyChanged(nameof(System6ProgramRom4Path));
         OnPropertyChanged(nameof(System6SoundRom1Path)); OnPropertyChanged(nameof(System6SoundRom2Path));
@@ -2646,6 +2652,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    private void ResetSystem6ReelOptosToDefaults()
+    {
+        System6ReelOptos = new ObservableCollection<System6ReelOptoSettingsViewModel>(System6NativeRomSettings.CreateDefaultReelOptos().Select(reel => new System6ReelOptoSettingsViewModel(reel, SaveSystem6NativeRomSettings)));
+        SaveSystem6NativeRomSettings();
+    }
+
     private System6NativeRomSettings BuildSystem6NativeRomSettingsForLaunch()
     {
         var settings = LoadedProject?.System6NativeRoms ?? new System6NativeRomSettings();
@@ -2660,7 +2672,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom2Path = ResolveProjectRelativePath(settings.SoundRom2Path, LoadedProject.ProjectDirectory),
             SoundRom3Path = ResolveProjectRelativePath(settings.SoundRom3Path, LoadedProject.ProjectDirectory),
             SoundRom4Path = ResolveProjectRelativePath(settings.SoundRom4Path, LoadedProject.ProjectDirectory),
-            FlashSwitch = settings.FlashSwitch
+            FlashSwitch = settings.FlashSwitch,
+            ReelOptos = (settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos())
+                .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
+                .ToList()
         };
     }
 
@@ -3543,6 +3558,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         writer.WriteString("SoundRom3Path", settings.SoundRom3Path);
         writer.WriteString("SoundRom4Path", settings.SoundRom4Path);
         writer.WriteBoolean("FlashSwitch", settings.FlashSwitch);
+        writer.WritePropertyName("ReelOptos");
+        writer.WriteStartArray();
+        foreach (var reel in settings.ReelOptos)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("ReelIndex", reel.ReelIndex);
+            writer.WriteNumber("Steps", reel.Steps);
+            writer.WriteNumber("OptoStart", reel.OptoStart);
+            writer.WriteNumber("OptoEnd", reel.OptoEnd);
+            writer.WriteBoolean("OptoInvert", reel.OptoInvert);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
         writer.WriteEndObject();
     }
 
@@ -3564,8 +3592,38 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom2Path = GetOptionalString(romsElement, "SoundRom2Path"),
             SoundRom3Path = GetOptionalString(romsElement, "SoundRom3Path"),
             SoundRom4Path = GetOptionalString(romsElement, "SoundRom4Path"),
-            FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True
+            FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True,
+            ReelOptos = ResolveSystem6ReelOptoSettings(romsElement)
         };
+    }
+
+
+    private static List<System6ReelOptoSettings> ResolveSystem6ReelOptoSettings(JsonElement romsElement)
+    {
+        if (!romsElement.TryGetProperty("ReelOptos", out var reelOptosElement) || reelOptosElement.ValueKind != JsonValueKind.Array)
+        {
+            return System6NativeRomSettings.CreateDefaultReelOptos();
+        }
+
+        var reelOptos = new List<System6ReelOptoSettings>();
+        foreach (var reelElement in reelOptosElement.EnumerateArray())
+        {
+            reelOptos.Add(new System6ReelOptoSettings
+            {
+                ReelIndex = GetOptionalInt(reelElement, "ReelIndex"),
+                Steps = GetOptionalInt(reelElement, "Steps", System6ReelOptoSettings.DefaultSteps),
+                OptoStart = GetOptionalInt(reelElement, "OptoStart", System6ReelOptoSettings.DefaultOptoStart),
+                OptoEnd = GetOptionalInt(reelElement, "OptoEnd", System6ReelOptoSettings.DefaultOptoEnd),
+                OptoInvert = reelElement.TryGetProperty("OptoInvert", out var invertElement) && invertElement.ValueKind == JsonValueKind.True
+            });
+        }
+
+        return reelOptos.Count > 0 ? reelOptos : System6NativeRomSettings.CreateDefaultReelOptos();
+    }
+
+    private static int GetOptionalInt(JsonElement element, string propertyName, int defaultValue = 0)
+    {
+        return element.TryGetProperty(propertyName, out var value) && value.TryGetInt32(out var parsed) ? parsed : defaultValue;
     }
 
     private static string GetOptionalString(JsonElement element, string propertyName)
@@ -4142,5 +4200,55 @@ internal static class EditorProjectInputDefinitionExtensions
         }
 
         return project;
+    }
+}
+
+public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
+{
+    private readonly Action _changed;
+    private int _steps;
+    private int _optoStart;
+    private int _optoEnd;
+    private bool _optoInvert;
+
+    public System6ReelOptoSettingsViewModel(System6ReelOptoSettings model, Action changed)
+    {
+        ReelIndex = model.ReelIndex;
+        _steps = model.Steps;
+        _optoStart = model.OptoStart;
+        _optoEnd = model.OptoEnd;
+        _optoInvert = model.OptoInvert;
+        _changed = changed;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public int ReelIndex { get; }
+    public int ReelNumber => ReelIndex + 1;
+
+    public int Steps { get => _steps; set => SetAndSave(ref _steps, value, nameof(Steps)); }
+    public int OptoStart { get => _optoStart; set => SetAndSave(ref _optoStart, value, nameof(OptoStart)); }
+    public int OptoEnd { get => _optoEnd; set => SetAndSave(ref _optoEnd, value, nameof(OptoEnd)); }
+    public bool OptoInvert { get => _optoInvert; set => SetAndSave(ref _optoInvert, value, nameof(OptoInvert)); }
+
+    public System6ReelOptoSettings ToModel() => new()
+    {
+        ReelIndex = ReelIndex,
+        Steps = Steps,
+        OptoStart = OptoStart,
+        OptoEnd = OptoEnd,
+        OptoInvert = OptoInvert
+    };
+
+    private void SetAndSave<T>(ref T field, T value, string propertyName)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        _changed();
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -20,6 +20,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -81,5 +83,28 @@
                 <CheckBox Grid.Row="8" Grid.Column="1" Margin="0,2,0,6" Content="Flash switch" IsChecked="{Binding System6FlashSwitch}" />
                 <TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
             </Grid>
+
+            <TextBlock Grid.Row="13" Margin="0,20,0,4" Text="System6 Reel Optos" Foreground="{DynamicResource TextSecondaryBrush}" />
+            <StackPanel Grid.Row="14" Orientation="Vertical">
+                <DataGrid ItemsSource="{Binding System6ReelOptos}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False"
+                          HeadersVisibility="Column"
+                          MaxHeight="260">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Reel" Binding="{Binding ReelNumber}" IsReadOnly="True" Width="80" />
+                        <DataGridTextColumn Header="Steps" Binding="{Binding Steps, UpdateSourceTrigger=LostFocus}" Width="100" />
+                        <DataGridTextColumn Header="Opto Start" Binding="{Binding OptoStart, UpdateSourceTrigger=LostFocus}" Width="120" />
+                        <DataGridTextColumn Header="Opto End" Binding="{Binding OptoEnd, UpdateSourceTrigger=LostFocus}" Width="120" />
+                        <DataGridCheckBoxColumn Header="Inverted" Binding="{Binding OptoInvert, UpdateSourceTrigger=PropertyChanged}" Width="100" />
+                    </DataGrid.Columns>
+                </DataGrid>
+                <Button Margin="0,8,0,0"
+                        HorizontalAlignment="Left"
+                        Padding="10,2"
+                        Command="{Binding ResetSystem6ReelOptosCommand}"
+                        Content="Reset Reel Optos To Defaults" />
+            </StackPanel>
     </Grid></ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Provide project-level, per-reel opto configuration so the native System6 core can be initialized with the correct reel steps/opto ranges and inversion at startup. 
- Persist these settings in the project file and expose them in Project Settings so users can edit and reset reel optos without changing MAME behavior. 
- Validate and apply opto settings before the first run frame and emit a concise startup diagnostic if configuration is applied or invalid. 

### Description
- Added `System6ReelOptoSettings` and a `ReelOptos` list on `System6NativeRomSettings` with an 8-slot default and default values `Steps=96`, `OptoStart=5`, `OptoEnd=7`, `OptoInvert=false` in `EditorProject.cs`. 
- Extended the native ABI (`ISystem6NativeLibrary`) and bound `SetSteps`, `SetOptoStart`, `SetOptoEnd`, and `SetOptoInvert` delegates in `System6NativeLibrary.cs` using the existing Cdecl/byte pattern. 
- Applied validated reel optos after ROM loading and before `Reset`/`Run` in `System6NativeBackend.cs`, added validation rules (range checks, `optoStart < optoEnd`, supported reel index range) and one-time `Debug.WriteLine` diagnostics for each reel. 
- Added UI in `ProjectSettingsView.xaml` to show a `System6 Reel Optos` table (`Reel | Steps | Opto Start | Opto End | Inverted`) and a `Reset Reel Optos To Defaults` button, and wired view-model plumbing and persistence in `MainWindowViewModel.cs` including `System6ReelOptoSettingsViewModel`. 
- Added unit test assertions in `OasisEditor.Tests/System6NativeBackendTests.cs` to verify default opto calls ordering and that invalid settings cause startup failure; left MAME path/code unchanged. 

### Testing
- New unit tests were added to `OasisEditor.Tests/System6NativeBackendTests.cs` to cover default application and invalid-value failure but they were not executed in this environment due to the repository `AGENTS.md` constraint. 
- Performed repository checks (`git diff --check`) and source edits here; no `dotnet build` or `dotnet test` was run in this agent environment. 
- Recommended local verification: run `dotnet test OasisEditor.sln` and verify the new and existing System6 native backend tests pass, open Project Settings to confirm UI round-trip and defaults, and start a System6 native launch to confirm startup log lines like `System6 reel 1 opto: steps=96 start=5 end=7 inverted=false` are emitted before the run loop.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a330585cd688327aeb14010ea874327)