### PR TITLE
Render Face artwork previews on Cabinet3D OasisFace targets

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/FaceDocumentArtworkPreviewRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/FaceDocumentArtworkPreviewRenderer.cs
@@ -1,0 +1,181 @@
+using System.IO;
+using System.Windows.Media.Imaging;
+using SkiaSharp;
+
+namespace OasisEditor.Features.CabinetEditor.Services;
+
+public sealed class FaceDocumentArtworkPreviewRenderer
+{
+    private const int DefaultPreviewWidth = 1024;
+    private const int DefaultPreviewHeight = 1024;
+
+    public BitmapSource? RenderPreview(FaceDocumentModel faceDocument)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+
+        var bounds = ResolveBounds(faceDocument);
+        if (bounds.Width <= 0d || bounds.Height <= 0d)
+        {
+            return null;
+        }
+
+        var width = Math.Clamp((int)Math.Round(bounds.Width), 1, DefaultPreviewWidth);
+        var height = Math.Clamp((int)Math.Round(bounds.Height), 1, DefaultPreviewHeight);
+        using var surface = SKSurface.Create(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+        if (surface is null)
+        {
+            return null;
+        }
+
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+        canvas.Scale((float)(width / bounds.Width), (float)(height / bounds.Height));
+        canvas.Translate((float)-bounds.X, (float)-bounds.Y);
+
+        var renderedAny = false;
+        foreach (var artwork in faceDocument.Elements.OfType<FaceArtworkElement>().Where(element => element.IsVisible))
+        {
+            if (TryDrawArtwork(canvas, artwork))
+            {
+                renderedAny = true;
+            }
+        }
+
+        if (!renderedAny)
+        {
+            return null;
+        }
+
+        using var image = surface.Snapshot();
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        if (data is null)
+        {
+            return null;
+        }
+
+        using var stream = new MemoryStream(data.ToArray());
+        var bitmap = new BitmapImage();
+        bitmap.BeginInit();
+        bitmap.CacheOption = BitmapCacheOption.OnLoad;
+        bitmap.StreamSource = stream;
+        bitmap.EndInit();
+        bitmap.Freeze();
+        return bitmap;
+    }
+
+    private static FacePreviewBounds ResolveBounds(FaceDocumentModel faceDocument)
+    {
+        if (faceDocument.SourceRegion is { Width: > 0d, Height: > 0d } sourceRegion)
+        {
+            return new FacePreviewBounds(0d, 0d, sourceRegion.Width, sourceRegion.Height);
+        }
+
+        var visibleArtwork = faceDocument.Elements.OfType<FaceArtworkElement>()
+            .Where(element => element.IsVisible && element.Width > 0d && element.Height > 0d)
+            .ToArray();
+        if (visibleArtwork.Length == 0)
+        {
+            return default;
+        }
+
+        var left = visibleArtwork.Min(element => element.X);
+        var top = visibleArtwork.Min(element => element.Y);
+        var right = visibleArtwork.Max(element => element.X + element.Width);
+        var bottom = visibleArtwork.Max(element => element.Y + element.Height);
+        return new FacePreviewBounds(left, top, Math.Max(0d, right - left), Math.Max(0d, bottom - top));
+    }
+
+    private static bool TryDrawArtwork(SKCanvas canvas, FaceArtworkElement element)
+    {
+        if (!TryLoadImage(element.AssetPath, out var image))
+        {
+            return false;
+        }
+
+        using (image)
+        {
+            var source = ResolveArtworkSourceRect(element, image);
+            var destination = SKRect.Create((float)element.X, (float)element.Y, (float)Math.Max(0d, element.Width), (float)Math.Max(0d, element.Height));
+            if (source.Width <= 0f || source.Height <= 0f || destination.Width <= 0f || destination.Height <= 0f)
+            {
+                return false;
+            }
+
+            canvas.DrawImage(image, source, destination);
+            return true;
+        }
+    }
+
+    private static SKRect ResolveArtworkSourceRect(FaceArtworkElement element, SKImage image)
+    {
+        var sourceRegion = element.SourceRegion;
+        var sourceBounds = element.Provenance?.SourceElementBounds;
+        if (sourceRegion is null || sourceBounds is null || sourceBounds.Width <= 0d || sourceBounds.Height <= 0d)
+        {
+            return SKRect.Create(0f, 0f, image.Width, image.Height);
+        }
+
+        var scaleX = image.Width / sourceBounds.Width;
+        var scaleY = image.Height / sourceBounds.Height;
+        var x = (sourceRegion.X - sourceBounds.X) * scaleX;
+        var y = (sourceRegion.Y - sourceBounds.Y) * scaleY;
+        var width = sourceRegion.Width * scaleX;
+        var height = sourceRegion.Height * scaleY;
+        var left = (float)Math.Clamp(x, 0d, image.Width);
+        var top = (float)Math.Clamp(y, 0d, image.Height);
+        var right = (float)Math.Clamp(x + width, left, image.Width);
+        var bottom = (float)Math.Clamp(y + height, top, image.Height);
+        return new SKRect(left, top, right, bottom);
+    }
+
+    private static bool TryLoadImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        if (!TryResolveAssetPath(assetPath, out var resolvedPath) || !File.Exists(resolvedPath))
+        {
+            return false;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            return false;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        if (bitmap is null)
+        {
+            return false;
+        }
+
+        image = SKImage.FromBitmap(bitmap);
+        return true;
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
+        {
+            return false;
+        }
+
+        var relativePath = candidate.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+        return true;
+    }
+
+    private readonly record struct FacePreviewBounds(double X, double Y, double Width, double Height);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetFaceTargetViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetFaceTargetViewModel.cs
@@ -6,6 +6,7 @@ public sealed class CabinetFaceTargetViewModel
 {
     public CabinetFaceTargetViewModel(CabinetFaceTarget target)
     {
+        Target = target;
         Id = target.Id;
         SourceName = target.SourceName;
         DisplayName = target.DisplayName;
@@ -13,6 +14,7 @@ public sealed class CabinetFaceTargetViewModel
         ErrorMessage = target.ErrorMessage;
     }
 
+    public CabinetFaceTarget Target { get; }
     public string Id { get; }
     public string SourceName { get; }
     public string DisplayName { get; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -2,7 +2,12 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Media.Media3D;
+using OasisEditor.Features.CabinetEditor.Models;
 using OasisEditor.Features.CabinetEditor.Services;
 
 namespace OasisEditor.Features.CabinetEditor.ViewModels;
@@ -10,13 +15,16 @@ namespace OasisEditor.Features.CabinetEditor.ViewModels;
 public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
 {
     private readonly ICabinetModelLoader _modelLoader;
+    private readonly Func<IReadOnlyList<DocumentTabViewModel>>? _openDocumentsAccessor;
+    private readonly FaceDocumentArtworkPreviewRenderer _previewRenderer = new();
     private string _loadStatus = "No cabinet model loaded.";
     private string? _errorMessage;
     private bool _isLoading;
 
-    public CabinetModelDocumentViewModel(ICabinetModelLoader modelLoader, string? modelPath = null)
+    public CabinetModelDocumentViewModel(ICabinetModelLoader modelLoader, string? modelPath = null, Func<IReadOnlyList<DocumentTabViewModel>>? openDocumentsAccessor = null)
     {
         _modelLoader = modelLoader;
+        _openDocumentsAccessor = openDocumentsAccessor;
         ModelPath = modelPath ?? string.Empty;
         Viewport = new CabinetViewportViewModel();
         ReloadCommand = new RelayCommand(async () => await LoadAsync(), CanLoad);
@@ -56,6 +64,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             if (!result.Succeeded || result.Model is null)
             {
                 Viewport.Model = null;
+                Viewport.FacePreviewModel = null;
                 FaceTargets.Clear();
                 OnPropertyChanged(nameof(HasFaceTargets));
                 OnPropertyChanged(nameof(FaceTargetStatus));
@@ -72,6 +81,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             }
             OnPropertyChanged(nameof(HasFaceTargets));
             OnPropertyChanged(nameof(FaceTargetStatus));
+            RefreshFacePreviews();
             LoadStatus = FaceTargets.Count == 0
                 ? $"Loaded {DisplayName}; no Oasis face targets found"
                 : $"Loaded {DisplayName}; detected {FaceTargets.Count} Oasis face target{(FaceTargets.Count == 1 ? string.Empty : "s")}";
@@ -85,6 +95,68 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             IsLoading = false;
         }
     }
+
+    public void RefreshFacePreviews()
+    {
+        var validTargets = FaceTargets.Where(target => target.IsValid).ToDictionary(target => target.Id, StringComparer.Ordinal);
+        if (validTargets.Count == 0 || _openDocumentsAccessor is null)
+        {
+            Viewport.FacePreviewModel = null;
+            return;
+        }
+
+        var previewGroup = new Model3DGroup();
+        foreach (var faceDocument in _openDocumentsAccessor()
+            .Where(document => document.Document.DocumentType == EditorDocumentType.Face)
+            .Select(document => document.GetFaceDocument()))
+        {
+            var targetId = NormalizeTargetId(faceDocument.AssignedCabinetFaceTargetId);
+            if (targetId is null || !validTargets.TryGetValue(targetId, out var target))
+            {
+                continue;
+            }
+
+            var preview = _previewRenderer.RenderPreview(faceDocument);
+            if (preview is null)
+            {
+                continue;
+            }
+
+            if (TryCreatePreviewGeometry(target.Target, preview, out var geometry))
+            {
+                previewGroup.Children.Add(geometry);
+            }
+        }
+
+        Viewport.FacePreviewModel = previewGroup.Children.Count == 0 ? null : previewGroup;
+    }
+
+    private static bool TryCreatePreviewGeometry(CabinetFaceTarget target, BitmapSource bitmap, out GeometryModel3D geometry)
+    {
+        geometry = default!;
+        if (!target.IsValid || target.Corners.Count != 4)
+        {
+            return false;
+        }
+
+        var mesh = new MeshGeometry3D
+        {
+            Positions = new Point3DCollection(target.Corners),
+            TriangleIndices = new Int32Collection(new[] { 0, 1, 2, 0, 2, 3 }),
+            TextureCoordinates = new PointCollection(new[]
+            {
+                new Point(0, 0),
+                new Point(1, 0),
+                new Point(1, 1),
+                new Point(0, 1)
+            })
+        };
+        var material = new DiffuseMaterial(new ImageBrush(bitmap));
+        geometry = new GeometryModel3D(mesh, material) { BackMaterial = material };
+        return true;
+    }
+
+    private static string? NormalizeTargetId(string? targetId) => string.IsNullOrWhiteSpace(targetId) ? null : targetId.Trim();
 
     private bool CanLoad() => !IsLoading && !string.IsNullOrWhiteSpace(ModelPath);
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetViewportViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetViewportViewModel.cs
@@ -8,6 +8,7 @@ namespace OasisEditor.Features.CabinetEditor.ViewModels;
 public sealed class CabinetViewportViewModel : INotifyPropertyChanged
 {
     private Model3DGroup? _model;
+    private Model3DGroup? _facePreviewModel;
     private Rect3D _modelBounds = Rect3D.Empty;
     private Point3D _cameraPosition;
     private Vector3D _cameraLookDirection;
@@ -32,6 +33,17 @@ public sealed class CabinetViewportViewModel : INotifyPropertyChanged
             OnPropertyChanged();
             ModelBounds = value?.Bounds ?? Rect3D.Empty;
             ResetCamera();
+        }
+    }
+
+    public Model3DGroup? FacePreviewModel
+    {
+        get => _facePreviewModel;
+        set
+        {
+            if (ReferenceEquals(_facePreviewModel, value)) return;
+            _facePreviewModel = value;
+            OnPropertyChanged();
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -62,6 +62,7 @@
                 <h:ArrowVisual3D Point1="0,0,0" Point2="{Binding CabinetViewer.Viewport.YAxisEnd}" Diameter="0.025" Fill="LimeGreen" />
                 <h:ArrowVisual3D Point1="0,0,0" Point2="{Binding CabinetViewer.Viewport.ZAxisEnd}" Diameter="0.025" Fill="DodgerBlue" />
                 <ModelVisual3D Content="{Binding CabinetViewer.Viewport.Model}" />
+                <ModelVisual3D Content="{Binding CabinetViewer.Viewport.FacePreviewModel}" />
             </h:HelixViewport3D>
 
             <Border Grid.Column="1" Margin="8,0,0,0" Padding="12"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -391,6 +391,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
+        OpenDocuments.CollectionChanged += OnOpenDocumentsChanged;
         _documentWorkspace = new DocumentWorkspaceViewModel(
             () => _loadedProject,
             value => LoadedProject = value,
@@ -1687,6 +1688,49 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(SelectedAssetDirectory));
         OnPropertyChanged(nameof(SelectedAssetDirectoryLabel));
         OnPropertyChanged(nameof(HasAssetBrowserItems));
+    }
+
+
+    private void OnOpenDocumentsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (DocumentTabViewModel document in e.OldItems)
+            {
+                document.PropertyChanged -= OnOpenDocumentPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (DocumentTabViewModel document in e.NewItems)
+            {
+                document.PropertyChanged += OnOpenDocumentPropertyChanged;
+            }
+        }
+
+        RefreshCabinetFacePreviews();
+    }
+
+    private void OnOpenDocumentPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is DocumentTabViewModel document
+            && document.Document.DocumentType == EditorDocumentType.Face
+            && string.Equals(e.PropertyName, nameof(DocumentTabViewModel.FaceDocumentJson), StringComparison.Ordinal))
+        {
+            RefreshCabinetFacePreviews();
+        }
+    }
+
+    private void RefreshCabinetFacePreviews()
+    {
+        foreach (var cabinetViewer in OpenDocuments
+            .Where(document => document.Document.DocumentType == EditorDocumentType.Cabinet3D)
+            .Select(document => document.CabinetViewer)
+            .Where(viewer => viewer is not null))
+        {
+            cabinetViewer!.RefreshFacePreviews();
+        }
     }
 
     private void OnAssetBrowserItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -30,6 +30,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private Dictionary<string, object>? _lastVisualStateByObjectId;
     private readonly MachineRuntimeState _runtimeState;
     private CabinetModelDocumentViewModel? _cabinetViewer;
