### PR TITLE
Add backend-specific internal reel offsets (Native System6 +0.07 for 16-stop)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -41,6 +41,7 @@ public sealed class EmulationBackendFactoryTests
 
     private sealed class FakeBackend : IEmulationBackend
     {
+        public EmulationBackendKind BackendKind => EmulationBackendKind.Mame;
         public EmulationBackendState State => EmulationBackendState.Stopped;
         public EmulationBackendCapabilities Capabilities { get; } = new(false, false, false, false, false, false, false, false);
         public event EventHandler<EmulationBackendState>? StateChanged

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
@@ -14,10 +14,21 @@ public sealed class MameReelRuntimeAdapterTests
         int stops,
         double expected)
     {
-        var actual = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(platform, stops);
+        var actual = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(EmulationBackendKind.Mame, platform, stops);
 
         Assert.Equal(expected, actual, 6);
     }
+
+    [Fact]
+    public void ResolvePlatformBandOffsetNormalized_NativeSystem6_UsesBackendSpecificSixteenStopCorrection()
+    {
+        var mameOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(EmulationBackendKind.Mame, FruitMachinePlatformType.Impact, 16);
+        var nativeOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(EmulationBackendKind.NativeSystem6, FruitMachinePlatformType.Impact, 16);
+
+        Assert.Equal(-0.08d, mameOffset, 6);
+        Assert.Equal(0.07d, nativeOffset, 6);
+    }
+
     [Fact]
     public void ApplyReelState_UpdatesFaceReelDisplaysByMachineObjectReference()
     {
@@ -26,6 +37,7 @@ public sealed class MameReelRuntimeAdapterTests
         var adapter = new MameReelRuntimeAdapter(
             () => [document],
             () => FruitMachinePlatformType.Impact,
+            () => EmulationBackendKind.Mame,
             () => false,
             _ => { },
             action => dispatches.Add(action));
@@ -53,6 +65,7 @@ public sealed class MameReelRuntimeAdapterTests
         var adapter = new MameReelRuntimeAdapter(
             () => [document],
             () => FruitMachinePlatformType.None,
+            () => EmulationBackendKind.Mame,
             () => false,
             _ => { },
             action => dispatches.Add(action));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -2,6 +2,8 @@ namespace OasisEditor;
 
 public interface IEmulationBackend : IAsyncDisposable
 {
+    EmulationBackendKind BackendKind { get; }
+
     EmulationBackendState State { get; }
 
     EmulationBackendCapabilities Capabilities { get; }
@@ -23,6 +25,12 @@ public interface IEmulationBackend : IAsyncDisposable
     Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
 
     Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
+}
+
+public enum EmulationBackendKind
+{
+    Mame,
+    NativeSystem6
 }
 
 public enum EmulationBackendState

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/MameEmulationBackend.cs
@@ -34,6 +34,8 @@ public sealed class MameEmulationBackend : IEmulationBackend
         _emulationService.StateChanged += OnMameStateChanged;
     }
 
+    public EmulationBackendKind BackendKind => EmulationBackendKind.Mame;
+
     public EmulationBackendState State => MapState(_emulationService.State);
 
     public EmulationBackendCapabilities Capabilities => MameCapabilities;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -77,6 +77,8 @@ public sealed class System6NativeBackend : IEmulationBackend
         _cyclesPerFrame = System6ClockHz / framesPerSecond;
     }
 
+    public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
+
     public EmulationBackendState State
     {
         get

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -56,10 +56,11 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
             reelDisplay.Stops.GetValueOrDefault(1),
             reelDisplay.IsReversed,
             reelDisplay.BandOffset.GetValueOrDefault(0d),
-            runtimeState.FruitMachinePlatform);
+            runtimeState.FruitMachinePlatform,
+            runtimeState.EmulationBackendKind);
     }
 
