### PR TITLE
Add native System 6 coin settings

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -71,6 +71,48 @@ public sealed class System6NativeBackendTests
         Assert.Equal(7, eighthReel.ToModel().ReelIndex);
     }
 
+
+    [Fact]
+    public async Task StartAsyncAppliesOnlyEnabledNativeCoinRows()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var request = CreateLaunchRequest(rom1, rom2);
+        request.System6NativeRoms!.Coins[0].Enabled = true;
+        request.System6NativeRoms.Coins[0].Name = "10p";
+        request.System6NativeRoms.Coins[0].Num = 2;
+        request.System6NativeRoms.Coins[0].Coin = 3;
+        request.System6NativeRoms.Coins[0].CoinValue = 10;
+        request.System6NativeRoms.Coins[0].CoinEnable = 1;
+        request.System6NativeRoms.Coins[0].LockoutValue = 4;
+        request.System6NativeRoms.Coins[0].LockoutInvert = 5;
+        request.System6NativeRoms.Coins[0].CounterIn = 6;
+        request.System6NativeRoms.Coins[0].CounterOut = 7;
+        request.System6NativeRoms.Coins[0].PortIndex = 8;
+        request.System6NativeRoms.Coins[0].Level = 9;
+        request.System6NativeRoms.Coins[0].FullLevel = 10;
+        request.System6NativeRoms.Coins[1].Enabled = false;
+        request.System6NativeRoms.Coins[1].Num = 9;
+
+        await backend.StartAsync(request, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Contains("SetCoinEnable:2:3:1", library.Calls);
+        Assert.Contains("SetCoinValue:2:3:10", library.Calls);
+        Assert.Contains("SetLockoutVal:2:3:4", library.Calls);
+        Assert.Contains("SetLockoutInvert:2:3:5", library.Calls);
+        Assert.Contains("SetEnable:2:1", library.Calls);
+        Assert.Contains("SetCounterIn:2:6", library.Calls);
+        Assert.Contains("SetCounterOut:2:7", library.Calls);
+        Assert.Contains("SetPortIndex:2:8", library.Calls);
+        Assert.Contains("SetCoin:2:3", library.Calls);
+        Assert.Contains("SetLevel:2:9", library.Calls);
+        Assert.Contains("SetFullLevel:2:10", library.Calls);
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetCoinEnable:9:", StringComparison.Ordinal));
+        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetEnable:9:", StringComparison.Ordinal));
+    }
+
     [Fact]
     public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
     {
@@ -453,6 +495,28 @@ public sealed class System6NativeBackendTests
         public bool IsSetPercentAvailable => true;
 
         public void SetPercent(byte percent) => Calls.Add($"SetPercent:{percent}");
+
+        public void SetCoinEnable(byte num, byte coin, byte coinEnable) => Calls.Add($"SetCoinEnable:{num}:{coin}:{coinEnable}");
+
+        public void SetCoinValue(byte num, byte coin, byte coinValue) => Calls.Add($"SetCoinValue:{num}:{coin}:{coinValue}");
+
+        public void SetLockoutVal(byte num, byte coin, byte lockoutValue) => Calls.Add($"SetLockoutVal:{num}:{coin}:{lockoutValue}");
+
+        public void SetLockoutInvert(byte num, byte coin, byte lockoutInvert) => Calls.Add($"SetLockoutInvert:{num}:{coin}:{lockoutInvert}");
+
+        public void SetEnable(byte num, byte enable) => Calls.Add($"SetEnable:{num}:{enable}");
+
+        public void SetCounterIn(byte num, byte counterIn) => Calls.Add($"SetCounterIn:{num}:{counterIn}");
+
+        public void SetCounterOut(byte num, byte counterOut) => Calls.Add($"SetCounterOut:{num}:{counterOut}");
+
+        public void SetPortIndex(byte num, byte portIndex) => Calls.Add($"SetPortIndex:{num}:{portIndex}");
+
+        public void SetCoin(byte num, byte coin) => Calls.Add($"SetCoin:{num}:{coin}");
+
+        public void SetLevel(byte num, byte level) => Calls.Add($"SetLevel:{num}:{level}");
+
+        public void SetFullLevel(byte num, byte fullLevel) => Calls.Add($"SetFullLevel:{num}:{fullLevel}");
 
         public void Reset()
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -19,8 +19,10 @@ public sealed class EditorProject
 public sealed class System6NativeRomSettings
 {
     public const int DefaultReelOptoSlotCount = 8;
+    public const int DefaultCoinSlotCount = 4;
     public const int DefaultPercentSwitchValue = 0;
     public List<System6ReelOptoSettings> ReelOptos { get; set; } = CreateDefaultReelOptos();
+    public List<System6CoinSettings> Coins { get; set; } = CreateDefaultCoins();
 
     public string ProgramRom1Path { get; set; } = string.Empty;
     public string ProgramRom2Path { get; set; } = string.Empty;
@@ -45,6 +47,17 @@ public sealed class System6NativeRomSettings
         }
 
         return reelOptos;
+    }
+
+    public static List<System6CoinSettings> CreateDefaultCoins()
+    {
+        var coins = new List<System6CoinSettings>(DefaultCoinSlotCount);
+        for (var coinIndex = 0; coinIndex < DefaultCoinSlotCount; coinIndex++)
+        {
+            coins.Add(System6CoinSettings.CreateDefault(coinIndex));
+        }
+
+        return coins;
     }
 }
 
