### PR TITLE
Implement native System6 button input

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -83,7 +83,7 @@ public sealed class EmulationBackendFactoryTests
         public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameEmulationBackendTests.cs
@@ -64,7 +64,7 @@ public sealed class MameEmulationBackendTests
     {
         var backend = CreateBackend(out _, out var inputService);
 
-        await backend.SetInputStateAsync(MachineInputReference.FromInputId("start"), isPressed: true, CancellationToken.None);
+        await backend.SetInputStateAsync(new InputDefinitionModel { Id = "start", Kind = InputDefinitionKind.Button, ButtonNumber = "1" }, isPressed: true, CancellationToken.None);
 
         var call = Assert.Single(inputService.Calls);
         Assert.Equal(FruitMachinePlatformType.MPU4, call.Platform);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -114,19 +114,38 @@ public sealed class System6NativeBackendTests
     }
 
     [Fact]
-    public async Task SetInputStateAsyncMapsNumericInputIdToNativeSwitchCalls()
+    public async Task SetInputStateAsyncMapsButtonNumberToNativeSwitchCalls()
     {
         var library = new FakeSystem6NativeLibrary();
         var (dllPath, rom1, rom2) = CreateNativeFiles(2);
         var backend = new System6NativeBackend(dllPath, _ => library);
 
         await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), true, CancellationToken.None);
-        await backend.SetInputStateAsync(MachineInputReference.FromInputId("12"), false, CancellationToken.None);
+        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "12" };
+
+        await backend.SetInputStateAsync(input, true, CancellationToken.None);
+        await backend.SetInputStateAsync(input, false, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Equal(new[] { 12 }, library.SwitchesTurnedOn);
         Assert.Equal(new[] { 12 }, library.SwitchesTurnedOff);
+    }
+
+
+    [Fact]
+    public async Task SetInputStateAsyncIgnoresCoinInputs()
+    {
+        var library = new FakeSystem6NativeLibrary();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library);
+        var input = new InputDefinitionModel { Id = "coin-1", Kind = InputDefinitionKind.Coin, CoinInput = true, ButtonNumber = "1" };
+
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+        await backend.SetInputStateAsync(input, true, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Empty(library.SwitchesTurnedOn);
+        Assert.Empty(library.SwitchesTurnedOff);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -22,7 +22,7 @@ public interface IEmulationBackend : IAsyncDisposable
 
     Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
 
-    Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken);
+    Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
 }
 
 public enum EmulationBackendState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
@@ -101,22 +101,22 @@ public sealed class MameEmulationBackend : IEmulationBackend
         };
     }
 
-    public async Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken)
+    public async Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(inputDefinition);
 
-        var inputDefinition = _inputDefinitionResolver(input);
-        if (inputDefinition is null)
+        var resolvedInputDefinition = _inputDefinitionResolver(MachineInputReference.FromInputId(inputDefinition.Id));
+        if (resolvedInputDefinition is null)
         {
-            throw new InvalidOperationException($"No MAME input definition was found for emulation input '{input.Id}'.");
+            throw new InvalidOperationException($"No MAME input definition was found for emulation input '{inputDefinition.Id}'.");
         }
 
         var sent = await _inputCommandService
-            .TrySendInputStateAsync(_processRunner, _platformProvider(), inputDefinition, isPressed, cancellationToken)
+            .TrySendInputStateAsync(_processRunner, _platformProvider(), resolvedInputDefinition, isPressed, cancellationToken)
             .ConfigureAwait(false);
         if (!sent)
         {
-            throw new InvalidOperationException($"MAME input '{input.Id}' could not be resolved to a MAME input command.");
+            throw new InvalidOperationException($"MAME input '{inputDefinition.Id}' could not be resolved to a MAME input command.");
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -324,14 +324,25 @@ public sealed class System6NativeBackend : IEmulationBackend
         return Task.CompletedTask;
     }
 