+    private Func<IReadOnlyList<DocumentTabViewModel>>? _openDocumentsAccessor;
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<PanelChangeEvent>? PanelChanged;
@@ -81,8 +82,13 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public bool IsDirty => Document.IsDirty;
     public bool HasCabinetViewer => Document.DocumentType == EditorDocumentType.Cabinet3D && string.Equals(System.IO.Path.GetExtension(Document.FilePath), ".glb", StringComparison.OrdinalIgnoreCase);
     public CabinetModelDocumentViewModel? CabinetViewer => HasCabinetViewer
-        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), Document.FilePath)
+        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), Document.FilePath, _openDocumentsAccessor)
         : null;
+
+    public void SetOpenDocumentsAccessor(Func<IReadOnlyList<DocumentTabViewModel>> openDocumentsAccessor)
+    {
+        _openDocumentsAccessor = openDocumentsAccessor;
+    }
 
     public void MarkDirty()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -569,12 +569,14 @@ public sealed class DocumentWorkspaceViewModel
         var documentId = Guid.NewGuid();
         var runtimeState = _runtimeStateStore.GetOrCreate(documentId);
         runtimeState.FruitMachinePlatform = _getLoadedProject()?.FruitMachinePlatform ?? FruitMachinePlatformType.None;
-        return new DocumentTabViewModel(
+        var tab = new DocumentTabViewModel(
             document,
             panelLayoutJson,
             documentId,
             runtimeState: runtimeState,
             faceDocumentJson: faceDocumentJson);
+        tab.SetOpenDocumentsAccessor(() => _openDocuments);
+        return tab;
     }
 
     internal static OpenDocumentData BuildOpenDocumentData(string path, string content)