@@ -71,5 +84,42 @@ public sealed class System6ReelOptoSettings
         OptoStart = DefaultOptoStart,
         OptoEnd = DefaultOptoEnd,
         OptoInvert = DefaultOptoInvert
+    };
+}
+
+
+public sealed class System6CoinSettings
+{
+    public const bool DefaultEnabled = false;
+    public const int DefaultCoin = 0;
+    public const int DefaultCoinValue = 0;
+    public const int DefaultCoinEnable = 1;
+    public const int DefaultLockoutValue = 0;
+    public const int DefaultLockoutInvert = 0;
+
+    public string Name { get; set; } = string.Empty;
+    public bool Enabled { get; set; } = DefaultEnabled;
+    public int Num { get; set; }
+    public int Coin { get; set; } = DefaultCoin;
+    public int CoinValue { get; set; } = DefaultCoinValue;
+    public int CoinEnable { get; set; } = DefaultCoinEnable;
+    public int LockoutValue { get; set; } = DefaultLockoutValue;
+    public int LockoutInvert { get; set; } = DefaultLockoutInvert;
+    public int CounterIn { get; set; }
+    public int CounterOut { get; set; }
+    public int PortIndex { get; set; }
+    public int Level { get; set; }
+    public int FullLevel { get; set; }
+
+    public static System6CoinSettings CreateDefault(int coinIndex) => new()
+    {
+        Name = $"Coin {coinIndex + 1}",
+        Enabled = DefaultEnabled,
+        Num = coinIndex,
+        Coin = DefaultCoin,
+        CoinValue = DefaultCoinValue,
+        CoinEnable = DefaultCoinEnable,
+        LockoutValue = DefaultLockoutValue,
+        LockoutInvert = DefaultLockoutInvert
     };
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -46,6 +46,28 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
 
     void SetPercent(byte percent);
 
+    void SetCoinEnable(byte num, byte coin, byte coinEnable);
+
+    void SetCoinValue(byte num, byte coin, byte coinValue);
+
+    void SetLockoutVal(byte num, byte coin, byte lockoutValue);
+
+    void SetLockoutInvert(byte num, byte coin, byte lockoutInvert);
+
+    void SetEnable(byte num, byte enable);
+
+    void SetCounterIn(byte num, byte counterIn);
+
+    void SetCounterOut(byte num, byte counterOut);
+
+    void SetPortIndex(byte num, byte portIndex);
+
+    void SetCoin(byte num, byte coin);
+
+    void SetLevel(byte num, byte level);
+
+    void SetFullLevel(byte num, byte fullLevel);
+
     void TurnSwitchOn(int switchIndex);
 
     void TurnSwitchOff(int switchIndex);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -159,6 +159,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
             var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
             var reelOptos = ValidateReelOptos(nativeRoms.ReelOptos);
+            var coins = ValidateCoins(nativeRoms.Coins);
             var percentSwitchValue = ValidatePercentSwitchValue(nativeRoms.PercentSwitchValue);
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -212,6 +213,9 @@ public sealed class System6NativeBackend : IEmulationBackend
                 LogStartupStage("Apply reel optos starting after Reset");
                 ApplyReelOptos(_library, reelOptos);
                 LogStartupStage("Apply reel optos completed before first Run");
+                LogStartupStage("Apply coins starting before first Run");
+                ApplyCoins(_library, coins);
+                LogStartupStage("Apply coins completed before first Run");
                 ApplyPercent(_library, percentSwitchValue);
             }
             catch (Exception ex)
@@ -451,6 +455,46 @@ public sealed class System6NativeBackend : IEmulationBackend
         return settings;
     }
 
