### PR TITLE
Add Panel2D Face Source Shapes (Perspective Rectangle) and generation workflow

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -6,6 +6,7 @@ public sealed class FaceDocumentModel
     public string Title { get; init; } = string.Empty;
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
+    public string? SourceFaceShapeId { get; init; }
     public string? AssignedCabinetFaceTargetId { get; init; }
     public FaceSourceRegionModel? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -159,6 +159,7 @@ public static class FaceDocumentStorage
             Title = file.Title ?? string.Empty,
             Summary = file.Summary,
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
+            SourceFaceShapeId = string.IsNullOrWhiteSpace(file.SourceFaceShapeId) ? null : file.SourceFaceShapeId.Trim(),
             AssignedCabinetFaceTargetId = string.IsNullOrWhiteSpace(file.AssignedCabinetFaceTargetId) ? null : file.AssignedCabinetFaceTargetId.Trim(),
             SourceRegion = ToModel(file.SourceRegion),
             LastRegeneratedAtUtc = file.LastRegeneratedAtUtc,
@@ -192,6 +193,7 @@ public static class FaceDocumentStorage
             Title = model.Title,
             Summary = model.Summary,
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
+            SourceFaceShapeId = model.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = string.IsNullOrWhiteSpace(model.AssignedCabinetFaceTargetId) ? null : model.AssignedCabinetFaceTargetId.Trim(),
             SourceRegion = ToFile(model.SourceRegion),
             LastRegeneratedAtUtc = model.LastRegeneratedAtUtc,
@@ -757,6 +759,7 @@ public sealed record FaceDocumentFile
     public string? Title { get; init; }
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
+    public string? SourceFaceShapeId { get; init; }
     public string? AssignedCabinetFaceTargetId { get; init; }
     public FaceSourceRegionFile? SourceRegion { get; init; }
     public DateTime? LastRegeneratedAtUtc { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using OasisEditor.Progress;
 
+using SkiaSharp;
+
 namespace OasisEditor;
 
 public enum FaceSourceRegionKind
@@ -81,6 +83,59 @@ internal sealed class FaceGenerationService
     {
         _machineObjectReferenceResolver = machineObjectReferenceResolver ?? MachineObjectReferenceResolver.Instance;
         _maskLayerExtractionService = new FaceMaskLayerExtractionService(_machineObjectReferenceResolver);
+    }
+
+
+
+    public FaceGenerationResult GenerateFromPanelFaceSourceShape(
+        Panel2DDocumentModel sourcePanel,
+        PanelFaceSourceShapeModel sourceShape,
+        string title,
+        string? sourcePanel2DDocumentId = null,
+        string? assignedCabinetFaceTargetId = null,
+        double? targetAspectRatio = null,
+        string? projectDirectory = null,
+        string? generatedDirectory = null,
+        FaceGenerationSettingsModel? generationSettings = null,
+        IEditorProgressReporter? progress = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePanel);
+        ArgumentNullException.ThrowIfNull(sourceShape);
+        var output = FaceSourceShapeTransformService.EstimateOutputSize(sourceShape, targetAspectRatio);
+        var region = FaceSourceRegionModel.FromRect(new Rect(0, 0, output.Width, output.Height));
+        var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, generatedDirectory);
+        var settings = (generationSettings ?? FaceGenerationSettingsModel.Default).Normalize();
+        var faceDocumentId = Guid.NewGuid().ToString("N");
+        var artwork = new FaceArtworkElement
+        {
+            ObjectId = $"face-artwork-{Guid.NewGuid():N}",
+            Name = "Perspective-corrected artwork",
+            X = 0,
+            Y = 0,
+            Width = output.Width,
+            Height = output.Height,
+            IsVisible = true,
+            AssetPath = assetPath,
+            SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
+            SourceRegion = region,
+            Provenance = new FaceArtworkProvenanceModel { Generator = "Generate Face From Face Source Shape", GeneratedAtUtc = DateTime.UtcNow }
+        };
+        var document = new FaceDocumentModel
+        {
+            Id = faceDocumentId,
+            Title = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim(),
+            Summary = $"Generated from Face Source Shape '{sourceShape.Name}' ({output.Width} x {output.Height}).",
+            SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
+            SourceFaceShapeId = NormalizeOptional(sourceShape.Id),
+            AssignedCabinetFaceTargetId = NormalizeOptional(assignedCabinetFaceTargetId),
+            SourceRegion = region,
+            LastRegeneratedAtUtc = DateTime.UtcNow,
+            GenerationSettings = settings,
+            Layers = [new FaceLayerModel { Id = "layer-artwork", Name = "Artwork", IsVisible = true }],
+            Elements = [artwork]
+        };
+        progress?.Report(1.0, "Face generation complete.");
+        return new FaceGenerationResult(document, 0, 1, 0, 0, 0, 0);
     }
 
     public FaceGenerationResult GenerateFromPanelRegion(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -106,6 +106,14 @@ internal sealed class FaceGenerationService
         var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, generatedDirectory);
         var settings = (generationSettings ?? FaceGenerationSettingsModel.Default).Normalize();
         var faceDocumentId = Guid.NewGuid().ToString("N");
+        var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(
+            new Panel2DDocumentModel(),
+            region.ToRect(),
+            faceDocumentId,
+            sourcePanel2DDocumentId,
+            projectDirectory,
+            generatedDirectory,
+            settings.MaskExtractionThreshold);
         var artwork = new FaceArtworkElement
         {
             ObjectId = $"face-artwork-{Guid.NewGuid():N}",
@@ -131,7 +139,12 @@ internal sealed class FaceGenerationService
             SourceRegion = region,
             LastRegeneratedAtUtc = DateTime.UtcNow,
             GenerationSettings = settings,
-            Layers = [new FaceLayerModel { Id = "layer-artwork", Name = "Artwork", IsVisible = true }],
+            MaskLayer = maskLayer,
+            Layers =
+            [
+                new FaceLayerModel { Id = "layer-artwork", Name = "Artwork", IsVisible = true },
+                new FaceLayerModel { Id = "layer-face-mask", Name = "Face Mask", IsVisible = true }
+            ],
             Elements = [artwork]
         };
         progress?.Report(1.0, "Face generation complete.");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -47,6 +47,7 @@ internal static class FaceMutationCommands
             Title = faceDocument.Title,
             Summary = faceDocument.Summary,
             SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+            SourceFaceShapeId = faceDocument.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = NormalizeTargetId(assignedTargetId),
             SourceRegion = faceDocument.SourceRegion,
             LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -129,6 +129,7 @@ internal sealed class FaceRegenerationService
             Title = existingFace.Title,
             Summary = $"Regenerated from Panel2D source region ({Format(sourceRegion.X)}, {Format(sourceRegion.Y)}, {Format(sourceRegion.Width)}, {Format(sourceRegion.Height)}).",
             SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
+            SourceFaceShapeId = existingFace.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = existingFace.AssignedCabinetFaceTargetId,
             SourceRegion = sourceRegion,
             LastRegeneratedAtUtc = DateTime.UtcNow,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -90,6 +90,7 @@ public sealed class FaceRuntimeExportService
             Title = faceDocument.Title,
             Summary = faceDocument.Summary,
             SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+            SourceFaceShapeId = faceDocument.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = faceDocument.AssignedCabinetFaceTargetId,
             SourceRegion = faceDocument.SourceRegion,
             LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using SkiaSharp;
