### PR TITLE
Use SYSTEM6GetAlphaSegments for alpha diagnostics; add SetPercent and project Percent setting

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -25,7 +25,8 @@ public sealed class System6NativeBackendTests
         Assert.True(library.InitialiseCalled);
         Assert.Equal(new[] { rom1, rom2, string.Empty, string.Empty }, library.LoadedRoms);
         Assert.True(library.ResetCalled);
-        Assert.Equal(8 * 4, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
+        Assert.Equal(8 * 4 + 1, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
+        Assert.Contains("SetPercent:0", library.Calls);
         Assert.True(library.Calls.IndexOf("Reset") < library.Calls.IndexOf("SetSteps:0:96"));
         Assert.True(library.ShutdownCalled);
         Assert.True(library.DisposeCalled);
@@ -133,7 +134,7 @@ public sealed class System6NativeBackendTests
 
         Assert.DoesNotContain("SetSteps:1:0", library.Calls);
         Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:1:", StringComparison.Ordinal));
-        Assert.Equal(7 * 4, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
+        Assert.Equal(7 * 4 + 1, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
         Assert.True(library.ResetCalled);
     }
 
@@ -160,6 +161,7 @@ public sealed class System6NativeBackendTests
                 "SetOptoStart:0:5",
                 "SetOptoEnd:0:7",
                 "SetOptoInvert:0:0",
+                "SetPercent:0",
                 "Run:133333");
         }
         finally
@@ -170,19 +172,26 @@ public sealed class System6NativeBackendTests
 
 
     [Fact]
-    public void FormatAlphaDebugString_MapsZeroToSpacePrintableAsciiToCharsAndNonPrintableToPlaceholder()
+    public void FormatAlphaSegments_FormatsHexAndDecimalValues()
     {
-        var text = System6NativeBackend.FormatAlphaDebugString(new byte[] { 0, 65, 31, 126 });
+        var raw = System6NativeBackend.FormatAlphaSegments(new[] { 0, 17615, -1 });
 
-        Assert.Equal(" A?~", text);
+        Assert.Equal("[0]=0x0000/0 [1]=0x44CF/17615 [2]=0xFFFF/-1", raw);
     }
 
     [Fact]
-    public void FormatAlphaRawBytes_FormatsUppercaseHexBytes()
+    public async Task StartAsyncAppliesConfiguredPercentSwitchValue()
     {
-        var raw = System6NativeBackend.FormatAlphaRawBytes(new byte[] { 0, 65, 255 });
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var request = CreateLaunchRequest(rom1, rom2);
+        request.System6NativeRoms!.PercentSwitchValue = 15;
 
-        Assert.Equal("00 41 FF", raw);
+        await backend.StartAsync(request, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Contains("SetPercent:15", library.Calls);
     }
 
     private static void AssertOrdered(IReadOnlyList<string> calls, params string[] expectedCalls)
@@ -289,6 +298,10 @@ public sealed class System6NativeBackendTests
 
         public void SetOptoInvert(byte reelNum, byte state) => Calls.Add($"SetOptoInvert:{reelNum}:{state}");
 
+        public bool IsSetPercentAvailable => true;
+
+        public void SetPercent(byte percent) => Calls.Add($"SetPercent:{percent}");
+
         public void Reset()
         {
             Calls.Add("Reset");
@@ -313,9 +326,9 @@ public sealed class System6NativeBackendTests
 
         public short GetPosOut(sbyte positionIndex) => 0;
 
-        public bool IsAlphaCharPollingAvailable => false;
+        public bool IsAlphaSegmentPollingAvailable => false;
 
-        public byte GetAlphaChar(byte index) => 0;
+        public int GetAlphaSegments(byte index) => 0;
 
         public void TurnSwitchOn(int switchIndex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -19,6 +19,7 @@ public sealed class EditorProject
 public sealed class System6NativeRomSettings
 {
     public const int DefaultReelOptoSlotCount = 8;
+    public const int DefaultPercentSwitchValue = 0;
     public List<System6ReelOptoSettings> ReelOptos { get; set; } = CreateDefaultReelOptos();
 
     public string ProgramRom1Path { get; set; } = string.Empty;
@@ -30,6 +31,7 @@ public sealed class System6NativeRomSettings
     public string SoundRom3Path { get; set; } = string.Empty;
     public string SoundRom4Path { get; set; } = string.Empty;
     public bool FlashSwitch { get; set; }
+    public int PercentSwitchValue { get; set; } = DefaultPercentSwitchValue;
 
     public IReadOnlyList<string> ProgramRomPaths => [ProgramRom1Path, ProgramRom2Path, ProgramRom3Path, ProgramRom4Path];
     public IReadOnlyList<string> SoundRomPaths => [SoundRom1Path, SoundRom2Path, SoundRom3Path, SoundRom4Path];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -28,9 +28,13 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 
     short GetPosOut(sbyte positionIndex);
 
-    bool IsAlphaCharPollingAvailable { get; }
+    bool IsAlphaSegmentPollingAvailable { get; }
 
-    byte GetAlphaChar(byte index);
+    int GetAlphaSegments(byte index);
+
+    bool IsSetPercentAvailable { get; }
+
+    void SetPercent(byte percent);
 
     void TurnSwitchOn(int switchIndex);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -33,7 +33,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly object _stateGate = new();
     private readonly int[] _lastLampValues = Enumerable.Repeat(-1, LampCount).ToArray();
     private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
-    private string? _lastAlphaString;
+    private int[]? _lastAlphaSegments;
     private bool _hasLoggedAlphaUnavailable;
 
     private ISystem6NativeLibrary? _library;
@@ -87,11 +87,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
     public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
-    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged
-    {
-        add { }
-        remove { }
-    }
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
 
     public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged
     {
@@ -129,6 +125,8 @@ public sealed class System6NativeBackend : IEmulationBackend
 
             _library = _libraryFactory(_libraryPath);
             LogStartupStage("native DLL loaded and exports bound");
+            LogStartupStage($"SYSTEM6GetAlphaSegments export {(_library.IsAlphaSegmentPollingAvailable ? "available" : "missing")}");
+            LogStartupStage($"SetPercent export {(_library.IsSetPercentAvailable ? "available" : "missing")}");
             if (startupStage is System6StartupStage.LoadBindOnly)
             {
                 return CompleteStagedStartup();
@@ -157,6 +155,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
             var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
             var reelOptos = ValidateReelOptos(nativeRoms.ReelOptos);
+            var percentSwitchValue = ValidatePercentSwitchValue(nativeRoms.PercentSwitchValue);
 
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -209,6 +208,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                 LogStartupStage("Apply reel optos starting after Reset");
                 ApplyReelOptos(_library, reelOptos);
                 LogStartupStage("Apply reel optos completed before first Run");
+                ApplyPercent(_library, percentSwitchValue);
             }
             catch (Exception ex)
             {
@@ -224,6 +224,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             {
                 var runResult = _library.Run(_cyclesPerFrame);
                 LogStartupStage($"first Run({_cyclesPerFrame}) returned {runResult}");
+                PollAlphaDebugOutput(_library);
                 return CompleteStagedStartup();
             }
 
@@ -372,29 +373,10 @@ public sealed class System6NativeBackend : IEmulationBackend
         return (int)MathF.Round(Math.Min(brightness, 255f));
     }
 
-    internal static string FormatAlphaDebugString(IReadOnlyList<byte> rawChars)
+    internal static string FormatAlphaSegments(IReadOnlyList<int> segments)
     {
-        ArgumentNullException.ThrowIfNull(rawChars);
-
-        var chars = new char[rawChars.Count];
-        for (var i = 0; i < rawChars.Count; i++)
-        {
-            var value = rawChars[i];
-            chars[i] = value switch
-            {
-                0 => ' ',
-                >= 32 and <= 126 => (char)value,
-                _ => '?'
-            };
-        }
-
-        return new string(chars);
-    }
-
-    internal static string FormatAlphaRawBytes(IReadOnlyList<byte> rawChars)
-    {
-        ArgumentNullException.ThrowIfNull(rawChars);
-        return string.Join(" ", rawChars.Select(value => value.ToString("X2", CultureInfo.InvariantCulture)));
+        ArgumentNullException.ThrowIfNull(segments);
+        return string.Join(" ", segments.Select((value, index) => $"[{index}]=0x{(value & 0xFFFF):X4}/{value.ToString(CultureInfo.InvariantCulture)}"));
     }
 
     private static void LogStartupStage(string message)
@@ -472,6 +454,16 @@ public sealed class System6NativeBackend : IEmulationBackend
         return settings;
     }
 
+    private static int ValidatePercentSwitchValue(int percentSwitchValue)
+    {
+        if (percentSwitchValue is < 0 or > 15)
+        {
+            throw new InvalidOperationException("System6 percent switch value must be between 0 and 15.");
+        }
+
+        return percentSwitchValue;
+    }
+
     private static void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
     {
         foreach (var reel in reelOptos.Where(reel => reel.Enabled))
@@ -484,6 +476,20 @@ public sealed class System6NativeBackend : IEmulationBackend
             library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
             LogStartupStage($"System6 reel {displayReelNumber} -> native index {nativeReelIndex}: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
         }
+    }
+
+    private static void ApplyPercent(ISystem6NativeLibrary library, int percentSwitchValue)
+    {
+        LogStartupStage($"SetPercent export {(library.IsSetPercentAvailable ? "available" : "missing")}");
+        LogStartupStage($"configured percent switch value = {percentSwitchValue}");
+        if (!library.IsSetPercentAvailable)
+        {
+            return;
+        }
+
+        var nativeValue = checked((byte)percentSwitchValue);
+        library.SetPercent(nativeValue);
+        LogStartupStage($"SetPercent passed value {nativeValue} (0x{nativeValue:X2}) to DLL");
     }
 
     private static IReadOnlyList<string> ValidateNativeRomPaths(IReadOnlyList<string> romPaths, bool requireFirst, string romKind)
@@ -553,41 +559,42 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private void PollAlphaDebugOutput(ISystem6NativeLibrary library)
     {
-        if (!library.IsAlphaCharPollingAvailable)
+        if (!library.IsAlphaSegmentPollingAvailable)
         {
             if (!_hasLoggedAlphaUnavailable)
             {
                 _hasLoggedAlphaUnavailable = true;
-                Debug.WriteLine("[System6 Alpha] GetAlphaChar unavailable; alpha debug polling disabled.");
+                Debug.WriteLine("[System6 Alpha] SYSTEM6GetAlphaSegments unavailable; alpha segment polling disabled.");
             }
 
             return;
         }
 
-        var rawChars = new byte[AlphaCharacterCount];
-        for (var index = 0; index < rawChars.Length; index++)
+        var segments = new int[AlphaCharacterCount];
+        for (var index = 0; index < segments.Length; index++)
         {
-            rawChars[index] = library.GetAlphaChar(checked((byte)index));
+            segments[index] = library.GetAlphaSegments(checked((byte)index));
         }
 
-        // The native TechsClass.cpp reference exposes GetAlphaChar(UINT8 num) as a raw byte.
-        // First-pass diagnostics treat printable ASCII values as characters while also logging
-        // raw byte values so we can verify whether the native core returns ASCII or display codes.
-        var alphaString = FormatAlphaDebugString(rawChars);
-        if (string.Equals(_lastAlphaString, alphaString, StringComparison.Ordinal))
+        if (_lastAlphaSegments is not null && segments.SequenceEqual(_lastAlphaSegments))
         {
             return;
         }
 
-        _lastAlphaString = alphaString;
-        Debug.WriteLine($"[System6 Alpha] chars=\"{alphaString}\" raw={FormatAlphaRawBytes(rawChars)}");
+        _lastAlphaSegments = segments;
+        Debug.WriteLine($"System6 alpha segs: {FormatAlphaSegments(segments)}");
+
+        for (var index = 0; index < segments.Length; index++)
+        {
+            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, segments[index], MameSegmentOutputType.Digiti));
+        }
     }
 
     private void ResetCachedOutputState()
     {
         Array.Fill(_lastLampValues, -1);
         Array.Fill(_lastReelPositions, int.MinValue);
-        _lastAlphaString = null;
+        _lastAlphaSegments = null;
         _hasLoggedAlphaUnavailable = false;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -18,7 +18,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6GetLampsOnDelegate _getLampsOn;
     private readonly System6GetLampBrightnessDelegate _getLampBrightness;
     private readonly System6GetPosOutDelegate _getPosOut;
-    private readonly System6GetAlphaCharDelegate? _getAlphaChar;
+    private readonly System6GetAlphaSegmentsDelegate? _getAlphaSegments;
+    private readonly System6SetPercentDelegate? _setPercent;
     private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
     private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
     private readonly List<IntPtr> _romPathBuffers = [];
@@ -45,7 +46,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _getLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
         _getLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
         _getPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
-        _getAlphaChar = TryBindOptionalExport<System6GetAlphaCharDelegate>("GetAlphaChar");
+        _getAlphaSegments = TryBindOptionalExport<System6GetAlphaSegmentsDelegate>("SYSTEM6GetAlphaSegments");
+        _setPercent = TryBindOptionalExport<System6SetPercentDelegate>("SetPercent");
         _turnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
         _turnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
     }
@@ -90,12 +92,20 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public short GetPosOut(sbyte positionIndex) => _getPosOut(positionIndex);
 
-    public bool IsAlphaCharPollingAvailable => _getAlphaChar is not null;
+    public bool IsAlphaSegmentPollingAvailable => _getAlphaSegments is not null;
 
-    public byte GetAlphaChar(byte index)
+    public int GetAlphaSegments(byte index)
     {
-        var getAlphaChar = _getAlphaChar ?? throw new NotSupportedException("System6 native core does not export GetAlphaChar.");
-        return getAlphaChar(index);
+        var getAlphaSegments = _getAlphaSegments ?? throw new NotSupportedException("System6 native core does not export SYSTEM6GetAlphaSegments.");
+        return getAlphaSegments(index);
+    }
+
+    public bool IsSetPercentAvailable => _setPercent is not null;
+
+    public void SetPercent(byte percent)
+    {
+        var setPercent = _setPercent ?? throw new NotSupportedException("System6 native core does not export SetPercent.");
+        setPercent(percent);
     }
 
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
@@ -120,7 +130,7 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         }
         catch (NativeCoreExportException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"System6 native optional export {exportName} unavailable; alpha debug polling disabled. {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"System6 native optional export {exportName} unavailable. {ex.Message}");
             return null;
         }
     }
@@ -208,7 +218,10 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     public delegate short System6GetPosOutDelegate(sbyte positionIndex);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte System6GetAlphaCharDelegate(byte index);
+    public delegate int System6GetAlphaSegmentsDelegate(byte index);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetPercentDelegate(byte percent);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6TurnSwitchOnDelegate(int switchIndex);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -64,6 +64,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _system6SoundRom3Path = string.Empty;
     private string _system6SoundRom4Path = string.Empty;
     private bool _system6FlashSwitch;
+    private int _system6PercentSwitchValue = System6NativeRomSettings.DefaultPercentSwitchValue;
     private string _system6NativeRomStatus = "Program ROM 1 and 2 are required for native DLL launch.";
     private ObservableCollection<System6ReelOptoSettingsViewModel> _system6ReelOptos = [];
     private string _mameRomStatus = "Unknown";
@@ -790,6 +791,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         set
         {
             if (SetProperty(ref _system6FlashSwitch, value))
+            {
+                SaveSystem6NativeRomSettings();
+            }
+        }
+    }
+    public int System6PercentSwitchValue
+    {
+        get => _system6PercentSwitchValue;
+        set
+        {
+            var clamped = Math.Clamp(value, 0, 15);
+            if (SetProperty(ref _system6PercentSwitchValue, clamped))
             {
                 SaveSystem6NativeRomSettings();
             }
@@ -2605,6 +2618,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom3Path = System6SoundRom3Path,
             SoundRom4Path = System6SoundRom4Path,
             FlashSwitch = System6FlashSwitch,
+            PercentSwitchValue = System6PercentSwitchValue,
             ReelOptos = System6ReelOptos.Select(reel => reel.ToModel()).ToList()
         };
         SaveLoadedProjectMetadata();
@@ -2621,12 +2635,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _system6SoundRom3Path = settings.SoundRom3Path;
         _system6SoundRom4Path = settings.SoundRom4Path;
         _system6FlashSwitch = settings.FlashSwitch;
+        _system6PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15);
         System6ReelOptos = new ObservableCollection<System6ReelOptoSettingsViewModel>((settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos()).Select(reel => new System6ReelOptoSettingsViewModel(reel, SaveSystem6NativeRomSettings)));
         OnPropertyChanged(nameof(System6ProgramRom1Path)); OnPropertyChanged(nameof(System6ProgramRom2Path));
         OnPropertyChanged(nameof(System6ProgramRom3Path)); OnPropertyChanged(nameof(System6ProgramRom4Path));
         OnPropertyChanged(nameof(System6SoundRom1Path)); OnPropertyChanged(nameof(System6SoundRom2Path));
         OnPropertyChanged(nameof(System6SoundRom3Path)); OnPropertyChanged(nameof(System6SoundRom4Path));
         OnPropertyChanged(nameof(System6FlashSwitch));
