### PR TITLE
Add Cabinet3D target mapping overrides

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
@@ -6,12 +6,17 @@ internal static class CabinetMutationCommands
 {
     public static Commands.ICommand CreateSetTargetFrontSideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string frontSide)
     {
-        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, CabinetTargetOverride.NormalizeFrontSide(frontSide), null, "Set cabinet target front side");
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, CabinetTargetOverride.NormalizeFrontSide(frontSide), null, null, "Set cabinet target front side");
     }
 
     public static Commands.ICommand CreateSetTargetFaceRotationCommand(Guid documentId, DocumentTabViewModel document, string targetId, int faceRotation)
     {
-        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, CabinetTargetOverride.NormalizeFaceRotation(faceRotation), "Set cabinet target face rotation");
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, CabinetTargetOverride.NormalizeFaceRotation(faceRotation), null, "Set cabinet target face rotation");
+    }
+
+    public static Commands.ICommand CreateSetTargetFaceFlipHorizontalCommand(Guid documentId, DocumentTabViewModel document, string targetId, bool faceFlipHorizontal)
+    {
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, null, faceFlipHorizontal, "Set cabinet target horizontal flip");
     }
 
     private sealed class SetCabinetTargetOverrideCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
@@ -21,16 +26,18 @@ internal static class CabinetMutationCommands
         private readonly string _targetId;
         private readonly string? _frontSide;
         private readonly int? _faceRotation;
+        private readonly bool? _faceFlipHorizontal;
         private readonly string _description;
         private CabinetDocument? _originalDocument;
 
-        public SetCabinetTargetOverrideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string? frontSide, int? faceRotation, string description)
+        public SetCabinetTargetOverrideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string? frontSide, int? faceRotation, bool? faceFlipHorizontal, string description)
         {
             _documentId = documentId;
             _document = document;
             _targetId = targetId.Trim();
             _frontSide = frontSide;
             _faceRotation = faceRotation;
+            _faceFlipHorizontal = faceFlipHorizontal;
             _description = description;
         }
 
@@ -51,10 +58,12 @@ internal static class CabinetMutationCommands
             var nextOverride = new CabinetTargetOverride(
                 _targetId,
                 _frontSide ?? currentOverride.FrontSide,
-                _faceRotation ?? currentOverride.FaceRotation).Normalized();
+                _faceRotation ?? currentOverride.FaceRotation,
+                _faceFlipHorizontal ?? currentOverride.FaceFlipHorizontal).Normalized();
 
             if (string.Equals(currentOverride.FrontSide, nextOverride.FrontSide, StringComparison.OrdinalIgnoreCase)
-                && currentOverride.FaceRotation == nextOverride.FaceRotation)
+                && currentOverride.FaceRotation == nextOverride.FaceRotation
+                && currentOverride.FaceFlipHorizontal == nextOverride.FaceFlipHorizontal)
             {
                 return;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
@@ -1,0 +1,79 @@
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor;
+
+internal static class CabinetMutationCommands
+{
+    public static Commands.ICommand CreateSetTargetFrontSideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string frontSide)
+    {
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, CabinetTargetOverride.NormalizeFrontSide(frontSide), null, "Set cabinet target front side");
+    }
+
+    public static Commands.ICommand CreateSetTargetTextureRotationCommand(Guid documentId, DocumentTabViewModel document, string targetId, int textureRotation)
+    {
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, CabinetTargetOverride.NormalizeTextureRotation(textureRotation), "Set cabinet target texture rotation");
+    }
+
+    private sealed class SetCabinetTargetOverrideCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly string _targetId;
+        private readonly string? _frontSide;
+        private readonly int? _textureRotation;
+        private readonly string _description;
+        private CabinetDocument? _originalDocument;
+
+        public SetCabinetTargetOverrideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string? frontSide, int? textureRotation, string description)
+        {
+            _documentId = documentId;
+            _document = document;
+            _targetId = targetId.Trim();
+            _frontSide = frontSide;
+            _textureRotation = textureRotation;
+            _description = description;
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => _description;
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            if (string.IsNullOrWhiteSpace(_targetId))
+            {
+                return;
+            }
+
+            var current = _document.GetCabinetDocument();
+            var currentOverride = current.GetTargetOverride(_targetId);
+            var nextOverride = new CabinetTargetOverride(
+                _targetId,
+                _frontSide ?? currentOverride.FrontSide,
+                _textureRotation ?? currentOverride.TextureRotation).Normalized();
+
+            if (string.Equals(currentOverride.FrontSide, nextOverride.FrontSide, StringComparison.OrdinalIgnoreCase)
+                && currentOverride.TextureRotation == nextOverride.TextureRotation)
+            {
+                return;
+            }
+
+            _originalDocument ??= current;
+            _document.SetCabinetDocument(current.WithTargetOverride(nextOverride));
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_originalDocument is null)
+            {
+                return;
+            }
+
+            _document.SetCabinetDocument(_originalDocument);
+            _document.MarkDirty();
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
@@ -9,9 +9,9 @@ internal static class CabinetMutationCommands
         return new SetCabinetTargetOverrideCommand(documentId, document, targetId, CabinetTargetOverride.NormalizeFrontSide(frontSide), null, "Set cabinet target front side");
     }
 