-    internal static double ResolveEffectiveReelPosition(double rawReelPosition, int stops, bool reelReversed, double reelBandOffset, FruitMachinePlatformType platform)
+    internal static double ResolveEffectiveReelPosition(double rawReelPosition, int stops, bool reelReversed, double reelBandOffset, FruitMachinePlatformType platform, EmulationBackendKind backendKind)
     {
         const double positionsPerRevolution = 96d;
         var safeStops = Math.Max(1, stops);
@@ -68,7 +69,7 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         var directionAdjusted = shouldReverse && wrapped != 0d
             ? positionsPerRevolution - wrapped
             : wrapped;
-        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(platform, safeStops);
+        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(backendKind, platform, safeStops);
         var offsetAdjusted = directionAdjusted + ((platformOffset + reelBandOffset) * positionsPerRevolution);
         return ((offsetAdjusted % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InternalReelOffsetResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InternalReelOffsetResolver.cs
@@ -1,0 +1,40 @@
+namespace OasisEditor;
+
+internal static class InternalReelOffsetResolver
+{
+    public static double ResolveBackendReelOffsetNormalized(
+        EmulationBackendKind backendKind,
+        FruitMachinePlatformType platform,
+        int stops)
+    {
+        var safeStops = Math.Max(1, stops);
+        return backendKind switch
+        {
+            EmulationBackendKind.NativeSystem6 => ResolveNativeSystem6ReelOffsetNormalized(platform, safeStops),
+            _ => ResolveMameReelOffsetNormalized(platform, safeStops)
+        };
+    }
+
+    // Backend calibration offsets only. These are deliberately separate from user/layout BandOffset values.
+    private static double ResolveMameReelOffsetNormalized(FruitMachinePlatformType platform, int stops)
+    {
+        return platform switch
+        {
+            FruitMachinePlatformType.MPU4 when stops == 16 => -0.05d,
+            FruitMachinePlatformType.Impact when stops == 12 => -0.025d,
+            FruitMachinePlatformType.Impact when stops == 16 => -0.08d,
+            FruitMachinePlatformType.Scorpion4 when stops == 12 => 0.2d,
+            FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
+            _ => 0d
+        };
+    }
+
+    private static double ResolveNativeSystem6ReelOffsetNormalized(FruitMachinePlatformType platform, int stops)
+    {
+        return platform switch
+        {
+            FruitMachinePlatformType.Impact when stops == 16 => 0.07d,
+            _ => 0d
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeState.cs
@@ -15,6 +15,7 @@ public class MachineRuntimeState
 
     public string? LampTestObjectId { get; set; }
     public FruitMachinePlatformType FruitMachinePlatform { get; set; } = FruitMachinePlatformType.None;
+    public EmulationBackendKind EmulationBackendKind { get; set; } = EmulationBackendKind.Mame;
 
     public bool IsLampTestActive => !string.IsNullOrWhiteSpace(LampTestObjectId);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -300,6 +300,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _reelRuntimeAdapter = new MameReelRuntimeAdapter(
             () => OpenDocuments,
             () => SelectedFruitMachinePlatform,
+            () => _activeEmulationBackend?.BackendKind ?? EmulationBackendKind.Mame,
             () => DebugOutputStdOut,
             message => AddOutputEntry(message, OutputLogStatus.Info),
             DispatchToUiThread);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MameReelRuntimeAdapter.cs
@@ -6,6 +6,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
     private readonly object _pendingSync = new();
     private readonly Func<IEnumerable<DocumentTabViewModel>> _documentProvider;
     private readonly Func<FruitMachinePlatformType> _platformProvider;
+    private readonly Func<EmulationBackendKind> _backendKindProvider;
     private readonly Func<bool> _debugOutputEnabledProvider;
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
@@ -18,12 +19,14 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
     public MameReelRuntimeAdapter(
         Func<IEnumerable<DocumentTabViewModel>> documentProvider,
         Func<FruitMachinePlatformType> platformProvider,
+        Func<EmulationBackendKind> backendKindProvider,
         Func<bool> debugOutputEnabledProvider,
         Action<string> infoLogger,
         Action<Action> uiDispatch)
     {
         _documentProvider = documentProvider ?? throw new ArgumentNullException(nameof(documentProvider));
         _platformProvider = platformProvider ?? throw new ArgumentNullException(nameof(platformProvider));
+        _backendKindProvider = backendKindProvider ?? throw new ArgumentNullException(nameof(backendKindProvider));
         _debugOutputEnabledProvider = debugOutputEnabledProvider ?? throw new ArgumentNullException(nameof(debugOutputEnabledProvider));
         _infoLogger = infoLogger ?? throw new ArgumentNullException(nameof(infoLogger));
         _uiDispatch = uiDispatch ?? throw new ArgumentNullException(nameof(uiDispatch));
@@ -69,6 +72,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         foreach (var document in documents)
         {
             document.RuntimeState.FruitMachinePlatform = platform;
+            document.RuntimeState.EmulationBackendKind = _backendKindProvider();
             var objectIdsByReel = GetOrBuildReelMapping(document);
             var faceObjectIdsByReel = FaceRuntimeDisplayReferenceIndex.GetObjectIdsByReference<FaceReelDisplayElement>(document, MachineObjectKind.Reel);
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
@@ -197,7 +201,7 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
             : wrapped;
-        var platformOffset = ResolvePlatformBandOffsetNormalized(_platformProvider(), stops);
+        var platformOffset = ResolvePlatformBandOffsetNormalized(_backendKindProvider(), _platformProvider(), stops);
         var totalOffset = platformOffset + reelBandOffset;
         var offsetSteps = totalOffset * ReelPositionsPerRevolution;
         var offsetAdjusted = directionAdjusted + offsetSteps;
@@ -209,17 +213,9 @@ public sealed class MameReelRuntimeAdapter : IMameReelRuntimeAdapter
         return platform == FruitMachinePlatformType.MPU4;
     }
 
-    internal static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)
+    internal static double ResolvePlatformBandOffsetNormalized(EmulationBackendKind backendKind, FruitMachinePlatformType platform, int stops)
     {
-        return platform switch
-        {
-            FruitMachinePlatformType.MPU4 when stops == 16 => -0.05d,
-            FruitMachinePlatformType.Impact when stops == 12 => -0.025d,
-            FruitMachinePlatformType.Impact when stops == 16 => -0.08d,
-            FruitMachinePlatformType.Scorpion4 when stops == 12 => 0.2d,
-            FruitMachinePlatformType.Scorpion4 when stops == 16 => 0.671d,
-            _ => 0d
-        };
+        return InternalReelOffsetResolver.ResolveBackendReelOffsetNormalized(backendKind, platform, stops);
     }
 
     private void OnDocumentPanelChanged()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ReelElementRenderer.cs
@@ -31,7 +31,7 @@ internal sealed class ReelElementRenderer : IPanelElementRenderer
             return runtimePosition + runtimeState.GetTemporaryReelOffset(element.ObjectId);
         }
 
-        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(runtimeState.FruitMachinePlatform, stops);
+        var platformOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(runtimeState.EmulationBackendKind, runtimeState.FruitMachinePlatform, stops);
         var bandOffset = element.BandOffset ?? 0d;
         return ((platformOffset + bandOffset) * LegacyReelPositionsPerRevolution)
             + runtimeState.GetTemporaryReelOffset(element.ObjectId);


### PR DESCRIPTION
### Motivation
- Provide internal, non-user-editable reel band offset corrections keyed by emulation backend so MAME behavior remains unchanged while Native System 6 can apply its own calibration. 
- Native System 6 16-stop reels require an additional normalized band offset correction of `+0.07` to align rendered bands with MAME-derived layouts. 
- Keep these corrections internal to the rendering / reel-position normalisation path and avoid exposing or persisting them as layout/user-editable data.

### Description
- Added `InternalReelOffsetResolver` with `ResolveBackendReelOffsetNormalized(EmulationBackendKind, FruitMachinePlatformType, int)` that centralises backend+platform+stop-count calibration offsets and documents them as internal-only corrections (file: `OasisEditor/InternalReelOffsetResolver.cs`).
- Introduced `EmulationBackendKind` to the backend abstraction and implemented `BackendKind` on existing backends, and threaded the active backend kind through `MameReelRuntimeAdapter` so runtime state carries both `FruitMachinePlatform` and `EmulationBackendKind` (files: `OasisEditor/Emulation/EmulationBackendAbstractions.cs`, `OasisEditor/Emulation/MameEmulationBackend.cs`, `OasisEditor/Emulation/Native/System6NativeBackend.cs`, `OasisEditor/MachineRuntimeState.cs`, `OasisEditor/MainWindowViewModel.cs`).
- Reworked reel-normalisation call sites to use the backend-aware lookup while preserving the user/layout `BandOffset` addition and existing wrapping/clamping logic, specifically in `MameReelRuntimeAdapter.ResolveEffectiveReelPosition`, `ReelElementRenderer.ResolvePreviewReelPosition`, and `FaceRuntimeStateResolver.ResolveEffectiveReelPosition` (files: `OasisEditor/MameReelRuntimeAdapter.cs`, `OasisEditor/Rendering/ReelElementRenderer.cs`, `OasisEditor/FaceRuntimeStateResolver.cs`).
- Added a unit test verifying the preserved MAME 16-stop Impact offset and the new Native System 6 16-stop correction (`0.07`) and updated test fakes for the new `BackendKind` contract (file: `OasisEditor.Tests/MameReelRuntimeAdapterTests.cs` and `OasisEditor.Tests/EmulationBackendFactoryTests.cs`).

### Testing
- Ran `git diff --check` and repository diff/stat to ensure no whitespace or simple diff errors were present, with no problems reported. 
- Updated unit tests to assert backend-specific offsets exist (added `ResolvePlatformBandOffsetNormalized_NativeSystem6_UsesBackendSpecificSixteenStopCorrection`), but no test runner was executed in this environment due to the projects Windows/.NET/WPF toolchain constraints. 
- Recommend local validation steps to run after pull: run the full test suite (`dotnet test`), verify a known MAME layout is unchanged, verify a Native System 6 16-stop layout shifts by `+0.07` normalized band offset, and confirm no layout files are altered by opening/saving.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a365d6aa6548327ad354054672a1de9)