+        OnPropertyChanged(nameof(System6PercentSwitchValue));
     }
 
     private void RefreshSystem6NativeRomStatus()
@@ -2673,6 +2689,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom3Path = ResolveProjectRelativePath(settings.SoundRom3Path, LoadedProject.ProjectDirectory),
             SoundRom4Path = ResolveProjectRelativePath(settings.SoundRom4Path, LoadedProject.ProjectDirectory),
             FlashSwitch = settings.FlashSwitch,
+            PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15),
             ReelOptos = (settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos())
                 .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Enabled = reel.Enabled, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
                 .ToList()
@@ -3558,6 +3575,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         writer.WriteString("SoundRom3Path", settings.SoundRom3Path);
         writer.WriteString("SoundRom4Path", settings.SoundRom4Path);
         writer.WriteBoolean("FlashSwitch", settings.FlashSwitch);
+        writer.WriteNumber("PercentSwitchValue", Math.Clamp(settings.PercentSwitchValue, 0, 15));
         writer.WritePropertyName("ReelOptos");
         writer.WriteStartArray();
         foreach (var reel in settings.ReelOptos)
@@ -3594,6 +3612,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom3Path = GetOptionalString(romsElement, "SoundRom3Path"),
             SoundRom4Path = GetOptionalString(romsElement, "SoundRom4Path"),
             FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True,
