### PR TITLE
Serialize System6 native Run and Poll into single owner loop to prevent alpha tearing

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -413,13 +413,52 @@ public sealed class System6NativeBackendTests
             await backend.StopAsync(CancellationToken.None);
 
             Assert.Equal(Enumerable.Range(0, 16).ToArray(), library.AlphaSegmentIndices);
+            Assert.Equal(16, segmentEvents.Count(e => e.OutputType == MameSegmentOutputType.NativeAlpha));
             Assert.Contains(segmentEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001 && e.OutputType == MameSegmentOutputType.NativeAlpha);
             Assert.Contains(segmentEvents, e => e.CellId == 1 && e.SegmentMask == 0x2002 && e.OutputType == MameSegmentOutputType.NativeAlpha);
+            Assert.Contains(segmentEvents, e => e.CellId == 15 && e.SegmentMask == 0x0000 && e.OutputType == MameSegmentOutputType.NativeAlpha);
         }
         finally
         {
             Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
         }
+    }
+
+
+    [Fact]
+    public async Task NativeCoreOwnerLoopDoesNotRunDuringFullAlphaFrameSnapshot()
+    {
+        var previousPolling = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING");
+        var previousPump = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", "1");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", "2000");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary { AlphaSegmentPollingAvailable = true };
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library, framesPerSecond: 60);
+
+            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+            var observedAlphaFrame = SpinWait.SpinUntil(() => Volatile.Read(ref library.AlphaSegmentPollCount) >= 16, TimeSpan.FromSeconds(1));
+            await backend.StopAsync(CancellationToken.None);
+
+            Assert.True(observedAlphaFrame, "Expected at least one full alpha frame poll.");
+            Assert.False(library.RunObservedDuringAlphaSnapshot);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", previousPolling);
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", previousPump);
+        }
+    }
+
+    [Theory]
+    [InlineData(new[] { 1, 2, 3 }, new[] { 1, 4, 3 }, true)]
+    [InlineData(new[] { 1, 2, 3 }, new[] { 4, 5, 6 }, false)]
+    [InlineData(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, false)]
+    public void IsPotentialTornAlphaFrame_FlagsMixedPreviousAndChangedCells(int[] previous, int[] current, bool expected)
+    {
+        Assert.Equal(expected, System6NativeBackend.IsPotentialTornAlphaFrame(previous, current));
     }
 
     [Fact]
@@ -633,6 +672,10 @@ public sealed class System6NativeBackendTests
 
         public int RunCallCount;
 
+        public bool AlphaSnapshotInProgress;
+
+        public bool RunObservedDuringAlphaSnapshot;
+
         public Dictionary<ushort, bool> GetLampsOnValues { get; } = new();
 
         public Dictionary<sbyte, short> PositionOutputs { get; } = new();
@@ -640,6 +683,8 @@ public sealed class System6NativeBackendTests
         public Dictionary<byte, int> AlphaSegments { get; } = new();
 
         public List<int> AlphaSegmentIndices { get; } = new();
+
+        public int AlphaSegmentPollCount;
 
         public bool AlphaSegmentPollingAvailable { get; set; }
 
@@ -731,6 +776,11 @@ public sealed class System6NativeBackendTests
         public int Run(int cycles)
         {
             Calls.Add($"Run:{cycles}");
+            if (Volatile.Read(ref AlphaSnapshotInProgress))
+            {
+                RunObservedDuringAlphaSnapshot = true;
+            }
+
             Interlocked.Increment(ref RunCallCount);
             return 1;
         }
@@ -765,9 +815,21 @@ public sealed class System6NativeBackendTests
 
         public int GetAlphaSegments(byte index)
         {
+            if (index == 0)
+            {
+                Volatile.Write(ref AlphaSnapshotInProgress, true);
+            }
+
             Calls.Add($"GetAlphaSegments:{index}");
             AlphaSegmentIndices.Add(index);
-            return AlphaSegments.TryGetValue(index, out var segments) ? segments : 0;
+            Interlocked.Increment(ref AlphaSegmentPollCount);
+            var value = AlphaSegments.TryGetValue(index, out var segments) ? segments : 0;
+            if (index == 15)
+            {
+                Volatile.Write(ref AlphaSnapshotInProgress, false);
+            }
+
+            return value;
         }
 
         public bool IsAlphaBrightnessPollingAvailable => AlphaBrightnessPollingAvailable;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -452,6 +452,39 @@ public sealed class System6NativeBackendTests
         }
     }
 
