### PR TITLE
Improve cabinet GLB material rendering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
@@ -50,13 +50,14 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
                 return CabinetModelLoadResult.Failure("The .glb loaded, but it did not contain a scene to display.");
             }
 
-            var primitiveMeshes = new Dictionary<Material?, MeshGeometry3D>();
+            var primitiveMeshes = new Dictionary<int, MeshGeometry3D>();
             var triangleCount = 0;
             foreach (var (a, b, c, material) in scene.EvaluateTriangles())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var mesh = GetMeshForMaterial(primitiveMeshes, material);
+                var materialIndex = GetLogicalIndex(material);
+                var mesh = GetMeshForMaterial(primitiveMeshes, materialIndex);
                 var pointA = ToPoint3D(a);
                 var pointB = ToPoint3D(b);
                 var pointC = ToPoint3D(c);
@@ -75,15 +76,16 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
             }
 
             var group = new Model3DGroup();
-            foreach (var (material, mesh) in primitiveMeshes)
+            foreach (var (materialIndex, mesh) in primitiveMeshes)
             {
                 mesh.Freeze();
-                var wpfMaterial = CreateMaterial(materialInfos.GetMaterialInfo(GetLogicalIndex(material)));
+                var materialInfo = materialInfos.GetMaterialInfo(materialIndex);
+                var wpfMaterial = CreateMaterial(materialInfo);
                 var model = new GeometryModel3D
                 {
                     Geometry = mesh,
                     Material = wpfMaterial,
-                    BackMaterial = materialInfos.GetMaterialInfo(GetLogicalIndex(material)).DoubleSided ? wpfMaterial : null
+                    BackMaterial = materialInfo.DoubleSided ? wpfMaterial : null
                 };
                 model.Freeze();
                 group.Children.Add(model);
@@ -102,12 +104,12 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         }
     }
 
-    private static MeshGeometry3D GetMeshForMaterial(Dictionary<Material?, MeshGeometry3D> meshes, Material? material)
+    private static MeshGeometry3D GetMeshForMaterial(Dictionary<int, MeshGeometry3D> meshes, int materialIndex)
     {
-        if (!meshes.TryGetValue(material, out var mesh))
+        if (!meshes.TryGetValue(materialIndex, out var mesh))
         {
             mesh = new MeshGeometry3D();
-            meshes.Add(material, mesh);
+            meshes.Add(materialIndex, mesh);
         }
 
         return mesh;
@@ -162,7 +164,7 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         return normal;
     }
 
-    private static int GetLogicalIndex(Material? material)
+    private static int GetLogicalIndex(SharpGLTF.Schema2.Material? material)
     {
         if (material is null) return -1;
         try { return material.LogicalIndex; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
@@ -1,5 +1,10 @@
 using System.IO;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using System.Windows;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Media.Media3D;
 using SharpGLTF.Geometry;
 using SharpGLTF.Geometry.VertexTypes;
@@ -37,6 +42,7 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var materialInfos = GlbMaterialInfoCollection.ReadFrom(modelPath);
             var modelRoot = ModelRoot.Load(modelPath);
             var scene = modelRoot.DefaultScene ?? modelRoot.LogicalScenes.FirstOrDefault();
             if (scene is null)
@@ -44,20 +50,21 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
                 return CabinetModelLoadResult.Failure("The .glb loaded, but it did not contain a scene to display.");
             }
 
-            var mesh = new MeshGeometry3D();
+            var primitiveMeshes = new Dictionary<Material?, MeshGeometry3D>();
             var triangleCount = 0;
-            foreach (var triangle in scene.EvaluateTriangles())
+            foreach (var (a, b, c, material) in scene.EvaluateTriangles())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var pointA = ToPoint3D(triangle.A);
-                var pointB = ToPoint3D(triangle.B);
-                var pointC = ToPoint3D(triangle.C);
-                var normal = CalculateNormal(pointA, pointB, pointC);
+                var mesh = GetMeshForMaterial(primitiveMeshes, material);
+                var pointA = ToPoint3D(a);
+                var pointB = ToPoint3D(b);
+                var pointC = ToPoint3D(c);
+                var fallbackNormal = CalculateNormal(pointA, pointB, pointC);
 
-                AddTriangleVertex(mesh, pointA, normal);
-                AddTriangleVertex(mesh, pointB, normal);
-                AddTriangleVertex(mesh, pointC, normal);
+                AddTriangleVertex(mesh, a, pointA, fallbackNormal);
+                AddTriangleVertex(mesh, b, pointB, fallbackNormal);
+                AddTriangleVertex(mesh, c, pointC, fallbackNormal);
 
                 triangleCount++;
             }
