### PR TITLE
Apply reel Band Offset in inspector preview before emulation

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -351,6 +351,42 @@ public sealed class Panel2DRendererTests
         Assert.Equal(expected, actual, 4);
     }
 
+
+    [Fact]
+    public void ReelPreviewPosition_UsesBandOffsetBeforeRuntimeStateExists()
+    {
+        var runtimeState = new PanelRuntimeState();
+        var element = new PanelElementModel
+        {
+            ObjectId = "reel-1",
+            Kind = PanelElementKind.Reel,
+            Stops = 12,
+            BandOffset = 0.25d
+        };
+
+        var actual = ReelElementRenderer.ResolvePreviewReelPosition(runtimeState, element, 12);
+
+        Assert.Equal(24d, actual);
+    }
+
+    [Fact]
+    public void ReelPreviewPosition_PrefersRuntimeStateAfterEmulationUpdatesReel()
+    {
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetReelPositionIfChanged("reel-1", 12d);
+        var element = new PanelElementModel
+        {
+            ObjectId = "reel-1",
+            Kind = PanelElementKind.Reel,
+            Stops = 12,
+            BandOffset = 0.25d
+        };
+
+        var actual = ReelElementRenderer.ResolvePreviewReelPosition(runtimeState, element, 12);
+
+        Assert.Equal(12d, actual);
+    }
+
     [Theory]
     [InlineData(null, 24f)]
     [InlineData(1d, 24f)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
@@ -163,12 +163,20 @@ public class MachineRuntimeState
 
     public double GetReelPosition(string objectId)
     {
+        return TryGetReelPosition(objectId, out var position)
+            ? position
+            : 0d;
+    }
+
+    public bool TryGetReelPosition(string objectId, out double position)
+    {
         if (string.IsNullOrWhiteSpace(objectId))
         {
-            return 0;
+            position = 0d;
+            return false;
         }
 
-        return _reelPositionByObjectId.GetValueOrDefault(objectId.Trim(), 0d);
+        return _reelPositionByObjectId.TryGetValue(objectId.Trim(), out position);
     }
 
     public double GetReelPosition(MachineObjectReference machineObjectReference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -20,8 +20,21 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
         }
 
         var stops = Math.Max(1, element.Stops.GetValueOrDefault(1));
-        var reelPosition = context.RuntimeState.GetEffectiveReelPosition(element.ObjectId);
+        var reelPosition = ResolvePreviewReelPosition(context.RuntimeState, element, stops);
         RenderReelDisplay(context.Canvas, bounds, element.AssetPath, reelPosition, stops, element.VisibleScale);
+    }
+
+    internal static double ResolvePreviewReelPosition(MachineRuntimeState runtimeState, PanelElementModel element, int stops)
+    {
+        if (runtimeState.TryGetReelPosition(element.ObjectId, out var runtimePosition))
+        {
+            return runtimePosition + runtimeState.GetTemporaryReelOffset(element.ObjectId);
+        }
+
+        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(runtimeState.FruitMachinePlatform, stops);
+        var bandOffset = element.BandOffset ?? 0d;
+        return ((platformOffset + bandOffset) * LegacyReelPositionsPerRevolution)
+            + runtimeState.GetTemporaryReelOffset(element.ObjectId);
     }
 
     public static void RenderReelDisplay(SKCanvas canvas, SKRect bounds, string? assetPath, double reelPosition, int stops, double? visibleScale)


### PR DESCRIPTION
### Motivation
- The Inspector's `Band Offset` edits did not affect panel reel visuals until emulation supplied a runtime reel position because preview rendering always used the runtime position default (zero) instead of falling back to the model's band offset when no runtime value existed. 
- The intent is for `BandOffset` to take effect immediately in the editor preview even before emulation has started for the session.

### Description
- Added `TryGetReelPosition(string, out double)` to `MachineRuntimeState` and made `GetReelPosition` delegate to it so callers can distinguish “no runtime state yet” from an actual zero position. (`WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs`)
- Changed reel preview logic in `ReelElementRenderer` to call `ResolvePreviewReelPosition(...)`, which uses the runtime position plus temporary offset if present, or otherwise computes the preview position using the platform offset plus the element's `BandOffset` and any temporary offset. (`WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs`)
- Added two unit tests that assert band-offset-based preview when no runtime position exists and runtime-state precedence once emulation updates the reel. (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs`)

### Testing
- Added automated unit tests: `ReelPreviewPosition_UsesBandOffsetBeforeRuntimeStateExists` and `ReelPreviewPosition_PrefersRuntimeStateAfterEmulationUpdatesReel` (new coverage in `Panel2DRendererTests`).
- Performed repository static checks locally in the editing environment and observed no check failures.
- Could not run the full .NET/WPF test suite in this environment due to toolchain constraints; please run the OasisEditor test suite locally on Windows to validate UI/integration behavior and confirm all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36596cfe1c8327aec3241f4974ce38)