### PR DESCRIPTION
### Motivation
- Provide a lightweight editor-only preview of assigned Face documents by mapping each Face document's background/artwork onto its assigned `OasisFace_*` target in the Cabinet3D viewer. 
- Keep preview rendering non-destructive and isolated from the `.glb` model and future runtime/export work. 
- Use existing ViewModel/service patterns so the Cabinet viewer remains thin and the feature can refresh on document open/save/assignment changes.

### Description
- Added a `FaceDocumentArtworkPreviewRenderer` service that composes visible `FaceArtworkElement` images into a static `BitmapSource` using SkiaSharp and returns `null` when no preview is available.  (`Features/CabinetEditor/Services/FaceDocumentArtworkPreviewRenderer.cs`).
- Extended `CabinetModelDocumentViewModel` to accept an open-documents accessor, find open Face documents whose `AssignedCabinetFaceTargetId` matches detected targets, request their static preview bitmaps, and construct textured `GeometryModel3D` quads mapped using the detected corner order (top-left, top-right, bottom-right, bottom-left). Preview geometry is editor-only and does not mutate the GLB. (`Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs`).
- Added a `FacePreviewModel` layer to `CabinetViewportViewModel` and the Cabinet view XAML so previews render on top of the existing model while preserving normal model rendering, camera controls, and target overlays. (`Features/CabinetEditor/ViewModels/CabinetViewportViewModel.cs`, `Features/CabinetEditor/Views/CabinetModelDocumentView.xaml`).
- Exposed the detected `CabinetFaceTarget` on `CabinetFaceTargetViewModel` to access corner positions for UV mapping. (`Features/CabinetEditor/ViewModels/CabinetFaceTargetViewModel.cs`).
- Wired document lifecycle notifications so previews refresh when Face documents open/close or when their serialized JSON changes by adding an `OpenDocuments` observer in `MainWindowViewModel` and passing an open-documents accessor into Cabinet viewers via `DocumentTabViewModel`/`DocumentWorkspaceViewModel`. (`MainWindowViewModel.cs`, `ViewModels/DocumentTabViewModel.cs`, `ViewModels/DocumentWorkspaceViewModel.cs`).
- Preserved the constraints: no GLB mutation, no uv rotation/flip flags added, no lamp/dynamic runtime behavior, and no Unity/export changes; when a Face has no preview the target overlay/list remains as before.

### Testing
- Ran repository sanity check `git diff --check` which produced no whitespace errors. 
- No builds or automated unit/UI tests were executed in this environment per repository instructions; local verification is required.
- Suggested local verification (manual checklist) is provided for running locally: open a GLB with `OasisFace_*` targets, open/create Face documents with `AssignedCabinetFaceTargetId`, confirm preview appears, reassign/clear assignment and confirm preview updates or disappears, and verify camera and existing target UI still work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4120d7d41c832792a2f213a8c2cc13)