+    private static IReadOnlyList<System6CoinSettings> ValidateCoins(IReadOnlyList<System6CoinSettings>? coins)
+    {
+        var defaults = System6NativeRomSettings.CreateDefaultCoins();
+        if (coins is null || coins.Count == 0)
+        {
+            return defaults;
+        }
+
+        var settings = new List<System6CoinSettings>(System6NativeRomSettings.DefaultCoinSlotCount);
+        for (var index = 0; index < System6NativeRomSettings.DefaultCoinSlotCount; index++)
+        {
+            settings.Add(index < coins.Count ? coins[index] : defaults[index]);
+        }
+
+        foreach (var coin in settings.Where(coin => coin.Enabled))
+        {
+            ValidateCoinByte(coin.Num, nameof(coin.Num));
+            ValidateCoinByte(coin.Coin, nameof(coin.Coin));
+            ValidateCoinByte(coin.CoinValue, nameof(coin.CoinValue));
+            ValidateCoinByte(coin.CoinEnable, nameof(coin.CoinEnable));
+            ValidateCoinByte(coin.LockoutValue, nameof(coin.LockoutValue));
+            ValidateCoinByte(coin.LockoutInvert, nameof(coin.LockoutInvert));
+            ValidateCoinByte(coin.CounterIn, nameof(coin.CounterIn));
+            ValidateCoinByte(coin.CounterOut, nameof(coin.CounterOut));
+            ValidateCoinByte(coin.PortIndex, nameof(coin.PortIndex));
+            ValidateCoinByte(coin.Level, nameof(coin.Level));
+            ValidateCoinByte(coin.FullLevel, nameof(coin.FullLevel));
+        }
+
+        return settings;
+    }
+
+    private static void ValidateCoinByte(int value, string propertyName)
+    {
+        if (value is < 0 or > byte.MaxValue)
+        {
+            throw new InvalidOperationException($"System6 coin {propertyName} must be between 0 and 255.");
+        }
+    }
+
     private static int ValidatePercentSwitchValue(int percentSwitchValue)
     {
         if (percentSwitchValue is < 0 or > 15)
@@ -472,6 +516,27 @@ public sealed class System6NativeBackend : IEmulationBackend
             library.SetOptoEnd(nativeReelIndex, checked((byte)reel.OptoEnd));
             library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
             LogStartupStage($"System6 reel {displayReelNumber} -> native index {nativeReelIndex}: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
+        }
+    }
+
+    private static void ApplyCoins(ISystem6NativeLibrary library, IReadOnlyList<System6CoinSettings> coins)
+    {
+        foreach (var coin in coins.Where(coin => coin.Enabled))
+        {
+            var num = checked((byte)coin.Num);
+            var channel = checked((byte)coin.Coin);
+            library.SetCoinEnable(num, channel, checked((byte)coin.CoinEnable));
+            library.SetCoinValue(num, channel, checked((byte)coin.CoinValue));
+            library.SetLockoutVal(num, channel, checked((byte)coin.LockoutValue));
+            library.SetLockoutInvert(num, channel, checked((byte)coin.LockoutInvert));
+            library.SetEnable(num, 1);
+            library.SetCounterIn(num, checked((byte)coin.CounterIn));
+            library.SetCounterOut(num, checked((byte)coin.CounterOut));
+            library.SetPortIndex(num, checked((byte)coin.PortIndex));
+            library.SetCoin(num, channel);
+            library.SetLevel(num, checked((byte)coin.Level));
+            library.SetFullLevel(num, checked((byte)coin.FullLevel));
+            LogStartupStage($"System6 coin '{coin.Name}' -> num={coin.Num} coin={coin.Coin} value={coin.CoinValue} enabled={coin.CoinEnable}");
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -23,6 +23,17 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6GetAlphaSegmentsDelegate? _getAlphaSegments;
     private readonly System6GetAlphaBrightnessDelegate? _getAlphaBrightness;
     private readonly System6SetPercentDelegate? _setPercent;
+    private readonly System6SetCoinEnableDelegate _setCoinEnable;
+    private readonly System6SetCoinValueDelegate _setCoinValue;
+    private readonly System6SetLockoutValDelegate _setLockoutVal;
+    private readonly System6SetLockoutInvertDelegate _setLockoutInvert;
+    private readonly System6SetEnableDelegate _setEnable;
+    private readonly System6SetCounterInDelegate _setCounterIn;
+    private readonly System6SetCounterOutDelegate _setCounterOut;
+    private readonly System6SetPortIndexDelegate _setPortIndex;
+    private readonly System6SetCoinDelegate _setCoin;
+    private readonly System6SetLevelDelegate _setLevel;
+    private readonly System6SetFullLevelDelegate _setFullLevel;
     private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
     private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
     private readonly List<IntPtr> _romPathBuffers = [];
@@ -53,6 +64,17 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _getAlphaSegments = TryBindOptionalExport<System6GetAlphaSegmentsDelegate>("SYSTEM6GetAlphaSegments");
         _getAlphaBrightness = TryBindOptionalExport<System6GetAlphaBrightnessDelegate>("SYSTEM6GetAlphaBright");
         _setPercent = TryBindOptionalExport<System6SetPercentDelegate>("SetPercent");
+        _setCoinEnable = _loader.BindExport<System6SetCoinEnableDelegate>("SYSTEM6SetCoinEnable");
+        _setCoinValue = _loader.BindExport<System6SetCoinValueDelegate>("SYSTEM6SetCoinValue");
+        _setLockoutVal = _loader.BindExport<System6SetLockoutValDelegate>("SYSTEM6SetLockoutVal");
+        _setLockoutInvert = _loader.BindExport<System6SetLockoutInvertDelegate>("SYSTEM6SetLockoutInvert");
+        _setEnable = _loader.BindExport<System6SetEnableDelegate>("SYSTEM6SetEnable");
+        _setCounterIn = _loader.BindExport<System6SetCounterInDelegate>("SYSTEM6SetCounterIn");
+        _setCounterOut = _loader.BindExport<System6SetCounterOutDelegate>("SYSTEM6SetCounterOut");
+        _setPortIndex = _loader.BindExport<System6SetPortIndexDelegate>("SYSTEM6SetPortIndex");
+        _setCoin = _loader.BindExport<System6SetCoinDelegate>("SYSTEM6SetCoin");
+        _setLevel = _loader.BindExport<System6SetLevelDelegate>("SYSTEM6SetLevel");
+        _setFullLevel = _loader.BindExport<System6SetFullLevelDelegate>("SYSTEM6SetFullLevel");
         _turnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
         _turnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
     }
@@ -130,6 +152,28 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         var setPercent = _setPercent ?? throw new NotSupportedException("System6 native core does not export SetPercent.");
         setPercent(percent);
     }
