### PR TITLE
System6: send zero-based reel indices to native DLL and log display->native mapping

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/Emulation/SYSTEM6_REEL_OPTO_PLAN.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Emulation/SYSTEM6_REEL_OPTO_PLAN.md
@@ -173,7 +173,7 @@ If validation fails, do not start the native backend.
 Log native startup stages:
 
 ```text
-System6 reel opto 1: steps=96 start=5 end=7 inverted=false
+System6 reel 1 -> native index 0: steps=96 start=5 end=7 inverted=false
 ```
 
 Avoid logging every frame. Log only setup/configuration.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -33,6 +33,44 @@ public sealed class System6NativeBackendTests
     }
 
     [Fact]
+    public async Task StartAsyncSendsZeroBasedNativeReelOptoIndicesForDisplayedReelsOneAndEight()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Contains("SetSteps:0:96", library.Calls);
+        Assert.Contains("SetOptoStart:0:5", library.Calls);
+        Assert.Contains("SetOptoEnd:0:7", library.Calls);
+        Assert.Contains("SetOptoInvert:0:0", library.Calls);
+        Assert.Contains("SetSteps:7:96", library.Calls);
+        Assert.Contains("SetOptoStart:7:5", library.Calls);
+        Assert.Contains("SetOptoEnd:7:7", library.Calls);
+        Assert.Contains("SetOptoInvert:7:0", library.Calls);
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetSteps:8:", StringComparison.Ordinal));
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:8:", StringComparison.Ordinal));
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoEnd:8:", StringComparison.Ordinal));
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoInvert:8:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void System6ReelOptoViewModelDisplaysOneBasedReelNumbersFromZeroBasedStoredIndices()
+    {
+        var firstReel = new System6ReelOptoSettingsViewModel(System6ReelOptoSettings.CreateDefault(0), () => { });
+        var eighthReel = new System6ReelOptoSettingsViewModel(System6ReelOptoSettings.CreateDefault(7), () => { });
+
+        Assert.Equal(0, firstReel.ReelIndex);
+        Assert.Equal(1, firstReel.ReelNumber);
+        Assert.Equal(7, eighthReel.ReelIndex);
+        Assert.Equal(8, eighthReel.ReelNumber);
+        Assert.Equal(0, firstReel.ToModel().ReelIndex);
+        Assert.Equal(7, eighthReel.ToModel().ReelIndex);
+    }
+
+    [Fact]
     public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
     {
         var library = new FakeSystem6NativeLibrary();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -465,12 +465,13 @@ public sealed class System6NativeBackend : IEmulationBackend
     {
         foreach (var reel in reelOptos.Where(reel => reel.Enabled))
         {
-            var reelNum = checked((byte)reel.ReelIndex);
-            library.SetSteps(reelNum, checked((byte)reel.Steps));
-            library.SetOptoStart(reelNum, checked((byte)reel.OptoStart));
-            library.SetOptoEnd(reelNum, checked((byte)reel.OptoEnd));
-            library.SetOptoInvert(reelNum, reel.OptoInvert ? (byte)1 : (byte)0);
-            LogStartupStage($"System6 reel {reel.ReelIndex + 1} opto: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
+            var nativeReelIndex = checked((byte)reel.ReelIndex);
+            var displayReelNumber = reel.ReelIndex + 1;
+            library.SetSteps(nativeReelIndex, checked((byte)reel.Steps));
+            library.SetOptoStart(nativeReelIndex, checked((byte)reel.OptoStart));
+            library.SetOptoEnd(nativeReelIndex, checked((byte)reel.OptoEnd));
+            library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
+            LogStartupStage($"System6 reel {displayReelNumber} -> native index {nativeReelIndex}: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
         }
     }
 


### PR DESCRIPTION
### Motivation
- Native System6 DLL exports (`SetSteps`, `SetOptoStart`, `SetOptoEnd`, `SetOptoInvert`) expect zero-based reel indices and the startup log previously only showed a one-based reel number, which risked passing 1-based values to the native core.
- Keep stored project format unchanged (stored `ReelIndex` remains zero-based) while ensuring the native backend receives correct zero-based indices and the UI still displays friendly 1-based reel numbers.

### Description
- ApplyReelOptos now computes `nativeReelIndex = (byte)reel.ReelIndex` and uses that value when calling `SetSteps`, `SetOptoStart`, `SetOptoEnd`, and `SetOptoInvert` so the native DLL always receives 0-based indices (`System6NativeBackend.cs`).
- Startup diagnostics now log both the one-based display reel number and the zero-based native index, e.g. `System6 reel 1 -> native index 0: ...` to make mapping explicit (`System6NativeBackend.cs` and `Docs/Emulation/SYSTEM6_REEL_OPTO_PLAN.md`).
- Added unit tests asserting the mapping and preserved behavior: `StartAsyncSendsZeroBasedNativeReelOptoIndicesForDisplayedReelsOneAndEight` and `System6ReelOptoViewModelDisplaysOneBasedReelNumbersFromZeroBasedStoredIndices` in `System6NativeBackendTests.cs`.
- No project format changes were made; `System6ReelOptoSettings.ReelIndex` remains zero-based and `ReelNumber` (UI) continues to be `ReelIndex + 1` (`EditorProject.cs`, `MainWindowViewModel.cs`, `ProjectSettingsView.xaml`).

### Testing
- Added automated tests `StartAsyncSendsZeroBasedNativeReelOptoIndicesForDisplayedReelsOneAndEight` and `System6ReelOptoViewModelDisplaysOneBasedReelNumbersFromZeroBasedStoredIndices` to `OasisEditor.Tests/System6NativeBackendTests.cs` that assert native calls use indices 0..7 and the view model displays 1..8.
- Tests were not executed in this environment because the Windows/.NET/WPF toolchain is not available here; please run `dotnet test` in the solution on a developer machine to validate the tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34216564908327b8d8b4d89b86de05)