### PR TITLE
Transform Face Source Shape lamp masks and produce aligned face mask layer

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -109,16 +109,18 @@ internal sealed class FaceGenerationService
         progress?.Report(0.2, "Converting source-shape lamps...");
         var lampWindows = sourcePanel.Elements
             .Where(element => element.Kind == PanelElementKind.Lamp && IsCenterInsideSourceShape(element, sourceShape))
-            .Select(element => CreateLampWindowFromSourceShape(element, sourceShape, output.Width, output.Height))
+            .Select(element => CreateLampWindowFromSourceShape(element, sourceShape, output.Width, output.Height, projectDirectory))
             .OfType<FaceLampWindowElement>()
             .ToArray();
-        var maskLayer = _maskLayerExtractionService.GenerateMaskLayer(
-            new Panel2DDocumentModel(),
-            region.ToRect(),
+        var maskLayer = CreateMaskLayerFromSourceShape(
+            sourcePanel,
+            sourceShape,
+            output.Width,
+            output.Height,
+            lampWindows,
             faceDocumentId,
             sourcePanel2DDocumentId,
             projectDirectory,
-            generatedDirectory,
             settings.MaskExtractionThreshold);
         var artwork = new FaceArtworkElement
         {
@@ -134,6 +136,9 @@ internal sealed class FaceGenerationService
             SourceRegion = region,
             Provenance = new FaceArtworkProvenanceModel { Generator = "Generate Face From Face Source Shape", GeneratedAtUtc = DateTime.UtcNow }
         };
+        var elements = new FaceElementModel[] { artwork }.Concat(lampWindows).ToArray();
+        progress?.Report(0.9, "Auto-authoring trays/emitters...");
+        var autoAuthored = _trayAutoAuthoringService.AutoAuthor(new FaceDocumentModel { GenerationSettings = settings, MaskLayer = maskLayer, Elements = elements }, projectDirectory);
         var document = new FaceDocumentModel
         {
             Id = faceDocumentId,
@@ -146,16 +151,94 @@ internal sealed class FaceGenerationService
             LastRegeneratedAtUtc = DateTime.UtcNow,
             GenerationSettings = settings,
             MaskLayer = maskLayer,
+            Trays = autoAuthored.Trays,
+            LampEmitters = autoAuthored.Emitters,
             Layers =
             [
                 new FaceLayerModel { Id = "layer-artwork", Name = "Artwork", IsVisible = true },
                 new FaceLayerModel { Id = "layer-face-mask", Name = "Face Mask", IsVisible = true },
                 new FaceLayerModel { Id = "layer-runtime-lamps", Name = "Runtime Lamps", IsVisible = true }
             ],
-            Elements = [artwork, .. lampWindows]
+            Elements = elements
         };
         progress?.Report(1.0, "Face generation complete.");
         return new FaceGenerationResult(document, lampWindows.Length, 1, 0, 0, 0, 0);
+    }
+
+    private FaceMaskLayerModel? CreateMaskLayerFromSourceShape(
+        Panel2DDocumentModel sourcePanel,
+        PanelFaceSourceShapeModel sourceShape,
+        int faceWidth,
+        int faceHeight,
+        IReadOnlyList<FaceLampWindowElement> lampWindows,
+        string faceDocumentId,
+        string? sourcePanel2DDocumentId,
+        string? projectDirectory,
+        byte extractionThreshold)
+    {
+        if (string.IsNullOrWhiteSpace(projectDirectory) || faceWidth <= 0 || faceHeight <= 0)
+        {
+            return null;
+        }
+
+        var sourceLampsById = sourcePanel.Elements
+            .Where(element => element.Kind == PanelElementKind.Lamp && !string.IsNullOrWhiteSpace(element.ObjectId))
+            .ToDictionary(element => element.ObjectId, StringComparer.Ordinal);
+        var maskPixels = new byte[faceWidth * faceHeight];
+        var contributions = new List<FaceMaskContributionModel>();
+
+        foreach (var lampWindow in lampWindows)
+        {
+            if (string.IsNullOrWhiteSpace(lampWindow.LinkedPanel2DElementId)
+                || !sourceLampsById.TryGetValue(lampWindow.LinkedPanel2DElementId, out var sourceLamp)
+                || string.IsNullOrWhiteSpace(sourceLamp.AssetPath))
+            {
+                continue;
+            }
+
+            var sourcePath = System.IO.Path.IsPathRooted(sourceLamp.AssetPath!)
+                ? sourceLamp.AssetPath!
+                : System.IO.Path.Combine(projectDirectory, sourceLamp.AssetPath!);
+            if (!System.IO.File.Exists(sourcePath))
+            {
+                continue;
+            }
+
+            using var bitmap = SKBitmap.Decode(sourcePath);
+            if (bitmap is null)
+            {
+                continue;
+            }
+
+            var contribution = CompositeSourceShapeLampMask(maskPixels, faceWidth, faceHeight, sourceShape, sourceLamp, bitmap, lampWindow, extractionThreshold);
+            if (contribution.PixelCount <= 0 || contribution.Bounds is null)
+            {
+                continue;
+            }
+
+            contributions.Add(new FaceMaskContributionModel
+            {
+                SourcePanel2DElementId = lampWindow.LinkedPanel2DElementId,
+                LinkedMachineObjectReference = lampWindow.LinkedMachineObjectReference,
+                Bounds = contribution.Bounds,
+                PixelCount = contribution.PixelCount
+            });
+        }
+
+        var assetPath = SaveSourceShapeMask(maskPixels, faceWidth, faceHeight, faceDocumentId, projectDirectory);
+        return new FaceMaskLayerModel
+        {
+            Id = "face-mask-layer",
+            Name = "Face Mask",
+            AssetPath = assetPath,
+            SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
+            SourceRegion = FaceSourceRegionModel.FromRect(new Rect(0, 0, faceWidth, faceHeight)),
+            ExtractionThreshold = extractionThreshold,
+            GeneratedUtc = DateTime.UtcNow,
+            Width = faceWidth,
+            Height = faceHeight,
+            Contributions = contributions.ToArray()
+        };
     }
 
     public FaceGenerationResult GenerateFromPanelRegion(
@@ -302,6 +385,89 @@ internal sealed class FaceGenerationService
         ];
     }
 