-    public static Commands.ICommand CreateSetTargetTextureRotationCommand(Guid documentId, DocumentTabViewModel document, string targetId, int textureRotation)
+    public static Commands.ICommand CreateSetTargetFaceRotationCommand(Guid documentId, DocumentTabViewModel document, string targetId, int faceRotation)
     {
-        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, CabinetTargetOverride.NormalizeTextureRotation(textureRotation), "Set cabinet target texture rotation");
+        return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, CabinetTargetOverride.NormalizeFaceRotation(faceRotation), "Set cabinet target face rotation");
     }
 
     private sealed class SetCabinetTargetOverrideCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
@@ -20,17 +20,17 @@ internal static class CabinetMutationCommands
         private readonly DocumentTabViewModel _document;
         private readonly string _targetId;
         private readonly string? _frontSide;
-        private readonly int? _textureRotation;
+        private readonly int? _faceRotation;
         private readonly string _description;
         private CabinetDocument? _originalDocument;
 
-        public SetCabinetTargetOverrideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string? frontSide, int? textureRotation, string description)
+        public SetCabinetTargetOverrideCommand(Guid documentId, DocumentTabViewModel document, string targetId, string? frontSide, int? faceRotation, string description)
         {
             _documentId = documentId;
             _document = document;
             _targetId = targetId.Trim();
             _frontSide = frontSide;
-            _textureRotation = textureRotation;
+            _faceRotation = faceRotation;
             _description = description;
         }
 
@@ -51,10 +51,10 @@ internal static class CabinetMutationCommands
             var nextOverride = new CabinetTargetOverride(
                 _targetId,
                 _frontSide ?? currentOverride.FrontSide,
-                _textureRotation ?? currentOverride.TextureRotation).Normalized();
+                _faceRotation ?? currentOverride.FaceRotation).Normalized();
 
             if (string.Equals(currentOverride.FrontSide, nextOverride.FrontSide, StringComparison.OrdinalIgnoreCase)
-                && currentOverride.TextureRotation == nextOverride.TextureRotation)
+                && currentOverride.FaceRotation == nextOverride.FaceRotation)
             {
                 return;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
@@ -15,14 +15,14 @@ public sealed record CabinetDocument(
         CabinetPreviewSettings.Default);
 }
 
-public sealed record CabinetTargetOverride(string TargetId, string FrontSide, int FaceRotation = 0)
+public sealed record CabinetTargetOverride(string TargetId, string FrontSide, int FaceRotation = 0, bool FaceFlipHorizontal = false)
 {
     public const string NormalFrontSide = "normal";
     public const string InvertedFrontSide = "inverted";
 
-    public static CabinetTargetOverride Default(string targetId) => new(targetId, NormalFrontSide, 0);
+    public static CabinetTargetOverride Default(string targetId) => new(targetId, NormalFrontSide, 0, false);
 
-    public CabinetTargetOverride Normalized() => new(TargetId, NormalizeFrontSide(FrontSide), NormalizeFaceRotation(FaceRotation));
+    public CabinetTargetOverride Normalized() => new(TargetId, NormalizeFrontSide(FrontSide), NormalizeFaceRotation(FaceRotation), FaceFlipHorizontal);
 
     public static string NormalizeFrontSide(string? frontSide)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
@@ -15,7 +15,50 @@ public sealed record CabinetDocument(
         CabinetPreviewSettings.Default);
 }
 