@@ -67,20 +74,22 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
                 return CabinetModelLoadResult.Failure("The .glb loaded, but it did not contain displayable triangle geometry.");
             }
 
-            mesh.Freeze();
-
-            var model = new GeometryModel3D
-            {
-                Geometry = mesh,
-                Material = DefaultMaterial,
-                BackMaterial = DefaultMaterial
-            };
-            model.Freeze();
-
             var group = new Model3DGroup();
-            group.Children.Add(model);
-            group.Freeze();
+            foreach (var (material, mesh) in primitiveMeshes)
+            {
+                mesh.Freeze();
+                var wpfMaterial = CreateMaterial(materialInfos.GetMaterialInfo(GetLogicalIndex(material)));
+                var model = new GeometryModel3D
+                {
+                    Geometry = mesh,
+                    Material = wpfMaterial,
+                    BackMaterial = materialInfos.GetMaterialInfo(GetLogicalIndex(material)).DoubleSided ? wpfMaterial : null
+                };
+                model.Freeze();
+                group.Children.Add(model);
+            }
 
+            group.Freeze();
             return CabinetModelLoadResult.Success(group);
         }
         catch (OperationCanceledException)
@@ -93,18 +102,52 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         }
     }
 
+    private static MeshGeometry3D GetMeshForMaterial(Dictionary<Material?, MeshGeometry3D> meshes, Material? material)
+    {
+        if (!meshes.TryGetValue(material, out var mesh))
+        {
+            mesh = new MeshGeometry3D();
+            meshes.Add(material, mesh);
+        }
+
+        return mesh;
+    }
+
     private static Point3D ToPoint3D(IVertexBuilder vertex)
     {
         var position = vertex.GetGeometry().GetPosition();
         return new Point3D(position.X, position.Y, position.Z);
     }
 
-    private static void AddTriangleVertex(MeshGeometry3D mesh, Point3D point, Vector3D normal)
+    private static void AddTriangleVertex(MeshGeometry3D mesh, IVertexBuilder vertex, Point3D point, Vector3D fallbackNormal)
     {
         var index = mesh.Positions.Count;
         mesh.Positions.Add(point);
-        mesh.Normals.Add(normal);
+        mesh.Normals.Add(TryGetNormal(vertex, out var normal) ? normal : fallbackNormal);
+        mesh.TextureCoordinates.Add(ToTextureCoordinate(vertex));
         mesh.TriangleIndices.Add(index);
+    }
+
+    private static bool TryGetNormal(IVertexBuilder vertex, out Vector3D normal)
+    {
+        if (vertex.GetGeometry().TryGetNormal(out Vector3 sourceNormal) && sourceNormal.LengthSquared() > float.Epsilon)
+        {
+            normal = new Vector3D(sourceNormal.X, sourceNormal.Y, sourceNormal.Z);
+            normal.Normalize();
+            return true;
+        }
+
+        normal = default;
+        return false;
+    }
+
+    private static Point ToTextureCoordinate(IVertexBuilder vertex)
+    {
+        var material = vertex.GetMaterial();
+        if (material is null) return new Point(0, 0);
+
+        var uv = material.GetTexCoord(0);
+        return new Point(uv.X, uv.Y);
     }
 
     private static Vector3D CalculateNormal(Point3D a, Point3D b, Point3D c)