+
+    private static SourceShapeMaskContribution CompositeSourceShapeLampMask(
+        byte[] maskPixels,
+        int faceWidth,
+        int faceHeight,
+        PanelFaceSourceShapeModel sourceShape,
+        PanelElementModel sourceLamp,
+        SKBitmap lampBitmap,
+        FaceLampWindowElement lampWindow,
+        byte extractionThreshold)
+    {
+        var left = Math.Max(0, (int)Math.Floor(lampWindow.X));
+        var top = Math.Max(0, (int)Math.Floor(lampWindow.Y));
+        var right = Math.Min(faceWidth, (int)Math.Ceiling(lampWindow.X + lampWindow.Width));
+        var bottom = Math.Min(faceHeight, (int)Math.Ceiling(lampWindow.Y + lampWindow.Height));
+        var count = 0;
+        var minX = faceWidth;
+        var minY = faceHeight;
+        var maxX = -1;
+        var maxY = -1;
+
+        for (var y = top; y < bottom; y++)
+        for (var x = left; x < right; x++)
+        {
+            if (!FaceSourceShapeTransformService.TryTransformFacePointToPanel(sourceShape, faceWidth, faceHeight, x + 0.5d, y + 0.5d, out var panelPoint)
+                || panelPoint.X < sourceLamp.X
+                || panelPoint.Y < sourceLamp.Y
+                || panelPoint.X > sourceLamp.X + sourceLamp.Width
+                || panelPoint.Y > sourceLamp.Y + sourceLamp.Height)
+            {
+                continue;
+            }
+
+            var sourceX = (panelPoint.X - sourceLamp.X) / Math.Max(1d, sourceLamp.Width) * lampBitmap.Width;
+            var sourceY = (panelPoint.Y - sourceLamp.Y) / Math.Max(1d, sourceLamp.Height) * lampBitmap.Height;
+            var color = lampBitmap.GetPixel(
+                Math.Clamp((int)Math.Round(sourceX), 0, lampBitmap.Width - 1),
+                Math.Clamp((int)Math.Round(sourceY), 0, lampBitmap.Height - 1));
+            var mask = color.Alpha >= extractionThreshold ? color.Alpha : (byte)0;
+            if (mask == 0)
+            {
+                continue;
+            }
+
+            var index = (y * faceWidth) + x;
+            if (mask > maskPixels[index])
+            {
+                maskPixels[index] = mask;
+            }
+
+            count++;
+            minX = Math.Min(minX, x);
+            minY = Math.Min(minY, y);
+            maxX = Math.Max(maxX, x);
+            maxY = Math.Max(maxY, y);
+        }
+
+        var bounds = count > 0
+            ? FaceSourceRegionModel.FromRect(new Rect(minX, minY, maxX - minX + 1, maxY - minY + 1))
+            : null;
+        return new SourceShapeMaskContribution(bounds, count);
+    }
+
+    private static string SaveSourceShapeMask(byte[] maskPixels, int width, int height, string faceDocumentId, string projectDirectory)
+    {
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        for (var y = 0; y < height; y++)
+        for (var x = 0; x < width; x++)
+        {
+            var value = maskPixels[(y * width) + x];
+            bitmap.SetPixel(x, y, new SKColor(value, value, value, value));
+        }
+
+        var relative = System.IO.Path.Combine("Generated", "Faces", $"{faceDocumentId}-face-source-shape-mask.png");
+        var path = System.IO.Path.Combine(projectDirectory, relative);
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = System.IO.File.Create(path);
+        data.SaveTo(stream);
+        return relative.Replace(System.IO.Path.DirectorySeparatorChar, '/');
+    }
+
     private static FaceArtworkElement CreateArtworkElement(PanelElementModel sourceElement, Rect region, string? sourcePanel2DDocumentId)
     {
         var sourceBounds = new Rect(sourceElement.X, sourceElement.Y, sourceElement.Width, sourceElement.Height);
@@ -332,7 +498,7 @@ internal sealed class FaceGenerationService
         };
     }
 
