### PR TITLE
Protect GLB assets by introducing .cabinet3d document metadata and save guards

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -57,6 +57,12 @@ public sealed class DocumentSaveService : IDocumentSaveService
             throw new ArgumentException("Save path is required.", nameof(savePath));
         }
 
+        if (current.Document.DocumentType == EditorDocumentType.Cabinet3D
+            && string.Equals(Path.GetExtension(savePath), ".glb", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Cabinet3D documents must be saved as .cabinet3d metadata files, never as .glb model assets.");
+        }
+
         var faceDocumentJson = current.FaceDocumentJson;
         var contentSource = current;
         progress.Report(0.1, "Collecting document content...");
@@ -71,7 +77,8 @@ public sealed class DocumentSaveService : IDocumentSaveService
                 current.DocumentId,
                 current.CommandService,
                 current.RuntimeState,
-                faceDocumentJson)
+                faceDocumentJson,
+                current.CabinetDocumentJson)
             {
                 PanelZoom = current.PanelZoom,
                 PanelPanX = current.PanelPanX,
@@ -94,7 +101,8 @@ public sealed class DocumentSaveService : IDocumentSaveService
             current.DocumentId,
             current.CommandService,
             current.RuntimeState,
-            faceDocumentJson)
+            faceDocumentJson,
+            current.CabinetDocumentJson)
         {
             PanelZoom = current.PanelZoom,
             PanelPanX = current.PanelPanX,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
@@ -1,6 +1,23 @@
 namespace OasisEditor.Features.CabinetEditor.Models;
 
-public sealed record CabinetDocument(CabinetModelReference Model)
+public sealed record CabinetDocument(
+    int Version,
+    CabinetModelReference Model,
+    CabinetTargetOverride[] TargetOverrides,
+    CabinetPreviewSettings Preview)
 {
-    public static CabinetDocument FromModelPath(string modelPath) => new(new CabinetModelReference(modelPath, 1.0, "Y"));
+    public static CabinetDocument Empty => new(1, new CabinetModelReference(string.Empty, 1.0, "Y"), [], CabinetPreviewSettings.Default);
+
+    public static CabinetDocument FromModelPath(string modelPath) => new(
+        1,
+        new CabinetModelReference(modelPath, 1.0, "Y"),
+        [],
+        CabinetPreviewSettings.Default);
+}
+
+public sealed record CabinetTargetOverride(string TargetId, string FrontSide);
+
+public sealed record CabinetPreviewSettings(bool ShowTargetOverlays, bool ShowFaceBackgrounds)
+{
+    public static CabinetPreviewSettings Default => new(true, true);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OasisEditor.Features.CabinetEditor.Models;
+
+public static class CabinetDocumentStorage
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string Serialize(CabinetDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return JsonSerializer.Serialize(document, Options);
+    }
+
+    public static bool TryRead(string? json, out CabinetDocument document)
+    {
+        document = CabinetDocument.Empty;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<CabinetDocument>(json, Options);
+            if (parsed?.Model is null || string.IsNullOrWhiteSpace(parsed.Model.Path))
+            {
+                return false;
+            }
+
+            document = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1666,7 +1666,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             openData.Summary,
             openData.PanelLayoutJson,
             openData.PanelTitle,
-            openData.FaceDocumentJson);
+            openData.FaceDocumentJson,
+            openData.CabinetDocumentJson);
         if (!openedNewTab)
         {
             AddOutputEntry($"Switched to already open document tab for {path}", OutputLogStatus.Info);
@@ -1751,7 +1752,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var current = SelectedDocument;
-        var savePath = current.Document.IsUntitled ? PromptSavePath() : current.FilePath;
+        var savePath = current.Document.IsUntitled || IsProtectedCabinetModelAssetPath(current) ? PromptSavePath() : current.FilePath;
         if (string.IsNullOrWhiteSpace(savePath))
         {
             return;
@@ -1775,6 +1776,12 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    private static bool IsProtectedCabinetModelAssetPath(DocumentTabViewModel document)
+    {
+        return document.Document.DocumentType == EditorDocumentType.Cabinet3D
+            && string.Equals(Path.GetExtension(document.FilePath), ".glb", StringComparison.OrdinalIgnoreCase);
+    }
+
     private string? PromptSavePath()
     {
         if (LoadedProject is null)
@@ -1784,6 +1791,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
         var selectedDocument = SelectedDocument;
         var defaultName = selectedDocument?.Document.Title ?? "Document";
+        if (selectedDocument is not null && IsProtectedCabinetModelAssetPath(selectedDocument))
+        {
+            defaultName = Path.GetFileNameWithoutExtension(selectedDocument.FilePath);
+        }
+
         var (defaultExtension, filter) = selectedDocument?.Document.DocumentType switch
         {
             EditorDocumentType.Face => (".face", "Face|*.face|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*"),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -4440,7 +4440,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
 }
 
-internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null, string? FaceDocumentJson = null);
+internal readonly record struct OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null, string? FaceDocumentJson = null, string? CabinetDocumentJson = null);
 
 
 internal static class EditorProjectInputDefinitionExtensions

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Linq;
 using OasisEditor.Commands;
+using OasisEditor.Features.CabinetEditor.Models;
 using OasisEditor.Features.CabinetEditor.Services;
 using OasisEditor.Features.CabinetEditor.ViewModels;
 
@@ -12,6 +13,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     private EditorDocument _document;
     private string? _panelLayoutJson;
     private string? _faceDocumentJson;
+    private string? _cabinetDocumentJson;
+    private CabinetDocument _cabinetDocumentModel;
     private Panel2DDocumentModel _panelDocumentModel;
     private FaceDocumentModel _faceDocumentModel;
     private Dictionary<string, PanelElementModel> _lampElementsByObjectId = new(StringComparer.Ordinal);
@@ -43,13 +46,15 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         Guid? documentId = null,
         CommandService? commandService = null,
         MachineRuntimeState? runtimeState = null,
-        string? faceDocumentJson = null)
+        string? faceDocumentJson = null,
+        string? cabinetDocumentJson = null)
     {
         _document = document;
         DocumentId = documentId ?? Guid.NewGuid();
         _commandService = commandService ?? new CommandService(new CommandHistory(), DocumentId);
         _panelLayoutJson = panelLayoutJson;
         _faceDocumentJson = faceDocumentJson;
+        _cabinetDocumentJson = cabinetDocumentJson;
         _runtimeState = runtimeState ?? new MachineRuntimeState();
         _panelDocumentModel = new Panel2DDocumentModel
         {
@@ -60,6 +65,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         _faceDocumentModel = FaceDocumentStorage.TryRead(faceDocumentJson, out var faceDocumentFile)
             ? FaceDocumentStorage.ToModel(faceDocumentFile)
             : new FaceDocumentModel();
+        _cabinetDocumentModel = CabinetDocumentStorage.TryRead(cabinetDocumentJson, out var cabinetDocument)
+            ? cabinetDocument
+            : CabinetDocument.Empty;
         RebuildLampCaches();
     }
 
@@ -80,9 +88,9 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public string FilePath => Document.FilePath;
     public string ContentSummary => Document.ContentSummary;
     public bool IsDirty => Document.IsDirty;
-    public bool HasCabinetViewer => Document.DocumentType == EditorDocumentType.Cabinet3D && string.Equals(System.IO.Path.GetExtension(Document.FilePath), ".glb", StringComparison.OrdinalIgnoreCase);
+    public bool HasCabinetViewer => Document.DocumentType == EditorDocumentType.Cabinet3D && !string.IsNullOrWhiteSpace(_cabinetDocumentModel.Model.Path);
     public CabinetModelDocumentViewModel? CabinetViewer => HasCabinetViewer
-        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), Document.FilePath, _openDocumentsAccessor)
+        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), _cabinetDocumentModel.Model.Path, _openDocumentsAccessor)
         : null;
 
     public void SetOpenDocumentsAccessor(Func<IReadOnlyList<DocumentTabViewModel>> openDocumentsAccessor)
