### PR TITLE
Fix NativeSystem6 reel offset test expectation

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs
@@ -26,7 +26,7 @@ public sealed class MameReelRuntimeAdapterTests
         var nativeOffset = MameReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(EmulationBackendKind.NativeSystem6, FruitMachinePlatformType.Impact, 16);
 
         Assert.Equal(-0.08d, mameOffset, 6);
-        Assert.Equal(0.07d, nativeOffset, 6);
+        Assert.Equal(-0.01d, nativeOffset, 6);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- A test was failing because the backend-specific sixteen-stop reel offset for `NativeSystem6` was corrected to `-0.01`, so the test expectation needed to match the corrected value.

### Description
- Updated the assertion in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MameReelRuntimeAdapterTests.cs` to expect `-0.01d` for the `NativeSystem6` sixteen-stop offset instead of `0.07d`.

### Testing
- No automated tests were run in this environment per `WindowsNetProjects/OasisEditor/AGENTS.md`; please run `dotnet test` locally and confirm the `OasisEditor.Tests` suite (including `ResolvePlatformBandOffsetNormalized_NativeSystem6_UsesBackendSpecificSixteenStopCorrection`) passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36779aa2dc83279ef2696d3e153858)