+
+    [Fact]
+    public async Task NativeCoreOwnerLoopDoesNotRunDuringFullPollOutputsPass()
+    {
+        var previousPolling = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING");
+        var previousPump = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", "1");
+        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", "2000");
+        try
+        {
+            var library = new FakeSystem6NativeLibrary
+            {
+                AlphaSegmentPollingAvailable = true,
+                SevenSegmentPollingAvailable = true
+            };
+            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+            var backend = new System6NativeBackend(dllPath, _ => library, framesPerSecond: 60);
+            var request = CreateLaunchRequest([0], rom1, rom2) with { ConfiguredSevenSegmentDisplayIds = [0] };
+
+            await backend.StartAsync(request, CancellationToken.None);
+            var observedPollPass = SpinWait.SpinUntil(() => Volatile.Read(ref library.PollOutputsPassCount) >= 1, TimeSpan.FromSeconds(1));
+            await backend.StopAsync(CancellationToken.None);
+
+            Assert.True(observedPollPass, "Expected at least one full PollOutputs pass.");
+            Assert.False(library.RunObservedDuringPollOutputs);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", previousPolling);
+            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", previousPump);
+        }
+    }
+
     [Theory]
     [InlineData(new[] { 1, 2, 3 }, new[] { 1, 4, 3 }, true)]
     [InlineData(new[] { 1, 2, 3 }, new[] { 4, 5, 6 }, false)]
@@ -676,6 +709,12 @@ public sealed class System6NativeBackendTests
 
         public bool RunObservedDuringAlphaSnapshot;
 
+        public bool PollOutputsInProgress;
+
+        public bool RunObservedDuringPollOutputs;
+
+        public int PollOutputsPassCount;
+
         public Dictionary<ushort, bool> GetLampsOnValues { get; } = new();
 
         public Dictionary<sbyte, short> PositionOutputs { get; } = new();
@@ -734,7 +773,14 @@ public sealed class System6NativeBackendTests
         public int GetSegsOn(ushort index)
         {
             Calls.Add($"GetSegsOn:{index}");
-            return SevenSegmentCells.TryGetValue(index, out var isOn) && isOn ? 1 : 0;
+            var value = SevenSegmentCells.TryGetValue(index, out var isOn) && isOn ? 1 : 0;
+            if (index == 7)
+            {
+                Interlocked.Increment(ref PollOutputsPassCount);
+                Volatile.Write(ref PollOutputsInProgress, false);
+            }
+
+            return value;
         }
 
         public byte GetSegsBright(ushort index)
@@ -781,6 +827,11 @@ public sealed class System6NativeBackendTests
                 RunObservedDuringAlphaSnapshot = true;
             }
 
+            if (Volatile.Read(ref PollOutputsInProgress))
+            {
+                RunObservedDuringPollOutputs = true;
+            }
+
             Interlocked.Increment(ref RunCallCount);
             return 1;
         }
@@ -795,7 +846,11 @@ public sealed class System6NativeBackendTests
 
         public string? LampsUpdateExportName => "SYSTEM6UpdateLamps";
 
-        public void LampsUpdate() => Calls.Add("LampsUpdate");
+        public void LampsUpdate()
+        {
+            Volatile.Write(ref PollOutputsInProgress, true);
+            Calls.Add("LampsUpdate");
+        }
 
         public bool GetLampsOn(ushort lampIndex)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -66,8 +66,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private ISystem6NativeLibrary? _library;
     private CancellationTokenSource? _runLoopCancellation;
-    private Task? _runLoopTask;
-    private Task? _pollLoopTask;
+    private Task? _nativeCoreLoopTask;
     private EmulationBackendState _state = EmulationBackendState.Stopped;
     private DateTime _lastRunWarningUtc = DateTime.MinValue;
 
