### PR TITLE
Apply System6 reel optos after Reset; add startup logs and tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -26,7 +26,7 @@ public sealed class System6NativeBackendTests
         Assert.Equal(new[] { rom1, rom2, string.Empty, string.Empty }, library.LoadedRoms);
         Assert.True(library.ResetCalled);
         Assert.Equal(8 * 4, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
-        Assert.True(library.Calls.IndexOf("SetOptoInvert:7:0") < library.Calls.IndexOf("Reset"));
+        Assert.True(library.Calls.IndexOf("Reset") < library.Calls.IndexOf("SetSteps:0:96"));
         Assert.True(library.ShutdownCalled);
         Assert.True(library.DisposeCalled);
         Assert.Equal(EmulationBackendState.Stopped, backend.State);
@@ -137,6 +137,37 @@ public sealed class System6NativeBackendTests
         Assert.True(library.ResetCalled);
     }
 
+    [Fact]
+    public async Task StartAsyncOneRunOnlyAppliesReelOptosAfterResetAndBeforeFirstRun()
+    {
+        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary();
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library);
+
+            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+            await backend.StopAsync(CancellationToken.None);
+
+            AssertOrdered(
+                library.Calls,
+                "Initialise",
+                "LoadRom",
+                "Reset",
+                "SetSteps:0:96",
+                "SetOptoStart:0:5",
+                "SetOptoEnd:0:7",
+                "SetOptoInvert:0:0",
+                "Run:133333");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
+        }
+    }
+
 
     [Fact]
     public void FormatAlphaDebugString_MapsZeroToSpacePrintableAsciiToCharsAndNonPrintableToPlaceholder()
@@ -152,6 +183,31 @@ public sealed class System6NativeBackendTests
         var raw = System6NativeBackend.FormatAlphaRawBytes(new byte[] { 0, 65, 255 });
 
         Assert.Equal("00 41 FF", raw);
+    }
+
+    private static void AssertOrdered(IReadOnlyList<string> calls, params string[] expectedCalls)
+    {
+        var previousIndex = -1;
+        foreach (var expectedCall in expectedCalls)
+        {
+            var index = FindCallIndex(calls, expectedCall);
+            Assert.True(index >= 0, $"Expected call '{expectedCall}' was not found. Calls: {string.Join(", ", calls)}");
+            Assert.True(index > previousIndex, $"Expected call '{expectedCall}' after index {previousIndex}. Calls: {string.Join(", ", calls)}");
+            previousIndex = index;
+        }
+    }
+
+    private static int FindCallIndex(IReadOnlyList<string> calls, string expectedCall)
+    {
+        for (var index = 0; index < calls.Count; index++)
+        {
+            if (string.Equals(calls[index], expectedCall, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -182,7 +182,6 @@ public sealed class System6NativeBackend : IEmulationBackend
                     LogStartupStage("LoadSoundROM skipped");
                 }
 
-                ApplyReelOptos(_library, reelOptos);
             }
             catch (Exception ex)
             {
@@ -195,6 +194,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
             try
             {
+                LogStartupStage("Reset starting");
                 _library.Reset();
                 LogStartupStage("Reset completed");
             }
@@ -203,6 +203,17 @@ public sealed class System6NativeBackend : IEmulationBackend
                 throw new InvalidOperationException($"System6 native backend failed to reset core '{_libraryPath}' during startup.", ex);
             }
             ResetCachedOutputState();
+
+            try
+            {
+                LogStartupStage("Apply reel optos starting after Reset");
+                ApplyReelOptos(_library, reelOptos);
+                LogStartupStage("Apply reel optos completed before first Run");
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"System6 native backend failed to apply reel optos with core '{_libraryPath}'.", ex);
+            }
             if (startupStage is System6StartupStage.ResetOnly)
             {
                 LogStartupStage("first Run skipped / pending");


### PR DESCRIPTION
### Motivation
- Prevent native `SYSTEM6Reset` from wiping configured reel opto settings by applying reel optos after the reset step during startup.
- Make startup ordering explicit in diagnostic logs so it's obvious whether ROM load, Reset, reel opto application and first Run occur in the correct sequence.
- Preserve existing lower-risk ROM order (program then optional sound ROM) and zero-based native reel indices while avoiding changes to alpha polling or MAME behavior.

### Description
- Moved `ApplyReelOptos(_library, reelOptos)` from before `Reset()` to immediately after `Reset()` and `ResetCachedOutputState()` in `OasisEditor/Emulation/Native/System6NativeBackend.cs` and added surrounding `LogStartupStage` messages (`"Reset starting"`, `"Reset completed"`, `"Apply reel optos starting after Reset"`, `"Apply reel optos completed before first Run"`).
- Kept `LoadSoundRom` in its existing position (i.e., before `Reset`) to choose the lower-risk startup order and documented that choice via the added diagnostic logs.
- Preserved zero-based indices in DLL calls and retained user-friendly log mapping when printing display vs native indices (e.g. "reel 1 -> native index 0").
- Added/updated unit tests in `OasisEditor.Tests/System6NativeBackendTests.cs`: adjusted an existing assertion to check `Reset` occurs before reel calls, and added `StartAsyncOneRunOnlyAppliesReelOptosAfterResetAndBeforeFirstRun` plus `AssertOrdered`/`FindCallIndex` helpers to validate the exact startup sequence including the one-run diagnostic stage.

### Testing
- Added unit test `StartAsyncOneRunOnlyAppliesReelOptosAfterResetAndBeforeFirstRun` and updated an existing startup-order assertion in `System6NativeBackendTests.cs`, but no test suite was executed in this environment.
- Ran automated repository check `git diff --check`, which completed successfully.
- Because the execution environment lacks the Windows/.NET toolchain per `AGENTS.md`, please run `dotnet test` locally to confirm the new and existing tests pass and to validate the startup-order behavior in an actual native core environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a342678111483278fdee8775740678b)