+            PercentSwitchValue = Math.Clamp(GetOptionalInt(romsElement, "PercentSwitchValue", System6NativeRomSettings.DefaultPercentSwitchValue), 0, 15),
             ReelOptos = ResolveSystem6ReelOptoSettings(romsElement)
         };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -70,7 +70,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 1" /><TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="0" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom1Command}" Content="Browse" />
                 <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 2" /><TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="1" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom2Command}" Content="Browse" />
@@ -81,7 +81,12 @@
                 <TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 3" /><TextBox Grid.Row="6" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="6" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom3Command}" Content="Browse" />
                 <TextBlock Grid.Row="7" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 4" /><TextBox Grid.Row="7" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="7" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom4Command}" Content="Browse" />
                 <CheckBox Grid.Row="8" Grid.Column="1" Margin="0,2,0,6" Content="Flash switch" IsChecked="{Binding System6FlashSwitch}" />
-                <TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBlock Grid.Row="9" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Percent switch value" />
+                <StackPanel Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,6">
+                    <TextBox Width="80" HorizontalAlignment="Left" Text="{Binding System6PercentSwitchValue, UpdateSourceTrigger=LostFocus}" />
+                    <TextBlock Margin="0,4,0,0" Text="Native System 6 SetPercent value. Low four bits map to DLL percentage switches 8–11." Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" />
+                </StackPanel>
+                <TextBlock Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
             </Grid>
 
             <TextBlock Grid.Row="13" Margin="0,20,0,4" Text="System6 Reel Optos" Foreground="{DynamicResource TextSecondaryBrush}" />

