### PR TITLE
Generate face lamps from Face Source Shape using homography

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -318,4 +318,72 @@ public sealed class FaceGenerationServiceTests
         Assert.All(progress.Reports.Where(report => report.Value.HasValue), report => Assert.InRange(report.Value!.Value, 0d, 1d));
     }
 
+    [Fact]
+    public void GenerateFromPanelFaceSourceShape_TransformsContainedLampsIntoFaceSpace()
+    {
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-17",
+                    Name = "Start Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 110,
+                    Y = 220,
+                    Width = 30,
+                    Height = 40,
+                    DisplayNumber = 17,
+                    SecondaryAssetPath = "Assets/Masks/lamp-17.png",
+                    SourceComponentIndex = 2,
+                    SharedSourceSetId = "set-a",
+                    SharedSourceSetCount = 3,
+                    SourceBlend = true,
+                    IsVisible = true
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-outside",
+                    Name = "Outside Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    DisplayNumber = 99,
+                    IsVisible = true
+                }
+            ]
+        };
+        var sourceShape = new PanelFaceSourceShapeModel
+        {
+            Id = "shape-1",
+            Name = "Glass",
+            TopLeft = new FacePointModel { X = 100, Y = 200 },
+            TopRight = new FacePointModel { X = 300, Y = 200 },
+            BottomRight = new FacePointModel { X = 300, Y = 400 },
+            BottomLeft = new FacePointModel { X = 100, Y = 400 }
+        };
+
+        var result = new FaceGenerationService().GenerateFromPanelFaceSourceShape(panel, sourceShape, "Face", "panel-doc-1");
+
+        Assert.Equal(1, result.ConvertedLampCount);
+        Assert.Equal("shape-1", result.Document.SourceFaceShapeId);
+        var lamp = Assert.IsType<FaceLampWindowElement>(Assert.Single(result.Document.Elements.OfType<FaceLampWindowElement>()));
+        Assert.Equal("face-lamp-17", lamp.ObjectId);
+        Assert.Equal("Start Lamp", lamp.Name);
+        Assert.Equal(10d, lamp.X);
+        Assert.Equal(20d, lamp.Y);
+        Assert.Equal(30d, lamp.Width);
+        Assert.Equal(40d, lamp.Height);
+        Assert.Equal("lamp:17", lamp.LinkedMachineObjectReference?.ToString());
+        Assert.Equal("lamp-17", lamp.LinkedPanel2DElementId);
+        Assert.Null(lamp.BulbMaskAssetPath);
+        Assert.Equal(2, lamp.SourceComponentIndex);
+        Assert.Equal("set-a", lamp.SharedSourceSetId);
+        Assert.Equal(3, lamp.SharedSourceSetCount);
+        Assert.True(lamp.SourceBlend);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -106,6 +106,12 @@ internal sealed class FaceGenerationService
         var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, generatedDirectory);
         var settings = (generationSettings ?? FaceGenerationSettingsModel.Default).Normalize();
         var faceDocumentId = Guid.NewGuid().ToString("N");
+        progress?.Report(0.2, "Converting source-shape lamps...");
+        var lampWindows = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Lamp && IsCenterInsideSourceShape(element, sourceShape))
+            .Select(element => CreateLampWindowFromSourceShape(element, sourceShape, output.Width, output.Height))
+            .OfType<FaceLampWindowElement>()
+            .ToArray();
         var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(
             new Panel2DDocumentModel(),
             region.ToRect(),
@@ -143,12 +149,13 @@ internal sealed class FaceGenerationService
             Layers =
             [
                 new FaceLayerModel { Id = "layer-artwork", Name = "Artwork", IsVisible = true },
-                new FaceLayerModel { Id = "layer-face-mask", Name = "Face Mask", IsVisible = true }
+                new FaceLayerModel { Id = "layer-face-mask", Name = "Face Mask", IsVisible = true },
+                new FaceLayerModel { Id = "layer-runtime-lamps", Name = "Runtime Lamps", IsVisible = true }
             ],
-            Elements = [artwork]
+            Elements = [artwork, .. lampWindows]
         };
         progress?.Report(1.0, "Face generation complete.");
-        return new FaceGenerationResult(document, 0, 1, 0, 0, 0, 0);
+        return new FaceGenerationResult(document, lampWindows.Length, 1, 0, 0, 0, 0);
     }
 
     public FaceGenerationResult GenerateFromPanelRegion(
@@ -325,6 +332,56 @@ internal sealed class FaceGenerationService
         };
     }
 