+
+    public void SetCoinEnable(byte num, byte coin, byte coinEnable) => _setCoinEnable(num, coin, coinEnable);
+
+    public void SetCoinValue(byte num, byte coin, byte coinValue) => _setCoinValue(num, coin, coinValue);
+
+    public void SetLockoutVal(byte num, byte coin, byte lockoutValue) => _setLockoutVal(num, coin, lockoutValue);
+
+    public void SetLockoutInvert(byte num, byte coin, byte lockoutInvert) => _setLockoutInvert(num, coin, lockoutInvert);
+
+    public void SetEnable(byte num, byte enable) => _setEnable(num, enable);
+
+    public void SetCounterIn(byte num, byte counterIn) => _setCounterIn(num, counterIn);
+
+    public void SetCounterOut(byte num, byte counterOut) => _setCounterOut(num, counterOut);
+
+    public void SetPortIndex(byte num, byte portIndex) => _setPortIndex(num, portIndex);
+
+    public void SetCoin(byte num, byte coin) => _setCoin(num, coin);
+
+    public void SetLevel(byte num, byte level) => _setLevel(num, level);
+
+    public void SetFullLevel(byte num, byte fullLevel) => _setFullLevel(num, fullLevel);
 
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
 
@@ -259,6 +303,39 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6SetPercentDelegate(byte percent);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetCoinEnableDelegate(byte num, byte coin, byte coinEnable);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetCoinValueDelegate(byte num, byte coin, byte coinValue);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetLockoutValDelegate(byte num, byte coin, byte lockoutValue);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetLockoutInvertDelegate(byte num, byte coin, byte lockoutInvert);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetEnableDelegate(byte num, byte enable);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetCounterInDelegate(byte num, byte counterIn);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetCounterOutDelegate(byte num, byte counterOut);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetPortIndexDelegate(byte num, byte portIndex);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetCoinDelegate(byte num, byte coin);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetLevelDelegate(byte num, byte level);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void System6SetFullLevelDelegate(byte num, byte fullLevel);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void System6TurnSwitchOnDelegate(int switchIndex);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -69,6 +69,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private int _system6PercentSwitchValue = System6NativeRomSettings.DefaultPercentSwitchValue;
     private string _system6NativeRomStatus = "Program ROM 1 and 2 are required for native DLL launch.";
     private ObservableCollection<System6ReelOptoSettingsViewModel> _system6ReelOptos = [];
+    private ObservableCollection<System6CoinSettingsViewModel> _system6Coins = [];
     private string _mameRomStatus = "Unknown";
     private bool _isMameRomDownloadInProgress;
     private bool _isMfmeImportInProgress;