--- a/WindowsNetProjects/OasisEditor/SYSTEM6_BOOT_DIAGNOSTICS.md
+++ b/WindowsNetProjects/OasisEditor/SYSTEM6_BOOT_DIAGNOSTICS.md
@@ -1,0 +1,31 @@
+# System 6 Boot Diagnostics
+
+## Native alpha diagnostics
+
+The native System 6 DLL export/API `GetAlphaChar` is deprecated for Oasis diagnostics because the current DLL implementation is known to return `0` from `SYSTEM6::GetAlphaChar` and does not reflect the live alpha display state.
+
+Oasis now binds and polls the native segment API `SYSTEM6GetAlphaSegments` instead. Startup/runtime diagnostic polling reads segment positions `0..15` and logs each value in both hexadecimal and decimal form, for example:
+
+```text
+System6 alpha segs: [0]=0x0000/0 [1]=0x44CF/17615 ...
+```
+
+The compact 16-position line is emitted when the alpha segment values change. If the export is missing, the startup/debug log records that alpha segment polling is disabled.
+
+## Percent switch configuration
+
+The native DLL export `SetPercent(char Percent)` is bound as an optional Native System 6 bridge call. The native implementation maps the low four bits of the supplied value onto percentage switches 8-11.
+
+Oasis stores the project-specific value in Project Settings under the Native DLL ROMs / System6 ROMs settings, alongside the existing System 6 reel opto configuration. The setting is persisted as `project_settings.System6NativeRoms.PercentSwitchValue` and is shown as **Percent switch value**. Valid values are `0..15`; the default is `0`.
+
+During Native System 6 startup, after ROM load/reset and at the same configuration stage as reel optos, Oasis logs whether `SetPercent` was found, the configured project value, and the byte value passed to the DLL.
+
+## If alpha segments remain all zero
+
+If diagnostics continue to log all zero segment values after this change, the log trail should prove that `SYSTEM6GetAlphaSegments` was successfully bound and called for positions `0..15`. Next investigation steps:
+
+1. Confirm the Native System 6 project is reaching the first run loop after ROM load and reset.
+2. Compare `SetPercent` and reel opto values with a known-working TechsClass configuration.
+3. Check whether the game requires additional door, stake/prize, meter, or DIP switch configuration before writing alpha output.
+4. Verify whether the DLL's `SYSTEM6GetAlphaSegments` export expects signed `char` indexing or another display bank selector for this specific game.
+5. If values change but render incorrectly, map the returned segment bit layout against Oasis alpha segment definitions before changing the native polling path.


