### PR TITLE
Update System 6 alpha segment test expectations

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -217,7 +217,7 @@ public sealed class System6NativeBackendTests
     [Fact]
     public void System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask()
     {
-        Assert.Equal(0x8003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
+        Assert.Equal(0x2003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
     }
 
     [Fact]
@@ -240,7 +240,7 @@ public sealed class System6NativeBackendTests
 
             Assert.Equal(Enumerable.Range(0, 16).ToArray(), library.AlphaSegmentIndices);
             Assert.Contains(segmentEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001 && e.OutputType == MameSegmentOutputType.NativeAlpha);
-            Assert.Contains(segmentEvents, e => e.CellId == 1 && e.SegmentMask == 0x8002 && e.OutputType == MameSegmentOutputType.NativeAlpha);
+            Assert.Contains(segmentEvents, e => e.CellId == 1 && e.SegmentMask == 0x2002 && e.OutputType == MameSegmentOutputType.NativeAlpha);
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- The native-to-Oasis alpha segment bit mapping in `System6AlphaSegmentMapper` was corrected so the tests that asserted the previous (incorrect) expected masks needed to be updated to match the remapped values.

### Description
- Updated two assertions in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs` to expect the corrected Oasis masks (`0x2003` for input `0x8003`, and `0x2002` for input `0x8002`).

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues (passed); no unit test run was performed here due to the environment constraints described in `AGENTS.md`, so please run `dotnet test` locally to verify all tests (including `OasisEditor.Tests`) pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a363ba6b19c8327bf1a67976468c217)