-public sealed record CabinetTargetOverride(string TargetId, string FrontSide);
+public sealed record CabinetTargetOverride(string TargetId, string FrontSide, int TextureRotation = 0)
+{
+    public const string NormalFrontSide = "normal";
+    public const string InvertedFrontSide = "inverted";
+
+    public static CabinetTargetOverride Default(string targetId) => new(targetId, NormalFrontSide, 0);
+
+    public CabinetTargetOverride Normalized() => new(TargetId, NormalizeFrontSide(FrontSide), NormalizeTextureRotation(TextureRotation));
+
+    public static string NormalizeFrontSide(string? frontSide)
+    {
+        return string.Equals(frontSide?.Trim(), InvertedFrontSide, StringComparison.OrdinalIgnoreCase)
+            ? InvertedFrontSide
+            : NormalFrontSide;
+    }
+
+    public static int NormalizeTextureRotation(int textureRotation) => textureRotation switch
+    {
+        90 => 90,
+        180 => 180,
+        270 => 270,
+        _ => 0
+    };
+}
+
+public static class CabinetDocumentTargetOverrideExtensions
+{
+    public static CabinetTargetOverride GetTargetOverride(this CabinetDocument document, string targetId)
+    {
+        var normalizedTargetId = targetId.Trim();
+        return (document.TargetOverrides ?? []).FirstOrDefault(candidate => string.Equals(candidate.TargetId, normalizedTargetId, StringComparison.Ordinal))?.Normalized()
+            ?? CabinetTargetOverride.Default(normalizedTargetId);
+    }
+
+    public static CabinetDocument WithTargetOverride(this CabinetDocument document, CabinetTargetOverride targetOverride)
+    {
+        var normalizedOverride = targetOverride.Normalized();
+        var overrides = (document.TargetOverrides ?? [])
+            .Where(candidate => !string.Equals(candidate.TargetId, normalizedOverride.TargetId, StringComparison.Ordinal))
+            .Append(normalizedOverride)
+            .ToArray();
+        return document with { TargetOverrides = overrides };
+    }
+}
 
 public sealed record CabinetPreviewSettings(bool ShowTargetOverlays, bool ShowFaceBackgrounds)
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
@@ -15,14 +15,14 @@ public sealed record CabinetDocument(
         CabinetPreviewSettings.Default);
 }
 
-public sealed record CabinetTargetOverride(string TargetId, string FrontSide, int TextureRotation = 0)
+public sealed record CabinetTargetOverride(string TargetId, string FrontSide, int FaceRotation = 0)
 {
     public const string NormalFrontSide = "normal";
     public const string InvertedFrontSide = "inverted";
 
     public static CabinetTargetOverride Default(string targetId) => new(targetId, NormalFrontSide, 0);
 
-    public CabinetTargetOverride Normalized() => new(TargetId, NormalizeFrontSide(FrontSide), NormalizeTextureRotation(TextureRotation));
+    public CabinetTargetOverride Normalized() => new(TargetId, NormalizeFrontSide(FrontSide), NormalizeFaceRotation(FaceRotation));
 
     public static string NormalizeFrontSide(string? frontSide)
     {
@@ -31,7 +31,7 @@ public sealed record CabinetTargetOverride(string TargetId, string FrontSide, in
             : NormalFrontSide;
     }
 
-    public static int NormalizeTextureRotation(int textureRotation) => textureRotation switch
+    public static int NormalizeFaceRotation(int faceRotation) => faceRotation switch
     {
         90 => 90,
         180 => 180,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
@@ -34,7 +34,14 @@ public static class CabinetDocumentStorage
                 return false;
             }
 
-            document = parsed;
+            document = parsed with
+            {
+                TargetOverrides = (parsed.TargetOverrides ?? [])
+                    .Where(targetOverride => !string.IsNullOrWhiteSpace(targetOverride.TargetId))
+                    .Select(targetOverride => targetOverride.Normalized())
+                    .ToArray(),
+                Preview = parsed.Preview ?? CabinetPreviewSettings.Default
+            };
             return true;
         }
         catch (JsonException)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/SharpGltfWpfModelLoader.cs
@@ -51,17 +51,23 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
                 return CabinetModelLoadResult.Failure("The .glb loaded, but it did not contain a scene to display.");
             }
 
+            var faceTargets = FaceTargetDetector.DetectTargets(modelPath, cancellationToken);
             var primitiveMeshes = new Dictionary<int, MeshGeometry3D>();
             var triangleCount = 0;
             foreach (var (a, b, c, material) in scene.EvaluateTriangles())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var materialIndex = GetLogicalIndex(material);
-                var mesh = GetMeshForMaterial(primitiveMeshes, materialIndex);
                 var pointA = ToPoint3D(a);
                 var pointB = ToPoint3D(b);
                 var pointC = ToPoint3D(c);
+                if (IsFaceTargetLocatorTriangle(pointA, pointB, pointC, faceTargets))
+                {
+                    continue;
+                }
+
+                var materialIndex = GetLogicalIndex(material);
+                var mesh = GetMeshForMaterial(primitiveMeshes, materialIndex);
                 var fallbackNormal = CalculateNormal(pointA, pointB, pointC);
 
                 AddTriangleVertex(mesh, a, pointA, fallbackNormal);
@@ -93,7 +99,6 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
             }
 
             group.Freeze();
-            var faceTargets = FaceTargetDetector.DetectTargets(modelPath, cancellationToken);
             return CabinetModelLoadResult.Success(group, faceTargets);
         }
         catch (OperationCanceledException)
