### PR TITLE
Add Enabled flag for System6 reel optos

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -80,6 +80,25 @@ public sealed class System6NativeBackendTests
         Assert.Empty(library.Calls.Where(call => call.StartsWith("Run", StringComparison.Ordinal)));
     }
 
+    [Fact]
+    public async Task StartAsyncSkipsDisabledReelOptos()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var request = CreateLaunchRequest(rom1, rom2);
+        request.System6NativeRoms!.ReelOptos[1].Enabled = false;
+        request.System6NativeRoms.ReelOptos[1].Steps = 0;
+
+        await backend.StartAsync(request, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.DoesNotContain("SetSteps:1:0", library.Calls);
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:1:", StringComparison.Ordinal));
+        Assert.Equal(7 * 4, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
+        Assert.True(library.ResetCalled);
+    }
+
 
     [Fact]
     public void FormatAlphaDebugString_MapsZeroToSpacePrintableAsciiToCharsAndNonPrintableToPlaceholder()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -51,9 +51,11 @@ public sealed class System6ReelOptoSettings
     public const int DefaultSteps = 96;
     public const int DefaultOptoStart = 5;
     public const int DefaultOptoEnd = 7;
+    public const bool DefaultEnabled = true;
     public const bool DefaultOptoInvert = false;
 
     public int ReelIndex { get; set; }
+    public bool Enabled { get; set; } = DefaultEnabled;
     public int Steps { get; set; } = DefaultSteps;
     public int OptoStart { get; set; } = DefaultOptoStart;
     public int OptoEnd { get; set; } = DefaultOptoEnd;
@@ -62,6 +64,7 @@ public sealed class System6ReelOptoSettings
     public static System6ReelOptoSettings CreateDefault(int reelIndex) => new()
     {
         ReelIndex = reelIndex,
+        Enabled = DefaultEnabled,
         Steps = DefaultSteps,
         OptoStart = DefaultOptoStart,
         OptoEnd = DefaultOptoEnd,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -436,6 +436,10 @@ public sealed class System6NativeBackend : IEmulationBackend
             {
                 throw new InvalidOperationException($"System6 reel opto setting has invalid reel index {reel.ReelIndex}; supported range is 0-{SupportedReelOptoCount - 1}.");
             }
+            if (!reel.Enabled)
+            {
+                continue;
+            }
             if (reel.Steps is < 1 or > byte.MaxValue)
             {
                 throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto steps must be between 1 and 255.");
@@ -459,7 +463,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private static void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
     {
-        foreach (var reel in reelOptos)
+        foreach (var reel in reelOptos.Where(reel => reel.Enabled))
         {
             var reelNum = checked((byte)reel.ReelIndex);
             library.SetSteps(reelNum, checked((byte)reel.Steps));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2674,7 +2674,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = ResolveProjectRelativePath(settings.SoundRom4Path, LoadedProject.ProjectDirectory),
             FlashSwitch = settings.FlashSwitch,
             ReelOptos = (settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos())
-                .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
+                .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Enabled = reel.Enabled, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
                 .ToList()
         };
     }
@@ -3564,6 +3564,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             writer.WriteStartObject();
             writer.WriteNumber("ReelIndex", reel.ReelIndex);
+            writer.WriteBoolean("Enabled", reel.Enabled);
             writer.WriteNumber("Steps", reel.Steps);
             writer.WriteNumber("OptoStart", reel.OptoStart);
             writer.WriteNumber("OptoEnd", reel.OptoEnd);
@@ -3611,6 +3612,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             reelOptos.Add(new System6ReelOptoSettings
             {
                 ReelIndex = GetOptionalInt(reelElement, "ReelIndex"),
+                Enabled = !reelElement.TryGetProperty("Enabled", out var enabledElement) || enabledElement.ValueKind != JsonValueKind.False,
                 Steps = GetOptionalInt(reelElement, "Steps", System6ReelOptoSettings.DefaultSteps),
                 OptoStart = GetOptionalInt(reelElement, "OptoStart", System6ReelOptoSettings.DefaultOptoStart),
                 OptoEnd = GetOptionalInt(reelElement, "OptoEnd", System6ReelOptoSettings.DefaultOptoEnd),
@@ -4206,6 +4208,7 @@ internal static class EditorProjectInputDefinitionExtensions
 public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
 {
     private readonly Action _changed;
+    private bool _enabled;
     private int _steps;
     private int _optoStart;
     private int _optoEnd;
@@ -4214,6 +4217,7 @@ public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
     public System6ReelOptoSettingsViewModel(System6ReelOptoSettings model, Action changed)
     {
         ReelIndex = model.ReelIndex;
+        _enabled = model.Enabled;
         _steps = model.Steps;
         _optoStart = model.OptoStart;
         _optoEnd = model.OptoEnd;
@@ -4226,6 +4230,7 @@ public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
     public int ReelIndex { get; }
     public int ReelNumber => ReelIndex + 1;
 
+    public bool Enabled { get => _enabled; set => SetAndSave(ref _enabled, value, nameof(Enabled)); }
     public int Steps { get => _steps; set => SetAndSave(ref _steps, value, nameof(Steps)); }
     public int OptoStart { get => _optoStart; set => SetAndSave(ref _optoStart, value, nameof(OptoStart)); }
     public int OptoEnd { get => _optoEnd; set => SetAndSave(ref _optoEnd, value, nameof(OptoEnd)); }
@@ -4234,6 +4239,7 @@ public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
     public System6ReelOptoSettings ToModel() => new()
     {
         ReelIndex = ReelIndex,
+        Enabled = Enabled,
         Steps = Steps,
         OptoStart = OptoStart,
         OptoEnd = OptoEnd,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -94,6 +94,7 @@
                           MaxHeight="260">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Reel" Binding="{Binding ReelNumber}" IsReadOnly="True" Width="80" />
+                        <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="90" />
                         <DataGridTextColumn Header="Steps" Binding="{Binding Steps, UpdateSourceTrigger=LostFocus}" Width="100" />
                         <DataGridTextColumn Header="Opto Start" Binding="{Binding OptoStart, UpdateSourceTrigger=LostFocus}" Width="120" />
                         <DataGridTextColumn Header="Opto End" Binding="{Binding OptoEnd, UpdateSourceTrigger=LostFocus}" Width="120" />


### PR DESCRIPTION
### Motivation
- Provide a per-row enable/disable control for System6 reel opto rows so the native DLL bridge only receives setup for reels actually used by a machine.
- Preserve backward compatibility by defaulting existing/default reel opto rows to enabled and treating older project files without the property as enabled.

### Description
- Added `Enabled` boolean (default true) to `System6ReelOptoSettings` and included it in the default factory. 
- Surfaced an `Enabled` checkbox column in the Project Settings `DataGrid` for System6 Reel Optos and added `Enabled` to the `System6ReelOptoSettingsViewModel` so changes are saved immediately. 
- Persisted `Enabled` when writing `System6NativeRoms` JSON and treated missing `Enabled` as true when reading project metadata. 
- Updated `System6NativeBackend` to skip disabled rows during validation and to only apply opto settings for enabled rows (filter in `ApplyReelOptos`).
- Added a unit test `StartAsyncSkipsDisabledReelOptos` to `System6NativeBackendTests` verifying disabled rows are not sent to the native library.

### Testing
- Added automated coverage: `System6NativeBackendTests.StartAsyncSkipsDisabledReelOptos` was added to assert disabled reel rows are skipped and only enabled rows are applied. 
- No tests were executed in this environment because the project requires the Windows/.NET/WPF toolchain and automated test runs are not performed here; please run the test suite locally with `dotnet test` to validate the change. 
- Expectation: existing tests should continue to pass and the new test should confirm skipped disabled rows; if any failures occur run the failing tests locally to inspect stack traces and adjust accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a341d4c0d008327a1765c2e874f72fa)