### PR TITLE
Add Native project settings sub-tabs (ROMS / Stake/Prize / Reels)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -53,6 +53,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameValidationSummary = "Not validated.";
     private string _selectedPreferencesCategory = "Appearance";
     private string _selectedProjectSettingsCategory = "General";
+    private string _selectedNativeProjectSettingsTab = "ROMS";
     private FruitMachinePlatformType _selectedFruitMachinePlatform = FruitMachinePlatformType.None;
     private string _mameRomName = string.Empty;
     private bool _automaticallyDownloadMissingRoms = true;
@@ -564,6 +565,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
     public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME", "Native Emulation"];
     public IReadOnlyList<string> ProjectSettingsCategories { get; } = ["General", "MAME", "Native"];
+    public IReadOnlyList<string> NativeProjectSettingsTabs { get; } = ["ROMS", "Stake/Prize", "Reels"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
     public IReadOnlyList<InputDefinitionModel> InputDefinitions => LoadedProject?.InputDefinitions ?? [];
     public IReadOnlyList<InputMapDiagnostic> InputMapDiagnostics
@@ -853,6 +855,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     {
         get => _selectedProjectSettingsCategory;
         set => SetProperty(ref _selectedProjectSettingsCategory, value);
+    }
+
+    public string SelectedNativeProjectSettingsTab
+    {
+        get => _selectedNativeProjectSettingsTab;
+        set => SetProperty(ref _selectedNativeProjectSettingsTab, value);
     }
 
     public string StatusMessage

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -83,9 +83,9 @@
                 </StackPanel>
             </ScrollViewer>
 
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <ScrollViewer.Style>
-                    <Style TargetType="ScrollViewer">
+            <Grid>
+                <Grid.Style>
+                    <Style TargetType="Grid">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding SelectedProjectSettingsCategory}" Value="Native">
@@ -93,62 +93,117 @@
                                 </DataTrigger>
                             </Style.Triggers>
                     </Style>
-                </ScrollViewer.Style>
-                <StackPanel>
-                    <TextBlock FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Native" />
+                </Grid.Style>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
-                    <TextBlock Margin="0,16,0,4" Text="Native DLL ROMs / System6 ROMs" Foreground="{DynamicResource TextSecondaryBrush}" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="120" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 1" /><TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="0" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom1Command}" Content="Browse" />
-                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 2" /><TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="1" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom2Command}" Content="Browse" />
-                        <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 3" /><TextBox Grid.Row="2" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="2" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom3Command}" Content="Browse" />
-                        <TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 4" /><TextBox Grid.Row="3" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="3" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom4Command}" Content="Browse" />
-                        <TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 1" /><TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="4" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom1Command}" Content="Browse" />
-                        <TextBlock Grid.Row="5" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 2" /><TextBox Grid.Row="5" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="5" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom2Command}" Content="Browse" />
-                        <TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 3" /><TextBox Grid.Row="6" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="6" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom3Command}" Content="Browse" />
-                        <TextBlock Grid.Row="7" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 4" /><TextBox Grid.Row="7" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="7" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom4Command}" Content="Browse" />
-                        <CheckBox Grid.Row="8" Grid.Column="1" Margin="0,2,0,6" Content="Flash switch" IsChecked="{Binding System6FlashSwitch}" />
-                        <TextBlock Grid.Row="9" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Percent switch value" />
-                        <StackPanel Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,0,0,6">
-                            <TextBox Width="80" HorizontalAlignment="Left" Text="{Binding System6PercentSwitchValue, UpdateSourceTrigger=LostFocus}" />
-                            <TextBlock Margin="0,4,0,0" Text="Native System 6 SetPercent value. Low four bits map to DLL percentage switches 8–11." Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" />
-                        </StackPanel>
-                        <TextBlock Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
-                    </Grid>
+                <TextBlock Grid.Row="0" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Native" />
+                <ListBox Grid.Row="1"
+                         Margin="0,14,0,12"
+                         ItemsSource="{Binding NativeProjectSettingsTabs}"
+                         SelectedItem="{Binding SelectedNativeProjectSettingsTab, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                </ListBox>
 