@@ -104,6 +109,22 @@ public sealed class SharpGltfWpfModelLoader : ICabinetModelLoader
         {
             return CabinetModelLoadResult.Failure($"SharpGLTF fallback failed: {ex.Message}");
         }
+    }
+
+
+    private static bool IsFaceTargetLocatorTriangle(Point3D a, Point3D b, Point3D c, IReadOnlyList<Models.CabinetFaceTarget> faceTargets)
+    {
+        return faceTargets.Any(target => target.IsValid
+            && target.Corners.Count == 4
+            && IsTargetCorner(a, target.Corners)
+            && IsTargetCorner(b, target.Corners)
+            && IsTargetCorner(c, target.Corners));
+    }
+
+    private static bool IsTargetCorner(Point3D point, IReadOnlyList<Point3D> targetCorners)
+    {
+        const double toleranceSquared = 1e-8;
+        return targetCorners.Any(corner => (corner - point).LengthSquared <= toleranceSquared);
     }
 
     private static MeshGeometry3D GetMeshForMaterial(Dictionary<int, MeshGeometry3D> meshes, int materialIndex)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -15,17 +15,20 @@ namespace OasisEditor.Features.CabinetEditor.ViewModels;
 public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
 {
     private readonly ICabinetModelLoader _modelLoader;
+    private readonly DocumentTabViewModel _document;
     private readonly Func<IReadOnlyList<DocumentTabViewModel>>? _openDocumentsAccessor;
     private readonly FaceDocumentArtworkPreviewRenderer _previewRenderer = new();
     private string _loadStatus = "No cabinet model loaded.";
     private string? _errorMessage;
     private bool _isLoading;
+    private CabinetFaceTargetViewModel? _selectedFaceTarget;
 
-    public CabinetModelDocumentViewModel(ICabinetModelLoader modelLoader, string? modelPath = null, Func<IReadOnlyList<DocumentTabViewModel>>? openDocumentsAccessor = null)
+    public CabinetModelDocumentViewModel(ICabinetModelLoader modelLoader, DocumentTabViewModel document, Func<IReadOnlyList<DocumentTabViewModel>>? openDocumentsAccessor = null)
     {
         _modelLoader = modelLoader;
+        _document = document;
         _openDocumentsAccessor = openDocumentsAccessor;
-        ModelPath = modelPath ?? string.Empty;
+        ModelPath = document.GetCabinetDocument().Model.Path;
         Viewport = new CabinetViewportViewModel();
         ReloadCommand = new RelayCommand(async () => await LoadAsync(), CanLoad);
         ResetCameraCommand = Viewport.ResetCameraCommand;
@@ -51,6 +54,51 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
     public bool IsLoading { get => _isLoading; private set { _isLoading = value; OnPropertyChanged(); if (ReloadCommand is RelayCommand relay) relay.RaiseCanExecuteChanged(); } }
     public ICommand ReloadCommand { get; }
     public ICommand ResetCameraCommand { get; }
+    public IReadOnlyList<string> FrontSideOptions { get; } = new[] { CabinetTargetOverride.NormalFrontSide, CabinetTargetOverride.InvertedFrontSide };
+    public IReadOnlyList<int> TextureRotationOptions { get; } = new[] { 0, 90, 180, 270 };
+
+    public CabinetFaceTargetViewModel? SelectedFaceTarget
+    {
+        get => _selectedFaceTarget;
+        set
+        {
+            if (ReferenceEquals(_selectedFaceTarget, value)) return;
+            _selectedFaceTarget = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasSelectedFaceTarget));
+            OnPropertyChanged(nameof(SelectedFrontSide));
+            OnPropertyChanged(nameof(SelectedTextureRotation));
+        }
+    }
+
+    public bool HasSelectedFaceTarget => SelectedFaceTarget is not null;
+
+    public string SelectedFrontSide
+    {
+        get => SelectedFaceTarget is null ? CabinetTargetOverride.NormalFrontSide : _document.GetCabinetDocument().GetTargetOverride(SelectedFaceTarget.Id).FrontSide;
+        set
+        {
+            if (SelectedFaceTarget is null) return;
+            _document.CommandService.Execute(CabinetMutationCommands.CreateSetTargetFrontSideCommand(_document.DocumentId, _document, SelectedFaceTarget.Id, value));
+        }
+    }
+
+    public int SelectedTextureRotation
+    {
+        get => SelectedFaceTarget is null ? 0 : _document.GetCabinetDocument().GetTargetOverride(SelectedFaceTarget.Id).TextureRotation;
+        set
+        {
+            if (SelectedFaceTarget is null) return;
+            _document.CommandService.Execute(CabinetMutationCommands.CreateSetTargetTextureRotationCommand(_document.DocumentId, _document, SelectedFaceTarget.Id, value));
+        }
+    }
+
+    public void RefreshFromDocument(CabinetDocument document)
+    {
+        OnPropertyChanged(nameof(SelectedFrontSide));
+        OnPropertyChanged(nameof(SelectedTextureRotation));
+        RefreshFacePreviews();
+    }
 
     public async Task LoadAsync(CancellationToken cancellationToken = default)
     {
@@ -81,6 +129,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             }
             OnPropertyChanged(nameof(HasFaceTargets));
             OnPropertyChanged(nameof(FaceTargetStatus));