-    public Task SetInputStateAsync(MachineInputReference input, bool isPressed, CancellationToken cancellationToken)
+    public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(inputDefinition);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot set input state before it has started.");
-        if (!int.TryParse(input.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var switchIndex))
+        if (inputDefinition.Kind is not InputDefinitionKind.Button || inputDefinition.CoinInput)
         {
-            throw new InvalidOperationException($"System6 native backend input '{input.Id}' is not a numeric switch index.");
+            return Task.CompletedTask;
+        }
+
+        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot set input state before it has started.");
+        if (!int.TryParse(inputDefinition.ButtonNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out var switchIndex))
+        {
+            throw new InvalidOperationException($"System6 native backend input '{inputDefinition.Id}' button number '{inputDefinition.ButtonNumber}' is not a numeric switch index.");
+        }
+
+        if (switchIndex is < byte.MinValue or > byte.MaxValue)
+        {
+            throw new InvalidOperationException($"System6 native backend input '{inputDefinition.Id}' switch index {switchIndex} is outside the supported range 0-255.");
         }
 
         if (isPressed)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -175,9 +175,9 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
 
     public void SetFullLevel(byte num, byte fullLevel) => _setFullLevel(num, fullLevel);
 
-    public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(switchIndex);
+    public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(checked((byte)switchIndex));
 
-    public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(switchIndex);
+    public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(checked((byte)switchIndex));
 
     public void Dispose()
     {
@@ -338,8 +338,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     public delegate void System6SetFullLevelDelegate(byte num, byte fullLevel);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6TurnSwitchOnDelegate(int switchIndex);
+    public delegate void System6TurnSwitchOnDelegate(byte switchIndex);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6TurnSwitchOffDelegate(int switchIndex);
+    public delegate void System6TurnSwitchOffDelegate(byte switchIndex);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -88,7 +88,7 @@ public sealed class PlayViewInputRouter
         {
             try
             {
-                await _backend.SetInputStateAsync(MachineInputReference.FromInputId(inputDefinition.Id), isPressed, cancellationToken).ConfigureAwait(false);
+                await _backend.SetInputStateAsync(inputDefinition, isPressed, cancellationToken).ConfigureAwait(false);
                 return true;
             }
             catch


### PR DESCRIPTION
### Motivation

- Fix Native System6 backend so keyboard/button mappings drive native switch calls instead of throwing `InvalidOperationException` when inputs mapped to buttons are pressed.
- Ensure Native System6 button handling uses the same Oasis/MFME `ButtonNumber` mapping used by the MAME path, and explicitly avoid adding coin input support in this change.

### Description

- Change backend input contract so `IEmulationBackend.SetInputStateAsync` accepts the full `InputDefinitionModel` (instead of `MachineInputReference`) and update the shared input routing path in `PlayViewInputRouter` to forward the full input definition to backends via `SetInputStateAsync`.
- Implement System6 button handling in `System6NativeBackend` by validating `InputDefinitionModel.ButtonNumber` as a numeric 0–255 switch index and forwarding press/release to the native wrapper via `TurnSwitchOn` / `TurnSwitchOff`, and early-return for non-button or coin inputs.
- Update the managed native wrapper in `System6NativeLibrary` to match the native `UINT8` switch API by using byte-typed delegates and `checked((byte)...)` casts in the public `TurnSwitchOn` / `TurnSwitchOff` calls.
- Adapt the MAME backend to the new backend input signature by resolving the `InputDefinitionModel` to the existing input-definition resolver and delegating to the existing `IMameInputCommandService` unchanged.
- Tests updated to reflect the new contract and behavior, including renaming/adapting `System6NativeBackendTests` to assert that `ButtonNumber` maps to native switch calls and that coin inputs are ignored, and small test updates in `MameEmulationBackendTests` and `EmulationBackendFactoryTests`.

### Testing

- Unit tests updated or added: `System6NativeBackendTests` (now includes `SetInputStateAsyncMapsButtonNumberToNativeSwitchCalls` and `SetInputStateAsyncIgnoresCoinInputs`), `MameEmulationBackendTests` (input routing assertion adjusted), and `EmulationBackendFactoryTests` (test stub updated for the new backend contract).
- No automated tests were executed in this environment per repository `AGENTS.md` constraints; please run `dotnet test` on the solution locally and confirm all tests pass (recommended command: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36513d58a8832783373f3d75c292fa)