@@ -101,6 +109,38 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Document)));
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDirty)));
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
+    }
+
+
+    public string? CabinetDocumentJson
+    {
+        get => _cabinetDocumentJson;
+        set
+        {
+            if (string.Equals(_cabinetDocumentJson, value, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _cabinetDocumentJson = value;
+            _cabinetDocumentModel = CabinetDocumentStorage.TryRead(value, out var cabinetDocument)
+                ? cabinetDocument
+                : CabinetDocument.Empty;
+            _cabinetViewer = null;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CabinetDocumentJson)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasCabinetViewer)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CabinetViewer)));
+        }
+    }
+
+    public CabinetDocument GetCabinetDocument()
+    {
+        return _cabinetDocumentModel;
+    }
+
+    public string GetCabinetDocumentJson()
+    {
+        return CabinetDocumentStorage.Serialize(_cabinetDocumentModel);
     }
 
     public string? FaceDocumentJson

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -913,4 +913,3 @@ public sealed class DocumentWorkspaceViewModel
     }
 }
 
-public sealed record OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null, string? FaceDocumentJson = null, string? CabinetDocumentJson = null);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Windows;
+using OasisEditor.Features.CabinetEditor.Models;
 using EditorCommands = OasisEditor.Commands;
 using OasisEditor.Progress;
 