+            SelectedFaceTarget = FaceTargets.FirstOrDefault();
             RefreshFacePreviews();
             LoadStatus = FaceTargets.Count == 0
                 ? $"Loaded {DisplayName}; no Oasis face targets found"
@@ -122,7 +171,8 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
                 continue;
             }
 
-            if (TryCreatePreviewGeometry(target.Target, preview, out var geometry))
+            var targetOverride = _document.GetCabinetDocument().GetTargetOverride(target.Id);
+            if (TryCreatePreviewGeometry(target.Target, targetOverride, preview, out var geometry))
             {
                 previewGroup.Children.Add(geometry);
             }
@@ -131,7 +181,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         Viewport.FacePreviewModel = previewGroup.Children.Count == 0 ? null : previewGroup;
     }
 
-    private static bool TryCreatePreviewGeometry(CabinetFaceTarget target, BitmapSource bitmap, out GeometryModel3D geometry)
+    private static bool TryCreatePreviewGeometry(CabinetFaceTarget target, CabinetTargetOverride targetOverride, BitmapSource bitmap, out GeometryModel3D geometry)
     {
         geometry = default!;
         if (!target.IsValid || target.Corners.Count != 4)
@@ -143,18 +193,22 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         {
             Positions = new Point3DCollection(target.Corners),
             TriangleIndices = new Int32Collection(new[] { 0, 1, 2, 0, 2, 3 }),
-            TextureCoordinates = new PointCollection(new[]
-            {
-                new Point(0, 0),
-                new Point(1, 0),
-                new Point(1, 1),
-                new Point(0, 1)
-            })
+            TextureCoordinates = new PointCollection(GetTextureCoordinates(targetOverride.TextureRotation))
         };
         var material = new DiffuseMaterial(new ImageBrush(bitmap));
-        geometry = new GeometryModel3D(mesh, material) { BackMaterial = material };
+        geometry = CabinetTargetOverride.NormalizeFrontSide(targetOverride.FrontSide) == CabinetTargetOverride.InvertedFrontSide
+            ? new GeometryModel3D { Geometry = mesh, BackMaterial = material }
+            : new GeometryModel3D(mesh, material);
         return true;
     }
+
+    private static Point[] GetTextureCoordinates(int textureRotation) => CabinetTargetOverride.NormalizeTextureRotation(textureRotation) switch
+    {
+        90 => new[] { new Point(1, 0), new Point(1, 1), new Point(0, 1), new Point(0, 0) },
+        180 => new[] { new Point(1, 1), new Point(0, 1), new Point(0, 0), new Point(1, 0) },
+        270 => new[] { new Point(0, 1), new Point(0, 0), new Point(1, 0), new Point(1, 1) },
+        _ => new[] { new Point(0, 0), new Point(1, 0), new Point(1, 1), new Point(0, 1) }
+    };
 
     private static string? NormalizeTargetId(string? targetId) => string.IsNullOrWhiteSpace(targetId) ? null : targetId.Trim();
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -55,7 +55,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
     public ICommand ReloadCommand { get; }
     public ICommand ResetCameraCommand { get; }
     public IReadOnlyList<string> FrontSideOptions { get; } = new[] { CabinetTargetOverride.NormalFrontSide, CabinetTargetOverride.InvertedFrontSide };
-    public IReadOnlyList<int> TextureRotationOptions { get; } = new[] { 0, 90, 180, 270 };
+    public IReadOnlyList<int> FaceRotationOptions { get; } = new[] { 0, 90, 180, 270 };
 
     public CabinetFaceTargetViewModel? SelectedFaceTarget
     {
@@ -67,7 +67,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             OnPropertyChanged();
             OnPropertyChanged(nameof(HasSelectedFaceTarget));
             OnPropertyChanged(nameof(SelectedFrontSide));
-            OnPropertyChanged(nameof(SelectedTextureRotation));
+            OnPropertyChanged(nameof(SelectedFaceRotation));
         }
     }
 
@@ -83,20 +83,20 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         }
     }
 
