### PR TITLE
Normalize Native System 6 reel positions

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -254,8 +254,8 @@ public sealed class System6NativeBackendTests
 
             Assert.True(library.Calls.IndexOf("LampsUpdate") < library.Calls.IndexOf("GetLampsOn:0"));
             Assert.Contains(lampEvents, e => e.LampId == 0 && e.Value == 255);
-            Assert.Contains(reelEvents, e => e.ReelId == 0 && e.Position == 10);
-            Assert.Contains(reelEvents, e => e.ReelId == 1 && e.Position == 20);
+            Assert.Contains(reelEvents, e => e.ReelId == 0 && e.Position == 86);
+            Assert.Contains(reelEvents, e => e.ReelId == 1 && e.Position == 76);
             Assert.Contains("GetPosOut:-1", library.Calls);
             Assert.Contains("GetPosOut:0", library.Calls);
         }
@@ -263,6 +263,18 @@ public sealed class System6NativeBackendTests
         {
             Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
         }
+    }
+
+
+    [Theory]
+    [InlineData(0, 96, 0)]
+    [InlineData(1, 96, 95)]
+    [InlineData(95, 96, 1)]
+    [InlineData(10, 0, 10)]
+    [InlineData(10, -1, 10)]
+    public void NormalizeNativeSystem6ReelPosition_ReversesDirectionWhenStepsAreKnown(int rawPosition, int steps, int expected)
+    {
+        Assert.Equal(expected, System6NativeBackend.NormalizeNativeSystem6ReelPosition(rawPosition, steps));
     }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -36,6 +36,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly int[] _lastLampValues = Enumerable.Repeat(-1, LampCount).ToArray();
     private readonly int[] _lastLampRawValues = Enumerable.Repeat(-1, LampCount).ToArray();
     private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
+    private readonly int[] _reelStepCounts = new int[ReelCount];
     private int[]? _lastAlphaSegments;
     private double? _lastAlphaBrightness;
     private bool _hasLoggedAlphaUnavailable;
@@ -207,6 +208,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                 throw new InvalidOperationException($"System6 native backend failed to reset core '{_libraryPath}' during startup.", ex);
             }
             ResetCachedOutputState();
+            ResetConfiguredReelStepCounts();
 
             try
             {
@@ -516,13 +518,14 @@ public sealed class System6NativeBackend : IEmulationBackend
         return percentSwitchValue;
     }
 
-    private static void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
+    private void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
     {
         foreach (var reel in reelOptos.Where(reel => reel.Enabled))
         {
             var nativeReelIndex = checked((byte)reel.ReelIndex);
             var displayReelNumber = reel.ReelIndex + 1;
             library.SetSteps(nativeReelIndex, checked((byte)reel.Steps));
+            _reelStepCounts[reel.ReelIndex] = reel.Steps;
             library.SetOptoStart(nativeReelIndex, checked((byte)reel.OptoStart));
             library.SetOptoEnd(nativeReelIndex, checked((byte)reel.OptoEnd));
             library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
@@ -663,13 +666,48 @@ public sealed class System6NativeBackend : IEmulationBackend
             // from the zero-based native reel index. Keep emitted Oasis reel IDs
             // zero-based while applying the selector offset only at the DLL call.
             var nativePositionSelector = checked((sbyte)(nativeReelIndex - 1));
-            var position = library.GetPosOut(nativePositionSelector);
+            var rawPosition = library.GetPosOut(nativePositionSelector);
+            var position = NormalizeNativeSystem6ReelPosition(reelIndex, rawPosition);
             if (_lastReelPositions[reelIndex] != position)
             {
                 _lastReelPositions[reelIndex] = position;
                 ReelChanged?.Invoke(this, new MachineReelChangedEventArgs(reelIndex, position));
             }
         }
+    }
+
+
+    private void ResetConfiguredReelStepCounts()
+    {
+        Array.Clear(_reelStepCounts);
+    }
+
+    internal int NormalizeNativeSystem6ReelPosition(int reelIndex, int rawPosition)
+    {
+        var steps = reelIndex >= 0 && reelIndex < _reelStepCounts.Length
+            ? _reelStepCounts[reelIndex]
+            : 0;
+
+        return NormalizeNativeSystem6ReelPosition(rawPosition, steps);
+    }
+
+    internal static int NormalizeNativeSystem6ReelPosition(int rawPosition, int steps)
+    {
+        if (steps <= 0)
+        {
+            return rawPosition;
+        }
+
+        // Native System 6 internals expose reel motion in the opposite direction
+        // to the MAME/Oasis convention. Normalize at the backend boundary so
+        // rendering can treat both emulation backends identically.
+        var positionWithinReel = rawPosition % steps;
+        if (positionWithinReel < 0)
+        {
+            positionWithinReel += steps;
+        }
+
+        return (steps - positionWithinReel) % steps;
     }
 
     private void LogLampPollingConfiguration(ISystem6NativeLibrary library)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -667,7 +667,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             // zero-based while applying the selector offset only at the DLL call.
             var nativePositionSelector = checked((sbyte)(nativeReelIndex - 1));
             var rawPosition = library.GetPosOut(nativePositionSelector);
