### PR TITLE
Add static cabinet lamp preview modes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CabinetMutationCommands.cs
@@ -19,6 +19,56 @@ internal static class CabinetMutationCommands
         return new SetCabinetTargetOverrideCommand(documentId, document, targetId, null, null, faceFlipHorizontal, "Set cabinet target horizontal flip");
     }
 
+    public static Commands.ICommand CreateSetPreviewLampModeCommand(Guid documentId, DocumentTabViewModel document, string lampPreviewMode)
+    {
+        return new SetCabinetPreviewLampModeCommand(documentId, document, CabinetLampPreviewMode.Normalize(lampPreviewMode));
+    }
+
+    private sealed class SetCabinetPreviewLampModeCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly string _lampPreviewMode;
+        private CabinetDocument? _originalDocument;
+
+        public SetCabinetPreviewLampModeCommand(Guid documentId, DocumentTabViewModel document, string lampPreviewMode)
+        {
+            _documentId = documentId;
+            _document = document;
+            _lampPreviewMode = CabinetLampPreviewMode.Normalize(lampPreviewMode);
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => "Set cabinet lamp preview mode";
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var current = _document.GetCabinetDocument();
+            if (string.Equals(CabinetLampPreviewMode.Normalize(current.Preview.LampPreviewMode), _lampPreviewMode, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _originalDocument ??= current;
+            _document.SetCabinetDocument(current with { Preview = current.Preview with { LampPreviewMode = _lampPreviewMode } });
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_originalDocument is null)
+            {
+                return;
+            }
+
+            _document.SetCabinetDocument(_originalDocument);
+            _document.MarkDirty();
+        }
+    }
+
     private sealed class SetCabinetTargetOverrideCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocument.cs
@@ -60,7 +60,26 @@ public static class CabinetDocumentTargetOverrideExtensions
     }
 }
 
