### PR TITLE
Detect OasisFace targets in cabinet model viewer

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetFaceTarget.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetFaceTarget.cs
@@ -1,0 +1,13 @@
+using System.Windows.Media.Media3D;
+
+namespace OasisEditor.Features.CabinetEditor.Models;
+
+public sealed record CabinetFaceTarget(
+    string Id,
+    string SourceName,
+    string DisplayName,
+    IReadOnlyList<Point3D> Corners,
+    Vector3D Normal,
+    Point3D Center,
+    bool IsValid,
+    string? ErrorMessage);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/CabinetModelLoadResult.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/CabinetModelLoadResult.cs
@@ -1,22 +1,25 @@
 using System.Windows.Media.Media3D;
+using OasisEditor.Features.CabinetEditor.Models;
 
 namespace OasisEditor.Features.CabinetEditor.Services;
 
 public sealed class CabinetModelLoadResult
 {
-    private CabinetModelLoadResult(bool succeeded, Model3DGroup? model, Rect3D bounds, string? errorMessage)
+    private CabinetModelLoadResult(bool succeeded, Model3DGroup? model, Rect3D bounds, IReadOnlyList<CabinetFaceTarget> faceTargets, string? errorMessage)
     {
         Succeeded = succeeded;
         Model = model;
         Bounds = bounds;
+        FaceTargets = faceTargets;
         ErrorMessage = errorMessage;
     }
 
     public bool Succeeded { get; }
     public Model3DGroup? Model { get; }
     public Rect3D Bounds { get; }
+    public IReadOnlyList<CabinetFaceTarget> FaceTargets { get; }
     public string? ErrorMessage { get; }
 
-    public static CabinetModelLoadResult Success(Model3DGroup model) => new(true, model, model.Bounds, null);
-    public static CabinetModelLoadResult Failure(string errorMessage) => new(false, null, Rect3D.Empty, errorMessage);
+    public static CabinetModelLoadResult Success(Model3DGroup model, IReadOnlyList<CabinetFaceTarget>? faceTargets = null) => new(true, model, model.Bounds, faceTargets ?? Array.Empty<CabinetFaceTarget>(), null);
+    public static CabinetModelLoadResult Failure(string errorMessage) => new(false, null, Rect3D.Empty, Array.Empty<CabinetFaceTarget>(), errorMessage);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/GlbCabinetFaceTargetDetector.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/GlbCabinetFaceTargetDetector.cs
@@ -210,7 +210,7 @@ public sealed class GlbCabinetFaceTargetDetector : ICabinetFaceTargetDetector
         }
 
         var scale = ReadVector3(node, "scale", new Vector3(1, 1, 1));
-        var rotation = ReadQuaternion(node, "rotation", Quaternion.Identity);
+        var rotation = ReadQuaternion(node, "rotation", System.Numerics.Quaternion.Identity);
         var translation = ReadVector3(node, "translation", Vector3.Zero);
         return Matrix4x4.CreateScale(scale) * Matrix4x4.CreateFromQuaternion(rotation) * Matrix4x4.CreateTranslation(translation);
     }
@@ -265,10 +265,10 @@ public sealed class GlbCabinetFaceTargetDetector : ICabinetFaceTargetDetector
         return new Vector3(array[0].GetSingle(), array[1].GetSingle(), array[2].GetSingle());
     }
 
-    private static Quaternion ReadQuaternion(JsonElement node, string propertyName, Quaternion fallback)
+    private static System.Numerics.Quaternion ReadQuaternion(JsonElement node, string propertyName, System.Numerics.Quaternion fallback)
     {
         if (!node.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array || array.GetArrayLength() < 4) return fallback;
-        return new Quaternion(array[0].GetSingle(), array[1].GetSingle(), array[2].GetSingle(), array[3].GetSingle());
+        return new System.Numerics.Quaternion(array[0].GetSingle(), array[1].GetSingle(), array[2].GetSingle(), array[3].GetSingle());
     }
 
     private static bool TryGetArrayItem(JsonElement root, string propertyName, int index, out JsonElement item)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/GlbCabinetFaceTargetDetector.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/GlbCabinetFaceTargetDetector.cs