@@ -565,7 +566,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
     public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME", "Native Emulation"];
     public IReadOnlyList<string> ProjectSettingsCategories { get; } = ["General", "MAME", "Native"];
-    public IReadOnlyList<string> NativeProjectSettingsTabs { get; } = ["ROMS", "Stake/Prize", "Reels"];
+    public IReadOnlyList<string> NativeProjectSettingsTabs { get; } = ["ROMS", "Stake/Prize", "Reels", "Coins"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
     public IReadOnlyList<InputDefinitionModel> InputDefinitions => LoadedProject?.InputDefinitions ?? [];
     public IReadOnlyList<InputMapDiagnostic> InputMapDiagnostics
@@ -816,6 +817,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
     public string System6NativeRomStatus { get => _system6NativeRomStatus; private set => SetProperty(ref _system6NativeRomStatus, value); }
     public ObservableCollection<System6ReelOptoSettingsViewModel> System6ReelOptos { get => _system6ReelOptos; private set => SetProperty(ref _system6ReelOptos, value); }
+    public ObservableCollection<System6CoinSettingsViewModel> System6Coins { get => _system6Coins; private set => SetProperty(ref _system6Coins, value); }
     public string MameValidationSummary { get => _mameValidationSummary; private set => SetProperty(ref _mameValidationSummary, value); }
     public string MameSetupPhaseDisplay => _mameSetupState.Phase.ToString();
     public string MameSetupLatestKnownVersion => _mameSetupState.LatestKnownVersion;
@@ -2641,7 +2643,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = System6SoundRom4Path,
             FlashSwitch = System6FlashSwitch,
             PercentSwitchValue = System6PercentSwitchValue,
-            ReelOptos = System6ReelOptos.Select(reel => reel.ToModel()).ToList()
+            ReelOptos = System6ReelOptos.Select(reel => reel.ToModel()).ToList(),
+            Coins = System6Coins.Select(coin => coin.ToModel()).ToList()
         };
         SaveLoadedProjectMetadata();
     }
@@ -2659,6 +2662,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _system6FlashSwitch = settings.FlashSwitch;
         _system6PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15);
         System6ReelOptos = new ObservableCollection<System6ReelOptoSettingsViewModel>((settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos()).Select(reel => new System6ReelOptoSettingsViewModel(reel, SaveSystem6NativeRomSettings)));
+        System6Coins = new ObservableCollection<System6CoinSettingsViewModel>(NormalizeSystem6CoinSettings(settings.Coins).Select(coin => new System6CoinSettingsViewModel(coin, SaveSystem6NativeRomSettings)));
         OnPropertyChanged(nameof(System6ProgramRom1Path)); OnPropertyChanged(nameof(System6ProgramRom2Path));
         OnPropertyChanged(nameof(System6ProgramRom3Path)); OnPropertyChanged(nameof(System6ProgramRom4Path));
         OnPropertyChanged(nameof(System6SoundRom1Path)); OnPropertyChanged(nameof(System6SoundRom2Path));
@@ -2696,6 +2700,23 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         SaveSystem6NativeRomSettings();
     }
 
+    private static List<System6CoinSettings> NormalizeSystem6CoinSettings(IReadOnlyList<System6CoinSettings>? coins)
+    {
+        var defaults = System6NativeRomSettings.CreateDefaultCoins();
+        if (coins is null || coins.Count == 0)
+        {
+            return defaults;
+        }
+
+        var normalized = new List<System6CoinSettings>(System6NativeRomSettings.DefaultCoinSlotCount);
+        for (var index = 0; index < System6NativeRomSettings.DefaultCoinSlotCount; index++)
+        {
+            normalized.Add(index < coins.Count ? coins[index] : defaults[index]);
+        }
+
+        return normalized;
+    }
+
     private System6NativeRomSettings BuildSystem6NativeRomSettingsForLaunch()
     {
         var settings = LoadedProject?.System6NativeRoms ?? new System6NativeRomSettings();
@@ -2714,6 +2735,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15),
             ReelOptos = (settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos())
                 .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Enabled = reel.Enabled, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
+                .ToList(),
+            Coins = NormalizeSystem6CoinSettings(settings.Coins)
+                .Select(coin => new System6CoinSettings { Name = coin.Name, Enabled = coin.Enabled, Num = coin.Num, Coin = coin.Coin, CoinValue = coin.CoinValue, CoinEnable = coin.CoinEnable, LockoutValue = coin.LockoutValue, LockoutInvert = coin.LockoutInvert, CounterIn = coin.CounterIn, CounterOut = coin.CounterOut, PortIndex = coin.PortIndex, Level = coin.Level, FullLevel = coin.FullLevel })
                 .ToList()
         };
     }