+
+namespace OasisEditor;
+
+internal readonly record struct FaceSourceShapeOutputSize(int Width, int Height);
+
+internal static class FaceSourceShapeTransformService
+{
+    public static FaceSourceShapeOutputSize EstimateOutputSize(PanelFaceSourceShapeModel shape, double? targetAspectRatio = null)
+    {
+        var sourceWidth = Math.Max(Distance(shape.TopLeft, shape.TopRight), Distance(shape.BottomLeft, shape.BottomRight));
+        var sourceHeight = Math.Max(Distance(shape.TopLeft, shape.BottomLeft), Distance(shape.TopRight, shape.BottomRight));
+        if (targetAspectRatio is > 0d and < double.PositiveInfinity)
+        {
+            var widthFromHeight = sourceHeight * targetAspectRatio.Value;
+            var heightFromWidth = sourceWidth / targetAspectRatio.Value;
+            if (widthFromHeight >= sourceWidth) sourceWidth = widthFromHeight;
+            else sourceHeight = heightFromWidth;
+        }
+        return new FaceSourceShapeOutputSize(Math.Max(1, (int)Math.Ceiling(sourceWidth)), Math.Max(1, (int)Math.Ceiling(sourceHeight)));
+    }
+
+    public static string? TryGenerateBackground(Panel2DDocumentModel panel, PanelFaceSourceShapeModel shape, int width, int height, string? projectDirectory, string? generatedDirectory)
+    {
+        var background = panel.Elements.FirstOrDefault(e => e.Kind == PanelElementKind.Background && !string.IsNullOrWhiteSpace(e.AssetPath));
+        if (background is null || string.IsNullOrWhiteSpace(projectDirectory)) return null;
+        var sourcePath = Path.IsPathRooted(background.AssetPath!) ? background.AssetPath! : Path.Combine(projectDirectory, background.AssetPath!);
+        if (!File.Exists(sourcePath)) return null;
+        using var source = SKBitmap.Decode(sourcePath);
+        if (source is null) return null;
+        using var output = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        for (var y = 0; y < height; y++)
+        for (var x = 0; x < width; x++)
+        {
+            var u = width <= 1 ? 0d : x / (double)(width - 1);
+            var v = height <= 1 ? 0d : y / (double)(height - 1);
+            var px = Bilinear(shape.TopLeft.X, shape.TopRight.X, shape.BottomRight.X, shape.BottomLeft.X, u, v) - background.X;
+            var py = Bilinear(shape.TopLeft.Y, shape.TopRight.Y, shape.BottomRight.Y, shape.BottomLeft.Y, u, v) - background.Y;
+            output.SetPixel(x, y, SampleBicubic(source, px / Math.Max(1d, background.Width) * source.Width, py / Math.Max(1d, background.Height) * source.Height));
+        }
+        var generatedRoot = string.IsNullOrWhiteSpace(generatedDirectory) ? Path.Combine(projectDirectory, "Generated") : generatedDirectory;
+        var relative = Path.Combine("Generated", "Faces", $"face-source-shape-{Guid.NewGuid():N}.png");
+        var path = Path.Combine(projectDirectory, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var image = SKImage.FromBitmap(output);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(path);
+        data.SaveTo(stream);
+        return relative.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static double Distance(FacePointModel a, FacePointModel b)
+    {
+        var dx = a.X - b.X; var dy = a.Y - b.Y; return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    private static double Bilinear(double tl, double tr, double br, double bl, double u, double v) =>
+        tl * (1 - u) * (1 - v) + tr * u * (1 - v) + br * u * v + bl * (1 - u) * v;
+
+    private static SKColor SampleBicubic(SKBitmap bitmap, double x, double y)
+    {
+        var ix = Math.Clamp((int)Math.Round(x), 0, bitmap.Width - 1);
+        var iy = Math.Clamp((int)Math.Round(y), 0, bitmap.Height - 1);
+        return bitmap.GetPixel(ix, iy);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -155,6 +155,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenPanel2DStubCommand = new RelayCommand(OpenPanel2DStubDocument, CanOpenUntitledDocument);
         OpenFaceStubCommand = new RelayCommand(OpenFaceStubDocument, CanOpenUntitledDocument);
         GenerateFaceFromRegionCommand = new RelayCommand(GenerateFaceFromRegion, CanGenerateFaceFromRegion);
+        GenerateFaceFromSourceShapeCommand = new RelayCommand(GenerateFaceFromSourceShape, CanGenerateFaceFromSourceShape);
         RegenerateFaceCommand = new RelayCommand(RegenerateFace, CanRegenerateFace);
         OpenFaceGenerationSettingsCommand = new RelayCommand(OpenFaceGenerationSettings, CanOpenFaceGenerationSettings);
         ValidateFaceCommand = new RelayCommand(ValidateFace, CanValidateFace);
@@ -473,6 +474,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenPanel2DStubCommand { get; }
     public ICommand OpenFaceStubCommand { get; }
     public ICommand GenerateFaceFromRegionCommand { get; }
+    public ICommand GenerateFaceFromSourceShapeCommand { get; }
     public ICommand RegenerateFaceCommand { get; }
     public ICommand OpenFaceGenerationSettingsCommand { get; }
     public ICommand ValidateFaceCommand { get; }
@@ -1196,6 +1198,35 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+
+
+    private bool CanGenerateFaceFromSourceShape()
+    {
+        return _documentWorkspace.CanGenerateFaceFromSelectedPanel2DRegion()
+            && SelectedDocument?.HierarchySelectedPanelSelection is { Kind: PanelFaceSourceShapeCommands.SelectionKind };
+    }
+
+    private async void GenerateFaceFromSourceShape()
+    {
+        if (!CanGenerateFaceFromSourceShape()) return;
+        try
+        {
+            await _progressDialogService.RunAsync(
+                new EditorProgressRequest("Generating Face", "Generating Face from Face Source Shape...", EditorProgressMode.Determinate),
+                (progress, _) =>
+                {
+                    _documentWorkspace.GenerateFaceFromSelectedFaceSourceShape(_defaultFaceGenerationSettings, progress);
+                    return Task.CompletedTask;
+                });
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+            AddOutputEntry($"Generate Face from Source Shape failed: {ex.Message}", OutputLogStatus.Error);
+            MessageBox.Show(ex.Message, "Generate Face Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
     private bool CanRegenerateFace()
     {
         return _documentWorkspace.CanRegenerateSelectedFace();
@@ -1344,6 +1375,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             Title = faceDocument.Title,
             Summary = faceDocument.Summary,
             SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+            SourceFaceShapeId = faceDocument.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = faceDocument.AssignedCabinetFaceTargetId,
             SourceRegion = faceDocument.SourceRegion,
             LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -245,7 +245,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => LoadedProject,
             _activeDocumentContext,
             ExecuteDocumentCanvasCommand,
-            ApplyInspectorSummary);
+            ApplyInspectorSummary,
+            GenerateFaceFromSourceShapeCommand);
         _hierarchy = new HierarchyViewModel(
             () => SelectedDocument,
             [new Panel2DHierarchyProvider(), new FaceHierarchyProvider()]);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace OasisEditor;
 
 internal sealed class Panel2DDocumentModel
@@ -5,6 +7,28 @@ internal sealed class Panel2DDocumentModel
     public string Title { get; init; } = string.Empty;
     public string Summary { get; init; } = string.Empty;
     public IReadOnlyList<PanelElementModel> Elements { get; init; } = [];
+    public IReadOnlyList<PanelFaceSourceShapeModel> FaceSourceShapes { get; init; } = [];
+}
+
+internal enum PanelFaceSourceShapeType
+{
+    PerspectiveRectangle
+}
+
+internal sealed class PanelFaceSourceShapeModel
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public PanelFaceSourceShapeType Type { get; init; } = PanelFaceSourceShapeType.PerspectiveRectangle;
+    public FacePointModel TopLeft { get; init; } = new();
+    public FacePointModel TopRight { get; init; } = new();
+    public FacePointModel BottomRight { get; init; } = new();
+    public FacePointModel BottomLeft { get; init; } = new();
+
+    public double X => new[] { TopLeft.X, TopRight.X, BottomRight.X, BottomLeft.X }.Min();
+    public double Y => new[] { TopLeft.Y, TopRight.Y, BottomRight.Y, BottomLeft.Y }.Min();
+    public double Width => new[] { TopLeft.X, TopRight.X, BottomRight.X, BottomLeft.X }.Max() - X;
+    public double Height => new[] { TopLeft.Y, TopRight.Y, BottomRight.Y, BottomLeft.Y }.Max() - Y;
 }
 
 internal sealed class PanelElementModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -86,16 +86,17 @@ internal static class Panel2DDocumentStorage
         };
     }
 
-    public static string Serialize(string title, string summary, IReadOnlyList<PanelElementFile> elements)
+    public static string Serialize(string title, string summary, IReadOnlyList<PanelElementFile> elements, IReadOnlyList<PanelFaceSourceShapeFile>? faceSourceShapes = null)
     {
-        var schemaVersion = DetermineSchemaVersion(elements);
+        var schemaVersion = (faceSourceShapes?.Count ?? 0) > 0 ? CurrentSchemaVersion : DetermineSchemaVersion(elements);
         var payload = new Panel2DDocumentFile
         {
             SchemaVersion = schemaVersion,
             Title = title,
             Summary = summary,
             SavedAtUtc = DateTime.UtcNow,
-            Elements = elements.ToArray()
+            Elements = elements.ToArray(),
+            FaceSourceShapes = (faceSourceShapes ?? []).Select(NormalizeFaceSourceShape).ToArray()
         };
 
         return JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
@@ -254,7 +255,8 @@ internal static class Panel2DDocumentStorage
 
         normalized = source with
         {
-            Elements = normalizedElements.ToArray()
+            Elements = normalizedElements.ToArray(),
+            FaceSourceShapes = (source.FaceSourceShapes ?? []).Select(NormalizeFaceSourceShape).ToArray()
         };
         errorMessage = string.Empty;
         return true;
@@ -304,7 +306,8 @@ internal static class Panel2DDocumentStorage
             Elements = document.Elements
                 .Select(NormalizeElement)
                 .Select(ToModel)
-                .ToArray()
+                .ToArray(),
+            FaceSourceShapes = (document.FaceSourceShapes ?? []).Select(ToModel).ToArray()
         };
     }
 
@@ -442,9 +445,79 @@ internal static class Panel2DDocumentStorage
         }
         catch (JsonException)
         {
-            return [];
+            try
+            {
+                var document = JsonSerializer.Deserialize<Panel2DDocumentFile>(layoutJson) ?? new Panel2DDocumentFile();
+                return document.Elements.Select(NormalizeElement).ToArray();
+            }
+            catch (JsonException)
+            {
+                return [];
+            }
         }
     }