@@ -1,0 +1,299 @@
+using System.Globalization;
+using System.IO;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using System.Windows.Media.Media3D;
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor.Features.CabinetEditor.Services;
+
+public sealed class GlbCabinetFaceTargetDetector : ICabinetFaceTargetDetector
+{
+    private const string TargetPrefix = "OasisFace_";
+
+    public IReadOnlyList<CabinetFaceTarget> DetectTargets(string modelPath, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(modelPath)) return Array.Empty<CabinetFaceTarget>();
+
+        var glb = ReadGlb(modelPath);
+        using var document = JsonDocument.Parse(glb.Json);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("nodes", out var nodes) || nodes.ValueKind != JsonValueKind.Array) return Array.Empty<CabinetFaceTarget>();
+
+        var sceneNodeIndexes = GetSceneNodeIndexes(root);
+        var transforms = new Dictionary<int, Matrix4x4>();
+        foreach (var nodeIndex in sceneNodeIndexes)
+        {
+            WalkNodeTransforms(nodes, nodeIndex, Matrix4x4.Identity, transforms, cancellationToken);
+        }
+
+        var targets = new List<CabinetFaceTarget>();
+        foreach (var (nodeIndex, transform) in transforms.OrderBy(x => x.Key))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var node = nodes[nodeIndex];
+            var nodeName = node.TryGetProperty("name", out var nameElement) ? nameElement.GetString() : null;
+            var meshIndex = node.TryGetProperty("mesh", out var meshElement) ? meshElement.GetInt32() : -1;
+            var meshName = TryGetMeshName(root, meshIndex);
+            var sourceName = IsTargetName(nodeName) ? nodeName! : IsTargetName(meshName) ? meshName! : null;
+            if (sourceName is null) continue;
+
+            targets.Add(ExtractTarget(root, glb.BinaryChunk, meshIndex, transform, sourceName));
+        }
+
+        return targets;
+    }
+
+    private static CabinetFaceTarget ExtractTarget(JsonElement root, byte[] binaryChunk, int meshIndex, Matrix4x4 transform, string sourceName)
+    {
+        var id = CreateStableId(sourceName);
+        var displayName = CreateDisplayName(sourceName);
+        try
+        {
+            if (meshIndex < 0 || !TryGetArrayItem(root, "meshes", meshIndex, out var mesh))
+            {
+                return Invalid(id, sourceName, displayName, "Target node does not reference a mesh.");
+            }
+
+            var points = new List<Point3D>();
+            if (mesh.TryGetProperty("primitives", out var primitives) && primitives.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var primitive in primitives.EnumerateArray())
+                {
+                    if (!primitive.TryGetProperty("attributes", out var attributes)
+                        || !attributes.TryGetProperty("POSITION", out var positionAccessorElement)) continue;
+
+                    var localPositions = ReadVector3Accessor(root, binaryChunk, positionAccessorElement.GetInt32());
+                    var indexes = primitive.TryGetProperty("indices", out var indicesElement)
+                        ? ReadIndexAccessor(root, binaryChunk, indicesElement.GetInt32())
+                        : Enumerable.Range(0, localPositions.Count).ToArray();
+
+                    foreach (var index in indexes)
+                    {
+                        if (index < 0 || index >= localPositions.Count) continue;
+                        var transformed = Vector3.Transform(localPositions[index], transform);
+                        AddUnique(points, new Point3D(transformed.X, transformed.Y, transformed.Z));
+                    }
+                }
+            }
+
+            if (points.Count != 4)
+            {
+                return Invalid(id, sourceName, displayName, $"Expected 4 unique quad corners, found {points.Count}.");
+            }
+
+            var center = new Point3D(points.Average(p => p.X), points.Average(p => p.Y), points.Average(p => p.Z));
+            var ordered = OrderCorners(points, center);
+            var normal = Vector3D.CrossProduct(ordered[1] - ordered[0], ordered[2] - ordered[1]);
+            if (normal.LengthSquared <= 1e-12)
+            {
+                return Invalid(id, sourceName, displayName, "Quad corners are degenerate.");
+            }
+
+            normal.Normalize();
+            if (!IsPlanar(ordered, normal, center))
+            {
+                return Invalid(id, sourceName, displayName, "Quad corners are not planar.");
+            }
+
+            return new CabinetFaceTarget(id, sourceName, displayName, ordered, normal, center, true, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return Invalid(id, sourceName, displayName, $"Target geometry could not be read: {ex.Message}");
+        }
+    }
+
+    private static IReadOnlyList<Point3D> OrderCorners(IReadOnlyList<Point3D> points, Point3D center)
+    {
+        var normal = Vector3D.CrossProduct(points[1] - points[0], points[2] - points[0]);
+        if (normal.LengthSquared <= 1e-12) normal = new Vector3D(0, 0, 1);
+        normal.Normalize();
+        var right = points.OrderByDescending(p => (p - center).LengthSquared).First() - center;
+        if (right.LengthSquared <= 1e-12) right = new Vector3D(1, 0, 0);
+        right.Normalize();
+        var up = Vector3D.CrossProduct(normal, right);
+        if (up.LengthSquared <= 1e-12) up = new Vector3D(0, 1, 0);
+        up.Normalize();
+
+        return points
+            .Select(p => new { Point = p, Angle = Math.Atan2(Vector3D.DotProduct(p - center, up), Vector3D.DotProduct(p - center, right)) })
+            .OrderByDescending(x => x.Angle)
+            .Select(x => x.Point)
+            .ToArray();
+    }
+
+    private static bool IsPlanar(IEnumerable<Point3D> points, Vector3D normal, Point3D center)
+        => points.All(p => Math.Abs(Vector3D.DotProduct(p - center, normal)) <= 0.001d);
+
+    private static void AddUnique(ICollection<Point3D> points, Point3D point)
+    {
+        if (!points.Any(existing => (existing - point).LengthSquared <= 1e-10)) points.Add(point);
+    }
+
+    private static List<Vector3> ReadVector3Accessor(JsonElement root, byte[] binaryChunk, int accessorIndex)
+    {
+        var accessor = GetAccessor(root, accessorIndex, out var bufferView, out var byteOffset, out var stride);
+        if (accessor.GetProperty("type").GetString() != "VEC3" || accessor.GetProperty("componentType").GetInt32() != 5126)
+        {
+            throw new InvalidDataException("POSITION accessor must be float VEC3.");
+        }
+
+        var count = accessor.GetProperty("count").GetInt32();
+        var result = new List<Vector3>(count);
+        for (var i = 0; i < count; i++)
+        {
+            var offset = byteOffset + i * stride;
+            result.Add(new Vector3(ReadSingle(binaryChunk, offset), ReadSingle(binaryChunk, offset + 4), ReadSingle(binaryChunk, offset + 8)));
+        }
+
+        return result;
+    }
+
+    private static int[] ReadIndexAccessor(JsonElement root, byte[] binaryChunk, int accessorIndex)
+    {
+        var accessor = GetAccessor(root, accessorIndex, out _, out var byteOffset, out var stride);
+        var count = accessor.GetProperty("count").GetInt32();
+        var componentType = accessor.GetProperty("componentType").GetInt32();
+        var result = new int[count];
+        for (var i = 0; i < count; i++)
+        {
+            var offset = byteOffset + i * stride;
+            result[i] = componentType switch
+            {
+                5121 => binaryChunk[offset],
+                5123 => BitConverter.ToUInt16(binaryChunk, offset),
+                5125 => unchecked((int)BitConverter.ToUInt32(binaryChunk, offset)),
+                _ => throw new InvalidDataException("Unsupported index component type.")
+            };
+        }
+
+        return result;
+    }
+
+    private static JsonElement GetAccessor(JsonElement root, int accessorIndex, out JsonElement bufferView, out int byteOffset, out int stride)
+    {
+        if (!TryGetArrayItem(root, "accessors", accessorIndex, out var accessor)) throw new InvalidDataException("Accessor missing.");
+        var bufferViewIndex = accessor.GetProperty("bufferView").GetInt32();
+        if (!TryGetArrayItem(root, "bufferViews", bufferViewIndex, out bufferView)) throw new InvalidDataException("Buffer view missing.");
+        byteOffset = (accessor.TryGetProperty("byteOffset", out var ao) ? ao.GetInt32() : 0)
+            + (bufferView.TryGetProperty("byteOffset", out var vo) ? vo.GetInt32() : 0);
+        stride = bufferView.TryGetProperty("byteStride", out var strideElement) ? strideElement.GetInt32() : GetElementSize(accessor);
+        return accessor;
+    }
+
+    private static int GetElementSize(JsonElement accessor)
+    {
+        var componentSize = accessor.GetProperty("componentType").GetInt32() switch { 5121 => 1, 5123 => 2, 5125 or 5126 => 4, _ => 4 };
+        var componentCount = accessor.GetProperty("type").GetString() switch { "SCALAR" => 1, "VEC2" => 2, "VEC3" => 3, "VEC4" => 4, _ => 1 };
+        return componentSize * componentCount;
+    }
+
+    private static void WalkNodeTransforms(JsonElement nodes, int nodeIndex, Matrix4x4 parentTransform, IDictionary<int, Matrix4x4> transforms, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (nodeIndex < 0 || nodeIndex >= nodes.GetArrayLength()) return;
+        var node = nodes[nodeIndex];
+        var world = ReadLocalTransform(node) * parentTransform;
+        transforms[nodeIndex] = world;
+        if (!node.TryGetProperty("children", out var children) || children.ValueKind != JsonValueKind.Array) return;
+        foreach (var child in children.EnumerateArray()) WalkNodeTransforms(nodes, child.GetInt32(), world, transforms, cancellationToken);
+    }
+
+    private static Matrix4x4 ReadLocalTransform(JsonElement node)
+    {
+        if (node.TryGetProperty("matrix", out var matrix) && matrix.ValueKind == JsonValueKind.Array && matrix.GetArrayLength() == 16)
+        {
+            var m = matrix.EnumerateArray().Select(e => e.GetSingle()).ToArray();
+            return new Matrix4x4(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15]);
+        }
+
+        var scale = ReadVector3(node, "scale", new Vector3(1, 1, 1));
+        var rotation = ReadQuaternion(node, "rotation", Quaternion.Identity);
+        var translation = ReadVector3(node, "translation", Vector3.Zero);
+        return Matrix4x4.CreateScale(scale) * Matrix4x4.CreateFromQuaternion(rotation) * Matrix4x4.CreateTranslation(translation);
+    }
+
+    private static IEnumerable<int> GetSceneNodeIndexes(JsonElement root)
+    {
+        if (root.TryGetProperty("scene", out var sceneIndexElement) && TryGetArrayItem(root, "scenes", sceneIndexElement.GetInt32(), out var scene))
+        {
+            return ReadSceneNodes(scene);
+        }
+
+        if (TryGetArrayItem(root, "scenes", 0, out var firstScene)) return ReadSceneNodes(firstScene);
+        return Enumerable.Empty<int>();
+    }
+
+    private static IEnumerable<int> ReadSceneNodes(JsonElement scene)
+        => scene.TryGetProperty("nodes", out var sceneNodes) && sceneNodes.ValueKind == JsonValueKind.Array
+            ? sceneNodes.EnumerateArray().Select(x => x.GetInt32()).ToArray()
+            : Array.Empty<int>();
+
+    private static string? TryGetMeshName(JsonElement root, int meshIndex)
+        => TryGetArrayItem(root, "meshes", meshIndex, out var mesh) && mesh.TryGetProperty("name", out var name) ? name.GetString() : null;
+
+    private static bool IsTargetName(string? name) => name?.StartsWith(TargetPrefix, StringComparison.Ordinal) == true;
+    private static CabinetFaceTarget Invalid(string id, string sourceName, string displayName, string message) => new(id, sourceName, displayName, Array.Empty<Point3D>(), default, default, false, message);
+
+    private static string CreateStableId(string sourceName)
+    {
+        var suffix = sourceName.StartsWith(TargetPrefix, StringComparison.Ordinal) ? sourceName[TargetPrefix.Length..] : sourceName;
+        var chars = suffix.Where(char.IsLetterOrDigit).ToArray();
+        if (chars.Length == 0) return "target";
+        var text = new string(chars);
+        return char.ToLowerInvariant(text[0]) + text[1..];
+    }
+
+    private static string CreateDisplayName(string sourceName)
+    {
+        var suffix = sourceName.StartsWith(TargetPrefix, StringComparison.Ordinal) ? sourceName[TargetPrefix.Length..] : sourceName;
+        var builder = new StringBuilder();
+        for (var i = 0; i < suffix.Length; i++)
+        {
+            var c = suffix[i] is '_' or '-' ? ' ' : suffix[i];
+            if (i > 0 && char.IsUpper(c) && char.IsLower(suffix[i - 1])) builder.Append(' ');
+            builder.Append(c);
+        }
+        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(builder.ToString().Trim());
+    }
+
+    private static Vector3 ReadVector3(JsonElement node, string propertyName, Vector3 fallback)
+    {
+        if (!node.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array || array.GetArrayLength() < 3) return fallback;
+        return new Vector3(array[0].GetSingle(), array[1].GetSingle(), array[2].GetSingle());
+    }
+
+    private static Quaternion ReadQuaternion(JsonElement node, string propertyName, Quaternion fallback)
+    {
+        if (!node.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array || array.GetArrayLength() < 4) return fallback;
+        return new Quaternion(array[0].GetSingle(), array[1].GetSingle(), array[2].GetSingle(), array[3].GetSingle());
+    }
+
+    private static bool TryGetArrayItem(JsonElement root, string propertyName, int index, out JsonElement item)
+    {
+        item = default;
+        if (!root.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array || index < 0 || index >= array.GetArrayLength()) return false;
+        item = array[index];
+        return true;
+    }
+
+    private static float ReadSingle(byte[] data, int offset) => BitConverter.ToSingle(data, offset);
+
+    private static (string Json, byte[] BinaryChunk) ReadGlb(string modelPath)
+    {
+        using var reader = new BinaryReader(File.OpenRead(modelPath));
+        if (reader.ReadUInt32() != 0x46546C67) throw new InvalidDataException("Not a GLB file.");
+        reader.ReadUInt32();
+        reader.ReadUInt32();
+        var jsonLength = reader.ReadInt32();
+        if (reader.ReadUInt32() != 0x4E4F534A) throw new InvalidDataException("GLB JSON chunk missing.");
+        var json = Encoding.UTF8.GetString(reader.ReadBytes(jsonLength));
+        if (reader.BaseStream.Position >= reader.BaseStream.Length) return (json, Array.Empty<byte>());
+        var binaryLength = reader.ReadInt32();
+        var chunkType = reader.ReadUInt32();
+        var binary = chunkType == 0x004E4942 ? reader.ReadBytes(binaryLength) : Array.Empty<byte>();
+        return (json, binary);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/HelixCabinetModelLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/HelixCabinetModelLoader.cs
@@ -6,6 +6,7 @@ namespace OasisEditor.Features.CabinetEditor.Services;
 public sealed class HelixCabinetModelLoader : ICabinetModelLoader
 {
     private readonly ICabinetModelLoader _fallbackLoader = new SharpGltfWpfModelLoader();
+    private readonly ICabinetFaceTargetDetector _faceTargetDetector = new GlbCabinetFaceTargetDetector();
 
     public Task<CabinetModelLoadResult> LoadAsync(string modelPath, CancellationToken cancellationToken = default)
     {
@@ -36,7 +37,8 @@ public sealed class HelixCabinetModelLoader : ICabinetModelLoader
                     return LoadWithFallback(modelPath, cancellationToken, "Helix loaded the .glb, but it did not contain displayable geometry.");
                 }
 
-                return CabinetModelLoadResult.Success(model);
+                var faceTargets = _faceTargetDetector.DetectTargets(modelPath, cancellationToken);
+                return CabinetModelLoadResult.Success(model, faceTargets);
             }
             catch (OperationCanceledException)
             {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/ICabinetFaceTargetDetector.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/ICabinetFaceTargetDetector.cs
@@ -1,0 +1,8 @@
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor.Features.CabinetEditor.Services;
+
+public interface ICabinetFaceTargetDetector
+{
+    IReadOnlyList<CabinetFaceTarget> DetectTargets(string modelPath, CancellationToken cancellationToken = default);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
@@ -15,6 +15,7 @@ namespace OasisEditor.Features.CabinetEditor.Services;
 public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
 {
     private static readonly DiffuseMaterial DefaultMaterial = CreateDefaultMaterial();
+    private static readonly ICabinetFaceTargetDetector FaceTargetDetector = new GlbCabinetFaceTargetDetector();
 
     public Task<CabinetModelLoadResult> LoadAsync(string modelPath, CancellationToken cancellationToken = default)
     {
@@ -92,7 +93,8 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
             }
 
             group.Freeze();
-            return CabinetModelLoadResult.Success(group);
+            var faceTargets = FaceTargetDetector.DetectTargets(modelPath, cancellationToken);
+            return CabinetModelLoadResult.Success(group, faceTargets);
         }
         catch (OperationCanceledException)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetFaceTargetViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetFaceTargetViewModel.cs
@@ -1,0 +1,22 @@
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor.Features.CabinetEditor.ViewModels;
+
+public sealed class CabinetFaceTargetViewModel
+{
+    public CabinetFaceTargetViewModel(CabinetFaceTarget target)
+    {
+        Id = target.Id;
+        SourceName = target.SourceName;
+        DisplayName = target.DisplayName;
+        IsValid = target.IsValid;
+        ErrorMessage = target.ErrorMessage;
+    }
+
+    public string Id { get; }
+    public string SourceName { get; }
+    public string DisplayName { get; }
+    public bool IsValid { get; }
+    public string? ErrorMessage { get; }
+    public string StateText => IsValid ? "Valid quad" : $"Invalid: {ErrorMessage}";
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -29,11 +30,16 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public CabinetViewportViewModel Viewport { get; }
+    public ObservableCollection<CabinetFaceTargetViewModel> FaceTargets { get; } = new();
     public string ModelPath { get; }
     public string DisplayName => string.IsNullOrWhiteSpace(ModelPath) ? "Cabinet Model Viewer" : Path.GetFileName(ModelPath);
     public string LoadStatus { get => _loadStatus; private set { _loadStatus = value; OnPropertyChanged(); } }
     public string? ErrorMessage { get => _errorMessage; private set { _errorMessage = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasError)); } }
     public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+    public bool HasFaceTargets => FaceTargets.Count > 0;
+    public string FaceTargetStatus => FaceTargets.Count == 0
+        ? "No Oasis face targets found."
+        : $"Detected {FaceTargets.Count} Oasis face target{(FaceTargets.Count == 1 ? string.Empty : "s")}.";
     public bool IsLoading { get => _isLoading; private set { _isLoading = value; OnPropertyChanged(); if (ReloadCommand is RelayCommand relay) relay.RaiseCanExecuteChanged(); } }
     public ICommand ReloadCommand { get; }
     public ICommand ResetCameraCommand { get; }
@@ -50,13 +56,25 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             if (!result.Succeeded || result.Model is null)
             {
                 Viewport.Model = null;
+                FaceTargets.Clear();
+                OnPropertyChanged(nameof(HasFaceTargets));
+                OnPropertyChanged(nameof(FaceTargetStatus));
                 ErrorMessage = result.ErrorMessage ?? "Unable to load the cabinet model.";
                 LoadStatus = "Cabinet model load failed.";
                 return;
             }
 
             Viewport.Model = result.Model;
-            LoadStatus = $"Loaded {DisplayName}";
+            FaceTargets.Clear();
+            foreach (var target in result.FaceTargets)
+            {
+                FaceTargets.Add(new CabinetFaceTargetViewModel(target));
+            }
+            OnPropertyChanged(nameof(HasFaceTargets));
+            OnPropertyChanged(nameof(FaceTargetStatus));
+            LoadStatus = FaceTargets.Count == 0
+                ? $"Loaded {DisplayName}; no Oasis face targets found"
+                : $"Loaded {DisplayName}; detected {FaceTargets.Count} Oasis face target{(FaceTargets.Count == 1 ? string.Empty : "s")}";
         }
         catch (OperationCanceledException)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -25,7 +25,12 @@
         </DockPanel>
 
         <Grid Grid.Row="1">
-            <h:HelixViewport3D ZoomExtentsWhenLoaded="True"
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="260" />
+            </Grid.ColumnDefinitions>
+
+            <h:HelixViewport3D Grid.Column="0" ZoomExtentsWhenLoaded="True"
                               ShowCoordinateSystem="False"
                               ShowViewCube="False"
                               IsHeadLightEnabled="False"
@@ -59,8 +64,36 @@
                 <ModelVisual3D Content="{Binding CabinetViewer.Viewport.Model}" />
             </h:HelixViewport3D>
 
+            <Border Grid.Column="1" Margin="8,0,0,0" Padding="12"
+                    Background="{DynamicResource ToolBarBackgroundBrush}"
+                    BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="1" CornerRadius="4">
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
+                        <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Oasis Face Targets" />
+                        <TextBlock Margin="0,4,0,0" Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" Text="{Binding CabinetViewer.FaceTargetStatus}" />
+                    </StackPanel>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding CabinetViewer.FaceTargets}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Margin="0,0,0,8" Padding="8"
+                                            Background="{DynamicResource PanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="1" CornerRadius="3">
+                                        <StackPanel>
+                                            <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="{Binding DisplayName}" />
+                                            <TextBlock Margin="0,3,0,0" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding SourceName}" />
+                                            <TextBlock Margin="0,3,0,0" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding Id, StringFormat=ID: {0}}" />
+                                            <TextBlock Margin="0,5,0,0" Foreground="{DynamicResource TextPrimaryBrush}" TextWrapping="Wrap" Text="{Binding StateText}" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </DockPanel>
+            </Border>
 