-    private FaceLampWindowElement? CreateLampWindowFromSourceShape(PanelElementModel sourceElement, PanelFaceSourceShapeModel sourceShape, int faceWidth, int faceHeight)
+    private FaceLampWindowElement? CreateLampWindowFromSourceShape(PanelElementModel sourceElement, PanelFaceSourceShapeModel sourceShape, int faceWidth, int faceHeight, string? projectDirectory)
     {
         var sourceCorners = new[]
         {
@@ -361,6 +527,17 @@ internal sealed class FaceGenerationService
             return null;
         }
 
+        var faceBounds = FaceSourceRegionModel.FromRect(new Rect(minX, minY, maxX - minX, maxY - minY));
+        var bulbMaskAssetPath = FaceSourceShapeTransformService.TryGenerateTransformedElementAsset(
+            sourceElement,
+            sourceElement.SecondaryAssetPath,
+            sourceShape,
+            faceWidth,
+            faceHeight,
+            faceBounds,
+            projectDirectory,
+            "face-source-shape-lamp-mask");
+
         _machineObjectReferenceResolver.TryGetReference(sourceElement, out var machineReference);
         return new FaceLampWindowElement
         {
@@ -374,7 +551,7 @@ internal sealed class FaceGenerationService
             IsLocked = sourceElement.IsLocked,
             LinkedMachineObjectReference = machineReference.IsEmpty ? null : machineReference,
             LinkedPanel2DElementId = string.IsNullOrWhiteSpace(sourceElement.ObjectId) ? null : sourceElement.ObjectId,
-            BulbMaskAssetPath = null,
+            BulbMaskAssetPath = bulbMaskAssetPath,
             SourceComponentIndex = sourceElement.SourceComponentIndex,
             SharedSourceSetId = NormalizeOptional(sourceElement.SharedSourceSetId),
             SharedSourceSetCount = sourceElement.SharedSourceSetCount,
@@ -588,4 +765,6 @@ internal sealed class FaceGenerationService
     }
 
     private static string Format(double value) => Math.Round(value, 2).ToString("0.##", System.Globalization.CultureInfo.InvariantCulture);
+
+    private readonly record struct SourceShapeMaskContribution(FaceSourceRegionModel? Bounds, int PixelCount);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
@@ -33,13 +33,16 @@ internal static class FaceSourceShapeTransformService
         for (var y = 0; y < height; y++)
         for (var x = 0; x < width; x++)
         {
-            var u = width <= 1 ? 0d : x / (double)(width - 1);
-            var v = height <= 1 ? 0d : y / (double)(height - 1);
-            var px = Bilinear(shape.TopLeft.X, shape.TopRight.X, shape.BottomRight.X, shape.BottomLeft.X, u, v) - background.X;
-            var py = Bilinear(shape.TopLeft.Y, shape.TopRight.Y, shape.BottomRight.Y, shape.BottomLeft.Y, u, v) - background.Y;
+            if (!TryTransformFacePointToPanel(shape, width, height, x, y, out var panelPoint))
+            {
+                output.SetPixel(x, y, SKColors.Transparent);
+                continue;
+            }
+
+            var px = panelPoint.X - background.X;
+            var py = panelPoint.Y - background.Y;
             output.SetPixel(x, y, SampleBicubic(source, px / Math.Max(1d, background.Width) * source.Width, py / Math.Max(1d, background.Height) * source.Height));
         }
-        var generatedRoot = string.IsNullOrWhiteSpace(generatedDirectory) ? Path.Combine(projectDirectory, "Generated") : generatedDirectory;
         var relative = Path.Combine("Generated", "Faces", $"face-source-shape-{Guid.NewGuid():N}.png");
         var path = Path.Combine(projectDirectory, relative);
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
@@ -48,6 +51,79 @@ internal static class FaceSourceShapeTransformService
         using var stream = File.Create(path);
         data.SaveTo(stream);
         return relative.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    public static string? TryGenerateTransformedElementAsset(
+        PanelElementModel sourceElement,
+        string? sourceAssetPath,
+        PanelFaceSourceShapeModel shape,
+        int faceWidth,
+        int faceHeight,
+        FaceSourceRegionModel faceBounds,
+        string? projectDirectory,
+        string fileNamePrefix)
+    {
+        if (string.IsNullOrWhiteSpace(sourceAssetPath) || string.IsNullOrWhiteSpace(projectDirectory) || !faceBounds.IsValid)
+        {
+            return null;
+        }
+
+        var sourcePath = Path.IsPathRooted(sourceAssetPath!) ? sourceAssetPath! : Path.Combine(projectDirectory, sourceAssetPath!);
+        if (!File.Exists(sourcePath))
+        {
+            return null;
+        }
+
+        using var source = SKBitmap.Decode(sourcePath);
+        if (source is null)
+        {
+            return null;
+        }
+
+        var outputWidth = Math.Max(1, (int)Math.Ceiling(faceBounds.Width));
+        var outputHeight = Math.Max(1, (int)Math.Ceiling(faceBounds.Height));
+        using var output = new SKBitmap(outputWidth, outputHeight, SKColorType.Rgba8888, SKAlphaType.Premul);
+        output.Erase(SKColors.Transparent);
+
+        for (var y = 0; y < outputHeight; y++)
+        for (var x = 0; x < outputWidth; x++)
+        {
+            var faceX = faceBounds.X + x;
+            var faceY = faceBounds.Y + y;
+            if (!TryTransformFacePointToPanel(shape, faceWidth, faceHeight, faceX, faceY, out var panelPoint)
+                || panelPoint.X < sourceElement.X
+                || panelPoint.Y < sourceElement.Y
+                || panelPoint.X > sourceElement.X + sourceElement.Width
+                || panelPoint.Y > sourceElement.Y + sourceElement.Height)
+            {
+                continue;
+            }
+
+            var sourceX = (panelPoint.X - sourceElement.X) / Math.Max(1d, sourceElement.Width) * source.Width;
+            var sourceY = (panelPoint.Y - sourceElement.Y) / Math.Max(1d, sourceElement.Height) * source.Height;
+            output.SetPixel(x, y, SampleBicubic(source, sourceX, sourceY));
+        }
+
+        var safePrefix = string.IsNullOrWhiteSpace(fileNamePrefix) ? "face-source-shape-asset" : fileNamePrefix.Trim();
+        var relative = Path.Combine("Generated", "Faces", $"{safePrefix}-{Guid.NewGuid():N}.png");
+        var path = Path.Combine(projectDirectory, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var image = SKImage.FromBitmap(output);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(path);
+        data.SaveTo(stream);
+        return relative.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    public static bool TryTransformFacePointToPanel(PanelFaceSourceShapeModel shape, int width, int height, double faceX, double faceY, out FacePointModel panelPoint)
+    {
+        panelPoint = new FacePointModel();
+        if (!TryCreateFaceToPanelHomography(shape, width, height, out var h))
+        {
+            return false;
+        }
+
+        return TryApplyHomography(h, faceX, faceY, out panelPoint);
     }
 
 
@@ -59,21 +135,7 @@ internal static class FaceSourceShapeTransformService
             return false;
         }
 
-        var denominator = (h[6] * panelX) + (h[7] * panelY) + h[8];
-        if (!IsFinite(denominator) || Math.Abs(denominator) < 1e-9)
-        {
-            return false;
-        }
-
-        var x = ((h[0] * panelX) + (h[1] * panelY) + h[2]) / denominator;
-        var y = ((h[3] * panelX) + (h[4] * panelY) + h[5]) / denominator;
-        if (!IsFinite(x) || !IsFinite(y))
-        {
-            return false;
-        }
-
-        facePoint = new FacePointModel { X = x, Y = y };
-        return true;
+        return TryApplyHomography(h, panelX, panelY, out facePoint);
     }
 
     public static bool ContainsPanelPoint(PanelFaceSourceShapeModel shape, double panelX, double panelY)
@@ -96,16 +158,29 @@ internal static class FaceSourceShapeTransformService
 
     private static bool TryCreatePanelToFaceHomography(PanelFaceSourceShapeModel shape, int width, int height, out double[] h)
     {
-        h = new double[9];
         var source = new[] { shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft };
-        var destination = new[]
-        {
-            new FacePointModel { X = 0, Y = 0 },
-            new FacePointModel { X = Math.Max(0, width), Y = 0 },
-            new FacePointModel { X = Math.Max(0, width), Y = Math.Max(0, height) },
-            new FacePointModel { X = 0, Y = Math.Max(0, height) }
-        };
+        var destination = CreateFaceCorners(width, height);
+        return TryCreateHomography(source, destination, out h);
+    }
 
+    private static bool TryCreateFaceToPanelHomography(PanelFaceSourceShapeModel shape, int width, int height, out double[] h)
+    {
+        var source = CreateFaceCorners(width, height);
+        var destination = new[] { shape.TopLeft, shape.TopRight, shape.BottomRight, shape.BottomLeft };
+        return TryCreateHomography(source, destination, out h);
+    }
+
+    private static FacePointModel[] CreateFaceCorners(int width, int height) =>
+    [
+        new FacePointModel { X = 0, Y = 0 },
+        new FacePointModel { X = Math.Max(0, width), Y = 0 },
+        new FacePointModel { X = Math.Max(0, width), Y = Math.Max(0, height) },
+        new FacePointModel { X = 0, Y = Math.Max(0, height) }
+    ];
+
+    private static bool TryCreateHomography(IReadOnlyList<FacePointModel> source, IReadOnlyList<FacePointModel> destination, out double[] h)
+    {
+        h = new double[9];
         var a = new double[8, 9];
         for (var i = 0; i < 4; i++)
         {
@@ -147,15 +222,32 @@ internal static class FaceSourceShapeTransformService
         return h.All(IsFinite);
     }
 
+    private static bool TryApplyHomography(double[] h, double sourceX, double sourceY, out FacePointModel point)
+    {
+        point = new FacePointModel();
+        var denominator = (h[6] * sourceX) + (h[7] * sourceY) + h[8];
+        if (!IsFinite(denominator) || Math.Abs(denominator) < 1e-9)
+        {
+            return false;
+        }
+
+        var x = ((h[0] * sourceX) + (h[1] * sourceY) + h[2]) / denominator;
+        var y = ((h[3] * sourceX) + (h[4] * sourceY) + h[5]) / denominator;
+        if (!IsFinite(x) || !IsFinite(y))
+        {
+            return false;
+        }
+
+        point = new FacePointModel { X = x, Y = y };
+        return true;
+    }
+
     private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
 
     private static double Distance(FacePointModel a, FacePointModel b)
     {
         var dx = a.X - b.X; var dy = a.Y - b.Y; return Math.Sqrt(dx * dx + dy * dy);
     }
-
-    private static double Bilinear(double tl, double tr, double br, double bl, double u, double v) =>
-        tl * (1 - u) * (1 - v) + tr * u * (1 - v) + br * u * v + bl * (1 - u) * v;
 
     private static SKColor SampleBicubic(SKBitmap bitmap, double x, double y)
     {


### PR DESCRIPTION
### Motivation
- Make Face Source Shape (perspective rectangle) generated Faces reach parity with Rect workflow by transforming lamp mask/support assets so lamps flash in Play View.
- Keep generated Face coordinate space consistent between background, lamp bounds, and transformed assets to allow existing runtime flashing code to work without runtime changes.
- Preserve existing lamp identity, machine mappings, MFME/source metadata, and the legacy Rect generation behavior while enabling future growth of the transform service.

### Description
- Generate transformed lamp bulb-mask/support images for each Panel2D lamp included in a Face Source Shape by adding `TryGenerateTransformedElementAsset` to `FaceSourceShapeTransformService` and invoking it from `CreateLampWindowFromSourceShape`, storing the result in `FaceLampWindowElement.BulbMaskAssetPath`.
- Reuse the homography implementation and add face↔panel helpers (`TryTransformFacePointToPanel`, `TryApplyHomography`, `TryCreateHomography`, and face-corner utilities) so the same perspective mapping used for the generated background is reused for per-lamp asset transforms.
- Produce a full-size Face mask-layer for perspective-generated faces by adding `CreateMaskLayerFromSourceShape` which composites transformed lamp mask contributions into a face-aligned mask image and emits per-lamp contribution bounds in generated Face coordinates.
- Preserve existing metadata (lamp IDs, names, machine references, shared-set fields, SourcePanel2D element links, and assigned Cabinet target ID) and keep the Rect-based generation path untouched; auto-author trays/emitters using existing services so Play View runtime data remains usable.

### Testing
- Automated tests: none were executed in this environment per repository constraints (no builds/tests run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a42bd279bd88327a9a60e6e22301794)