+
+    public static Panel2DDocumentModel DeserializeModel(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Panel2DDocumentModel();
+        }
+
+        if (TryReadValidated(json, out var document, out _))
+        {
+            return ToModel(document);
+        }
+
+        return new Panel2DDocumentModel
+        {
+            Elements = DeserializeLayout(json).Select(ToModel).ToArray()
+        };
+    }
+
+    public static PanelFaceSourceShapeFile ToStorageFaceSourceShape(PanelFaceSourceShapeModel shape)
+    {
+        return NormalizeFaceSourceShape(new PanelFaceSourceShapeFile
+        {
+            Id = shape.Id,
+            Name = shape.Name,
+            Type = "perspectiveRectangle",
+            Points = [ToPointFile(shape.TopLeft), ToPointFile(shape.TopRight), ToPointFile(shape.BottomRight), ToPointFile(shape.BottomLeft)]
+        });
+    }
+
+    private static PanelFaceSourceShapeModel ToModel(PanelFaceSourceShapeFile shape)
+    {
+        var normalized = NormalizeFaceSourceShape(shape);
+        return new PanelFaceSourceShapeModel
+        {
+            Id = normalized.Id,
+            Name = normalized.Name,
+            Type = PanelFaceSourceShapeType.PerspectiveRectangle,
+            TopLeft = ToFacePoint(normalized.Points[0]),
+            TopRight = ToFacePoint(normalized.Points[1]),
+            BottomRight = ToFacePoint(normalized.Points[2]),
+            BottomLeft = ToFacePoint(normalized.Points[3])
+        };
+    }
+
+    private static PanelFaceSourceShapeFile NormalizeFaceSourceShape(PanelFaceSourceShapeFile shape)
+    {
+        var id = string.IsNullOrWhiteSpace(shape.Id) ? Guid.NewGuid().ToString("N") : shape.Id.Trim();
+        var points = shape.Points is { Length: 4 } ? shape.Points : [new(0,0), new(100,0), new(100,100), new(0,100)];
+        return shape with
+        {
+            Id = id,
+            Name = string.IsNullOrWhiteSpace(shape.Name) ? "Face Source Shape" : shape.Name.Trim(),
+            Type = "perspectiveRectangle",
+            Points = points.Select(p => new PanelPointFile(IsFinite(p.X) ? p.X : 0d, IsFinite(p.Y) ? p.Y : 0d)).ToArray()
+        };
+    }
+
+    private static PanelPointFile ToPointFile(FacePointModel point) => new(point.X, point.Y);
+    private static FacePointModel ToFacePoint(PanelPointFile point) => new() { X = point.X, Y = point.Y };
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
 
     private static PanelElementFile NormalizeElement(PanelElementFile element)
     {
@@ -775,7 +848,18 @@ internal sealed record Panel2DDocumentFile
     public string Summary { get; init; } = string.Empty;
     public DateTime SavedAtUtc { get; init; }
     public PanelElementFile[] Elements { get; init; } = [];
+    public PanelFaceSourceShapeFile[] FaceSourceShapes { get; init; } = [];
 }