@@ -3626,6 +3650,27 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             writer.WriteEndObject();
         }
         writer.WriteEndArray();
+        writer.WritePropertyName("Coins");
+        writer.WriteStartArray();
+        foreach (var coin in settings.Coins)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Name", coin.Name);
+            writer.WriteBoolean("Enabled", coin.Enabled);
+            writer.WriteNumber("Num", coin.Num);
+            writer.WriteNumber("Coin", coin.Coin);
+            writer.WriteNumber("CoinValue", coin.CoinValue);
+            writer.WriteNumber("CoinEnable", coin.CoinEnable);
+            writer.WriteNumber("LockoutValue", coin.LockoutValue);
+            writer.WriteNumber("LockoutInvert", coin.LockoutInvert);
+            writer.WriteNumber("CounterIn", coin.CounterIn);
+            writer.WriteNumber("CounterOut", coin.CounterOut);
+            writer.WriteNumber("PortIndex", coin.PortIndex);
+            writer.WriteNumber("Level", coin.Level);
+            writer.WriteNumber("FullLevel", coin.FullLevel);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
         writer.WriteEndObject();
     }
 
@@ -3649,7 +3694,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = GetOptionalString(romsElement, "SoundRom4Path"),
             FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True,
             PercentSwitchValue = Math.Clamp(GetOptionalInt(romsElement, "PercentSwitchValue", System6NativeRomSettings.DefaultPercentSwitchValue), 0, 15),
-            ReelOptos = ResolveSystem6ReelOptoSettings(romsElement)
+            ReelOptos = ResolveSystem6ReelOptoSettings(romsElement),
+            Coins = ResolveSystem6CoinSettings(romsElement)
         };
     }
 
@@ -3678,14 +3724,46 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         return reelOptos.Count > 0 ? reelOptos : System6NativeRomSettings.CreateDefaultReelOptos();
     }
 
+    private static List<System6CoinSettings> ResolveSystem6CoinSettings(JsonElement romsElement)
+    {
+        if (!romsElement.TryGetProperty("Coins", out var coinsElement) || coinsElement.ValueKind != JsonValueKind.Array)
+        {
+            return System6NativeRomSettings.CreateDefaultCoins();
+        }
+
+        var coins = new List<System6CoinSettings>();
+        foreach (var coinElement in coinsElement.EnumerateArray().Take(System6NativeRomSettings.DefaultCoinSlotCount))
+        {
+            var coinIndex = coins.Count;
+            coins.Add(new System6CoinSettings
+            {
+                Name = GetOptionalString(coinElement, "Name", $"Coin {coinIndex + 1}"),
+                Enabled = coinElement.TryGetProperty("Enabled", out var enabledElement) && enabledElement.ValueKind == JsonValueKind.True,
+                Num = GetOptionalInt(coinElement, "Num", coinIndex),
+                Coin = GetOptionalInt(coinElement, "Coin", System6CoinSettings.DefaultCoin),
+                CoinValue = GetOptionalInt(coinElement, "CoinValue", System6CoinSettings.DefaultCoinValue),
+                CoinEnable = GetOptionalInt(coinElement, "CoinEnable", System6CoinSettings.DefaultCoinEnable),
+                LockoutValue = GetOptionalInt(coinElement, "LockoutValue", System6CoinSettings.DefaultLockoutValue),
+                LockoutInvert = GetOptionalInt(coinElement, "LockoutInvert", System6CoinSettings.DefaultLockoutInvert),
+                CounterIn = GetOptionalInt(coinElement, "CounterIn"),
+                CounterOut = GetOptionalInt(coinElement, "CounterOut"),
+                PortIndex = GetOptionalInt(coinElement, "PortIndex"),
+                Level = GetOptionalInt(coinElement, "Level"),
+                FullLevel = GetOptionalInt(coinElement, "FullLevel")
+            });
+        }
+
+        return NormalizeSystem6CoinSettings(coins);
+    }
+
     private static int GetOptionalInt(JsonElement element, string propertyName, int defaultValue = 0)
     {
         return element.TryGetProperty(propertyName, out var value) && value.TryGetInt32(out var parsed) ? parsed : defaultValue;
     }
 