+    private FaceLampWindowElement? CreateLampWindowFromSourceShape(PanelElementModel sourceElement, PanelFaceSourceShapeModel sourceShape, int faceWidth, int faceHeight)
+    {
+        var sourceCorners = new[]
+        {
+            (X: sourceElement.X, Y: sourceElement.Y),
+            (X: sourceElement.X + sourceElement.Width, Y: sourceElement.Y),
+            (X: sourceElement.X + sourceElement.Width, Y: sourceElement.Y + sourceElement.Height),
+            (X: sourceElement.X, Y: sourceElement.Y + sourceElement.Height)
+        };
+        var transformed = new List<FacePointModel>(4);
+        foreach (var corner in sourceCorners)
+        {
+            if (!FaceSourceShapeTransformService.TryTransformPanelPointToFace(sourceShape, faceWidth, faceHeight, corner.X, corner.Y, out var point))
+            {
+                return null;
+            }
+
+            transformed.Add(point);
+        }
+
+        var minX = transformed.Min(point => point.X);
+        var minY = transformed.Min(point => point.Y);
+        var maxX = transformed.Max(point => point.X);
+        var maxY = transformed.Max(point => point.Y);
+        if (!PanelElementValidation.IsFinite(minX) || !PanelElementValidation.IsFinite(minY) || !PanelElementValidation.IsFinite(maxX) || !PanelElementValidation.IsFinite(maxY) || maxX <= minX || maxY <= minY)
+        {
+            return null;
+        }
+
+        _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
+        return new FaceLampWindowElement
+        {
+            ObjectId = CreateGeneratedElementId(sourceElement),
+            Name = sourceElement.Name ?? string.Empty,
+            X = Math.Round(minX, 2),
+            Y = Math.Round(minY, 2),
+            Width = Math.Round(maxX - minX, 2),
+            Height = Math.Round(maxY - minY, 2),
+            IsVisible = sourceElement.IsVisible,
+            IsLocked = sourceElement.IsLocked,
+            LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
+            LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
+            BulbMaskAssetPath = null,
+            SourceComponentIndex = sourceElement.SourceComponentIndex,
+            SharedSourceSetId = NormalizeOptional(sourceElement.SharedSourceSetId),
+            SharedSourceSetCount = sourceElement.SharedSourceSetCount,
+            SourceBlend = sourceElement.SourceBlend
+        };
+    }
+
     private FaceLampWindowElement CreateLampWindow(PanelElementModel sourceElement, Rect region)
     {
         _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
@@ -491,6 +548,16 @@ internal sealed class FaceGenerationService
         return string.IsNullOrWhiteSpace(sourceElement.ObjectId)
             ? $"face-artwork-{Guid.NewGuid():N}"
             : $"face-artwork-{sourceElement.ObjectId.Trim()}";
+    }
+
+    private static bool IsCenterInsideSourceShape(PanelElementModel element, PanelFaceSourceShapeModel sourceShape)
+    {
+        if (element.Width <= 0 || element.Height <= 0)
+        {
+            return false;
+        }
+
+        return FaceSourceShapeTransformService.ContainsPanelPoint(sourceShape, element.X + (element.Width / 2d), element.Y + (element.Height / 2d));
     }
 
     private static bool IsContainedBy(PanelElementModel element, Rect region)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
@@ -50,6 +50,105 @@ internal static class FaceSourceShapeTransformService
         return relative.Replace(Path.DirectorySeparatorChar, '/');
     }
 