+
+internal sealed record PanelFaceSourceShapeFile
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Type { get; init; } = "perspectiveRectangle";
+    public PanelPointFile[] Points { get; init; } = [];
+}
+
+internal readonly record struct PanelPointFile(double X, double Y);
 
 internal sealed record PanelElementFile : IPanelSelectableObject
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelFaceSourceShapeCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelFaceSourceShapeCommands.cs
@@ -1,0 +1,64 @@
+using OasisEditor.Commands;
+
+namespace OasisEditor;
+
+internal static class PanelFaceSourceShapeCommands
+{
+    public const string SelectionKind = "faceSourceShape";
+
+    public static PanelSelectionInfo ToSelection(PanelFaceSourceShapeModel shape) => new(shape.Id, SelectionKind, shape.X, shape.Y, shape.Width, shape.Height);
+
+    public static ICommand CreateAddCommand(Guid documentId, DocumentTabViewModel document, PanelFaceSourceShapeModel shape) => new Add(documentId, document, shape);
+    public static ICommand CreateUpdateCommand(Guid documentId, DocumentTabViewModel document, PanelFaceSourceShapeModel shape, string description = "Update Face Source Shape") => new Update(documentId, document, shape, description);
+
+    private sealed class Add(Guid documentId, DocumentTabViewModel document, PanelFaceSourceShapeModel shape) : IDocumentCommand, IExecutionTrackedCommand
+    {
+        public string Description => "Add Face Source Shape";
+        public Guid DocumentId => documentId;
+        public bool WasExecuted { get; private set; }
+        public void Execute()
+        {
+            if (document.DocumentId != documentId || document.GetPanelFaceSourceShapes().Any(s => s.Id == shape.Id)) return;
+            var shapes = document.GetPanelFaceSourceShapes().Concat([shape]).ToArray();
+            document.SetPanelFaceSourceShapes(shapes, new PanelChangeEvent(documentId, shape.Id, PanelChangeProperties.Structure, true, true, true, true));
+            document.HierarchySelectedPanelSelection = ToSelection(shape);
+            document.MarkDirty();
+            WasExecuted = true;
+        }
+        public void Undo()
+        {
+            var shapes = document.GetPanelFaceSourceShapes().Where(s => s.Id != shape.Id).ToArray();
+            document.SetPanelFaceSourceShapes(shapes, new PanelChangeEvent(documentId, shape.Id, PanelChangeProperties.Structure, true, true, true, true));
+            WasExecuted = false;
+        }
+    }
+
+    private sealed class Update(Guid documentId, DocumentTabViewModel document, PanelFaceSourceShapeModel shape, string description) : IDocumentCommand, IExecutionTrackedCommand
+    {
+        private PanelFaceSourceShapeModel? _previous;
+        public string Description => description;
+        public Guid DocumentId => documentId;
+        public bool WasExecuted { get; private set; }
+        public void Execute()
+        {
+            var list = document.GetPanelFaceSourceShapes().ToArray();
+            var index = Array.FindIndex(list, s => s.Id == shape.Id);
+            if (document.DocumentId != documentId || index < 0) return;
+            _previous = list[index];
+            list[index] = shape;
+            document.SetPanelFaceSourceShapes(list, new PanelChangeEvent(documentId, shape.Id, PanelChangeProperties.Geometry | PanelChangeProperties.Metadata, true, false, true, true));
+            document.HierarchySelectedPanelSelection = ToSelection(shape);
+            document.MarkDirty();
+            WasExecuted = true;
+        }
+        public void Undo()
+        {
+            if (_previous is null) return;
+            var list = document.GetPanelFaceSourceShapes().ToArray();
+            var index = Array.FindIndex(list, s => s.Id == shape.Id);
+            if (index < 0) return;
+            list[index] = _previous;
+            document.SetPanelFaceSourceShapes(list, new PanelChangeEvent(documentId, shape.Id, PanelChangeProperties.Geometry | PanelChangeProperties.Metadata, true, false, true, true));
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -56,12 +56,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         _faceDocumentJson = faceDocumentJson;
         _cabinetDocumentJson = cabinetDocumentJson;
         _runtimeState = runtimeState ?? new MachineRuntimeState();
-        _panelDocumentModel = new Panel2DDocumentModel
-        {
-            Elements = Panel2DDocumentStorage.DeserializeLayout(panelLayoutJson)
-                .Select(Panel2DDocumentStorage.ToModel)
-                .ToArray()
-        };
+        _panelDocumentModel = Panel2DDocumentStorage.DeserializeModel(panelLayoutJson);
         _faceDocumentModel = FaceDocumentStorage.TryRead(faceDocumentJson, out var faceDocumentFile)
             ? FaceDocumentStorage.ToModel(faceDocumentFile)
             : new FaceDocumentModel();
@@ -183,12 +178,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             }
 
             _panelLayoutJson = value;
-            _panelDocumentModel = new Panel2DDocumentModel
-            {
-                Elements = Panel2DDocumentStorage.DeserializeLayout(value)
-                    .Select(Panel2DDocumentStorage.ToModel)
-                    .ToArray()
-            };
+            _panelDocumentModel = Panel2DDocumentStorage.DeserializeModel(value);
             RebuildLampCaches();
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
         }
@@ -246,6 +236,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             Title = _faceDocumentModel.Title,
             Summary = _faceDocumentModel.Summary,
             SourcePanel2DDocumentId = _faceDocumentModel.SourcePanel2DDocumentId,
+            SourceFaceShapeId = _faceDocumentModel.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = _faceDocumentModel.AssignedCabinetFaceTargetId,
             SourceRegion = _faceDocumentModel.SourceRegion,
             LastRegeneratedAtUtc = _faceDocumentModel.LastRegeneratedAtUtc,
@@ -267,6 +258,31 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
     internal IReadOnlyList<PanelElementModel> GetPanelElements()
     {
         return _panelDocumentModel.Elements;
+    }
+
+    internal IReadOnlyList<PanelFaceSourceShapeModel> GetPanelFaceSourceShapes()
+    {
+        return _panelDocumentModel.FaceSourceShapes;
+    }
+
+    internal bool TryGetPanelFaceSourceShape(string id, out PanelFaceSourceShapeModel shape)
+    {
+        shape = _panelDocumentModel.FaceSourceShapes.FirstOrDefault(s => string.Equals(s.Id, id, StringComparison.Ordinal)) ?? new PanelFaceSourceShapeModel();
+        return !string.IsNullOrWhiteSpace(shape.Id);
+    }
+
+    internal void SetPanelFaceSourceShapes(IReadOnlyList<PanelFaceSourceShapeModel> shapes, PanelChangeEvent? panelChange = null)
+    {
+        _panelDocumentModel = new Panel2DDocumentModel
+        {
+            Title = _panelDocumentModel.Title,
+            Summary = _panelDocumentModel.Summary,
+            Elements = _panelDocumentModel.Elements,
+            FaceSourceShapes = shapes.ToArray()
+        };
+        _panelLayoutJson = GetPanelLayoutProjectionJson();
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PanelLayoutJson)));
+        if (panelChange is PanelChangeEvent change) PanelChanged?.Invoke(change);
     }
 
     internal bool TryGetPanelElement(PanelSelectionInfo selection, out PanelElementModel element)
@@ -293,7 +309,8 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         {
             Title = _panelDocumentModel.Title,
             Summary = _panelDocumentModel.Summary,
-            Elements = elements.ToArray()
+            Elements = elements.ToArray(),
+            FaceSourceShapes = _panelDocumentModel.FaceSourceShapes
         };
         RebuildLampCaches();
 
@@ -437,8 +454,11 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
 
     internal string GetPanelLayoutProjectionJson()
     {
-        return Panel2DDocumentStorage.SerializeLayout(
-            Panel2DDocumentStorage.ToStorageElements(_panelDocumentModel));
+        return Panel2DDocumentStorage.Serialize(
+            _panelDocumentModel.Title,
+            _panelDocumentModel.Summary,
+            Panel2DDocumentStorage.ToStorageElements(_panelDocumentModel),
+            _panelDocumentModel.FaceSourceShapes.Select(Panel2DDocumentStorage.ToStorageFaceSourceShape).ToArray());
     }
 
     public PanelSelectionInfo? HierarchySelectedPanelSelection

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -150,6 +150,44 @@ public sealed class DocumentWorkspaceViewModel
         return document;
     }
 
+
+    public DocumentTabViewModel? GenerateFaceFromSelectedFaceSourceShape(FaceGenerationSettingsModel? generationSettings = null, IEditorProgressReporter? progress = null)
+    {
+        var sourceDocument = _getSelectedDocument();
+        var loadedProject = _getLoadedProject();
+        if (loadedProject is null || sourceDocument is null || sourceDocument.Document.DocumentType != EditorDocumentType.Panel2D) return null;
+        var selection = sourceDocument.HierarchySelectedPanelSelection;
+        if (selection is null || !string.Equals(selection.Value.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal)) return null;
+        if (!sourceDocument.TryGetPanelFaceSourceShape(selection.Value.ObjectId, out var shape)) return null;
+
+        var target = _openDocuments.Select(d => d.CabinetViewer?.SelectedFaceTarget?.Target).FirstOrDefault(t => t is not null);
+        var targetAspect = target is null || target.Corners.Count < 4
+            ? (double?)null
+            : (target.Corners[1] - target.Corners[0]).Length / Math.Max(0.0001, (target.Corners[3] - target.Corners[0]).Length);
+        progress ??= NoOpEditorProgressReporter.Instance;
+        var title = $"{sourceDocument.Title} Face";
+        var result = _faceGenerationService.GenerateFromPanelFaceSourceShape(
+            sourceDocument.GetPanelDocument(),
+            shape,
+            title,
+            sourceDocument.DocumentId.ToString("N"),
+            target?.Id,
+            targetAspect,
+            loadedProject.ProjectDirectory,
+            loadedProject.GeneratedDirectory,
+            generationSettings,
+            progress.CreateChild(0.0, 0.8));
+        var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, progress.CreateChild(0.8, 0.95));
+        var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
+        var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(generatedFaceDocument.Summary ?? "Generated Face document.");
+        var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
+        ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
+        _setStatusMessage($"Generated face document from Face Source Shape '{shape.Name}'.");
+        _addOutputEntry($"Generated face '{document.Title}' from Face Source Shape '{shape.Name}'.", OutputLogStatus.Info);
+        progress.Report(1.0, "Face generation complete.");
+        return document;
+    }
+
     private FaceDocumentModel ExportRuntimeAssetsForPreview(FaceDocumentModel faceDocument, EditorProject loadedProject, IEditorProgressReporter? progress = null)
     {
         try
@@ -622,7 +660,7 @@ public sealed class DocumentWorkspaceViewModel
                 var title = string.IsNullOrWhiteSpace(panelDocument.Title)
                     ? Path.GetFileName(path)
                     : panelDocument.Title.Trim();
-                return new OpenDocumentData(summary, Panel2DDocumentStorage.SerializeLayout(panelDocument.Elements), title);
+                return new OpenDocumentData(summary, Panel2DDocumentStorage.Serialize(panelDocument.Title, panelDocument.Summary, panelDocument.Elements, panelDocument.FaceSourceShapes), title);
             }
 
             return new OpenDocumentData(
@@ -667,7 +705,8 @@ public sealed class DocumentWorkspaceViewModel
             var elements = document.GetPanelElements()
                 .Select(Panel2DDocumentStorage.ToStorageElement)
                 .ToArray();
-            return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements);
+            var shapes = document.GetPanelFaceSourceShapes().Select(Panel2DDocumentStorage.ToStorageFaceSourceShape).ToArray();
+            return Panel2DDocumentStorage.Serialize(document.Document.Title, document.ContentSummary, elements, shapes);
         }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -509,3 +509,15 @@ public sealed class InspectorChoicePropertyViewModel : InspectorPropertyRowViewM
         RaisePropertyChanged(nameof(Value));
     }
 }