@@ -119,10 +162,164 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         return normal;
     }
 
+    private static int GetLogicalIndex(Material? material)
+    {
+        if (material is null) return -1;
+        try { return material.LogicalIndex; }
+        catch { return -1; }
+    }
+
+    private static System.Windows.Media.Media3D.Material CreateMaterial(GlbMaterialInfo info)
+    {
+        try
+        {
+            Brush brush = info.BaseColorTexture is null
+                ? new SolidColorBrush(info.BaseColor)
+                : new ImageBrush(info.BaseColorTexture) { ViewportUnits = BrushMappingMode.Absolute, TileMode = TileMode.None, Stretch = Stretch.Fill };
+            brush.Opacity = info.AlphaMode == GlbAlphaMode.Opaque ? 1d : info.BaseColor.A / 255d;
+            brush.Freeze();
+            var material = new DiffuseMaterial(brush);
+            material.Freeze();
+            return material;
+        }
+        catch
+        {
+            return DefaultMaterial;
+        }
+    }
+
     private static DiffuseMaterial CreateDefaultMaterial()
     {
         var material = new DiffuseMaterial(new SolidColorBrush(Color.FromRgb(192, 196, 204)));
         material.Freeze();
         return material;
+    }
+
+    private sealed record GlbMaterialInfo(Color BaseColor, ImageSource? BaseColorTexture, GlbAlphaMode AlphaMode, bool DoubleSided)
+    {
+        public static GlbMaterialInfo Default { get; } = new(Color.FromRgb(192, 196, 204), null, GlbAlphaMode.Opaque, true);
+    }
+
+    private enum GlbAlphaMode { Opaque, Mask, Blend }
+
+    private sealed class GlbMaterialInfoCollection
+    {
+        private readonly Dictionary<int, GlbMaterialInfo> _materials;
+        public GlbMaterialInfoCollection(Dictionary<int, GlbMaterialInfo> materials) => _materials = materials;
+        public GlbMaterialInfo GetMaterialInfo(int index) => _materials.TryGetValue(index, out var info) ? info : GlbMaterialInfo.Default;
+
+        public static GlbMaterialInfoCollection ReadFrom(string modelPath)
+        {
+            try
+            {
+                var glb = ReadGlb(modelPath);
+                using var document = JsonDocument.Parse(glb.Json);
+                var root = document.RootElement;
+                var result = new Dictionary<int, GlbMaterialInfo>();
+                if (!root.TryGetProperty("materials", out var materials) || materials.ValueKind != JsonValueKind.Array)
+                {
+                    return new GlbMaterialInfoCollection(result);
+                }
+
+                for (var i = 0; i < materials.GetArrayLength(); i++)
+                {
+                    var material = materials[i];
+                    var baseColor = ReadBaseColor(material);
+                    var texture = ReadBaseColorTexture(root, glb.BinaryChunk, material);
+                    var alphaMode = ReadAlphaMode(material);
+                    var doubleSided = material.TryGetProperty("doubleSided", out var doubleSidedElement) && doubleSidedElement.GetBoolean();
+                    result[i] = new GlbMaterialInfo(baseColor, texture, alphaMode, doubleSided);
+                }
+
+                return new GlbMaterialInfoCollection(result);
+            }
+            catch
+            {
+                return new GlbMaterialInfoCollection(new Dictionary<int, GlbMaterialInfo>());
+            }
+        }
+
+        private static Color ReadBaseColor(JsonElement material)
+        {
+            if (material.TryGetProperty("pbrMetallicRoughness", out var pbr)
+                && pbr.TryGetProperty("baseColorFactor", out var factor)
+                && factor.ValueKind == JsonValueKind.Array
+                && factor.GetArrayLength() >= 4)
+            {
+                return Color.FromArgb(ToByte(factor[3]), ToByte(factor[0]), ToByte(factor[1]), ToByte(factor[2]));
+            }
+
+            return GlbMaterialInfo.Default.BaseColor;
+        }
+
+        private static GlbAlphaMode ReadAlphaMode(JsonElement material)
+        {
+            if (!material.TryGetProperty("alphaMode", out var alphaMode)) return GlbAlphaMode.Opaque;
+            return alphaMode.GetString() switch
+            {
+                "MASK" => GlbAlphaMode.Mask,
+                "BLEND" => GlbAlphaMode.Blend,
+                _ => GlbAlphaMode.Opaque
+            };
+        }
+
+        private static BitmapImage? ReadBaseColorTexture(JsonElement root, byte[] binaryChunk, JsonElement material)
+        {
+            if (!material.TryGetProperty("pbrMetallicRoughness", out var pbr)
+                || !pbr.TryGetProperty("baseColorTexture", out var baseColorTexture)
+                || !baseColorTexture.TryGetProperty("index", out var textureIndexElement)) return null;
+
+            var textureIndex = textureIndexElement.GetInt32();
+            if (!TryGetArrayItem(root, "textures", textureIndex, out var texture)
+                || !texture.TryGetProperty("source", out var sourceIndexElement)) return null;
+
+            var sourceIndex = sourceIndexElement.GetInt32();
+            if (!TryGetArrayItem(root, "images", sourceIndex, out var image)
+                || !image.TryGetProperty("bufferView", out var bufferViewIndexElement)) return null;
+
+            var bufferViewIndex = bufferViewIndexElement.GetInt32();
+            if (!TryGetArrayItem(root, "bufferViews", bufferViewIndex, out var bufferView)) return null;
+
+            var offset = bufferView.TryGetProperty("byteOffset", out var offsetElement) ? offsetElement.GetInt32() : 0;
+            var length = bufferView.GetProperty("byteLength").GetInt32();
+            if (offset < 0 || length <= 0 || offset + length > binaryChunk.Length) return null;
+
+            using var stream = new MemoryStream(binaryChunk, offset, length, writable: false);
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.StreamSource = stream;
+            bitmap.EndInit();
+            bitmap.Freeze();
+            return bitmap;
+        }
+
+        private static bool TryGetArrayItem(JsonElement root, string propertyName, int index, out JsonElement item)
+        {
+            item = default;
+            if (!root.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array || index < 0 || index >= array.GetArrayLength()) return false;
+            item = array[index];
+            return true;
+        }
+
+        private static byte ToByte(JsonElement value) => (byte)Math.Clamp((int)Math.Round(value.GetSingle() * 255f), 0, 255);
+
+        private static (string Json, byte[] BinaryChunk) ReadGlb(string modelPath)
+        {
+            using var reader = new BinaryReader(File.OpenRead(modelPath));
+            if (reader.ReadUInt32() != 0x46546C67) throw new InvalidDataException("Not a GLB file.");
+            reader.ReadUInt32();
+            reader.ReadUInt32();
+
+            var jsonLength = reader.ReadInt32();
+            if (reader.ReadUInt32() != 0x4E4F534A) throw new InvalidDataException("GLB JSON chunk missing.");
+            var json = Encoding.UTF8.GetString(reader.ReadBytes(jsonLength));
+
+            if (reader.BaseStream.Position >= reader.BaseStream.Length) return (json, Array.Empty<byte>());
+            var binaryLength = reader.ReadInt32();
+            var chunkType = reader.ReadUInt32();
+            var binary = chunkType == 0x004E4942 ? reader.ReadBytes(binaryLength) : Array.Empty<byte>();
+            return (json, binary);
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -28,7 +28,7 @@
             <h:HelixViewport3D ZoomExtentsWhenLoaded="True"
                               ShowCoordinateSystem="False"
                               ShowViewCube="False"
-                              IsHeadLightEnabled="True"
+                              IsHeadLightEnabled="False"
                               CameraRotationMode="Turntable"
                               ModelUpDirection="0,1,0"
                               RotateAroundMouseDownPoint="False">
@@ -38,7 +38,15 @@
                                        UpDirection="{Binding CabinetViewer.Viewport.CameraUpDirection, Mode=TwoWay}"
                                        FieldOfView="{Binding CabinetViewer.Viewport.CameraFieldOfView, Mode=TwoWay}" />
                 </h:HelixViewport3D.Camera>
-                <h:SunLight />
+                <ModelVisual3D>
+                    <ModelVisual3D.Content>
+                        <Model3DGroup>
+                            <AmbientLight Color="#666666" />
+                            <DirectionalLight Color="#F4F4F4" Direction="-0.45,-0.8,-0.35" />
+                            <DirectionalLight Color="#8C98AA" Direction="0.6,-0.35,0.55" />
+                        </Model3DGroup>
+                    </ModelVisual3D.Content>
+                </ModelVisual3D>
                 <h:GridLinesVisual3D Width="{Binding CabinetViewer.Viewport.GridWidth}"
                                      Length="{Binding CabinetViewer.Viewport.GridLength}"
                                      MinorDistance="{Binding CabinetViewer.Viewport.GridMinorDistance}"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -81,7 +81,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public bool IsDirty => Document.IsDirty;
     public bool HasCabinetViewer => Document.DocumentType == EditorDocumentType.Cabinet3D && string.Equals(System.IO.Path.GetExtension(Document.FilePath), ".glb", StringComparison.OrdinalIgnoreCase);
     public CabinetModelDocumentViewModel? CabinetViewer => HasCabinetViewer
-        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new HelixCabinetModelLoader(), Document.FilePath)
+        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), Document.FilePath)
         : null;
 
     public void MarkDirty()


