### PR TITLE
Reduce System 6 native output polling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -265,6 +265,76 @@ public sealed class System6NativeBackendTests
         }
     }
 
+    [Fact]
+    public async Task StartAsyncOneRunOnlyPollsOnlyEnabledReelOptos()
+    {
+        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary();
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library);
+            var request = CreateLaunchRequest(rom1, rom2);
+            foreach (var reel in request.System6NativeRoms!.ReelOptos)
+            {
+                reel.Enabled = reel.ReelIndex is 0 or 2 or 4;
+            }
+
+            await backend.StartAsync(request, CancellationToken.None);
+            await backend.StopAsync(CancellationToken.None);
+
+            Assert.Contains("SetSteps:0:96", library.Calls);
+            Assert.Contains("SetSteps:2:96", library.Calls);
+            Assert.Contains("SetSteps:4:96", library.Calls);
+            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetSteps:1:", StringComparison.Ordinal));
+            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:3:", StringComparison.Ordinal));
+            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoEnd:5:", StringComparison.Ordinal));
+            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoInvert:7:", StringComparison.Ordinal));
+
+            var getPosOutCalls = library.Calls.Where(call => call.StartsWith("GetPosOut:", StringComparison.Ordinal)).ToArray();
+            Assert.Equal(new[] { "GetPosOut:-1", "GetPosOut:1", "GetPosOut:3" }, getPosOutCalls);
+            Assert.DoesNotContain("GetPosOut:0", library.Calls);
+            Assert.DoesNotContain("GetPosOut:2", library.Calls);
+            Assert.DoesNotContain("GetPosOut:4", library.Calls);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsyncOneRunOnlyPollsOnlyConfiguredLampIdsIncludingHighLamp()
+    {
+        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary();
+            library.GetLampsOnValues[5] = true;
+            library.GetLampsOnValues[255] = true;
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library);
+            var lampEvents = new List<MachineLampChangedEventArgs>();
+            backend.LampChanged += (_, e) => lampEvents.Add(e);
+
+            await backend.StartAsync(CreateLaunchRequest([5, 255], rom1, rom2), CancellationToken.None);
+            await backend.StopAsync(CancellationToken.None);
+
+            var getLampCalls = library.Calls.Where(call => call.StartsWith("GetLampsOn:", StringComparison.Ordinal)).ToArray();
+            Assert.Equal(new[] { "GetLampsOn:5", "GetLampsOn:255" }, getLampCalls);
+            Assert.Contains(lampEvents, e => e.LampId == 5 && e.Value == 255);
+            Assert.Contains(lampEvents, e => e.LampId == 255 && e.Value == 255);
+            Assert.DoesNotContain("GetLampsOn:0", library.Calls);
+            Assert.DoesNotContain("GetLampsOn:31", library.Calls);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
+        }
+    }
+
 
     [Theory]
     [InlineData(0, 96, 0)]
@@ -432,6 +502,11 @@ public sealed class System6NativeBackendTests
 
     private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)
     {
+        return CreateLaunchRequest(null, romPaths);
+    }
+
+    private static EmulationLaunchRequest CreateLaunchRequest(IReadOnlyList<int>? configuredLampIds, params string[] romPaths)
+    {
         return new EmulationLaunchRequest(
             FruitMachinePlatformType.None,
             "test-machine",
@@ -442,7 +517,8 @@ public sealed class System6NativeBackendTests
             {
                 ProgramRom1Path = romPaths.Length > 0 ? romPaths[0] : string.Empty,
                 ProgramRom2Path = romPaths.Length > 1 ? romPaths[1] : string.Empty
-            });
+            },
+            configuredLampIds);
     }
 
     private static (string DllPath, string Rom1, string Rom2) CreateNativeFiles(int romCount)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -65,7 +65,8 @@ public sealed record EmulationLaunchRequest(
     string RomRootPath,
     IReadOnlyList<string> RomPaths,
     string AdditionalArguments,
-    System6NativeRomSettings? System6NativeRoms = null);
+    System6NativeRomSettings? System6NativeRoms = null,
+    IReadOnlyList<int>? ConfiguredLampIds = null);
 
 public sealed class MachineLampChangedEventArgs : EventArgs
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -8,7 +8,8 @@ public sealed class System6NativeBackend : IEmulationBackend
 {
     private const int DefaultFramesPerSecond = 60;
     private const int System6ClockHz = 8000000;
-    private const int LampCount = 32;
+    private const int FallbackLampCount = 32;
+    private const int MaximumLampId = byte.MaxValue;
     private const int ReelCount = 16;
     private const int DiagnosticChangedLampSampleCount = 8;
     private const int DiagnosticMappingSampleCount = 8;
@@ -40,8 +41,8 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly long _frameDurationTimestampTicks;
     private readonly bool _timingDiagnosticsEnabled;
     private readonly object _stateGate = new();
-    private readonly int[] _lastLampValues = Enumerable.Repeat(-1, LampCount).ToArray();
-    private readonly int[] _lastLampRawValues = Enumerable.Repeat(-1, LampCount).ToArray();
+    private readonly int[] _lastLampValues = Enumerable.Repeat(-1, MaximumLampId + 1).ToArray();
+    private readonly int[] _lastLampRawValues = Enumerable.Repeat(-1, MaximumLampId + 1).ToArray();
     private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
     private readonly int[] _reelStepCounts = new int[ReelCount];
     private int[]? _lastAlphaSegments;
@@ -49,6 +50,8 @@ public sealed class System6NativeBackend : IEmulationBackend
     private bool _hasLoggedAlphaUnavailable;
     private bool _hasLoggedLampPollingConfiguration;
     private bool _hasLoggedReelPollingMapping;
+    private int[]? _configuredLampPollingIds;
+    private int[] _enabledReelPollingIndices = [];
 
     private ISystem6NativeLibrary? _library;
     private CancellationTokenSource? _runLoopCancellation;
@@ -173,6 +176,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             var reelOptos = ValidateReelOptos(nativeRoms.ReelOptos);
             var coins = ValidateCoins(nativeRoms.Coins);
             var percentSwitchValue = ValidatePercentSwitchValue(nativeRoms.PercentSwitchValue);
+            ConfigureLampPolling(request.ConfiguredLampIds);
 
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -220,6 +224,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             }
             ResetCachedOutputState();
             ResetConfiguredReelStepCounts();