-            var position = NormalizeNativeSystem6ReelPosition(reelIndex, rawPosition);
+            var position = NormalizeConfiguredNativeSystem6ReelPosition(reelIndex, rawPosition);
             if (_lastReelPositions[reelIndex] != position)
             {
                 _lastReelPositions[reelIndex] = position;
@@ -682,7 +682,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         Array.Clear(_reelStepCounts);
     }
 
-    internal int NormalizeNativeSystem6ReelPosition(int reelIndex, int rawPosition)
+    private int NormalizeConfiguredNativeSystem6ReelPosition(int reelIndex, int rawPosition)
     {
         var steps = reelIndex >= 0 && reelIndex < _reelStepCounts.Length
             ? _reelStepCounts[reelIndex]


### PR DESCRIPTION
### Motivation
- Native System 6 DLLs expose reel position output in the opposite direction to the MAME/Oasis convention, causing reels to spin visually reversed when using the native backend. 
- Normalize the native backend at the boundary so Oasis rendering can remain backend-agnostic and no conditional rendering logic is required.

### Description
- Track configured reel step counts in the native backend by adding `_reelStepCounts` and resetting them at startup via `ResetConfiguredReelStepCounts()` so the backend knows per-reel `SetSteps` values (`WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs`).
- Store each reel's `Steps` when applying opto configuration in `ApplyReelOptos(...)` so the step count is available to normalization logic.
- Read raw values from `GetPosOut(...)` and normalize them before emitting `ReelChanged` events by calling `NormalizeNativeSystem6ReelPosition(...)`, preserving the existing zero-based reel IDs and selector offset behavior.
- Add a clearly named helper `NormalizeNativeSystem6ReelPosition(int rawPosition, int steps)` which reverses known-step reels using `(steps - rawPosition) % steps`, safely handles negative/modulus wrapping, and falls back to the raw value when `steps <= 0`.
- Add/adjust unit test coverage in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs` to assert the normalized outputs and to exercise the static helper with cases: raw `0`, raw `1` -> `steps - 1`, raw `steps - 1` -> `1`, and invalid/unknown `steps` fallback.

### Testing
- Added unit tests exercising the normalization helper and updated an existing `StartAsyncOneRunOnly` test to expect normalized reel positions; these tests are in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs` and should be run locally with `dotnet test`.
- Per repository `AGENTS.md` this environment did not run the test suite; only repository checks such as `git diff --check` were executed and passed.
- Please run `dotnet build` and `dotnet test` locally on Windows/.NET to validate the new tests and verify runtime behavior under both MAME and Native System 6 backends (manual verification steps described in the task).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36545a6c24832780df381970aa0024)