@@ -276,11 +275,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             LogStartupStage("first Run skipped / pending");
             Debug.WriteLine($"System6 native backend timing config: emulationPumpHz={_emulationPumpHz}; slice={_emulationInterval.TotalMilliseconds:0.###} ms; outputPollingEnabled={_outputPollingEnabled}; outputPollHz={_outputPollsPerSecond}.");
             _runLoopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _runLoopTask = Task.Run(() => RunLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
-            if (_outputPollingEnabled)
-            {
-                _pollLoopTask = Task.Run(() => PollLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
-            }
+            _nativeCoreLoopTask = Task.Run(() => NativeCoreOwnerLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
             SetState(EmulationBackendState.Running);
             return Task.CompletedTask;
         }
@@ -307,41 +302,26 @@ public sealed class System6NativeBackend : IEmulationBackend
             await runLoopCancellation.CancelAsync().ConfigureAwait(false);
         }
 
-        if (_runLoopTask is not null)
+        if (_nativeCoreLoopTask is not null)
         {
             try
             {
-                await _runLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _nativeCoreLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (runLoopCancellation?.IsCancellationRequested == true)
             {
             }
             catch
             {
-                // The run loop moves the backend to Failed before faulting. Stop should still
+                // The native-core owner loop moves the backend to Failed before faulting. Stop should still
                 // release the native core and return the backend to a clean stopped state.
-            }
-        }
-
-        if (_pollLoopTask is not null)
-        {
-            try
-            {
-                await _pollLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (runLoopCancellation?.IsCancellationRequested == true)
-            {
-            }
-            catch
-            {
             }
         }
 
         ShutdownAndDisposeLibrary();
         _runLoopCancellation?.Dispose();
         _runLoopCancellation = null;
-        _runLoopTask = null;
-        _pollLoopTask = null;
+        _nativeCoreLoopTask = null;
         SetState(EmulationBackendState.Stopped);
     }
 
@@ -501,10 +481,12 @@ public sealed class System6NativeBackend : IEmulationBackend
         Debug.WriteLine($"System6 native startup: {message}");
     }
 
-    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    private async Task NativeCoreOwnerLoopAsync(CancellationToken cancellationToken)
     {
         var nextSliceTimestamp = Stopwatch.GetTimestamp();
+        var nextPollTimestamp = nextSliceTimestamp + _pollIntervalTimestampTicks;
         var sliceIndex = 0L;
+        var skippedPolls = 0L;
         var diagnosticsStartedAt = Stopwatch.GetTimestamp();
         var diagnosticsCycles = 0L;
 
@@ -514,13 +496,19 @@ public sealed class System6NativeBackend : IEmulationBackend
             {
                 if (State is not EmulationBackendState.Running || _library is not { } library)
                 {
-                    nextSliceTimestamp = Stopwatch.GetTimestamp() + _emulationIntervalTimestampTicks;
+                    var now = Stopwatch.GetTimestamp();
+                    nextSliceTimestamp = now + _emulationIntervalTimestampTicks;
+                    nextPollTimestamp = now + _pollIntervalTimestampTicks;
                     await Task.Delay(_emulationInterval, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
 
+                var now = Stopwatch.GetTimestamp();
                 var slicesRunThisLoop = 0;
-                do
+                while (!cancellationToken.IsCancellationRequested
+                    && State is EmulationBackendState.Running
+                    && slicesRunThisLoop < MaxCatchUpSlicesPerLoop
+                    && now >= nextSliceTimestamp)
                 {
                     var cycles = CalculateCyclesForSlice(sliceIndex++);
                     var runStartTimestamp = Stopwatch.GetTimestamp();
@@ -535,73 +523,40 @@ public sealed class System6NativeBackend : IEmulationBackend
                     WarnIfEmulationTimingIsSlow(cycles, runElapsed, Stopwatch.GetTimestamp() - diagnosticsStartedAt, diagnosticsCycles, 0);
                     nextSliceTimestamp += _emulationIntervalTimestampTicks;
                     slicesRunThisLoop++;
+                    now = Stopwatch.GetTimestamp();
                 }
-                while (!cancellationToken.IsCancellationRequested
-                    && State is EmulationBackendState.Running
-                    && slicesRunThisLoop < MaxCatchUpSlicesPerLoop
-                    && Stopwatch.GetTimestamp() >= nextSliceTimestamp);
 
-                var now = Stopwatch.GetTimestamp();
-                if (now >= nextSliceTimestamp)
+                if (now >= nextSliceTimestamp && slicesRunThisLoop >= MaxCatchUpSlicesPerLoop)
                 {
                     WarnIfEmulationTimingIsSlow(0, TimeSpan.Zero, now - diagnosticsStartedAt, diagnosticsCycles, slicesRunThisLoop);
-                    if (slicesRunThisLoop >= MaxCatchUpSlicesPerLoop)
+                    nextSliceTimestamp = now + _emulationIntervalTimestampTicks;
+                }
+
+                if (_outputPollingEnabled && now >= nextPollTimestamp)
+                {
+                    var pollStartTimestamp = Stopwatch.GetTimestamp();
+                    var pollInvokeCount = PollOutputs(library);
+                    var pollElapsed = TimestampTicksToTimeSpan(Stopwatch.GetTimestamp() - pollStartTimestamp);
+                    nextPollTimestamp += _pollIntervalTimestampTicks;
+
+                    now = Stopwatch.GetTimestamp();
+                    while (now >= nextPollTimestamp)
                     {
-                        nextSliceTimestamp = now + _emulationIntervalTimestampTicks;
+                        skippedPolls++;
+                        nextPollTimestamp += _pollIntervalTimestampTicks;
                     }
 
-                    continue;
+                    WarnIfPollTimingIsSlow(pollElapsed, skippedPolls, pollInvokeCount);
                 }
-
-                await Task.Delay(TimestampTicksToTimeSpan(nextSliceTimestamp - now), cancellationToken).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-        catch
-        {
-            SetState(EmulationBackendState.Failed);
-            throw;
-        }
-    }
-
-    private async Task PollLoopAsync(CancellationToken cancellationToken)
-    {
-        var nextPollTimestamp = Stopwatch.GetTimestamp() + _pollIntervalTimestampTicks;
-        var skippedPolls = 0L;
-
-        try
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                if (State is not EmulationBackendState.Running || _library is not { } library)
-                {
-                    nextPollTimestamp = Stopwatch.GetTimestamp() + _pollIntervalTimestampTicks;
-                    await Task.Delay(_pollInterval, cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                var now = Stopwatch.GetTimestamp();
-                if (now < nextPollTimestamp)
-                {
-                    await Task.Delay(TimestampTicksToTimeSpan(nextPollTimestamp - now), cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                var pollStartTimestamp = Stopwatch.GetTimestamp();
-                var pollInvokeCount = PollOutputs(library);
-                var pollElapsed = TimestampTicksToTimeSpan(Stopwatch.GetTimestamp() - pollStartTimestamp);
-                nextPollTimestamp += _pollIntervalTimestampTicks;
 
                 now = Stopwatch.GetTimestamp();
-                while (now >= nextPollTimestamp)
+                var nextWakeTimestamp = _outputPollingEnabled
+                    ? Math.Min(nextSliceTimestamp, nextPollTimestamp)
+                    : nextSliceTimestamp;
+                if (now < nextWakeTimestamp)
                 {
-                    skippedPolls++;
-                    nextPollTimestamp += _pollIntervalTimestampTicks;
+                    await Task.Delay(TimestampTicksToTimeSpan(nextWakeTimestamp - now), cancellationToken).ConfigureAwait(false);
                 }
-
-                WarnIfPollTimingIsSlow(pollElapsed, skippedPolls, pollInvokeCount);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -1104,11 +1059,16 @@ public sealed class System6NativeBackend : IEmulationBackend
             return nativeInvokeCount;
         }
 
+        var previousAlphaSegments = _lastAlphaSegments;
         _lastAlphaSegments = segments;
         if (_timingDiagnosticsEnabled)
         {
             Debug.WriteLine($"System6 alpha segs: {FormatAlphaSegments(segments)}");
             Debug.WriteLine($"System6 alpha mapped segs: {FormatAlphaSegments(mappedSegments)}");
+            if (IsPotentialTornAlphaFrame(previousAlphaSegments, segments))
+            {
+                Debug.WriteLine($"[System6 Alpha] possible torn full-frame snapshot during message change: previous={FormatAlphaSegments(previousAlphaSegments!)} current={FormatAlphaSegments(segments)}");
+            }
         }
 
         for (var index = 0; index < segments.Length; index++)
@@ -1122,6 +1082,32 @@ public sealed class System6NativeBackend : IEmulationBackend
         }
 
         return nativeInvokeCount;
+    }
+
+
+    internal static bool IsPotentialTornAlphaFrame(IReadOnlyList<int>? previousSegments, IReadOnlyList<int> currentSegments)
+    {
+        ArgumentNullException.ThrowIfNull(currentSegments);
+        if (previousSegments is null || previousSegments.Count != currentSegments.Count || currentSegments.Count == 0)
+        {
+            return false;
+        }
+
+        var unchangedCells = 0;
+        var changedCells = 0;
+        for (var index = 0; index < currentSegments.Count; index++)
+        {
+            if (previousSegments[index] == currentSegments[index])
+            {
+                unchangedCells++;
+            }
+            else
+            {
+                changedCells++;
+            }
+        }
+
+        return changedCells > 0 && unchangedCells > 0;
     }
 
     internal static double NormalizeSystem6AlphaBrightness(byte rawBrightness)
@@ -1170,8 +1156,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         ShutdownAndDisposeLibrary();
         _runLoopCancellation?.Dispose();
         _runLoopCancellation = null;
-        _runLoopTask = null;
-        _pollLoopTask = null;
+        _nativeCoreLoopTask = null;
     }
 
     private void ShutdownAndDisposeLibrary()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -496,9 +496,9 @@ public sealed class System6NativeBackend : IEmulationBackend
             {
                 if (State is not EmulationBackendState.Running || _library is not { } library)
                 {
-                    var now = Stopwatch.GetTimestamp();
-                    nextSliceTimestamp = now + _emulationIntervalTimestampTicks;
-                    nextPollTimestamp = now + _pollIntervalTimestampTicks;
+                    var pausedTimestamp = Stopwatch.GetTimestamp();
+                    nextSliceTimestamp = pausedTimestamp + _emulationIntervalTimestampTicks;
+                    nextPollTimestamp = pausedTimestamp + _pollIntervalTimestampTicks;
                     await Task.Delay(_emulationInterval, cancellationToken).ConfigureAwait(false);
                     continue;
                 }


### PR DESCRIPTION
### Motivation
- Alpha output tearing/stale 16-cell alpha frames were caused by concurrent calls into the native System6 DLL (`SYSTEM6Run` vs output getters) capturing mixed intermediate state during message transitions.
- The native core must be owned by a single background loop so `Run` and output polling never race and full 16-cell alpha snapshots are consistent.
- Add diagnostics and regression coverage to detect and log torn full-frame alpha snapshots during message changes.

### Description
- Replaced the separate run and poll tasks with a single `NativeCoreOwnerLoopAsync` owner loop and replaced `_runLoopTask`/`_pollLoopTask` with `_nativeCoreLoopTask` so all DLL calls are serialized on one background task.
- Owner loop advances emulation slices at the configured pump rate, polls outputs when due, skips visual polls when behind, and computes a single next-wake timestamp to avoid concurrent native calls.
- Modified alpha polling to read the full 16-cell frame before publishing; added `IsPotentialTornAlphaFrame` helper and timing-diagnostic logging when a mixed/torn frame is detected.
- Added regression unit test `NativeCoreOwnerLoopDoesNotRunDuringFullAlphaFrameSnapshot` and extended existing alpha tests to assert full 16-cell emissions (including blank cells); extended the `FakeSystem6NativeLibrary` test double to mark alpha snapshot progress and detect `Run` calls during a snapshot.

### Testing
- Ran `git diff --check` to validate whitespace/patch-level issues, which succeeded.
- No .NET unit tests were executed in this environment due to the project environment constraints; the new/modified tests to exercise the owner loop and torn-frame detection were added and should be run on the Windows/.NET toolchain (`dotnet test`) locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36b1d95c688327a48c8146d5be9245)