+
+
+public sealed class InspectorActionPropertyViewModel : InspectorPropertyRowViewModel
+{
+    public InspectorActionPropertyViewModel(string displayName, string groupName, System.Windows.Input.ICommand command)
+        : base(displayName, groupName, false)
+    {
+        Command = command;
+    }
+
+    public System.Windows.Input.ICommand Command { get; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -21,6 +21,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
     private readonly ActiveDocumentContextService _activeDocumentContext;
     private readonly Func<Guid, EditorCommands.ICommand, bool> _executeCanvasCommand;
     private readonly Func<DocumentTabViewModel, string, DocumentTabViewModel?> _applySummary;
+    private readonly ICommand? _generateFaceFromSourceShapeCommand;
     private readonly ObservableCollection<InspectorPropertyRowViewModel> _propertyRows = [];
     private string _inspectorEditableSummary = string.Empty;
     private DateTime _suppressPropertyRowRefreshUntilUtc;
@@ -35,7 +36,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         Func<EditorProject?> loadedProjectAccessor,
         ActiveDocumentContextService activeDocumentContext,
         Func<Guid, EditorCommands.ICommand, bool> executeCanvasCommand,
-        Func<DocumentTabViewModel, string, DocumentTabViewModel?> applySummary)
+        Func<DocumentTabViewModel, string, DocumentTabViewModel?> applySummary,
+        ICommand? generateFaceFromSourceShapeCommand = null)
         : this(
             selectedAssetAccessor,
             selectedDocumentAccessor,
@@ -43,7 +45,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             loadedProjectAccessor,
             activeDocumentContext,
             executeCanvasCommand,
-            applySummary)
+            applySummary,
+            generateFaceFromSourceShapeCommand)
     {
     }
 
@@ -54,7 +57,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         Func<EditorProject?> loadedProjectAccessor,
         ActiveDocumentContextService activeDocumentContext,
         Func<Guid, EditorCommands.ICommand, bool> executeCanvasCommand,
-        Func<DocumentTabViewModel, string, DocumentTabViewModel?> applySummary)
+        Func<DocumentTabViewModel, string, DocumentTabViewModel?> applySummary,
+        ICommand? generateFaceFromSourceShapeCommand = null)
     {
         _selectedAssetAccessor = selectedAssetAccessor;
         _selectedDocumentAccessor = selectedDocumentAccessor;
@@ -63,6 +67,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         _activeDocumentContext = activeDocumentContext;
         _executeCanvasCommand = executeCanvasCommand;
         _applySummary = applySummary;
+        _generateFaceFromSourceShapeCommand = generateFaceFromSourceShapeCommand;
         ApplyInspectorSummaryCommand = new RelayCommand(ApplyInspectorSummary, CanApplyInspectorSummary);
     }
 
@@ -354,6 +359,21 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
+            && selection is PanelSelectionInfo sourceShapeSelection
+            && string.Equals(sourceShapeSelection.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal)
+            && selectedDocument.TryGetPanelFaceSourceShape(sourceShapeSelection.ObjectId, out var selectedSourceShape))
+        {
+            if (!_hadInspectorSelection)
+            {
+                return true;
+            }
+
+            return !string.Equals(_lastInspectorSelectionObjectId, selectedSourceShape.Id, StringComparison.Ordinal)
+                || !string.Equals(_lastInspectorFaceSelectionKind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal);
+        }
+
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))
         {
             _hadInspectorSelection = false;
@@ -413,6 +433,67 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorPropertyRows));
     }
 
+
+    private void RebuildFaceSourceShapePropertyRows(DocumentTabViewModel selectedDocument, PanelFaceSourceShapeModel sourceShape)
+    {
+        _lastInspectorFaceSelectionKind = PanelFaceSourceShapeCommands.SelectionKind;
+        _lastInspectorSelectionObjectId = sourceShape.Id;
+        _lastInspectorSelectionKind = null;
+        _hadInspectorSelection = true;
+
+        if (_generateFaceFromSourceShapeCommand is not null)
+        {
+            _propertyRows.Add(new InspectorActionPropertyViewModel("Create Face from this Source Shape", "Actions", _generateFaceFromSourceShapeCommand));
+        }
+
+        _propertyRows.Add(new InspectorTextPropertyViewModel("Name", "Face Source Shape", sourceShape.Name, commit: value => TryApplyFaceSourceShapeUpdate(selectedDocument, sourceShape, new PanelFaceSourceShapeModel { Id = sourceShape.Id, Name = value, Type = sourceShape.Type, TopLeft = sourceShape.TopLeft, TopRight = sourceShape.TopRight, BottomRight = sourceShape.BottomRight, BottomLeft = sourceShape.BottomLeft })));
+        _propertyRows.Add(new InspectorInfoPropertyViewModel("Type", "Face Source Shape", "Perspective Rectangle"));
+        AddFaceSourceShapePointRows(selectedDocument, sourceShape, "Top Left", 0, sourceShape.TopLeft);
+        AddFaceSourceShapePointRows(selectedDocument, sourceShape, "Top Right", 1, sourceShape.TopRight);
+        AddFaceSourceShapePointRows(selectedDocument, sourceShape, "Bottom Right", 2, sourceShape.BottomRight);
+        AddFaceSourceShapePointRows(selectedDocument, sourceShape, "Bottom Left", 3, sourceShape.BottomLeft);
+        OnPropertyChanged(nameof(InspectorPropertyRows));
+    }
+
+    private void AddFaceSourceShapePointRows(DocumentTabViewModel selectedDocument, PanelFaceSourceShapeModel sourceShape, string label, int pointIndex, FacePointModel point)
+    {
+        _propertyRows.Add(new InspectorDoublePropertyViewModel($"{label} X", "Corners", point.X, commit: value => TryApplyFaceSourceShapePointUpdate(selectedDocument, sourceShape, pointIndex, value, isX: true)));
+        _propertyRows.Add(new InspectorDoublePropertyViewModel($"{label} Y", "Corners", point.Y, commit: value => TryApplyFaceSourceShapePointUpdate(selectedDocument, sourceShape, pointIndex, value, isX: false)));
+    }
+
+    private string? TryApplyFaceSourceShapePointUpdate(DocumentTabViewModel selectedDocument, PanelFaceSourceShapeModel sourceShape, int pointIndex, double value, bool isX)
+    {
+        var current = pointIndex switch
+        {
+            0 => sourceShape.TopLeft,
+            1 => sourceShape.TopRight,
+            2 => sourceShape.BottomRight,
+            _ => sourceShape.BottomLeft
+        };
+        var point = new FacePointModel { X = isX ? value : current.X, Y = isX ? current.Y : value };
+        return TryApplyFaceSourceShapeUpdate(selectedDocument, sourceShape, CreateFaceSourceShapeWithPoint(sourceShape, pointIndex, point));
+    }
+
+    private string? TryApplyFaceSourceShapeUpdate(DocumentTabViewModel selectedDocument, PanelFaceSourceShapeModel sourceShape, PanelFaceSourceShapeModel updated)
+    {
+        var command = PanelFaceSourceShapeCommands.CreateUpdateCommand(selectedDocument.DocumentId, selectedDocument, updated, "Update Face Source Shape");
+        return _executeCanvasCommand(selectedDocument.DocumentId, command) ? null : "Could not update Face Source Shape.";
+    }
+
+    private static PanelFaceSourceShapeModel CreateFaceSourceShapeWithPoint(PanelFaceSourceShapeModel source, int pointIndex, FacePointModel point)
+    {
+        return new PanelFaceSourceShapeModel
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Type = source.Type,
+            TopLeft = pointIndex == 0 ? point : source.TopLeft,
+            TopRight = pointIndex == 1 ? point : source.TopRight,
+            BottomRight = pointIndex == 2 ? point : source.BottomRight,
+            BottomLeft = pointIndex == 3 ? point : source.BottomLeft
+        };
+    }
+
     private bool ShouldRebuildRowsForContextChange()
     {
         var selectedDocument = _selectedDocumentAccessor();
@@ -452,6 +533,21 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
                 || !selectedDocument.TryGetFaceElement(selectedFaceSelection, out _)))
         {
             return true;
+        }
+
+        if (selectedDocument is not null
+            && selectedDocument.Document.DocumentType == EditorDocumentType.Panel2D
+            && selection is PanelSelectionInfo sourceShapeSelection
+            && string.Equals(sourceShapeSelection.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal)
+            && selectedDocument.TryGetPanelFaceSourceShape(sourceShapeSelection.ObjectId, out var selectedSourceShape))
+        {
+            if (!_hadInspectorSelection)
+            {
+                return true;
+            }
+
+            return !string.Equals(_lastInspectorSelectionObjectId, selectedSourceShape.Id, StringComparison.Ordinal)
+                || !string.Equals(_lastInspectorFaceSelectionKind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal);
         }
 
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -365,13 +365,8 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             && string.Equals(sourceShapeSelection.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal)
             && selectedDocument.TryGetPanelFaceSourceShape(sourceShapeSelection.ObjectId, out var selectedSourceShape))
         {
-            if (!_hadInspectorSelection)
-            {
-                return true;
-            }
-
-            return !string.Equals(_lastInspectorSelectionObjectId, selectedSourceShape.Id, StringComparison.Ordinal)
-                || !string.Equals(_lastInspectorFaceSelectionKind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal);
+            RebuildFaceSourceShapePropertyRows(selectedDocument, selectedSourceShape);
+            return;
         }
 
         if (selectedDocument is null || selection is not PanelSelectionInfo selectedSelection || !selectedDocument.TryGetPanelElement(selectedSelection, out var selectedElement))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs
@@ -18,6 +18,7 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
         var elements = panelDocument.GetPanelElements();
         var groups = new List<HierarchyItemViewModel>
         {
+            BuildFaceSourceShapeGroup(panelDocument.GetPanelFaceSourceShapes()),
             BuildGroup("Backgrounds", elements, PanelElementKind.Background, "Background"),
             BuildGroup("Lamps", elements, PanelElementKind.Lamp, "Lamp"),
             BuildGroup("Reels", elements, PanelElementKind.Reel, "Reel"),
@@ -32,6 +33,19 @@ public sealed class Panel2DHierarchyProvider : IDocumentHierarchyProvider
         };
 
         return groups;
+    }
+
+    private static HierarchyItemViewModel BuildFaceSourceShapeGroup(IReadOnlyList<PanelFaceSourceShapeModel> shapes)
+    {
+        var matches = shapes.Select((shape, index) =>
+        {
+            var displayName = string.IsNullOrWhiteSpace(shape.Name) ? $"Face Source Shape {index + 1}" : shape.Name.Trim();
+            return new HierarchyItemViewModel(
+                displayName,
+                $"faceSourceShape:{shape.Id}",
+                panelSelection: PanelFaceSourceShapeCommands.ToSelection(shape));
+        }).ToArray();
+        return new HierarchyItemViewModel($"Face Source Shapes ({matches.Length})", "group:faceSourceShapes", isGroup: true, children: matches);
     }
 
     private static HierarchyItemViewModel BuildGroup(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -105,7 +105,15 @@
                 <ComboBox Grid.Column="1" ItemsSource="{Binding Choices}" SelectedItem="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
-<DataTemplate DataType="{x:Type vm:InspectorInfoPropertyViewModel}">
+<DataTemplate DataType="{x:Type vm:InspectorActionPropertyViewModel}">
+            <Button Margin="0,8,0,0"
+                    HorizontalAlignment="Left"
+                    Padding="10,4"
+                    Content="{Binding DisplayName}"
+                    Command="{Binding Command}" />
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:InspectorInfoPropertyViewModel}">
             <Grid Margin="0,3,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="120" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -338,6 +338,12 @@ public partial class SkiaPanel2DEditView : UserControl
                 return;
             }
 
+            if (_isResizingSelection)
+            {
+                RequestRender();
+                return;
+            }
+
             if (!_isDragSelecting && Panel2DViewportInteractionService.ShouldStartDragSelection(_leftMouseDownStart, _dragSelectionCurrent, DragSelectionStartThreshold))
             {
                 _isDragSelecting = true;
@@ -479,7 +485,13 @@ public partial class SkiaPanel2DEditView : UserControl
             Placement = PlacementMode.MousePoint
         };
 
-        if (document.HierarchySelectedPanelSelection is { Kind: PanelFaceSourceShapeCommands.SelectionKind }
+        var shapeAtPoint = document.GetPanelFaceSourceShapes().LastOrDefault(shape => IsInsideShapeBounds(shape, panelPoint));
+        if (shapeAtPoint is not null)
+        {
+            document.HierarchySelectedPanelSelection = PanelFaceSourceShapeCommands.ToSelection(shapeAtPoint);
+        }
+
+        if ((document.HierarchySelectedPanelSelection is { Kind: PanelFaceSourceShapeCommands.SelectionKind } || shapeAtPoint is not null)
             && Window.GetWindow(this)?.DataContext is MainWindowViewModel mainWindow)
         {
             var createFaceItem = new MenuItem { Header = "Create Face from Source Shape", Command = mainWindow.GenerateFaceFromSourceShapeCommand };
@@ -717,13 +729,14 @@ public partial class SkiaPanel2DEditView : UserControl
         return Panel2DResizeHandleHitTestService.TryHitHandle(selectedElement, docPoint, handleSizeDoc, out handleKind);
     }
 
-    private static void DrawFaceSourceShapes(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
+    private void DrawFaceSourceShapes(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
     {
         using var linePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0xFF, 0xC1, 0x07), StrokeWidth = (float)(2d / viewport.NormalizedZoom), IsAntialias = true };
         using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xC1, 0x07, 0x28), IsAntialias = true };
         using var handlePaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xA0, 0x00), IsAntialias = true };
-        foreach (var shape in document.GetPanelFaceSourceShapes())
+        foreach (var sourceShape in document.GetPanelFaceSourceShapes())
         {
+            var shape = GetPreviewShape(sourceShape, viewport);
             using var path = new SKPath();
             path.MoveTo((float)shape.TopLeft.X, (float)shape.TopLeft.Y);
             path.LineTo((float)shape.TopRight.X, (float)shape.TopRight.Y);
@@ -735,6 +748,35 @@ public partial class SkiaPanel2DEditView : UserControl
             var radius = (float)(5d / viewport.NormalizedZoom);
             foreach (var point in GetShapePoints(shape)) canvas.DrawCircle((float)point.X, (float)point.Y, radius, handlePaint);
         }