-public sealed record CabinetPreviewSettings(bool ShowTargetOverlays, bool ShowFaceBackgrounds)
+public sealed record CabinetPreviewSettings(bool ShowTargetOverlays, bool ShowFaceBackgrounds, string LampPreviewMode = CabinetLampPreviewMode.BackgroundOnly)
 {
-    public static CabinetPreviewSettings Default => new(true, true);
+    public static CabinetPreviewSettings Default => new(true, true, CabinetLampPreviewMode.BackgroundOnly);
+
+    public CabinetPreviewSettings Normalized() => new(ShowTargetOverlays, ShowFaceBackgrounds, CabinetLampPreviewMode.Normalize(LampPreviewMode));
+}
+
+public static class CabinetLampPreviewMode
+{
+    public const string BackgroundOnly = "Background Only";
+    public const string LampsOff = "Lamps Off";
+    public const string LampsAllOn = "Lamps All On";
+
+    public static string Normalize(string? mode)
+    {
+        return mode?.Trim() switch
+        {
+            LampsOff => LampsOff,
+            LampsAllOn => LampsAllOn,
+            _ => BackgroundOnly
+        };
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Models/CabinetDocumentStorage.cs
@@ -40,7 +40,7 @@ public static class CabinetDocumentStorage
                     .Where(targetOverride => !string.IsNullOrWhiteSpace(targetOverride.TargetId))
                     .Select(targetOverride => targetOverride.Normalized())
                     .ToArray(),
-                Preview = parsed.Preview ?? CabinetPreviewSettings.Default
+                Preview = (parsed.Preview ?? CabinetPreviewSettings.Default).Normalized()
             };
             return true;
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/FaceDocumentArtworkPreviewRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Services/FaceDocumentArtworkPreviewRenderer.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Windows.Media.Imaging;
+using OasisEditor.Features.CabinetEditor.Models;
+using OasisEditor.Rendering;
 using SkiaSharp;
 
 namespace OasisEditor.Features.CabinetEditor.Services;
@@ -9,9 +11,16 @@ public sealed class FaceDocumentArtworkPreviewRenderer
     private const int DefaultPreviewWidth = 1024;
     private const int DefaultPreviewHeight = 1024;
 
-    public BitmapSource? RenderPreview(FaceDocumentModel faceDocument)
+    public BitmapSource? RenderPreview(FaceDocumentModel faceDocument, string? lampPreviewMode = null)
     {
         ArgumentNullException.ThrowIfNull(faceDocument);
+
+        var normalizedMode = CabinetLampPreviewMode.Normalize(lampPreviewMode);
+        if (normalizedMode != CabinetLampPreviewMode.BackgroundOnly
+            && TryRenderRuntimeTexturePreview(faceDocument, normalizedMode, out var runtimePreview))
+        {
+            return runtimePreview;
+        }
 
         var bounds = ResolveBounds(faceDocument);
         if (bounds.Width <= 0d || bounds.Height <= 0d)
@@ -61,6 +70,52 @@ public sealed class FaceDocumentArtworkPreviewRenderer
         bitmap.EndInit();
         bitmap.Freeze();
         return bitmap;
+    }
+
+
+    private static bool TryRenderRuntimeTexturePreview(FaceDocumentModel faceDocument, string lampPreviewMode, out BitmapSource? preview)
+    {
+        preview = null;
+        var runtimeState = new MachineRuntimeState();
+        if (lampPreviewMode == CabinetLampPreviewMode.LampsAllOn)
+        {
+            foreach (var lampWindow in faceDocument.Elements.OfType<FaceLampWindowElement>())
+            {
+                if (lampWindow.LinkedMachineObjectReference is MachineObjectReference { Kind: MachineObjectKind.Lamp } reference && !reference.IsEmpty)
+                {
+                    runtimeState.SetLampIntensity(reference, 1d);
+                }
+            }
+        }
+
+        using var renderer = new FaceTexturePreviewRenderer(ResolveAssetPathOrNull);
+        using var result = renderer.Render(faceDocument, runtimeState);
+        if (!result.Rendered || result.Bitmap is null)
+        {
+            return false;
+        }
+
+        preview = ToBitmapSource(result.Bitmap);
+        return preview is not null;
+    }
+
+    private static BitmapSource? ToBitmapSource(SKBitmap bitmap)
+    {
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        if (data is null)
+        {
+            return null;
+        }
+
+        using var stream = new MemoryStream(data.ToArray());
+        var source = new BitmapImage();
+        source.BeginInit();
+        source.CacheOption = BitmapCacheOption.OnLoad;
+        source.StreamSource = stream;
+        source.EndInit();
+        source.Freeze();
+        return source;
     }
 
     private static FacePreviewBounds ResolveBounds(FaceDocumentModel faceDocument)
@@ -150,6 +205,11 @@ public sealed class FaceDocumentArtworkPreviewRenderer
 
         image = SKImage.FromBitmap(bitmap);
         return true;
+    }
+
+    private static string? ResolveAssetPathOrNull(string? assetPath)
+    {
+        return TryResolveAssetPath(assetPath, out var resolvedPath) ? resolvedPath : null;
     }
 
     private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/ViewModels/CabinetModelDocumentViewModel.cs
@@ -56,6 +56,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
     public ICommand ResetCameraCommand { get; }
     public IReadOnlyList<string> FrontSideOptions { get; } = new[] { CabinetTargetOverride.NormalFrontSide, CabinetTargetOverride.InvertedFrontSide };
     public IReadOnlyList<int> FaceRotationOptions { get; } = new[] { 0, 90, 180, 270 };
+    public IReadOnlyList<string> LampPreviewModeOptions { get; } = new[] { CabinetLampPreviewMode.BackgroundOnly, CabinetLampPreviewMode.LampsOff, CabinetLampPreviewMode.LampsAllOn };
 
     public CabinetFaceTargetViewModel? SelectedFaceTarget
     {
@@ -70,6 +71,12 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(SelectedFaceRotation));
             OnPropertyChanged(nameof(IsSelectedFaceFlippedHorizontally));
         }