-    public int SelectedTextureRotation
+    public int SelectedFaceRotation
     {
-        get => SelectedFaceTarget is null ? 0 : _document.GetCabinetDocument().GetTargetOverride(SelectedFaceTarget.Id).TextureRotation;
+        get => SelectedFaceTarget is null ? 0 : _document.GetCabinetDocument().GetTargetOverride(SelectedFaceTarget.Id).FaceRotation;
         set
         {
             if (SelectedFaceTarget is null) return;
-            _document.CommandService.Execute(CabinetMutationCommands.CreateSetTargetTextureRotationCommand(_document.DocumentId, _document, SelectedFaceTarget.Id, value));
+            _document.CommandService.Execute(CabinetMutationCommands.CreateSetTargetFaceRotationCommand(_document.DocumentId, _document, SelectedFaceTarget.Id, value));
         }
     }
 
     public void RefreshFromDocument(CabinetDocument document)
     {
         OnPropertyChanged(nameof(SelectedFrontSide));
-        OnPropertyChanged(nameof(SelectedTextureRotation));
+        OnPropertyChanged(nameof(SelectedFaceRotation));
         RefreshFacePreviews();
     }
 
@@ -189,25 +189,33 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             return false;
         }
 
+        var positions = GetRenderQuadCorners(target.Corners, targetOverride);
+        var triangleIndices = CabinetTargetOverride.NormalizeFrontSide(targetOverride.FrontSide) == CabinetTargetOverride.InvertedFrontSide
+            ? new[] { 0, 2, 1, 0, 3, 2 }
+            : new[] { 0, 1, 2, 0, 2, 3 };
         var mesh = new MeshGeometry3D
         {
-            Positions = new Point3DCollection(target.Corners),
-            TriangleIndices = new Int32Collection(new[] { 0, 1, 2, 0, 2, 3 }),
-            TextureCoordinates = new PointCollection(GetTextureCoordinates(targetOverride.TextureRotation))
+            Positions = new Point3DCollection(positions),
+            TriangleIndices = new Int32Collection(triangleIndices),
+            TextureCoordinates = new PointCollection(new[]
+            {
+                new Point(0, 0),
+                new Point(1, 0),
+                new Point(1, 1),
+                new Point(0, 1)
+            })
         };
         var material = new DiffuseMaterial(new ImageBrush(bitmap));
-        geometry = CabinetTargetOverride.NormalizeFrontSide(targetOverride.FrontSide) == CabinetTargetOverride.InvertedFrontSide
-            ? new GeometryModel3D { Geometry = mesh, BackMaterial = material }
-            : new GeometryModel3D(mesh, material);
+        geometry = new GeometryModel3D(mesh, material);
         return true;
     }
 
-    private static Point[] GetTextureCoordinates(int textureRotation) => CabinetTargetOverride.NormalizeTextureRotation(textureRotation) switch
+    private static Point3D[] GetRenderQuadCorners(IReadOnlyList<Point3D> sourceCorners, CabinetTargetOverride targetOverride) => CabinetTargetOverride.NormalizeFaceRotation(targetOverride.FaceRotation) switch
     {
-        90 => new[] { new Point(1, 0), new Point(1, 1), new Point(0, 1), new Point(0, 0) },
-        180 => new[] { new Point(1, 1), new Point(0, 1), new Point(0, 0), new Point(1, 0) },
-        270 => new[] { new Point(0, 1), new Point(0, 0), new Point(1, 0), new Point(1, 1) },
-        _ => new[] { new Point(0, 0), new Point(1, 0), new Point(1, 1), new Point(0, 1) }
+        90 => new[] { sourceCorners[3], sourceCorners[0], sourceCorners[1], sourceCorners[2] },
+        180 => new[] { sourceCorners[2], sourceCorners[3], sourceCorners[0], sourceCorners[1] },
+        270 => new[] { sourceCorners[1], sourceCorners[2], sourceCorners[3], sourceCorners[0] },
+        _ => new[] { sourceCorners[0], sourceCorners[1], sourceCorners[2], sourceCorners[3] }
     };
 
     private static string? NormalizeTargetId(string? targetId) => string.IsNullOrWhiteSpace(targetId) ? null : targetId.Trim();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -68,6 +68,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(HasSelectedFaceTarget));
             OnPropertyChanged(nameof(SelectedFrontSide));
             OnPropertyChanged(nameof(SelectedFaceRotation));
+            OnPropertyChanged(nameof(IsSelectedFaceFlippedHorizontally));
         }
     }
 
@@ -93,10 +94,21 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         }
     }
 
+    public bool IsSelectedFaceFlippedHorizontally
+    {
+        get => SelectedFaceTarget is not null && _document.GetCabinetDocument().GetTargetOverride(SelectedFaceTarget.Id).FaceFlipHorizontal;
+        set
+        {
+            if (SelectedFaceTarget is null) return;
+            _document.CommandService.Execute(CabinetMutationCommands.CreateSetTargetFaceFlipHorizontalCommand(_document.DocumentId, _document, SelectedFaceTarget.Id, value));
+        }
+    }
+
     public void RefreshFromDocument(CabinetDocument document)
     {
         OnPropertyChanged(nameof(SelectedFrontSide));
         OnPropertyChanged(nameof(SelectedFaceRotation));
+        OnPropertyChanged(nameof(IsSelectedFaceFlippedHorizontally));
         RefreshFacePreviews();
     }
 