### PR DESCRIPTION
### Motivation
- Improve visual fidelity of loaded `.glb` cabinet models while retaining the existing Helix viewport and SharpGLTF-based loading architecture.  
- Preserve glTF primitive/material grouping so source material regions remain distinct instead of collapsing to one grey mesh.  
- Apply simple, safe material and normal handling (base color, embedded base color textures, alpha approximation, double-sided, and vertex normals) as an incremental step toward later PBR parity and surface editing.

### Description
- Switched viewer tabs to use `SharpGltfWpfModelLoader` (`DocumentTabViewModel`) so glTF conversion and material parsing are isolated in the loader service.  
- Preserve glTF mesh/material grouping by building a separate `MeshGeometry3D`/`GeometryModel3D` per evaluated glTF material (using `scene.EvaluateTriangles()`), so each source material can be represented independently.  
- Added basic glTF material parsing (`GlbMaterialInfoCollection`) that reads `baseColorFactor`, embedded `baseColorTexture` (from GLB binary chunk), `alphaMode`, and `doubleSided`, and maps them to WPF materials (using `DiffuseMaterial` with `SolidColorBrush` or `ImageBrush`); texture/parse failures fall back to `DefaultMaterial`.  
- Preserve source vertex normals via `IVertexBuilder.GetGeometry().TryGetNormal(...)` and only compute face normals as a fallback; also populate texture coordinates from vertex builders.  
- Replace the prior headlight/SunLight setup with a simple editor-friendly lighting rig by disabling headlight and adding a small ambient + key + fill `DirectionalLight` rig in `CabinetModelDocumentView.xaml`.  

### Testing
- No automated tests were executed in this environment per repository instructions; local WPF/.NET build and the manual checklist below should be run by the integrator.

Manual testing checklist (to run locally):
- Load a textured `.glb` and confirm base color textures appear where expected.  
- Load an untextured `.glb` and confirm `baseColorFactor` or a reasonable material fallback is used instead of uniform grey.  
- Load a multi-material `.glb` and confirm distinct material regions remain distinct in the viewer.  
- Load an invalid or corrupted `.glb` and confirm the viewer surfaces a safe error message and does not crash.  
- Verify camera controls (orbit, pan, zoom) and `Reset Camera` still behave correctly and that model bounds/frame calculation is correct.  
- Confirm existing Panel2D editor workflows are unaffected by these changes (solution builds, editor launches, Panel2D open/edit/render remain functional).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3adc1515e083279e821dc8b7d6c68f)