-                    <TextBlock Margin="0,20,0,4" Text="System6 Reel Optos" Foreground="{DynamicResource TextSecondaryBrush}" />
-                    <DataGrid ItemsSource="{Binding System6ReelOptos}"
-                              AutoGenerateColumns="False"
-                              CanUserAddRows="False"
-                              CanUserDeleteRows="False"
-                              HeadersVisibility="Column"
-                              MaxHeight="260">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Reel" Binding="{Binding ReelNumber}" IsReadOnly="True" Width="80" />
-                            <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="90" />
-                            <DataGridTextColumn Header="Steps" Binding="{Binding Steps, UpdateSourceTrigger=LostFocus}" Width="100" />
-                            <DataGridTextColumn Header="Opto Start" Binding="{Binding OptoStart, UpdateSourceTrigger=LostFocus}" Width="120" />
-                            <DataGridTextColumn Header="Opto End" Binding="{Binding OptoEnd, UpdateSourceTrigger=LostFocus}" Width="120" />
-                            <DataGridCheckBoxColumn Header="Inverted" Binding="{Binding OptoInvert, UpdateSourceTrigger=PropertyChanged}" Width="100" />
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    <Button Margin="0,8,0,0"
-                            HorizontalAlignment="Left"
-                            Padding="10,2"
-                            Command="{Binding ResetSystem6ReelOptosCommand}"
-                            Content="Reset Reel Optos To Defaults" />
-                </StackPanel>
-            </ScrollViewer>
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                    <ScrollViewer.Style>
+                        <Style TargetType="ScrollViewer">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedNativeProjectSettingsTab}" Value="ROMS">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ScrollViewer.Style>
+                    <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="Native DLL ROMs / System6 ROMs" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="120" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 1" /><TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="0" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom1Command}" Content="Browse" />
+                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 2" /><TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="1" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom2Command}" Content="Browse" />
+                            <TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 3" /><TextBox Grid.Row="2" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="2" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom3Command}" Content="Browse" />
+                            <TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Program ROM 4" /><TextBox Grid.Row="3" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6ProgramRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="3" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6ProgramRom4Command}" Content="Browse" />
+                            <TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 1" /><TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom1Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="4" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom1Command}" Content="Browse" />
+                            <TextBlock Grid.Row="5" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 2" /><TextBox Grid.Row="5" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom2Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="5" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom2Command}" Content="Browse" />
+                            <TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 3" /><TextBox Grid.Row="6" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom3Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="6" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom3Command}" Content="Browse" />
+                            <TextBlock Grid.Row="7" Grid.Column="0" Margin="0,0,8,6" VerticalAlignment="Center" Text="Sound ROM 4" /><TextBox Grid.Row="7" Grid.Column="1" Margin="0,0,8,6" Text="{Binding System6SoundRom4Path, UpdateSourceTrigger=LostFocus}" /><Button Grid.Row="7" Grid.Column="2" Margin="0,0,0,6" Padding="10,2" Command="{Binding BrowseSystem6SoundRom4Command}" Content="Browse" />
+                            <CheckBox Grid.Row="8" Grid.Column="1" Margin="0,2,0,6" Content="Flash switch" IsChecked="{Binding System6FlashSwitch}" />
+                            <TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding System6NativeRomStatus, StringFormat=Status: {0}}" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        </Grid>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                    <ScrollViewer.Style>
+                        <Style TargetType="ScrollViewer">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedNativeProjectSettingsTab}" Value="Stake/Prize">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ScrollViewer.Style>
+                    <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="Percent switch value" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <TextBox Width="80" HorizontalAlignment="Left" Text="{Binding System6PercentSwitchValue, UpdateSourceTrigger=LostFocus}" />
+                        <TextBlock Margin="0,4,0,0" Text="Native System 6 SetPercent value. Low four bits map to DLL percentage switches 8–11." Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" />
+                    </StackPanel>
+                </ScrollViewer>
+
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                    <ScrollViewer.Style>
+                        <Style TargetType="ScrollViewer">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedNativeProjectSettingsTab}" Value="Reels">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ScrollViewer.Style>
+                    <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="System6 Reel Optos" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <DataGrid ItemsSource="{Binding System6ReelOptos}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  HeadersVisibility="Column"
+                                  MaxHeight="260">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Reel" Binding="{Binding ReelNumber}" IsReadOnly="True" Width="80" />
+                                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="90" />
+                                <DataGridTextColumn Header="Steps" Binding="{Binding Steps, UpdateSourceTrigger=LostFocus}" Width="100" />
+                                <DataGridTextColumn Header="Opto Start" Binding="{Binding OptoStart, UpdateSourceTrigger=LostFocus}" Width="120" />
+                                <DataGridTextColumn Header="Opto End" Binding="{Binding OptoEnd, UpdateSourceTrigger=LostFocus}" Width="120" />
+                                <DataGridCheckBoxColumn Header="Inverted" Binding="{Binding OptoInvert, UpdateSourceTrigger=PropertyChanged}" Width="100" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <Button Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                Padding="10,2"
+                                Command="{Binding ResetSystem6ReelOptosCommand}"
+                                Content="Reset Reel Optos To Defaults" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Split the large Native settings column into logical sub-tabs so the Native pane is easier to navigate and can be extended later. 
- Preserve the existing left Project Settings sidebar and all existing bindings, commands and persisted property names. 

### Description
- Added view-model tab state: `IReadOnlyList<string> NativeProjectSettingsTabs = ["ROMS", "Stake/Prize", "Reels"]` and `string SelectedNativeProjectSettingsTab` with default `"ROMS"` in `MainWindowViewModel.cs`.
- Reworked the Native right-hand pane in `ProjectSettingsView.xaml` to render a top horizontal tab selector bound to `NativeProjectSettingsTabs` and `SelectedNativeProjectSettingsTab` and to show tab content via three `ScrollViewer` panes triggered by the selected tab.
- Moved existing Native controls into the new tabs without renaming or altering bindings: ROM paths, browse commands, `System6FlashSwitch` and `System6NativeRomStatus` are in ROMS; `System6PercentSwitchValue` and explanatory text are in Stake/Prize; `System6ReelOptos` DataGrid and `ResetSystem6ReelOptosCommand` are in Reels.
- No persisted project property names or save/load logic were changed and all original bindings/commands were preserved.

### Testing
- Parsed the edited XAML with `xml.etree.ElementTree` (`ET.parse('WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml')`) and it succeeded. 
- Ran `git diff --check` to ensure no trailing whitespace or simple diff issues and it reported no problems. 
- WPF/.NET build and runtime UI verification were not run in this environment per repository guidance, so a local build and manual UI check should be performed to confirm visual layout and command interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3643b62d548327a30636899ab2678d)