@@ -190,7 +202,9 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         }
 
         var positions = GetRenderQuadCorners(target.Corners, targetOverride);
-        var triangleIndices = CabinetTargetOverride.NormalizeFrontSide(targetOverride.FrontSide) == CabinetTargetOverride.InvertedFrontSide
+        var isInverted = CabinetTargetOverride.NormalizeFrontSide(targetOverride.FrontSide) == CabinetTargetOverride.InvertedFrontSide;
+        var reverseWinding = targetOverride.FaceFlipHorizontal ^ isInverted;
+        var triangleIndices = reverseWinding
             ? new[] { 0, 2, 1, 0, 3, 2 }
             : new[] { 0, 1, 2, 0, 2, 3 };
         var mesh = new MeshGeometry3D
@@ -210,13 +224,20 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         return true;
     }
 
-    private static Point3D[] GetRenderQuadCorners(IReadOnlyList<Point3D> sourceCorners, CabinetTargetOverride targetOverride) => CabinetTargetOverride.NormalizeFaceRotation(targetOverride.FaceRotation) switch
+    private static Point3D[] GetRenderQuadCorners(IReadOnlyList<Point3D> sourceCorners, CabinetTargetOverride targetOverride)
     {
-        90 => new[] { sourceCorners[3], sourceCorners[0], sourceCorners[1], sourceCorners[2] },
-        180 => new[] { sourceCorners[2], sourceCorners[3], sourceCorners[0], sourceCorners[1] },
-        270 => new[] { sourceCorners[1], sourceCorners[2], sourceCorners[3], sourceCorners[0] },
-        _ => new[] { sourceCorners[0], sourceCorners[1], sourceCorners[2], sourceCorners[3] }
-    };
+        var rotated = CabinetTargetOverride.NormalizeFaceRotation(targetOverride.FaceRotation) switch
+        {
+            90 => new[] { sourceCorners[3], sourceCorners[0], sourceCorners[1], sourceCorners[2] },
+            180 => new[] { sourceCorners[2], sourceCorners[3], sourceCorners[0], sourceCorners[1] },
+            270 => new[] { sourceCorners[1], sourceCorners[2], sourceCorners[3], sourceCorners[0] },
+            _ => new[] { sourceCorners[0], sourceCorners[1], sourceCorners[2], sourceCorners[3] }
+        };
+
+        return targetOverride.FaceFlipHorizontal
+            ? new[] { rotated[1], rotated[0], rotated[3], rotated[2] }
+            : rotated;
+    }
 
     private static string? NormalizeTargetId(string? targetId) => string.IsNullOrWhiteSpace(targetId) ? null : targetId.Trim();
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -89,6 +89,7 @@
                         <ComboBox ItemsSource="{Binding CabinetViewer.FrontSideOptions}" SelectedItem="{Binding CabinetViewer.SelectedFrontSide, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Face Rotation" />
                         <ComboBox ItemsSource="{Binding CabinetViewer.FaceRotationOptions}" SelectedItem="{Binding CabinetViewer.SelectedFaceRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Margin="0,10,0,0" Foreground="{DynamicResource TextPrimaryBrush}" Content="Flip Horizontally" IsChecked="{Binding CabinetViewer.IsSelectedFaceFlippedHorizontally, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <ListBox ItemsSource="{Binding CabinetViewer.FaceTargets}" SelectedItem="{Binding CabinetViewer.SelectedFaceTarget, Mode=TwoWay}" Background="Transparent" BorderThickness="0">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -87,8 +87,8 @@
                         <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Target Mapping" />
                         <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Front Side" />
                         <ComboBox ItemsSource="{Binding CabinetViewer.FrontSideOptions}" SelectedItem="{Binding CabinetViewer.SelectedFrontSide, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Texture Rotation" />
-                        <ComboBox ItemsSource="{Binding CabinetViewer.TextureRotationOptions}" SelectedItem="{Binding CabinetViewer.SelectedTextureRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Face Rotation" />
+                        <ComboBox ItemsSource="{Binding CabinetViewer.FaceRotationOptions}" SelectedItem="{Binding CabinetViewer.SelectedFaceRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <ListBox ItemsSource="{Binding CabinetViewer.FaceTargets}" SelectedItem="{Binding CabinetViewer.SelectedFaceTarget, Mode=TwoWay}" Background="Transparent" BorderThickness="0">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -73,8 +73,25 @@
                         <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Oasis Face Targets" />
                         <TextBlock Margin="0,4,0,0" Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" Text="{Binding CabinetViewer.FaceTargetStatus}" />
                     </StackPanel>
+                    <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CabinetViewer.HasSelectedFaceTarget}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Target Mapping" />
+                        <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Front Side" />
+                        <ComboBox ItemsSource="{Binding CabinetViewer.FrontSideOptions}" SelectedItem="{Binding CabinetViewer.SelectedFrontSide, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Texture Rotation" />
+                        <ComboBox ItemsSource="{Binding CabinetViewer.TextureRotationOptions}" SelectedItem="{Binding CabinetViewer.SelectedTextureRotation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <ItemsControl ItemsSource="{Binding CabinetViewer.FaceTargets}">
+                        <ListBox ItemsSource="{Binding CabinetViewer.FaceTargets}" SelectedItem="{Binding CabinetViewer.SelectedFaceTarget, Mode=TwoWay}" Background="Transparent" BorderThickness="0">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <Border Margin="0,0,0,8" Padding="8"
@@ -89,7 +106,7 @@
                                     </Border>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        </ListBox>
                     </ScrollViewer>
                 </DockPanel>
             </Border>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -90,7 +90,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public bool IsDirty => Document.IsDirty;
     public bool HasCabinetViewer => Document.DocumentType == EditorDocumentType.Cabinet3D && !string.IsNullOrWhiteSpace(_cabinetDocumentModel.Model.Path);
     public CabinetModelDocumentViewModel? CabinetViewer => HasCabinetViewer
