### PR TITLE
Wire native System 6 alpha segment output

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -148,14 +148,15 @@ public sealed class MameSegmentRuntimeAdapterTests
 
 
     [Fact]
-    public void ApplySegmentState_NativeAlphaPublishesRawOasisMaskToMachineReference()
+    public void ApplySegmentState_NativeAlphaPublishesCanonicalFourteenSegmentMaskToMachineReference()
     {
         var document = CreateDocument();
         document.SetFaceElements([
             new FaceAlphaDisplayElement
             {
                 ObjectId = "face-alpha-0",
-                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0)
+                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0),
+                SegmentDisplayType = "led14seg"
             }
         ]);
         var changedFaceIds = new List<string>();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -146,6 +146,57 @@ public sealed class MameSegmentRuntimeAdapterTests
         Assert.Contains("face-seven-3", changedFaceIds);
     }
 
+
+    [Fact]
+    public void ApplySegmentState_NativeAlphaPublishesRawOasisMaskToMachineReference()
+    {
+        var document = CreateDocument();
+        document.SetFaceElements([
+            new FaceAlphaDisplayElement
+            {
+                ObjectId = "face-alpha-0",
+                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0)
+            }
+        ]);
+        var changedFaceIds = new List<string>();
+        document.FaceVisualStateChanged += changed => changedFaceIds.AddRange(changed.ObjectIds);
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, 0x8002, MameSegmentOutputType.NativeAlpha);
+
+        var dispatch = Assert.Single(dispatches);
+        dispatch();
+
+        var masks = document.RuntimeState.GetSegmentCellMasks(MachineObjectReference.AlphaDisplay(0), 16);
+        Assert.Equal(0x8002, masks[0]);
+        Assert.Contains("face-alpha-0", changedFaceIds);
+    }
+
+    [Fact]
+    public void ApplySegmentState_UnchangedNativeAlphaMaskDoesNotNotifyFaceAgain()
+    {
+        var document = CreateDocument();
+        document.SetFaceElements([
+            new FaceAlphaDisplayElement
+            {
+                ObjectId = "face-alpha-0",
+                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0)
+            }
+        ]);
+        var notifyCount = 0;
+        document.FaceVisualStateChanged += _ => notifyCount++;
+        var dispatches = new List<Action>();
+        var adapter = new MameSegmentRuntimeAdapter(() => [document], action => dispatches.Add(action));
+
+        adapter.ApplySegmentState(0, 0x1234, MameSegmentOutputType.NativeAlpha);
+        Assert.Single(dispatches)();
+        adapter.ApplySegmentState(0, 0x1234, MameSegmentOutputType.NativeAlpha);
+        Assert.Single(dispatches.Skip(1))();
+
+        Assert.Equal(1, notifyCount);
+    }
+
     private static DocumentTabViewModel CreateDocument()
     {
         var panelDocument = EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel");

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameSegmentRuntimeAdapterTests.cs
@@ -148,15 +148,14 @@ public sealed class MameSegmentRuntimeAdapterTests
 
 
     [Fact]
-    public void ApplySegmentState_NativeAlphaPublishesCanonicalFourteenSegmentMaskToMachineReference()
+    public void ApplySegmentState_NativeAlphaPublishesRawOasisMaskToMachineReference()
     {
         var document = CreateDocument();
         document.SetFaceElements([
             new FaceAlphaDisplayElement
             {
                 ObjectId = "face-alpha-0",
-                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0),
-                SegmentDisplayType = "led14seg"
+                LinkedMachineObjectReference = MachineObjectReference.AlphaDisplay(0)
             }
         ]);
         var changedFaceIds = new List<string>();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -217,7 +217,7 @@ public sealed class System6NativeBackendTests
     [Fact]
     public void System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask()
     {
-        Assert.Equal((1 << 11) | (1 << 8), System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x0180));
+        Assert.Equal(0x8003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -213,6 +213,66 @@ public sealed class System6NativeBackendTests
         Assert.Equal("[0]=0x0000/0 [1]=0x44CF/17615 [2]=0xFFFF/-1", raw);
     }
 
+
+    [Fact]
+    public void System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask()
+    {
+        Assert.Equal(0x8003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
+    }
+
+    [Fact]
+    public async Task StartAsyncOneRunOnlyPollsAlphaSegmentsAndPublishesNativeAlphaSegmentMasks()
+    {
+        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary { AlphaSegmentPollingAvailable = true };
+            library.AlphaSegments[0] = 0x0001;
+            library.AlphaSegments[1] = 0x8002;
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library);
+            var segmentEvents = new List<MachineSegmentChangedEventArgs>();
+            backend.SegmentChanged += (_, e) => segmentEvents.Add(e);
+
+            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+            await backend.StopAsync(CancellationToken.None);
+
+            Assert.Equal(Enumerable.Range(0, 16).ToArray(), library.AlphaSegmentIndices);
+            Assert.Contains(segmentEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001 && e.OutputType == MameSegmentOutputType.NativeAlpha);
+            Assert.Contains(segmentEvents, e => e.CellId == 1 && e.SegmentMask == 0x8002 && e.OutputType == MameSegmentOutputType.NativeAlpha);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsyncOneRunOnlyDoesNotPublishAlphaSegmentsWhenExportMissing()
+    {
+        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary { AlphaSegmentPollingAvailable = false };
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library);
+            var segmentEvents = new List<MachineSegmentChangedEventArgs>();
+            backend.SegmentChanged += (_, e) => segmentEvents.Add(e);
+
+            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+            await backend.StopAsync(CancellationToken.None);
+
+            Assert.Empty(library.AlphaSegmentIndices);
+            Assert.Empty(segmentEvents);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
+        }
+    }
+
     [Fact]
     public async Task StartAsyncAppliesConfiguredPercentSwitchValue()
     {
@@ -309,6 +369,12 @@ public sealed class System6NativeBackendTests
 
         public Dictionary<sbyte, short> PositionOutputs { get; } = new();
 
+        public Dictionary<byte, int> AlphaSegments { get; } = new();
+
+        public List<int> AlphaSegmentIndices { get; } = new();
+
+        public bool AlphaSegmentPollingAvailable { get; set; }
+
         public byte Initialise()
         {
             Calls.Add("Initialise");
@@ -378,9 +444,14 @@ public sealed class System6NativeBackendTests
             return PositionOutputs.TryGetValue(positionIndex, out var position) ? position : (short)0;
         }
 
-        public bool IsAlphaSegmentPollingAvailable => false;
+        public bool IsAlphaSegmentPollingAvailable => AlphaSegmentPollingAvailable;
 
-        public int GetAlphaSegments(byte index) => 0;
+        public int GetAlphaSegments(byte index)
+        {
+            Calls.Add($"GetAlphaSegments:{index}");
+            AlphaSegmentIndices.Add(index);
+            return AlphaSegments.TryGetValue(index, out var segments) ? segments : 0;
+        }
 
         public void TurnSwitchOn(int switchIndex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -217,7 +217,7 @@ public sealed class System6NativeBackendTests
     [Fact]
     public void System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask()
     {
-        Assert.Equal(0x8003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
+        Assert.Equal((1 << 11) | (1 << 8), System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x0180));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
@@ -5,26 +5,25 @@ internal static class System6AlphaSegmentMapper
     // Native System 6 DLL alpha output is already segment data, not text.
     // DLL author note: bit 0 / 0x1 is top-left outer; bit 1 / 0x2 is top-right outer;
     // numbering continues clockwise around outside first, then inside.
-    // The initial Oasis mapping targets the canonical Oasis 14-segment ordering; the runtime
-    // adapter expands that canonical mask when a 16-segment visual is selected.
+    // The initial Oasis mapping is intentionally explicit and easy to correct after visual inspection.
     private static readonly int[] NativeBitToOasisBit =
     [
-        0,  // 0x0001: outer top horizontal
-        1,  // 0x0002: outer right upper vertical
-        2,  // 0x0004: outer right lower vertical
-        3,  // 0x0008: outer bottom horizontal
-        4,  // 0x0010: outer left lower vertical
-        5,  // 0x0020: outer left upper vertical
-        6,  // 0x0040: inner left center horizontal
-        11, // 0x0080: inner up-left diagonal
-        8,  // 0x0100: inner up vertical
-        12, // 0x0200: inner up-right diagonal
-        7,  // 0x0400: inner right center horizontal
-        13, // 0x0800: inner down-right diagonal
-        9,  // 0x1000: inner down vertical
-        10, // 0x2000: inner down-left diagonal
-        14, // 0x4000: optional colon/semicolon segment
-        15  // 0x8000: optional colon/semicolon segment
+        0,  // 0x0001: top-left outer
+        1,  // 0x0002: top-right outer
+        2,  // 0x0004: right-upper outer
+        3,  // 0x0008: right-lower outer
+        4,  // 0x0010: bottom-right outer
+        5,  // 0x0020: bottom-left outer
+        6,  // 0x0040: left-lower outer
+        7,  // 0x0080: left-upper outer
+        8,  // 0x0100: inside/crossbar/diagonal segment 0
+        9,  // 0x0200: inside/crossbar/diagonal segment 1
+        10, // 0x0400: inside/crossbar/diagonal segment 2
+        11, // 0x0800: inside/crossbar/diagonal segment 3
+        12, // 0x1000: inside/crossbar/diagonal segment 4
+        13, // 0x2000: inside/crossbar/diagonal segment 5
+        14, // 0x4000: inside/crossbar/diagonal segment 6
+        15  // 0x8000: inside/crossbar/diagonal segment 7
     ];
 
     public static int MapNativeMaskToOasisMask(int nativeMask)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
@@ -1,0 +1,44 @@
+namespace OasisEditor;
+
+internal static class System6AlphaSegmentMapper
+{
+    // Native System 6 DLL alpha output is already segment data, not text.
+    // DLL author note: bit 0 / 0x1 is top-left outer; bit 1 / 0x2 is top-right outer;
+    // numbering continues clockwise around outside first, then inside.
+    // The initial Oasis mapping is intentionally explicit and easy to correct after visual inspection.
+    private static readonly int[] NativeBitToOasisBit =
+    [
+        0,  // 0x0001: top-left outer
+        1,  // 0x0002: top-right outer
+        2,  // 0x0004: right-upper outer
+        3,  // 0x0008: right-lower outer
+        4,  // 0x0010: bottom-right outer
+        5,  // 0x0020: bottom-left outer
+        6,  // 0x0040: left-lower outer
+        7,  // 0x0080: left-upper outer
+        8,  // 0x0100: inside/crossbar/diagonal segment 0
+        9,  // 0x0200: inside/crossbar/diagonal segment 1
+        10, // 0x0400: inside/crossbar/diagonal segment 2
+        11, // 0x0800: inside/crossbar/diagonal segment 3
+        12, // 0x1000: inside/crossbar/diagonal segment 4
+        13, // 0x2000: inside/crossbar/diagonal segment 5
+        14, // 0x4000: inside/crossbar/diagonal segment 6
+        15  // 0x8000: inside/crossbar/diagonal segment 7
+    ];
+
+    public static int MapNativeMaskToOasisMask(int nativeMask)
+    {
+        var mappedMask = 0;
+        for (var nativeBit = 0; nativeBit < NativeBitToOasisBit.Length; nativeBit++)
+        {
+            if ((nativeMask & (1 << nativeBit)) == 0)
+            {
+                continue;
+            }
+
+            mappedMask |= 1 << NativeBitToOasisBit[nativeBit];
+        }
+
+        return mappedMask;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6AlphaSegmentMapper.cs
@@ -5,25 +5,26 @@ internal static class System6AlphaSegmentMapper
     // Native System 6 DLL alpha output is already segment data, not text.
     // DLL author note: bit 0 / 0x1 is top-left outer; bit 1 / 0x2 is top-right outer;
     // numbering continues clockwise around outside first, then inside.
-    // The initial Oasis mapping is intentionally explicit and easy to correct after visual inspection.
+    // The initial Oasis mapping targets the canonical Oasis 14-segment ordering; the runtime
+    // adapter expands that canonical mask when a 16-segment visual is selected.
     private static readonly int[] NativeBitToOasisBit =
     [
-        0,  // 0x0001: top-left outer
-        1,  // 0x0002: top-right outer
-        2,  // 0x0004: right-upper outer
-        3,  // 0x0008: right-lower outer
-        4,  // 0x0010: bottom-right outer
-        5,  // 0x0020: bottom-left outer
-        6,  // 0x0040: left-lower outer
-        7,  // 0x0080: left-upper outer
-        8,  // 0x0100: inside/crossbar/diagonal segment 0
-        9,  // 0x0200: inside/crossbar/diagonal segment 1
-        10, // 0x0400: inside/crossbar/diagonal segment 2
-        11, // 0x0800: inside/crossbar/diagonal segment 3
-        12, // 0x1000: inside/crossbar/diagonal segment 4
-        13, // 0x2000: inside/crossbar/diagonal segment 5
-        14, // 0x4000: inside/crossbar/diagonal segment 6
-        15  // 0x8000: inside/crossbar/diagonal segment 7
+        0,  // 0x0001: outer top horizontal
+        1,  // 0x0002: outer right upper vertical
+        2,  // 0x0004: outer right lower vertical
+        3,  // 0x0008: outer bottom horizontal
+        4,  // 0x0010: outer left lower vertical
+        5,  // 0x0020: outer left upper vertical
+        6,  // 0x0040: inner left center horizontal
+        11, // 0x0080: inner up-left diagonal
+        8,  // 0x0100: inner up vertical
+        12, // 0x0200: inner up-right diagonal
+        7,  // 0x0400: inner right center horizontal
+        13, // 0x0800: inner down-right diagonal
+        9,  // 0x1000: inner down vertical
+        10, // 0x2000: inner down-left diagonal
+        14, // 0x4000: optional colon/semicolon segment
+        15  // 0x8000: optional colon/semicolon segment
     ];
 
     public static int MapNativeMaskToOasisMask(int nativeMask)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -12,7 +12,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private const int ReelCount = 16;
     private const int DiagnosticChangedLampSampleCount = 8;
     private const int DiagnosticMappingSampleCount = 8;
-    private const int AlphaCharacterCount = 16;
+    private const int AlphaCellCount = 16;
     private const int SupportedReelOptoCount = 8;
     private const string DiagnosticStageEnvironmentVariable = "OASIS_SYSTEM6_STARTUP_STAGE";
     private static readonly TimeSpan SlowRunWarningThreshold = TimeSpan.FromMilliseconds(250);
@@ -639,10 +639,12 @@ public sealed class System6NativeBackend : IEmulationBackend
             return;
         }
 
-        var segments = new int[AlphaCharacterCount];
+        var segments = new int[AlphaCellCount];
+        var mappedSegments = new int[AlphaCellCount];
         for (var index = 0; index < segments.Length; index++)
         {
             segments[index] = library.GetAlphaSegments(checked((byte)index));
+            mappedSegments[index] = System6AlphaSegmentMapper.MapNativeMaskToOasisMask(segments[index]);
         }
 
         if (_lastAlphaSegments is not null && segments.SequenceEqual(_lastAlphaSegments))
@@ -652,10 +654,12 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         _lastAlphaSegments = segments;
         Debug.WriteLine($"System6 alpha segs: {FormatAlphaSegments(segments)}");
+        Debug.WriteLine($"System6 alpha mapped segs: {FormatAlphaSegments(mappedSegments)}");
 
         for (var index = 0; index < segments.Length; index++)
         {
-            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, segments[index], MameSegmentOutputType.Digiti));
+            Debug.WriteLine($"System6 alpha cell {index} raw=0x{(segments[index] & 0xFFFF):X4} mapped=0x{(mappedSegments[index] & 0xFFFF):X4}");
+            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, mappedSegments[index], MameSegmentOutputType.NativeAlpha));
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -98,6 +98,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private readonly IEmulationBackendFactory _emulationBackendFactory;
     private readonly IMameLampRuntimeAdapter _lampRuntimeAdapter;
     private readonly IMameReelRuntimeAdapter _reelRuntimeAdapter;
+    private readonly IMameSegmentRuntimeAdapter _segmentRuntimeAdapter;
     private IEmulationBackend? _activeEmulationBackend;
     private readonly IMameDebuggerService _mameDebuggerService;
     private readonly MameDebuggerShellViewModel _mameDebuggerShell;
@@ -299,16 +300,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => DebugOutputStdOut,
             message => AddOutputEntry(message, OutputLogStatus.Info),
             DispatchToUiThread);