-            <Border Margin="12" Padding="12" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+            <Border Grid.Column="0" Margin="12" Padding="12" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
                     CornerRadius="4" Background="{DynamicResource ToolBarBackgroundBrush}"
                     BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="1">
                 <Border.Style>


### PR DESCRIPTION
### Motivation
- Implement the next Cabinet Model Viewer milestone so Blender-authored face target meshes named `OasisFace_*` are detected and exposed to the editor for later Face document assignment.
- Keep existing rendering and camera behavior unchanged while providing a safe, first-pass geometry extraction that marks non-quad or non-planar geometry as invalid rather than crashing.

### Description
- Add a domain model `CabinetFaceTarget` to carry stable `Id`, `SourceName`, `DisplayName`, transformed quad `Corners`, `Normal`, `Center`, validity and an optional `ErrorMessage` (new file: `Features/CabinetEditor/Models/CabinetFaceTarget.cs`).
- Implement `GlbCabinetFaceTargetDetector` that reads the `.glb` JSON/binary, walks scene node transforms, finds `OasisFace_` node/mesh names, applies world transforms to vertex positions, derives four unique corners, orders them, computes normal/center and returns valid/invalid targets (new files: `GlbCabinetFaceTargetDetector.cs`, `ICabinetFaceTargetDetector.cs`).
- Return detected targets from both existing loaders (`SharpGltfWpfModelLoader` and `HelixCabinetModelLoader`) via `CabinetModelLoadResult` (extended to include `FaceTargets`) and surface them in the `CabinetModelDocumentViewModel` as `FaceTargets` view models (changes to loader, load result and viewmodel files).
- Add a simple side panel UI in `CabinetModelDocumentView.xaml` to list detected targets with display name, source name, stable id and validity text, while preserving Helix viewport, camera controls and current rendering behavior.

### Testing
- Automated tests were not run in this environment because the Codex environment lacks the Windows/.NET/WPF toolchain and per repository guidance no builds/tests should be executed here.
- No new automated unit tests were added in this change; local build-and-run verification is required (see checklist included above in Description for local testing steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a41047c7b088327a5c5f086fcd8848f)