### PR DESCRIPTION
### Motivation
- Native System 6 DLLs return broken/empty values from the old `GetAlphaChar` API, so diagnostics must use the correct `SYSTEM6GetAlphaSegments` export. 
- The native DLL exposes a `SetPercent(char)` export that maps low 4 bits to percentage switches and must be configurable per project during startup alongside reel opto settings. 
- Provide clear startup diagnostics and a persisted project setting so failures (all-zero segments) leave an auditable log trail for next-step investigation.

### Description
- Replaced alpha polling to use the segment API: added `IsAlphaSegmentPollingAvailable` / `GetAlphaSegments(byte)` to `ISystem6NativeLibrary` and bound `SYSTEM6GetAlphaSegments` in `System6NativeLibrary` using the existing `CallingConvention.Cdecl` delegate pattern. 
- Switched runtime/startup polling in `System6NativeBackend` to read segment indices `0..15`, log a compact 16-position line via `FormatAlphaSegments`, and emit `MachineSegmentChangedEventArgs` for each segment when values change. 
- Added optional `SetPercent` binding: `IsSetPercentAvailable` / `SetPercent(byte)` in the native bridge, validation and `ApplyPercent` call after ROM `Reset`/reel opto application, and startup logging for export availability, configured value, and byte passed. 
- Added a persisted project setting `System6NativeRoms.PercentSwitchValue` (default `0`) with `0..15` clamping, UI entry in Project Settings (`Percent switch value`) and help text, and plumbing in `MainWindowViewModel` to save/load/apply the setting alongside existing reel opto settings. 
- Kept all existing reel opto settings and application logic intact; `SetPercent` is applied in addition to, not replacing, reel opto configuration. 
- Added diagnostics doc `SYSTEM6_BOOT_DIAGNOSTICS.md` describing the deprecation of `GetAlphaChar`, the new `SYSTEM6GetAlphaSegments` diagnostics path, `SetPercent` behavior and project location, and next investigation steps. 
- Updated unit test scaffolding / fakes to reflect the new APIs and added/updated tests in `System6NativeBackendTests` for `FormatAlphaSegments` and `StartAsyncAppliesConfiguredPercentSwitchValue`.

### Testing
- No automated tests or builds were executed in this agent environment per project `AGENTS.md` rules; changes include updated unit tests that must be run locally. 
- Updated/added tests to exercise the changes: `OasisEditor.Tests:System6NativeBackendTests` (includes `FormatAlphaSegments_FormatsHexAndDecimalValues` and `StartAsyncAppliesConfiguredPercentSwitchValue`). 
- Local validation instructions: run `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln` and `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and then launch the Oasis Editor with a Native System 6 project to confirm logs show `SYSTEM6GetAlphaSegments`/`SetPercent` bindings, 16 alpha segment values at startup, and that `PercentSwitchValue` persists in Project Settings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a343c8d191c83279a8d8d9b31a0b4af)