+            ResetEnabledReelPollingIndices();
 
             try
             {
@@ -589,17 +594,21 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
     {
+        var enabledReelIndices = new List<int>();
         foreach (var reel in reelOptos.Where(reel => reel.Enabled))
         {
             var nativeReelIndex = checked((byte)reel.ReelIndex);
             var displayReelNumber = reel.ReelIndex + 1;
             library.SetSteps(nativeReelIndex, checked((byte)reel.Steps));
+            enabledReelIndices.Add(reel.ReelIndex);
             _reelStepCounts[reel.ReelIndex] = reel.Steps;
             library.SetOptoStart(nativeReelIndex, checked((byte)reel.OptoStart));
             library.SetOptoEnd(nativeReelIndex, checked((byte)reel.OptoEnd));
             library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
             LogStartupStage($"System6 reel {displayReelNumber} -> native index {nativeReelIndex}: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
         }
+
+        _enabledReelPollingIndices = enabledReelIndices.Distinct().OrderBy(index => index).ToArray();
     }
 
     private static void ApplyCoins(ISystem6NativeLibrary library, IReadOnlyList<System6CoinSettings> coins)
@@ -717,7 +726,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         }
 
         var changedDiagnostics = new List<string>();
-        for (var lampIndex = 0; lampIndex < LampCount; lampIndex++)
+        foreach (var lampIndex in GetLampPollingIds())
         {
             var nativeLampIndex = checked((ushort)lampIndex);
             var rawValue = library.GetLampsOn(nativeLampIndex) ? 1 : 0;
@@ -758,7 +767,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     {
         var nativeInvokeCount = 0;
         LogReelPollingMapping();
-        for (var reelIndex = 0; reelIndex < ReelCount; reelIndex++)
+        foreach (var reelIndex in _enabledReelPollingIndices)
         {
             var nativeReelIndex = reelIndex;
             // GetPosOut uses the System 6 position-output selector, which is offset
@@ -782,6 +791,29 @@ public sealed class System6NativeBackend : IEmulationBackend
     private void ResetConfiguredReelStepCounts()
     {
         Array.Clear(_reelStepCounts);
+    }
+
+    private void ResetEnabledReelPollingIndices()
+    {
+        _enabledReelPollingIndices = [];
+    }
+
+    private void ConfigureLampPolling(IReadOnlyList<int>? configuredLampIds)
+    {
+        _configuredLampPollingIds = configuredLampIds?
+            .Where(lampId => lampId is >= 0 and <= MaximumLampId)
+            .Distinct()
+            .OrderBy(lampId => lampId)
+            .ToArray();
+        if (_configuredLampPollingIds is { Length: 0 })
+        {
+            _configuredLampPollingIds = null;
+        }
+    }
+
+    private IReadOnlyList<int> GetLampPollingIds()
+    {
+        return _configuredLampPollingIds ?? Enumerable.Range(0, FallbackLampCount).ToArray();
     }
 
     private int NormalizeConfiguredNativeSystem6ReelPosition(int reelIndex, int rawPosition)
@@ -820,8 +852,10 @@ public sealed class System6NativeBackend : IEmulationBackend
         }
 
         _hasLoggedLampPollingConfiguration = true;
-        Debug.WriteLine($"[System6 Lamps] SYSTEM6UpdateLamps export {FormatOptionalExportStatus(library.IsLampsUpdateAvailable, library.LampsUpdateExportName)}; SYSTEM6GetLampsOn export available; value source=SYSTEM6GetLampsOn; polling native lamps 0-{LampCount - 1}");
-        var mappings = Enumerable.Range(0, Math.Min(LampCount, DiagnosticMappingSampleCount))
+        var lampIds = GetLampPollingIds();
+        var source = _configuredLampPollingIds is null ? $"fallback native lamps 0-{FallbackLampCount - 1}" : $"configured native lamp IDs ({lampIds.Count} total, range {lampIds.Min()}-{lampIds.Max()})";
+        Debug.WriteLine($"[System6 Lamps] SYSTEM6UpdateLamps export {FormatOptionalExportStatus(library.IsLampsUpdateAvailable, library.LampsUpdateExportName)}; SYSTEM6GetLampsOn export available; value source=SYSTEM6GetLampsOn; polling {source}");
+        var mappings = lampIds.Take(DiagnosticMappingSampleCount)
             .Select(index => $"native {index} -> lamp:{index}");
         Debug.WriteLine($"[System6 Lamps] mapping sample: {string.Join("; ", mappings)}");
     }
@@ -834,7 +868,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         }
 
         _hasLoggedReelPollingMapping = true;
-        var mappings = Enumerable.Range(0, Math.Min(ReelCount, DiagnosticMappingSampleCount))
+        var mappings = _enabledReelPollingIndices.Take(DiagnosticMappingSampleCount)
             .Select(index => $"native {index} -> reel:{index} (GetPosOut selector {index - 1})");
         Debug.WriteLine($"[System6 Reels] mapping sample: {string.Join("; ", mappings)}");
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2610,7 +2610,33 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             romRootPath,
             romPaths,
             MameCommandLineOverrides,
-            BuildSystem6NativeRomSettingsForLaunch());
+            BuildSystem6NativeRomSettingsForLaunch(),
+            BuildConfiguredLampIdsForLaunch());
+    }
+
+    private IReadOnlyList<int>? BuildConfiguredLampIdsForLaunch()
+    {
+        var lampIds = new SortedSet<int>();
+        foreach (var document in OpenDocuments)
+        {
+            foreach (var element in document.GetPanelElements())
+            {
+                if (element.Kind == PanelElementKind.Lamp && element.DisplayNumber is int lampId && lampId is >= 0 and <= byte.MaxValue)
+                {
+                    lampIds.Add(lampId);
+                }
+            }
+
+            foreach (var emitter in document.GetFaceDocument().LampEmitters)
+            {
+                if (emitter.LampId is int lampId && lampId is >= 0 and <= byte.MaxValue)
+                {
+                    lampIds.Add(lampId);
+                }
+            }
+        }
+
+        return lampIds.Count == 0 ? null : lampIds.ToArray();
     }
 
     private bool SetSystem6RomPath(ref string field, string value, string propertyName)