+    }
+
+    public string SelectedLampPreviewMode
+    {
+        get => CabinetLampPreviewMode.Normalize(_document.GetCabinetDocument().Preview.LampPreviewMode);
+        set => _document.CommandService.Execute(CabinetMutationCommands.CreateSetPreviewLampModeCommand(_document.DocumentId, _document, value));
     }
 
     public bool HasSelectedFaceTarget => SelectedFaceTarget is not null;
@@ -109,6 +116,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(SelectedFrontSide));
         OnPropertyChanged(nameof(SelectedFaceRotation));
         OnPropertyChanged(nameof(IsSelectedFaceFlippedHorizontally));
+        OnPropertyChanged(nameof(SelectedLampPreviewMode));
         RefreshFacePreviews();
     }
 
@@ -177,7 +185,7 @@ public sealed class CabinetModelDocumentViewModel : INotifyPropertyChanged
                 continue;
             }
 
-            var preview = _previewRenderer.RenderPreview(faceDocument);
+            var preview = _previewRenderer.RenderPreview(faceDocument, _document.GetCabinetDocument().Preview.LampPreviewMode);
             if (preview is null)
             {
                 continue;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/CabinetEditor/Views/CabinetModelDocumentView.xaml
@@ -71,7 +71,9 @@
                 <DockPanel>
                     <StackPanel DockPanel.Dock="Top" Margin="0,0,0,10">
                         <TextBlock FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Text="Oasis Face Targets" />
-                        <TextBlock Margin="0,4,0,0" Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" Text="{Binding CabinetViewer.FaceTargetStatus}" />
+                        <TextBlock Margin="0,8,0,3" Foreground="{DynamicResource TextSecondaryBrush}" Text="Lamp Preview" />
+                        <ComboBox ItemsSource="{Binding CabinetViewer.LampPreviewModeOptions}" SelectedItem="{Binding CabinetViewer.SelectedLampPreviewMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock Margin="0,8,0,0" Foreground="{DynamicResource TextSecondaryBrush}" TextWrapping="Wrap" Text="{Binding CabinetViewer.FaceTargetStatus}" />
                     </StackPanel>
                     <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
                         <StackPanel.Style>


### PR DESCRIPTION
### Motivation
- Provide editor-only static lamp preview modes for Cabinet3D so assigned Face documents can show lamp states (background, all-off, all-on) without changing Face data or mutating `.glb` assets.
- Reuse existing Face texture preview composition logic to avoid reimplementing lamp/brightness rendering and to keep the viewer code-behind thin.

### Description
- Added persisted preview mode to `CabinetPreviewSettings` and a `CabinetLampPreviewMode` normalizer with values `Background Only`, `Lamps Off`, and `Lamps All On`, and normalized on document load (`CabinetDocument.cs` / `CabinetDocumentStorage.cs`).
- Exposed a `LampPreviewMode` dropdown in the Cabinet3D viewer UI and bound it to a new `SelectedLampPreviewMode` property on `CabinetModelDocumentViewModel` that dispatches a document-scoped command (`CabinetModelDocumentView.xaml` / `CabinetModelDocumentViewModel.cs` / `CabinetMutationCommands.cs`).
- Implemented a command-backed setter `CreateSetPreviewLampModeCommand` so mode changes follow existing document mutation/undo/dirty patterns and do not alter Face documents (`CabinetMutationCommands.cs`).
- Wired the cabinet preview composition to call the existing Face texture renderer for non-background modes, composing a static texture per assigned Face and applying it to the generated target quad while preserving `frontSide`, `faceRotation`, and horizontal flip overrides (`FaceDocumentArtworkPreviewRenderer.cs` and `CabinetModelDocumentViewModel.cs`).
- Kept all behavior editor-only and avoided any `.glb` modification or changes to Face document data; fallback to the previous artwork-only path remains for `Background Only`.

### Testing
- No automated tests were executed in this environment per project constraints (no builds/tests run in Codex).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a42c916ef2c83279d9b453c4ca6e1d2)