@@ -449,7 +450,7 @@ public sealed class DocumentWorkspaceViewModel
         _addOutputEntry($"Closed document tab: {selectedDocument.Title}", OutputLogStatus.Info);
     }
 
-    public bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson, string? panelTitle = null, string? faceDocumentJson = null)
+    public bool OpenOrSelectDocument(string path, string summary, string? panelLayoutJson, string? panelTitle = null, string? faceDocumentJson = null, string? cabinetDocumentJson = null)
     {
         var existing = _openDocuments.FirstOrDefault(tab => string.Equals(tab.FilePath, path, StringComparison.OrdinalIgnoreCase));
         if (existing is not null)
@@ -458,7 +459,7 @@ public sealed class DocumentWorkspaceViewModel
             return false;
         }
 
-        var document = CreateDocumentTab(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson, faceDocumentJson);
+        var document = CreateDocumentTab(EditorDocument.CreateFromFile(path, summary, panelTitle), panelLayoutJson, faceDocumentJson, cabinetDocumentJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         return true;
     }
@@ -551,7 +552,8 @@ public sealed class DocumentWorkspaceViewModel
             selectedDocument.DocumentId,
             selectedDocument.CommandService,
             selectedDocument.RuntimeState,
-            selectedDocument.FaceDocumentJson)
+            selectedDocument.FaceDocumentJson,
+            selectedDocument.CabinetDocumentJson)
         {
             PanelZoom = selectedDocument.PanelZoom,
             PanelPanX = selectedDocument.PanelPanX,
@@ -564,7 +566,7 @@ public sealed class DocumentWorkspaceViewModel
         return updated;
     }
 
-    private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null, string? faceDocumentJson = null)
+    private DocumentTabViewModel CreateDocumentTab(EditorDocument document, string? panelLayoutJson = null, string? faceDocumentJson = null, string? cabinetDocumentJson = null)
     {
         var documentId = Guid.NewGuid();
         var runtimeState = _runtimeStateStore.GetOrCreate(documentId);
@@ -574,7 +576,8 @@ public sealed class DocumentWorkspaceViewModel
             panelLayoutJson,
             documentId,
             runtimeState: runtimeState,
-            faceDocumentJson: faceDocumentJson);
+            faceDocumentJson: faceDocumentJson,
+            cabinetDocumentJson: cabinetDocumentJson);
         tab.SetOpenDocumentsAccessor(() => _openDocuments);
         return tab;
     }
@@ -583,7 +586,30 @@ public sealed class DocumentWorkspaceViewModel
     {
         if (string.Equals(Path.GetExtension(path), ".glb", StringComparison.OrdinalIgnoreCase))
         {
-            return new OpenDocumentData("Cabinet GLB model opened for viewing. Orbit, pan, zoom, or reset the camera from the viewer toolbar.", null, Path.GetFileName(path));
+            var cabinetDocument = CabinetDocument.FromModelPath(path);
+            return new OpenDocumentData("Cabinet GLB model opened as an unsaved .cabinet3d wrapper. Save Document will save cabinet metadata, not the .glb model asset.", null, Path.GetFileName(path), CabinetDocumentJson: CabinetDocumentStorage.Serialize(cabinetDocument));
+        }
+
+
+        if (string.Equals(Path.GetExtension(path), ".cabinet3d", StringComparison.OrdinalIgnoreCase))
+        {
+            if (CabinetDocumentStorage.TryRead(content, out var cabinetDocument))
+            {
+                var modelPath = cabinetDocument.Model.Path;
+                if (!Path.IsPathFullyQualified(modelPath))
+                {
+                    modelPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path) ?? string.Empty, modelPath));
+                    cabinetDocument = cabinetDocument with { Model = cabinetDocument.Model with { Path = modelPath } };
+                }
+
+                var summary = "Cabinet 3D document opened.";
+                return new OpenDocumentData(summary, null, Path.GetFileName(path), CabinetDocumentJson: CabinetDocumentStorage.Serialize(cabinetDocument));
+            }
+
+            return new OpenDocumentData(
+                "Failed to open cabinet document: invalid .cabinet3d JSON or missing model.path.",
+                null,
+                Path.GetFileName(path));
         }
 
         if (string.Equals(Path.GetExtension(path), ".panel2d", StringComparison.OrdinalIgnoreCase))