-        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), _cabinetDocumentModel.Model.Path, _openDocumentsAccessor)
+        ? _cabinetViewer ??= new CabinetModelDocumentViewModel(new SharpGltfWpfModelLoader(), this, _openDocumentsAccessor)
         : null;
 
     public void SetOpenDocumentsAccessor(Func<IReadOnlyList<DocumentTabViewModel>> openDocumentsAccessor)
@@ -141,6 +141,17 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     public string GetCabinetDocumentJson()
     {
         return CabinetDocumentStorage.Serialize(_cabinetDocumentModel);
+    }
+
+    internal void SetCabinetDocument(CabinetDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        _cabinetDocumentModel = document;
+        _cabinetDocumentJson = GetCabinetDocumentJson();
+        _cabinetViewer?.RefreshFromDocument(document);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CabinetDocumentJson)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasCabinetViewer)));
     }
 
     public string? FaceDocumentJson


### PR DESCRIPTION
### Motivation
- Provide per-target mapping controls so users can correct Blender-authored OasisFace_* target orientation and rotation without modifying the source .glb, and persist those overrides in the .cabinet3d document.

### Description
- Add `CabinetTargetOverride` (frontSide + textureRotation) with normalization and defaults and extend `CabinetDocument` to store per-target overrides (file: `Features/CabinetEditor/Models/CabinetDocument.cs`).
- Normalize and load saved overrides when reading `.cabinet3d` JSON to preserve older/missing data and ensure safe defaults (file: `Features/CabinetEditor/Models/CabinetDocumentStorage.cs`).
- Introduce document-scoped commands `CreateSetTargetFrontSideCommand` and `CreateSetTargetTextureRotationCommand` that follow the existing command/undo/redo conventions, detect no-ops, and mark the document dirty only via the document pathway (file: `OasisEditor/CabinetMutationCommands.cs`).
- Wire UI and preview behavior so detected `OasisFace_*` targets are selectable, selecting a target exposes Front Side and Texture Rotation controls, and applied overrides update the static Face preview by adjusting texture coordinates and front/back material logic without writing to the referenced `.glb` (files: `Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs`, `Features/CabinetEditor/Views/CabinetModelDocumentView.xaml`, and `ViewModels/DocumentTabViewModel.cs`).

### Testing
- Automated tests: none executed in this environment due to toolchain constraints, so no automated test results are available.
- Local testing checklist for John: build the solution locally; launch Oasis Editor and open/create a project; open a `.cabinet3d` referencing a `.glb` with `OasisFace_*` targets and confirm detected targets appear in the Cabinet3D target list; select a target and confirm mapping controls appear in the side panel; assign a Face document to a target and verify a static preview is rendered; change Texture Rotation through `0`, `90`, `180`, and `270` and confirm the static preview rotates accordingly; change Front Side between `normal` and `inverted` and confirm the preview displays on the expected side; verify changes mark the `.cabinet3d` document dirty and that undo/redo restores mapping values; save and reopen the `.cabinet3d` and confirm overrides persist and the referenced `.glb` was not modified; verify no-op changes do not create undo entries when the value is unchanged and do not incorrectly dirty the document; confirm orbit/pan/zoom/reset camera still function and that Panel2D/Face workflows remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a412fa587908327a3a48f04f4b36b35)