### PR TITLE
Add System6 alpha display debug polling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -80,6 +80,23 @@ public sealed class System6NativeBackendTests
         Assert.Empty(library.Calls.Where(call => call.StartsWith("Run", StringComparison.Ordinal)));
     }
 
+
+    [Fact]
+    public void FormatAlphaDebugString_MapsZeroToSpacePrintableAsciiToCharsAndNonPrintableToPlaceholder()
+    {
+        var text = System6NativeBackend.FormatAlphaDebugString(new byte[] { 0, 65, 31, 126 });
+
+        Assert.Equal(" A?~", text);
+    }
+
+    [Fact]
+    public void FormatAlphaRawBytes_FormatsUppercaseHexBytes()
+    {
+        var raw = System6NativeBackend.FormatAlphaRawBytes(new byte[] { 0, 65, 255 });
+
+        Assert.Equal("00 41 FF", raw);
+    }
+
     private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)
     {
         return new EmulationLaunchRequest(
@@ -182,6 +199,10 @@ public sealed class System6NativeBackendTests
         public float GetLampBrightness(ushort lampIndex) => 0f;
 
         public short GetPosOut(sbyte positionIndex) => 0;
+
+        public bool IsAlphaCharPollingAvailable => false;
+
+        public byte GetAlphaChar(byte index) => 0;
 
         public void TurnSwitchOn(int switchIndex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -28,6 +28,10 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 
     short GetPosOut(sbyte positionIndex);
 
+    bool IsAlphaCharPollingAvailable { get; }
+
+    byte GetAlphaChar(byte index);
+
     void TurnSwitchOn(int switchIndex);
 
     void TurnSwitchOff(int switchIndex);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -10,6 +10,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private const int System6ClockHz = 8000000;
     private const int LampCount = 32;
     private const int ReelCount = 16;
+    private const int AlphaCharacterCount = 16;
     private const int SupportedReelOptoCount = 8;
     private const string DiagnosticStageEnvironmentVariable = "OASIS_SYSTEM6_STARTUP_STAGE";
     private static readonly TimeSpan SlowRunWarningThreshold = TimeSpan.FromMilliseconds(250);
@@ -32,6 +33,8 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly object _stateGate = new();
     private readonly int[] _lastLampValues = Enumerable.Repeat(-1, LampCount).ToArray();
     private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
+    private string? _lastAlphaString;
+    private bool _hasLoggedAlphaUnavailable;
 
     private ISystem6NativeLibrary? _library;
     private CancellationTokenSource? _runLoopCancellation;
@@ -358,6 +361,31 @@ public sealed class System6NativeBackend : IEmulationBackend
         return (int)MathF.Round(Math.Min(brightness, 255f));
     }
 
+    internal static string FormatAlphaDebugString(IReadOnlyList<byte> rawChars)
+    {
+        ArgumentNullException.ThrowIfNull(rawChars);
+
+        var chars = new char[rawChars.Count];
+        for (var i = 0; i < rawChars.Count; i++)
+        {
+            var value = rawChars[i];
+            chars[i] = value switch
+            {
+                0 => ' ',
+                >= 32 and <= 126 => (char)value,
+                _ => '?'
+            };
+        }
+
+        return new string(chars);
+    }
+
+    internal static string FormatAlphaRawBytes(IReadOnlyList<byte> rawChars)
+    {
+        ArgumentNullException.ThrowIfNull(rawChars);
+        return string.Join(" ", rawChars.Select(value => value.ToString("X2", CultureInfo.InvariantCulture)));
+    }
+
     private static void LogStartupStage(string message)
     {
         Debug.WriteLine($"System6 native startup: {message}");
@@ -503,12 +531,48 @@ public sealed class System6NativeBackend : IEmulationBackend
                 ReelChanged?.Invoke(this, new MachineReelChangedEventArgs(reelIndex, position));
             }
         }
+
+        PollAlphaDebugOutput(library);
+    }
+
+    private void PollAlphaDebugOutput(ISystem6NativeLibrary library)
+    {
+        if (!library.IsAlphaCharPollingAvailable)
+        {
+            if (!_hasLoggedAlphaUnavailable)
+            {
+                _hasLoggedAlphaUnavailable = true;
+                Debug.WriteLine("[System6 Alpha] GetAlphaChar unavailable; alpha debug polling disabled.");
+            }
+
+            return;
+        }
+
+        var rawChars = new byte[AlphaCharacterCount];
+        for (var index = 0; index < rawChars.Length; index++)
+        {
+            rawChars[index] = library.GetAlphaChar(checked((byte)index));
+        }
+
+        // The native TechsClass.cpp reference exposes GetAlphaChar(UINT8 num) as a raw byte.
+        // First-pass diagnostics treat printable ASCII values as characters while also logging
+        // raw byte values so we can verify whether the native core returns ASCII or display codes.
+        var alphaString = FormatAlphaDebugString(rawChars);
+        if (string.Equals(_lastAlphaString, alphaString, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _lastAlphaString = alphaString;
+        Debug.WriteLine($"[System6 Alpha] chars=\"{alphaString}\" raw={FormatAlphaRawBytes(rawChars)}");
     }
 
     private void ResetCachedOutputState()
     {
         Array.Fill(_lastLampValues, -1);
         Array.Fill(_lastReelPositions, int.MinValue);
+        _lastAlphaString = null;
+        _hasLoggedAlphaUnavailable = false;
     }
 
     private void CleanupLibraryAfterFailedStart()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -18,6 +18,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6GetLampsOnDelegate _getLampsOn;
     private readonly System6GetLampBrightnessDelegate _getLampBrightness;
     private readonly System6GetPosOutDelegate _getPosOut;
+    private readonly System6GetAlphaCharDelegate? _getAlphaChar;
     private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
     private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
     private readonly List<IntPtr> _romPathBuffers = [];
@@ -44,6 +45,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _getLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
         _getLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
         _getPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
+        _getAlphaChar = TryBindOptionalExport<System6GetAlphaCharDelegate>("GetAlphaChar");
         _turnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
         _turnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
     }
@@ -88,6 +90,14 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public short GetPosOut(sbyte positionIndex) => _getPosOut(positionIndex);
 
+    public bool IsAlphaCharPollingAvailable => _getAlphaChar is not null;
+
+    public byte GetAlphaChar(byte index)
+    {
+        var getAlphaChar = _getAlphaChar ?? throw new NotSupportedException("System6 native core does not export GetAlphaChar.");
+        return getAlphaChar(index);
+    }
+
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
 
     public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(switchIndex);
@@ -100,6 +110,20 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate byte System6InitialiseDelegate();
+
+    private TDelegate? TryBindOptionalExport<TDelegate>(string exportName)
+        where TDelegate : Delegate
+    {
+        try
+        {
+            return _loader.BindExport<TDelegate>(exportName);
+        }
+        catch (NativeCoreExportException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"System6 native optional export {exportName} unavailable; alpha debug polling disabled. {ex.Message}");
+            return null;
+        }
+    }
 
     private IntPtr[] AllocateRomPathSlots(IReadOnlyList<string> romPaths)
     {
@@ -182,6 +206,9 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate short System6GetPosOutDelegate(sbyte positionIndex);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate byte System6GetAlphaCharDelegate(byte index);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6TurnSwitchOnDelegate(int switchIndex);


### PR DESCRIPTION
### Motivation

- Provide a temporary diagnostic path to observe System6 alphanumeric display output from the native core without changing runtime rendering or machine behavior. 
- Make the bridge resilient when the native export is missing so startup never crashes and polling is disabled gracefully. 

### Description

- Added `IsAlphaCharPollingAvailable` and `GetAlphaChar(byte index)` to `ISystem6NativeLibrary` and implemented an optional Cdecl binding `System6GetAlphaCharDelegate` in `System6NativeLibrary` with a safe wrapper and `TryBindOptionalExport` helper. 
- Bound the optional `GetAlphaChar` export in `System6NativeLibrary` and expose `IsAlphaCharPollingAvailable` to indicate availability; the wrapper throws only if explicitly called when unavailable. 
- In `System6NativeBackend` added `AlphaCharacterCount = 16`, fields to cache last alpha string and a one-time-unavailable log flag, and a new `PollAlphaDebugOutput` method invoked from the existing `PollOutputs` path to sample `GetAlphaChar` each update. 
- Implemented helper formatters `FormatAlphaDebugString` and `FormatAlphaRawBytes` that map `0` to space, printable ASCII to characters, non-printable to `?`, and always include raw byte hex in the debug line; logging emits a single `Debug.WriteLine` only when the constructed alpha string changes. 
- Reset cache state in `ResetCachedOutputState` so diagnostics restart after resets, and updated the `FakeSystem6NativeLibrary` in tests to include the new members. 
- Kept diagnostic-only scope: no wiring into `MachineRuntimeState` or face/panel rendering and no functional changes to MAME emulation logic. 

### Testing

- Added unit tests `FormatAlphaDebugString_MapsZeroToSpacePrintableAsciiToCharsAndNonPrintableToPlaceholder` and `FormatAlphaRawBytes_FormatsUppercaseHexBytes` to `System6NativeBackendTests` and updated the fake native library to expose `IsAlphaCharPollingAvailable`/`GetAlphaChar`; no test execution was performed in this environment per project `AGENTS.md`. 
- Recommend running the test suite locally with `dotnet test` (solution/project containing `OasisEditor.Tests`) to validate the new formatters and ensure no regressions; the new tests are expected to pass. 
- Verified via repository inspection and commit that the bridge binds the optional export and that polling emits debug output only on changes and degrades gracefully when the export is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34195324908327a79792bf0e490a8a)