### PR DESCRIPTION
### Motivation
- System6 native backend was excessively chatty by polling a fixed range of lamps (`0-31`) and all 16 reels each frame instead of just the lamps/reels actually configured by the project or enabled by reel optos.
- Polling unused native outputs increased native call counts and timing diagnostics, and prevented support for lamp IDs above 31 even when the project used higher IDs.

### Description
- Added `ConfiguredLampIds` to `EmulationLaunchRequest` and populated it from open documents by `BuildConfiguredLampIdsForLaunch()` so the backend can receive a layout-derived lamp polling set via the launch request.
- Updated `System6NativeBackend` to support lamp IDs up to `255`, track an optional configured lamp ID list (`_configuredLampPollingIds`) and to poll only `GetLampsOn` for `GetLampPollingIds()` with a safe fallback of `0-31` when no configured set is supplied.
- Tracked enabled reel opto indices in `ApplyReelOptos` and stored them in `_enabledReelPollingIndices`, reset that set during startup/reset, and changed `PollReelOutputs`/logging to poll and report only those enabled reel indices while preserving the native selector mapping (`nativePositionSelector = nativeReelIndex - 1`) and zero-based Oasis reel IDs.
- Updated lamp/reel diagnostic logging to reflect whether configured lamp IDs or the fallback are used and to sample only actually polled mappings.
- Added unit tests in `System6NativeBackendTests` covering: only enabled reels are polled (assert `SetSteps`/`SetOpto*` and `GetPosOut` usage) and configured lamp ID polling including a high-value lamp such as `255` (assert `GetLampsOn` and `LampChanged` behavior).

### Testing
- No automated tests were executed in this environment because the agent cannot run the Windows/.NET/WPF toolchain here; the change adds two tests: `StartAsyncOneRunOnlyPollsOnlyEnabledReelOptos` and `StartAsyncOneRunOnlyPollsOnlyConfiguredLampIdsIncludingHighLamp` to `System6NativeBackendTests` and preserves existing tests.
- Please run the solution tests locally with `dotnet test` for `OasisEditor` and confirm the new tests and existing test suite pass on the target Windows/.NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a366d05dda88327b94c64eb8df29a9e)