+        _segmentRuntimeAdapter = new MameSegmentRuntimeAdapter(
+            () => OpenDocuments,
+            DispatchToUiThread,
+            () => SelectedFruitMachinePlatform);
         var mameStdoutParser = new MameStdoutParser(
             new MameLampStateParser(),
             _lampRuntimeAdapter,
             new MameReelStateParser(),
             _reelRuntimeAdapter,
             new MameSegmentStateParser(),
-            new MameSegmentRuntimeAdapter(
-                () => OpenDocuments,
-                DispatchToUiThread,
-                () => SelectedFruitMachinePlatform),
+            _segmentRuntimeAdapter,
             platformProvider: () => SelectedFruitMachinePlatform,
             vfdDotMatrixStateParser: new MameVfdDotMatrixStateParser(),
             vfdDotMatrixRuntimeAdapter: new MameVfdDotMatrixRuntimeAdapter(
@@ -2556,6 +2558,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         backend.StateChanged += OnActiveBackendStateChanged;
         backend.LampChanged += OnActiveBackendLampChanged;
         backend.ReelChanged += OnActiveBackendReelChanged;
+        backend.SegmentChanged += OnActiveBackendSegmentChanged;
         try
         {
             await backend.StartAsync(BuildEmulationLaunchRequest(), cancellationToken).ConfigureAwait(false);
@@ -2566,6 +2569,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             backend.StateChanged -= OnActiveBackendStateChanged;
             backend.LampChanged -= OnActiveBackendLampChanged;
             backend.ReelChanged -= OnActiveBackendReelChanged;
+            backend.SegmentChanged -= OnActiveBackendSegmentChanged;
             await backend.DisposeAsync().ConfigureAwait(false);
             _activeEmulationBackend = null;
             throw;
@@ -2724,6 +2728,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _reelRuntimeAdapter.ApplyReelState(e.ReelId, e.Position);
     }
 
+    private void OnActiveBackendSegmentChanged(object? sender, MachineSegmentChangedEventArgs e)
+    {
+        _segmentRuntimeAdapter.ApplySegmentState(e.CellId, e.SegmentMask, e.OutputType);
+    }
+
     private void OnActiveBackendStateChanged(object? sender, EmulationBackendState state)
     {
         DispatchToUiThread(() =>
@@ -2817,6 +2826,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 _activeEmulationBackend.StateChanged -= OnActiveBackendStateChanged;
                 _activeEmulationBackend.LampChanged -= OnActiveBackendLampChanged;
                 _activeEmulationBackend.ReelChanged -= OnActiveBackendReelChanged;
+                _activeEmulationBackend.SegmentChanged -= OnActiveBackendSegmentChanged;
                 _activeEmulationBackend.DisposeAsync().AsTask().GetAwaiter().GetResult();
                 _activeEmulationBackend = null;
                 _playViewInputRouter = null;
@@ -2855,6 +2865,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 _activeEmulationBackend.StateChanged -= OnActiveBackendStateChanged;
                 _activeEmulationBackend.LampChanged -= OnActiveBackendLampChanged;
                 _activeEmulationBackend.ReelChanged -= OnActiveBackendReelChanged;
+                _activeEmulationBackend.SegmentChanged -= OnActiveBackendSegmentChanged;
                 await _activeEmulationBackend.DisposeAsync();
                 _activeEmulationBackend = null;
                 _playViewInputRouter = null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -270,8 +270,23 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private int NormalizeAlphaMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType, int cellId)
     {
         return _latestNativeAlphaCells.Contains(cellId)
-            ? rawMask
+            ? NormalizeNativeAlphaMaskForSelectedDisplayType(rawMask, segmentDisplayType)
             : NormalizeMameMaskForSelectedDisplayType(rawMask, segmentDisplayType);
+    }
+
+    private static int NormalizeNativeAlphaMaskForSelectedDisplayType(int canonicalFourteenSegmentMask, string? segmentDisplayType)
+    {
+        var displayType = string.IsNullOrWhiteSpace(segmentDisplayType)
+            ? "led16seg"
+            : segmentDisplayType.Trim();
+
+        return displayType.ToLowerInvariant() switch
+        {
+            "led14seg" => canonicalFourteenSegmentMask & 0x3FFF,
+            "led14segsc" => canonicalFourteenSegmentMask & 0xFFFF,
+            "led16segsc" => ExpandFourteenSegmentSourceToSixteenSegmentTarget(canonicalFourteenSegmentMask) & 0x3FFFF,
+            _ => ExpandFourteenSegmentSourceToSixteenSegmentTarget(canonicalFourteenSegmentMask) & 0xFFFF
+        };
     }
 
     private static int NormalizeMameMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -12,6 +12,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private readonly Dictionary<int, int> _latestVfdMasksByCell = new();
     private readonly Dictionary<int, int> _latestDigitMasksByCell = new();
     private readonly Dictionary<int, double> _latestVfdBrightnessByDisplay = new();
+    private readonly HashSet<int> _latestNativeAlphaCells = new();
     private bool _uiUpdateScheduled;
 
     public MameSegmentRuntimeAdapter(
@@ -70,9 +71,17 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
             foreach (var (cellId, state) in snapshot)
             {
-                if (state.OutputType == MameSegmentOutputType.Vfd)
+                if (state.OutputType == MameSegmentOutputType.Vfd || state.OutputType == MameSegmentOutputType.NativeAlpha)
                 {
                     _latestVfdMasksByCell[cellId] = state.Mask;
+                    if (state.OutputType == MameSegmentOutputType.NativeAlpha)
+                    {
+                        _latestNativeAlphaCells.Add(cellId);
+                    }
+                    else
+                    {
+                        _latestNativeAlphaCells.Remove(cellId);
+                    }
                 }
                 else
                 {
@@ -92,7 +101,9 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                 var cellCount = element.Kind == PanelElementKind.SevenSegment ? 1 : 16;
                 var cellMasks = new int[cellCount];
                 var cellBrightness = new double[cellCount];
-                var reversePlatformAlphaCells = element.Kind == PanelElementKind.Alpha && RequiresPlatformAlphaCellReversal(_platformProvider());
+                var reversePlatformAlphaCells = element.Kind == PanelElementKind.Alpha
+                    && RequiresPlatformAlphaCellReversal(_platformProvider())
+                    && !HasNativeAlphaCells(baseIndex, cellMasks.Length);
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
                     var source = element.Kind == PanelElementKind.SevenSegment ? _latestDigitMasksByCell : _latestVfdMasksByCell;
@@ -101,7 +112,7 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
                     {
                         cellMasks[i] = element.Kind == PanelElementKind.SevenSegment
                             ? mask
-                            : NormalizeMameMaskForSelectedDisplayType(mask, element.SegmentDisplayType);
+                            : NormalizeAlphaMaskForSelectedDisplayType(mask, element.SegmentDisplayType, baseIndex + sourceOffset);
                     }
 
                     if (element.Kind == PanelElementKind.Alpha && _latestVfdBrightnessByDisplay.TryGetValue(baseIndex, out var brightness))
@@ -170,13 +181,14 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
 
                 var cellMasks = new int[16];
                 var cellBrightness = new double[16];
-                var reversePlatformAlphaCells = RequiresPlatformAlphaCellReversal(_platformProvider());
+                var reversePlatformAlphaCells = RequiresPlatformAlphaCellReversal(_platformProvider())
+                    && !HasNativeAlphaCells(baseIndex, cellMasks.Length);
                 for (var i = 0; i < cellMasks.Length; i++)
                 {
                     var sourceOffset = reversePlatformAlphaCells ? cellMasks.Length - 1 - i : i;
                     if (_latestVfdMasksByCell.TryGetValue(baseIndex + sourceOffset, out var mask))
                     {
-                        cellMasks[i] = NormalizeMameMaskForSelectedDisplayType(mask, faceDisplay.SegmentDisplayType);
+                        cellMasks[i] = NormalizeAlphaMaskForSelectedDisplayType(mask, faceDisplay.SegmentDisplayType, baseIndex + sourceOffset);
                     }
 
                     cellBrightness[i] = _latestVfdBrightnessByDisplay.TryGetValue(baseIndex, out var brightness)
@@ -230,6 +242,19 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
         return element.DisplayNumber.GetValueOrDefault(0);
     }
 
+    private bool HasNativeAlphaCells(int baseIndex, int cellCount)
+    {
+        for (var offset = 0; offset < cellCount; offset++)
+        {
+            if (_latestNativeAlphaCells.Contains(baseIndex + offset))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool RequiresPlatformAlphaCellReversal(FruitMachinePlatformType platform)
     {
         return platform switch
@@ -240,6 +265,13 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
             FruitMachinePlatformType.Impact => true,
             _ => false
         };
+    }
+
+    private int NormalizeAlphaMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType, int cellId)
+    {
+        return _latestNativeAlphaCells.Contains(cellId)
+            ? rawMask
+            : NormalizeMameMaskForSelectedDisplayType(rawMask, segmentDisplayType);
     }
 
     private static int NormalizeMameMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentRuntimeAdapter.cs
@@ -270,23 +270,8 @@ public sealed class MameSegmentRuntimeAdapter : IMameSegmentRuntimeAdapter
     private int NormalizeAlphaMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType, int cellId)
     {
         return _latestNativeAlphaCells.Contains(cellId)
-            ? NormalizeNativeAlphaMaskForSelectedDisplayType(rawMask, segmentDisplayType)
+            ? rawMask
             : NormalizeMameMaskForSelectedDisplayType(rawMask, segmentDisplayType);
-    }
-
-    private static int NormalizeNativeAlphaMaskForSelectedDisplayType(int canonicalFourteenSegmentMask, string? segmentDisplayType)
-    {
-        var displayType = string.IsNullOrWhiteSpace(segmentDisplayType)
-            ? "led16seg"
-            : segmentDisplayType.Trim();
-
-        return displayType.ToLowerInvariant() switch
-        {
-            "led14seg" => canonicalFourteenSegmentMask & 0x3FFF,
-            "led14segsc" => canonicalFourteenSegmentMask & 0xFFFF,
-            "led16segsc" => ExpandFourteenSegmentSourceToSixteenSegmentTarget(canonicalFourteenSegmentMask) & 0x3FFFF,
-            _ => ExpandFourteenSegmentSourceToSixteenSegmentTarget(canonicalFourteenSegmentMask) & 0xFFFF
-        };
     }
 
     private static int NormalizeMameMaskForSelectedDisplayType(int rawMask, string? segmentDisplayType)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameSegmentStateParser.cs
@@ -10,7 +10,8 @@ public enum MameSegmentOutputType
 {
     Digit,
     Digiti,
-    Vfd
+    Vfd,
+    NativeAlpha
 }
 
 public sealed class MameSegmentStateParser : IMameSegmentStateParser


### PR DESCRIPTION
### Motivation
- Native System 6 DLLs provide alpha displays as raw segment bitmasks (not characters) and the codebase must stop treating this output as text and instead render the segment bits.
- The runtime must receive these native segment masks and feed them into the existing segment/alpha rendering pipeline so Face views light the correct segments.
- Provide clear diagnostics and an easy-to-edit mapping layer so the bit-order can be adjusted quickly after visual inspection.

### Description
- Poll `SYSTEM6GetAlphaSegments` for positions `0..15` and treat the returned `int` as a raw segment bitmask rather than as characters in `System6NativeBackend.PollAlphaDebugOutput` and publish mapped masks via `SegmentChanged` events with a new `MameSegmentOutputType.NativeAlpha` output type.
- Add `System6AlphaSegmentMapper` with an explicit `NativeBitToOasisBit` lookup and a `MapNativeMaskToOasisMask(int)` function to map DLL bit ordering into Oasis/MAME segment bit ordering.
- Route backend `SegmentChanged` events into the existing adapter by subscribing `MainWindowViewModel` to `SegmentChanged` and forwarding events to `MameSegmentRuntimeAdapter.ApplySegmentState`, preserving existing `MachineRuntimeState` -> Face renderer flow.
- Extend `MameSegmentRuntimeAdapter` to recognize `NativeAlpha` output and treat native-mapped masks as already-corrected Oasis masks (skip VFD normalization/reversal), add a `_latestNativeAlphaCells` set to track native cells, and add `NormalizeAlphaMaskForSelectedDisplayType` and `HasNativeAlphaCells` helpers to avoid reprocessing native-mapped cells.
- Add detailed diagnostics: compact `System6 alpha segs` line and per-cell `System6 alpha cell N raw=0x.... mapped=0x....` entries when values change.
- Add unit tests that verify the mapper and native alpha behavior, including `System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask`, `StartAsyncOneRunOnlyPollsAlphaSegmentsAndPublishesNativeAlphaSegmentMasks`, `StartAsyncOneRunOnlyDoesNotPublishAlphaSegmentsWhenExportMissing`, `ApplySegmentState_NativeAlphaPublishesRawOasisMaskToMachineReference`, and `ApplySegmentState_UnchangedNativeAlphaMaskDoesNotNotifyFaceAgain`.

### Testing
- No automated tests were executed in this environment per repository `AGENTS.md` constraints; the change adds unit tests under `OasisEditor.Tests` covering mapper correctness and end-to-end native alpha polling/publication.
- Tests added: `System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask`, `StartAsyncOneRunOnlyPollsAlphaSegmentsAndPublishesNativeAlphaSegmentMasks`, `StartAsyncOneRunOnlyDoesNotPublishAlphaSegmentsWhenExportMissing`, `ApplySegmentState_NativeAlphaPublishesRawOasisMaskToMachineReference`, and `ApplySegmentState_UnchangedNativeAlphaMaskDoesNotNotifyFaceAgain` (please run `dotnet test` locally to verify).
- Local validation performed in this agent: `git diff --check` and repository status checks completed successfully; recommend running the full Windows/.NET build and test suite locally to confirm everything passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3452065d5483278c63bf34dd77e18a)