+    }
+
+
+    private PanelFaceSourceShapeModel GetPreviewShape(PanelFaceSourceShapeModel sourceShape, PanelViewportTransform viewport)
+    {
+        if (!_isResizingSelection
+            || _shapeDragSource is null
+            || _activeShapeCornerIndex < 0
+            || !string.Equals(sourceShape.Id, _shapeDragSource.Id, StringComparison.Ordinal))
+        {
+            return sourceShape;
+        }
+
+        var point = viewport.ScreenToDocument(_dragSelectionCurrent);
+        return CreateShapeWithCorner(sourceShape, _activeShapeCornerIndex, new FacePointModel { X = point.X, Y = point.Y });
+    }
+
+    private static PanelFaceSourceShapeModel CreateShapeWithCorner(PanelFaceSourceShapeModel source, int cornerIndex, FacePointModel point)
+    {
+        return new PanelFaceSourceShapeModel
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Type = source.Type,
+            TopLeft = cornerIndex == 0 ? point : source.TopLeft,
+            TopRight = cornerIndex == 1 ? point : source.TopRight,
+            BottomRight = cornerIndex == 2 ? point : source.BottomRight,
+            BottomLeft = cornerIndex == 3 ? point : source.BottomLeft
+        };
     }
 
     private static bool IsInsideShapeBounds(PanelFaceSourceShapeModel shape, Point point)
@@ -776,16 +818,7 @@ public partial class SkiaPanel2DEditView : UserControl
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var point = viewport.ScreenToDocument(screenPoint);
         FacePointModel fp = new() { X = point.X, Y = point.Y };
-        var updated = new PanelFaceSourceShapeModel
-        {
-            Id = _shapeDragSource.Id,
-            Name = _shapeDragSource.Name,
-            Type = _shapeDragSource.Type,
-            TopLeft = _activeShapeCornerIndex == 0 ? fp : _shapeDragSource.TopLeft,
-            TopRight = _activeShapeCornerIndex == 1 ? fp : _shapeDragSource.TopRight,
-            BottomRight = _activeShapeCornerIndex == 2 ? fp : _shapeDragSource.BottomRight,
-            BottomLeft = _activeShapeCornerIndex == 3 ? fp : _shapeDragSource.BottomLeft
-        };
+        var updated = CreateShapeWithCorner(_shapeDragSource, _activeShapeCornerIndex, fp);
         document.CommandService.Execute(PanelFaceSourceShapeCommands.CreateUpdateCommand(document.DocumentId, document, updated, "Move Face Source Shape corner"));
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -27,6 +27,8 @@ public partial class SkiaPanel2DEditView : UserControl
     private Point _dragSelectionCurrent;
     private PanelElementModel? _moveSourceElement;
     private PanelElementModel? _resizeSourceElement;
+    private PanelFaceSourceShapeModel? _shapeDragSource;
+    private int _activeShapeCornerIndex = -1;
     private ResizeHandleKind _activeResizeHandle;
     private bool _isRenderQueued;
     private bool _isRenderDirty;
@@ -161,6 +163,7 @@ public partial class SkiaPanel2DEditView : UserControl
         canvas.Translate((float)viewport.PanX, (float)viewport.PanY);
         canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
         _renderer.Render(canvas, document.GetPanelElements(), document.RuntimeState, viewport);
+        DrawFaceSourceShapes(canvas, document, viewport);
         DrawSelectionOutline(canvas, document, viewport);
         DrawResizeHandles(canvas, document, viewport);
         DrawDragSelectionRect(canvas, viewport);
@@ -252,6 +255,22 @@ public partial class SkiaPanel2DEditView : UserControl
         {
             var document = Document;
             var pointer = eventArgs.GetPosition(EditSkiaSurface);
+            if (document is not null
+                && TryGetFaceSourceShapeCornerAtPoint(document, pointer, out var shape, out var cornerIndex))
+            {
+                _isLeftMouseDown = true;
+                _isDragSelecting = false;
+                _isMovingSelection = false;
+                _isResizingSelection = true;
+                _shapeDragSource = shape;
+                _activeShapeCornerIndex = cornerIndex;
+                _leftMouseDownStart = pointer;
+                _dragSelectionCurrent = pointer;
+                EditSkiaSurface.CaptureMouse();
+                eventArgs.Handled = true;
+                return;
+            }
+
             if (document is not null
                 && TryGetResizeHandleAtPoint(document, pointer, out var resizeHandle, out var resizeElement))
             {
@@ -368,7 +387,14 @@ public partial class SkiaPanel2DEditView : UserControl
                 }
                 else if (_isResizingSelection)
                 {
-                    HandleResizeSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                    if (_shapeDragSource is not null)
+                    {
+                        HandleShapeCornerDrag(document, _dragSelectionCurrent);
+                    }
+                    else
+                    {
+                        HandleResizeSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                    }
                 }
                 else
                 {
@@ -382,6 +408,8 @@ public partial class SkiaPanel2DEditView : UserControl
             _isResizingSelection = false;
             _moveSourceElement = null;
             _resizeSourceElement = null;
+            _shapeDragSource = null;
+            _activeShapeCornerIndex = -1;
             _activeResizeHandle = ResizeHandleKind.None;
             EditSkiaSurface.ReleaseMouseCapture();
             RequestRender();
@@ -451,6 +479,19 @@ public partial class SkiaPanel2DEditView : UserControl
             Placement = PlacementMode.MousePoint
         };
 
+        if (document.HierarchySelectedPanelSelection is { Kind: PanelFaceSourceShapeCommands.SelectionKind }
+            && Window.GetWindow(this)?.DataContext is MainWindowViewModel mainWindow)
+        {
+            var createFaceItem = new MenuItem { Header = "Create Face from Source Shape", Command = mainWindow.GenerateFaceFromSourceShapeCommand };
+            contextMenu.Items.Add(createFaceItem);
+            contextMenu.Items.Add(new Separator());
+        }
+
+        var sourceShapeItem = new MenuItem { Header = "Add Face Source Shape" };
+        sourceShapeItem.Click += (_, _) => AddFaceSourceShapeAt(panelPoint);
+        contextMenu.Items.Add(sourceShapeItem);
+        contextMenu.Items.Add(new Separator());
+
         AddAddElementMenuItem(contextMenu, "Add Lamp", AddablePanelElementKind.Lamp, panelPoint);
         AddAddElementMenuItem(contextMenu, "Add Reel", AddablePanelElementKind.Reel, panelPoint);
         AddAddElementMenuItem(contextMenu, "Add 7 Segment Display", AddablePanelElementKind.SevenSegmentDisplay, panelPoint);
@@ -468,6 +509,23 @@ public partial class SkiaPanel2DEditView : UserControl
         };
         menuItem.Click += (_, _) => AddElementAt(kind, panelPoint);
         contextMenu.Items.Add(menuItem);
+    }
+
+    private void AddFaceSourceShapeAt(Point panelPoint)
+    {
+        var document = Document;
+        if (document is null || document.Document.DocumentType != EditorDocumentType.Panel2D) return;
+        var shape = new PanelFaceSourceShapeModel
+        {
+            Id = $"faceSourceShape-{Guid.NewGuid():N}",
+            Name = "Face Source Shape",
+            TopLeft = new FacePointModel { X = panelPoint.X, Y = panelPoint.Y },
+            TopRight = new FacePointModel { X = panelPoint.X + 300, Y = panelPoint.Y },
+            BottomRight = new FacePointModel { X = panelPoint.X + 300, Y = panelPoint.Y + 200 },
+            BottomLeft = new FacePointModel { X = panelPoint.X, Y = panelPoint.Y + 200 }
+        };
+        document.CommandService.Execute(PanelFaceSourceShapeCommands.CreateAddCommand(document.DocumentId, document, shape));
+        RequestRender();
     }
 
     private void AddElementAt(AddablePanelElementKind kind, Point panelPoint)