@@ -644,6 +670,17 @@ public sealed class DocumentWorkspaceViewModel
             return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
         }
 
+
+        if (document.Document.DocumentType == EditorDocumentType.Cabinet3D)
+        {
+            var cabinetDocument = document.GetCabinetDocument();
+            if (string.IsNullOrWhiteSpace(cabinetDocument.Model.Path))
+            {
+                cabinetDocument = CabinetDocument.FromModelPath(string.Empty);
+            }
+
+            return CabinetDocumentStorage.Serialize(cabinetDocument);
+        }
 
         if (document.Document.DocumentType == EditorDocumentType.Face)
         {
@@ -875,3 +912,5 @@ public sealed class DocumentWorkspaceViewModel
         }
     }
 }
+
+public sealed record OpenDocumentData(string Summary, string? PanelLayoutJson, string? PanelTitle = null, string? FaceDocumentJson = null, string? CabinetDocumentJson = null);


### PR DESCRIPTION
### Motivation
- Prevent the editor from ever overwriting or writing Oasis data into a `.glb` model asset by treating `.glb` files as referenced model assets only. 
- Provide a proper `.cabinet3d` JSON document shape to persist Oasis-specific cabinet metadata (model reference, preview settings, target overrides) separate from the `.glb` geometry.
- Keep existing GLB rendering, `OasisFace_` target detection, and static Face preview behavior while enabling future per-target settings.

### Description
- Added a concrete Cabinet3D document model `CabinetDocument` with `version`, `model.path`, `targetOverrides`, and `preview` fields in `Features/CabinetEditor/Models/CabinetDocument.cs`.
- Implemented JSON persistence helpers in `CabinetDocumentStorage` to `Serialize`/`TryRead` `.cabinet3d` content and validate presence of `model.path` in `Features/CabinetEditor/Models/CabinetDocumentStorage.cs`.
- When opening a `.glb` the workspace now creates an unsaved `.cabinet3d` wrapper (`DocumentWorkspaceViewModel.BuildOpenDocumentData` returns `CabinetDocumentJson`) so viewers load the referenced GLB while the active document is a metadata wrapper.
- Added explicit `.cabinet3d` open handling that resolves relative `model.path` against the `.cabinet3d` location and loads the JSON metadata instead of treating the `.glb` as the document source (`DocumentWorkspaceViewModel`).
- Document tab VM now stores and exposes the parsed `CabinetDocument` (`DocumentTabViewModel` additions) and the `CabinetModelDocumentViewModel` loads the viewer from the referenced `Model.Path` rather than treating the `.glb` file itself as the document path.
- `DocumentWorkspaceViewModel.BuildDocumentContent` now serializes cabinet metadata for `EditorDocumentType.Cabinet3D` so saving writes only JSON metadata, not Model binaries.
- `MainWindowViewModel.SaveSelectedDocument` routes save for GLB-originated cabinet tabs through `Save As` by prompting a path when the active Cabinet3D tab is backed by a `.glb` asset (helper `IsProtectedCabinetModelAssetPath`).
- Added a safety guard in the save service `Automation.DocumentSaveService` to throw if a save is attempted to a `.glb` path so programmatic callers cannot write Oasis JSON into a `.glb` file.

### Testing
- No automated tests were executed in this environment per repository instructions; changes were implemented without running the WPF build or unit tests here.
- Local manual test checklist for verification (to be run by developer/QA): open a `.glb` directly and press Save to confirm the `.glb` is not modified and the UI prompts to save an external `.cabinet3d` file; create and save a `.cabinet3d` referencing a `.glb` and confirm reopening loads the GLB and preserves face target detection and static Face previews; confirm saving a `.cabinet3d` writes JSON only and that attempts to save a Cabinet3D document to a `.glb` path are blocked by the guard.
- Also verify existing `Panel2D` and `Face` open/save workflows remain unchanged and that the application builds and runs the WPF editor locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4124ff31c083279d86f8aadd5c6747)