-    private static string GetOptionalString(JsonElement element, string propertyName)
+    private static string GetOptionalString(JsonElement element, string propertyName, string defaultValue = "")
     {
-        return element.TryGetProperty(propertyName, out var value) ? value.GetString() ?? string.Empty : string.Empty;
+        return element.TryGetProperty(propertyName, out var value) ? value.GetString() ?? defaultValue : defaultValue;
     }
 
     private FruitMachinePlatformType ResolveFruitMachinePlatform(JsonElement root)
@@ -4257,6 +4335,88 @@ internal static class EditorProjectInputDefinitionExtensions
         }
 
         return project;
+    }
+}
+
+
+public sealed class System6CoinSettingsViewModel : INotifyPropertyChanged
+{
+    private readonly Action _changed;
+    private string _name;
+    private bool _enabled;
+    private int _num;
+    private int _coin;
+    private int _coinValue;
+    private int _coinEnable;
+    private int _lockoutValue;
+    private int _lockoutInvert;
+    private int _counterIn;
+    private int _counterOut;
+    private int _portIndex;
+    private int _level;
+    private int _fullLevel;
+
+    public System6CoinSettingsViewModel(System6CoinSettings model, Action changed)
+    {
+        _name = model.Name;
+        _enabled = model.Enabled;
+        _num = model.Num;
+        _coin = model.Coin;
+        _coinValue = model.CoinValue;
+        _coinEnable = model.CoinEnable;
+        _lockoutValue = model.LockoutValue;
+        _lockoutInvert = model.LockoutInvert;
+        _counterIn = model.CounterIn;
+        _counterOut = model.CounterOut;
+        _portIndex = model.PortIndex;
+        _level = model.Level;
+        _fullLevel = model.FullLevel;
+        _changed = changed;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string Name { get => _name; set => SetAndSave(ref _name, value, nameof(Name)); }
+    public bool Enabled { get => _enabled; set => SetAndSave(ref _enabled, value, nameof(Enabled)); }
+    public int Num { get => _num; set => SetAndSave(ref _num, Math.Clamp(value, 0, byte.MaxValue), nameof(Num)); }
+    public int Coin { get => _coin; set => SetAndSave(ref _coin, Math.Clamp(value, 0, byte.MaxValue), nameof(Coin)); }
+    public int CoinValue { get => _coinValue; set => SetAndSave(ref _coinValue, Math.Clamp(value, 0, byte.MaxValue), nameof(CoinValue)); }
+    public int CoinEnable { get => _coinEnable; set => SetAndSave(ref _coinEnable, Math.Clamp(value, 0, byte.MaxValue), nameof(CoinEnable)); }
+    public int LockoutValue { get => _lockoutValue; set => SetAndSave(ref _lockoutValue, Math.Clamp(value, 0, byte.MaxValue), nameof(LockoutValue)); }
+    public int LockoutInvert { get => _lockoutInvert; set => SetAndSave(ref _lockoutInvert, Math.Clamp(value, 0, byte.MaxValue), nameof(LockoutInvert)); }
+    public int CounterIn { get => _counterIn; set => SetAndSave(ref _counterIn, Math.Clamp(value, 0, byte.MaxValue), nameof(CounterIn)); }
+    public int CounterOut { get => _counterOut; set => SetAndSave(ref _counterOut, Math.Clamp(value, 0, byte.MaxValue), nameof(CounterOut)); }
+    public int PortIndex { get => _portIndex; set => SetAndSave(ref _portIndex, Math.Clamp(value, 0, byte.MaxValue), nameof(PortIndex)); }
+    public int Level { get => _level; set => SetAndSave(ref _level, Math.Clamp(value, 0, byte.MaxValue), nameof(Level)); }
+    public int FullLevel { get => _fullLevel; set => SetAndSave(ref _fullLevel, Math.Clamp(value, 0, byte.MaxValue), nameof(FullLevel)); }
+
+    public System6CoinSettings ToModel() => new()
+    {
+        Name = Name,
+        Enabled = Enabled,
+        Num = Num,
+        Coin = Coin,
+        CoinValue = CoinValue,
+        CoinEnable = CoinEnable,
+        LockoutValue = LockoutValue,
+        LockoutInvert = LockoutInvert,
+        CounterIn = CounterIn,
+        CounterOut = CounterOut,
+        PortIndex = PortIndex,
+        Level = Level,
+        FullLevel = FullLevel
+    };
+
+    private void SetAndSave<T>(ref T field, T value, string propertyName)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        _changed();
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -203,6 +203,45 @@
                                 Content="Reset Reel Optos To Defaults" />
                     </StackPanel>
                 </ScrollViewer>
+
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                    <ScrollViewer.Style>
+                        <Style TargetType="ScrollViewer">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedNativeProjectSettingsTab}" Value="Coins">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ScrollViewer.Style>
+                    <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="System6 Coin Setup" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <DataGrid ItemsSource="{Binding System6Coins}"
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  HeadersVisibility="Column"
+                                  MaxHeight="260">
+                            <DataGrid.Columns>
+                                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="80" />
+                                <DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=LostFocus}" Width="110" />
+                                <DataGridTextColumn Header="Num" Binding="{Binding Num, UpdateSourceTrigger=LostFocus}" Width="70" />
+                                <DataGridTextColumn Header="Coin" Binding="{Binding Coin, UpdateSourceTrigger=LostFocus}" Width="70" />
+                                <DataGridTextColumn Header="Coin Value" Binding="{Binding CoinValue, UpdateSourceTrigger=LostFocus}" Width="90" />
+                                <DataGridTextColumn Header="Coin Enable" Binding="{Binding CoinEnable, UpdateSourceTrigger=LostFocus}" Width="100" />
+                                <DataGridTextColumn Header="Lockout Value" Binding="{Binding LockoutValue, UpdateSourceTrigger=LostFocus}" Width="110" />
+                                <DataGridTextColumn Header="Lockout Invert" Binding="{Binding LockoutInvert, UpdateSourceTrigger=LostFocus}" Width="110" />
+                                <DataGridTextColumn Header="Counter In" Binding="{Binding CounterIn, UpdateSourceTrigger=LostFocus}" Width="90" />
+                                <DataGridTextColumn Header="Counter Out" Binding="{Binding CounterOut, UpdateSourceTrigger=LostFocus}" Width="95" />
+                                <DataGridTextColumn Header="Port Index" Binding="{Binding PortIndex, UpdateSourceTrigger=LostFocus}" Width="90" />
+                                <DataGridTextColumn Header="Level" Binding="{Binding Level, UpdateSourceTrigger=LostFocus}" Width="70" />
+                                <DataGridTextColumn Header="Full Level" Binding="{Binding FullLevel, UpdateSourceTrigger=LostFocus}" Width="85" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Margin="0,8,0,0" Text="Only enabled coin rows are sent to the native System 6 backend at startup." Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" />
+                    </StackPanel>
+                </ScrollViewer>
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
### Motivation
- Provide editor support for configuring native System 6 coin inputs so projects can persist coin-slot configuration and the native backend can be initialised with coin settings at startup.
- Mirror the existing reel opto pattern for UI, persistence and startup application to keep behaviour consistent with other System6 native settings.