@@ -494,10 +552,13 @@ public partial class SkiaPanel2DEditView : UserControl
 
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var documentPoint = viewport.ScreenToDocument(screenPoint);
-        var selection = Panel2DSelectionService.SelectFromPoint(
-            document.GetPanelElements(),
-            documentPoint,
-            document.HierarchySelectedPanelSelection);
+        var shapeSelection = document.GetPanelFaceSourceShapes().LastOrDefault(shape => IsInsideShapeBounds(shape, documentPoint));
+        var selection = shapeSelection is not null
+            ? PanelFaceSourceShapeCommands.ToSelection(shapeSelection)
+            : Panel2DSelectionService.SelectFromPoint(
+                document.GetPanelElements(),
+                documentPoint,
+                document.HierarchySelectedPanelSelection);
         NotifySelection(document, selection);
     }
 
@@ -655,4 +716,77 @@ public partial class SkiaPanel2DEditView : UserControl
         var handleSizeDoc = ResizeHandleScreenSize / viewport.NormalizedZoom;
         return Panel2DResizeHandleHitTestService.TryHitHandle(selectedElement, docPoint, handleSizeDoc, out handleKind);
     }
+
+    private static void DrawFaceSourceShapes(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
+    {
+        using var linePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0xFF, 0xC1, 0x07), StrokeWidth = (float)(2d / viewport.NormalizedZoom), IsAntialias = true };
+        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xC1, 0x07, 0x28), IsAntialias = true };
+        using var handlePaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0xFF, 0xA0, 0x00), IsAntialias = true };
+        foreach (var shape in document.GetPanelFaceSourceShapes())
+        {
+            using var path = new SKPath();
+            path.MoveTo((float)shape.TopLeft.X, (float)shape.TopLeft.Y);
+            path.LineTo((float)shape.TopRight.X, (float)shape.TopRight.Y);
+            path.LineTo((float)shape.BottomRight.X, (float)shape.BottomRight.Y);
+            path.LineTo((float)shape.BottomLeft.X, (float)shape.BottomLeft.Y);
+            path.Close();
+            canvas.DrawPath(path, fillPaint);
+            canvas.DrawPath(path, linePaint);
+            var radius = (float)(5d / viewport.NormalizedZoom);
+            foreach (var point in GetShapePoints(shape)) canvas.DrawCircle((float)point.X, (float)point.Y, radius, handlePaint);
+        }
+    }
+
+    private static bool IsInsideShapeBounds(PanelFaceSourceShapeModel shape, Point point)
+    {
+        return point.X >= shape.X && point.X <= shape.X + shape.Width && point.Y >= shape.Y && point.Y <= shape.Y + shape.Height;
+    }
+
+    private static FacePointModel[] GetShapePoints(PanelFaceSourceShapeModel shape) => [shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft];
+
+    private bool TryGetFaceSourceShapeCornerAtPoint(DocumentTabViewModel document, Point screenPoint, out PanelFaceSourceShapeModel shape, out int cornerIndex)
+    {
+        shape = new PanelFaceSourceShapeModel();
+        cornerIndex = -1;
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var docPoint = viewport.ScreenToDocument(screenPoint);
+        var hitRadius = 8d / viewport.NormalizedZoom;
+        foreach (var candidate in document.GetPanelFaceSourceShapes().Reverse())
+        {
+            var points = GetShapePoints(candidate);
+            for (var i = 0; i < points.Length; i++)
+            {
+                var dx = points[i].X - docPoint.X;
+                var dy = points[i].Y - docPoint.Y;
+                if (Math.Sqrt(dx * dx + dy * dy) <= hitRadius)
+                {
+                    shape = candidate;
+                    cornerIndex = i;
+                    document.HierarchySelectedPanelSelection = PanelFaceSourceShapeCommands.ToSelection(candidate);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void HandleShapeCornerDrag(DocumentTabViewModel document, Point screenPoint)
+    {
+        if (_shapeDragSource is null || _activeShapeCornerIndex < 0) return;
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var point = viewport.ScreenToDocument(screenPoint);
+        FacePointModel fp = new() { X = point.X, Y = point.Y };
+        var updated = new PanelFaceSourceShapeModel
+        {
+            Id = _shapeDragSource.Id,
+            Name = _shapeDragSource.Name,
+            Type = _shapeDragSource.Type,
+            TopLeft = _activeShapeCornerIndex == 0 ? fp : _shapeDragSource.TopLeft,
+            TopRight = _activeShapeCornerIndex == 1 ? fp : _shapeDragSource.TopRight,
+            BottomRight = _activeShapeCornerIndex == 2 ? fp : _shapeDragSource.BottomRight,
+            BottomLeft = _activeShapeCornerIndex == 3 ? fp : _shapeDragSource.BottomLeft
+        };
+        document.CommandService.Execute(PanelFaceSourceShapeCommands.CreateUpdateCommand(document.DocumentId, document, updated, "Move Face Source Shape corner"));
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Provide a first-class workflow for creating rectangular Face documents from photographed/perspective Panel2D artwork by letting users mark source regions with a persisted Face Source Shape and generate a corrected Face from it.
- Preserve legacy behavior (typed Rect workflow) while adding a UI-independent transform service to enable future homography/image-warp improvements and to keep generation logic out of WPF views.

### Description

- Persisted Panel2D face-source-shape model and storage: added `PanelFaceSourceShapeModel` and `faceSourceShapes` persistence, plus serialization helpers in `Panel2DDocumentStorage` and a `Panel2DDocumentModel` `FaceSourceShapes` collection (`WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs`).
- Document-scoped commands and undo/redo: added `PanelFaceSourceShapeCommands` to create/update shapes and integrate selection/dirty notifications (`WindowsNetProjects/OasisEditor/OasisEditor/PanelFaceSourceShapeCommands.cs`).
- Canvas UI and interaction: render amber overlay for shapes, show corner handles, support corner-drag editing, and add context-menu entry to create a shape and to create a Face from the selected shape (`WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs`).
- Hierarchy & inspector integration: expose Face Source Shapes under a new hierarchy group and wire selection mapping (`WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/Panel2DHierarchyProvider.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs`).
- Face generation workflow: added a `GenerateFromPanelFaceSourceShape` flow that estimates automatic output resolution, optionally uses a selected Cabinet3D target aspect ratio, assigns the selected target ID to the generated `FaceDocumentModel`, and produces a perspective-corrected artwork element in the Face (`WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`).
- UI‑independent transform service: added `FaceSourceShapeTransformService` to estimate output size and generate perspective-corrected background artwork from the Panel2D background image (automatic output resolution only) (`WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs`).
- Persist generated Face metadata: store `SourceFaceShapeId` on generated Faces and propagate through storage and export code (`WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs`, other Face plumbing).
- Key changed files (major additions/edits): `Panel2DDocumentModel.cs`, `Panel2DDocumentStorage.cs`, `PanelFaceSourceShapeCommands.cs`, `SkiaPanel2DEditView.xaml.cs`, `Panel2DHierarchyProvider.cs`, `FaceGenerationService.cs`, `FaceSourceShapeTransformService.cs`, `FaceDocumentModel.cs`, `FaceDocumentStorage.cs`, `DocumentWorkspaceViewModel.cs`, `MainWindowViewModel.cs`.
- Local testing checklist for John: build the WPF solution; open/create a Panel2D with a background image; right-click the canvas and `Add Face Source Shape` and confirm an amber four-corner overlay appears; confirm the shape is listed under `Face Source Shapes` in the Hierarchy; drag each corner and verify updates, undo/redo, and persistence after save/reopen; use `Create Face from Source Shape` with and without a selected Cabinet3D face target and verify the generated Face uses automatic sizing, stores `SourceFaceShapeId`, and (when a target is selected) stores the assigned cabinet target ID and respects target aspect ratio; verify generated Face background is perspective-corrected; ensure the legacy typed-rect Face generation still works.

### Testing

- No automated builds or unit tests were executed in the Codex environment per repository and task constraints; the change set was committed but WPF/.NET builds must be run locally.
- Performed repository sanity checks (`git diff --check`) and code edits committed successfully with no whitespace/merge conflicts reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a41499039208327a38d111298bcd408)