+
+    public static bool TryTransformPanelPointToFace(PanelFaceSourceShapeModel shape, int width, int height, double panelX, double panelY, out FacePointModel facePoint)
+    {
+        facePoint = new FacePointModel();
+        if (!TryCreatePanelToFaceHomography(shape, width, height, out var h))
+        {
+            return false;
+        }
+
+        var denominator = (h[6] * panelX) + (h[7] * panelY) + h[8];
+        if (!IsFinite(denominator) || Math.Abs(denominator) < 1e-9)
+        {
+            return false;
+        }
+
+        var x = ((h[0] * panelX) + (h[1] * panelY) + h[2]) / denominator;
+        var y = ((h[3] * panelX) + (h[4] * panelY) + h[5]) / denominator;
+        if (!IsFinite(x) || !IsFinite(y))
+        {
+            return false;
+        }
+
+        facePoint = new FacePointModel { X = x, Y = y };
+        return true;
+    }
+
+    public static bool ContainsPanelPoint(PanelFaceSourceShapeModel shape, double panelX, double panelY)
+    {
+        var points = new[] { shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft };
+        var inside = false;
+        for (var i = 0, j = points.Length - 1; i < points.Length; j = i++)
+        {
+            var pi = points[i];
+            var pj = points[j];
+            if (((pi.Y > panelY) != (pj.Y > panelY))
+                && panelX < ((pj.X - pi.X) * (panelY - pi.Y) / (pj.Y - pi.Y)) + pi.X)
+            {
+                inside = !inside;
+            }
+        }
+
+        return inside;
+    }
+
+    private static bool TryCreatePanelToFaceHomography(PanelFaceSourceShapeModel shape, int width, int height, out double[] h)
+    {
+        h = new double[9];
+        var source = new[] { shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft };
+        var destination = new[]
+        {
+            new FacePointModel { X = 0, Y = 0 },
+            new FacePointModel { X = Math.Max(0, width), Y = 0 },
+            new FacePointModel { X = Math.Max(0, width), Y = Math.Max(0, height) },
+            new FacePointModel { X = 0, Y = Math.Max(0, height) }
+        };
+
+        var a = new double[8, 9];
+        for (var i = 0; i < 4; i++)
+        {
+            var x = source[i].X;
+            var y = source[i].Y;
+            var u = destination[i].X;
+            var v = destination[i].Y;
+            var row = i * 2;
+            a[row, 0] = x; a[row, 1] = y; a[row, 2] = 1; a[row, 6] = -u * x; a[row, 7] = -u * y; a[row, 8] = u;
+            a[row + 1, 3] = x; a[row + 1, 4] = y; a[row + 1, 5] = 1; a[row + 1, 6] = -v * x; a[row + 1, 7] = -v * y; a[row + 1, 8] = v;
+        }
+
+        for (var col = 0; col < 8; col++)
+        {
+            var pivot = col;
+            for (var row = col + 1; row < 8; row++)
+            {
+                if (Math.Abs(a[row, col]) > Math.Abs(a[pivot, col])) pivot = row;
+            }
+
+            if (Math.Abs(a[pivot, col]) < 1e-9) return false;
+            if (pivot != col)
+            {
+                for (var k = col; k < 9; k++) (a[col, k], a[pivot, k]) = (a[pivot, k], a[col, k]);
+            }
+
+            var divisor = a[col, col];
+            for (var k = col; k < 9; k++) a[col, k] /= divisor;
+            for (var row = 0; row < 8; row++)
+            {
+                if (row == col) continue;
+                var factor = a[row, col];
+                for (var k = col; k < 9; k++) a[row, k] -= factor * a[col, k];
+            }
+        }
+
+        for (var i = 0; i < 8; i++) h[i] = a[i, 8];
+        h[8] = 1;
+        return h.All(IsFinite);
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
     private static double Distance(FacePointModel a, FacePointModel b)
     {
         var dx = a.X - b.X; var dy = a.Y - b.Y; return Math.Sqrt(dx * dx + dy * dy);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
@@ -80,7 +80,7 @@ internal static class FaceSourceShapeTransformService
     {
         var points = new[] { shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft };
         var inside = false;
-        for (var i = 0, j = points.Length - 1; i < points.Length; j = i++)
+        for (int i = 0, j = points.Length - 1; i < points.Length; j = i++)
         {
             var pi = points[i];
             var pj = points[j];


### PR DESCRIPTION
### Motivation
- Enable generating Face documents from a Panel2D Face Source Shape by projecting Panel2D lamp elements into Face space using the existing source-shape homography. 
- Include only lamps that are visually inside the selected Face Source Shape while preserving element identity and machine-reference metadata. 
- Map rectangular lamp bounds by transforming each corner and taking the axis-aligned bounding rectangle in Face coordinates, and defer bulb/mask image warping and dynamic 3D flashing to later iterations. 

### Description
- Added homography helpers to `FaceSourceShapeTransformService`: `TryTransformPanelPointToFace`, `ContainsPanelPoint`, and an internal `TryCreatePanelToFaceHomography` to compute panel->face point transforms. 
- Extended `FaceGenerationService.GenerateFromPanelFaceSourceShape` to filter lamps by center inclusion and to create transformed Face lamp windows via `CreateLampWindowFromSourceShape`, adding a "Runtime Lamps" layer and including transformed lamps in the generated `FaceDocumentModel`. 
- Implemented corner-based rectangle mapping in `CreateLampWindowFromSourceShape` by transforming all four lamp corners, deriving `min/max` bounds, and rounding results while preserving IDs, names, `LinkedMachineObjectReference`, `LinkedPanel2DElementId`, and source/MFME-related fields; bulb mask asset path is intentionally set to `null` for V1. 
- Added a unit test `GenerateFromPanelFaceSourceShape_TransformsContainedLampsIntoFaceSpace` in `FaceGenerationServiceTests.cs` to cover center-inclusion, transformed bounds, and preserved metadata.

### Testing
- Per repository constraints, no test suite was executed in this environment; `git diff --check` passed with no whitespace errors. 
- A regression unit test was added at `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs` but was not run here. 
- Please run the project tests locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` to validate the new test and ensure all suites pass on the Windows/.NET toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a42b93cd6e4832785173e4539315bab)