### Description
- Add `System6CoinSettings` model with `CreateDefaultCoins()` (4-slot default) and include `Coins` in `System6NativeRomSettings` for persistence and defaults when missing.
- Extend the Project Settings UI by adding a top-level `Coins` tab in `ProjectSettingsView.xaml` showing a 4-row `DataGrid` with `Enabled`, `Name`, `Num`, `Coin`, `CoinValue`, `CoinEnable`, `LockoutValue`, `LockoutInvert`, and optional `CounterIn/CounterOut/PortIndex/Level/FullLevel` fields bound to a new `System6Coins` collection on the view model.
- Add `System6CoinSettingsViewModel` and wire `System6Coins` into `MainWindowViewModel` for edit/save/load, including normalization so older projects without coin settings get four disabled default rows.
- Persist/restore coins alongside existing `System6NativeRoms` by updating the JSON read/write logic in `MainWindowViewModel` to write and resolve the `Coins` array, and ensure values are bounded/normalized.
- Extend the native wrapper and interface: add delegates and methods for `SetCoinEnable`, `SetCoinValue`, `SetLockoutVal`, `SetLockoutInvert`, `SetEnable`, `SetCounterIn`, `SetCounterOut`, `SetPortIndex`, `SetCoin`, `SetLevel`, `SetFullLevel` in `ISystem6NativeLibrary` and `System6NativeLibrary`.
- Apply enabled coin rows during native System6 backend startup (after `Reset` and after applying reel optos) in `System6NativeBackend` via `ValidateCoins` and `ApplyCoins`, calling the appropriate native exports per enabled row and skipping disabled rows.
- Add a unit test `StartAsyncAppliesOnlyEnabledNativeCoinRows` to `System6NativeBackendTests` that verifies only enabled coins trigger backend calls.

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity (passed).
- Added an automated unit test (`StartAsyncAppliesOnlyEnabledNativeCoinRows`) covering that enabled coin rows call the native setup methods; the test was added to `WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs` but was not executed in this environment.
- No WPF/.NET build or test runs were executed here per repository guidance; a local Windows build and `dotnet test` should be run to validate compilation and the new unit test (expected to pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a364608b7388327971ae69d08232c4d)