### PR TITLE
Update OasisEditor current priority docs

### DIFF
--- a/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
+++ b/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
@@ -6,50 +6,63 @@ Read only:
 
 1. `AGENTS.md`
 2. `00_CURRENT_PRIORITY.md`
+3. `Docs/AssetLayout/CODEX_START_PROMPT.md`
 
 Do not scan all Markdown files in this directory.
-Open additional plans or task documents only when they are directly relevant to the requested work.
+
+Open additional AssetLayout task documents only as directed by `Docs/AssetLayout/CODEX_START_PROMPT.md` or when directly relevant to the requested work.
 
 ## Current Focus
 
 Priority workstream:
 
-- CLI/headless automation pipeline architecture
-- Extraction of reusable project/import/save services
-- Automation command runner abstractions
-- UI-independent MFME import workflow
-- Future CLI conversion workflow support
-- Preparing for future OasisEditor.Core / OasisEditor.Cli separation
+- Asset package layout redesign
+- Folder-as-asset storage model
+- Fixed asset manifest filenames
+- Authored assets under `Assets/`
+- Disposable runtime/cache/export files under `Generated/`
+- Panel2D, Face, and Cabinet3D first-save/package creation flow
 
 ## Immediate Direction
 
-Do not build an in-app terminal.
+Implement the folder-as-asset package model described in:
 
-Instead:
+```text
+Docs/AssetLayout/CODEX_START_PROMPT.md
+```
 
-- extract reusable project/import/save services
-- add automation command abstractions
-- make MFME import callable without WPF dialogs/views
-- build a reusable automation pipeline
-- prepare for future CLI/headless workflows
+Core target layout:
+
+```text
+Assets/Panel2D/<AssetName>/asset.panel2d
+Assets/Faces/<AssetName>/asset.face
+Assets/Faces/<AssetName>/artwork.png
+Assets/Faces/<AssetName>/mask.png
+Assets/Cabinet3D/<AssetName>/asset.cabinet3d
+Generated/Faces/<AssetName>/runtime/
+```
+
+Do not add migration code for old generated/document layouts unless it makes tests or current code clearer.
 
 ## Architectural Goals
 
-- Core project/import/export logic should become UI-independent
-- GUI and CLI workflows should reuse the same services
-- Automation should not require visible WPF views
-- Existing editor workflows should continue working
-- Future OasisEditor.Core / OasisEditor.Cli separation should become easier
+- The asset folder is the asset.
+- The manifest file inside the folder describes the asset.
+- Use stable internal asset IDs in manifests where practical.
+- Keep authored/user-editable files under `Assets/`.
+- Keep disposable runtime/export/cache files under `Generated/`.
+- Keep Cabinet3D GLB reference/protection behavior intact.
+- Do not silently overwrite user-edited Face `artwork.png` or `mask.png` outside explicit regeneration.
 
 ## Testing Direction
 
 Prefer tests around:
 
-- automation command runner behavior
-- command sequencing and failure handling
-- cancellation handling
-- create project and panel services
-- MFME import automation invocation
-- save service invocation
+- asset package path service behavior
+- path sanitization and collision handling
+- first-save/package creation paths for Panel2D, Face, and Cabinet3D
+- Face Source Shape generation writing authored Face files under `Assets/Faces/<AssetName>/`
+- runtime export writing only under `Generated/Faces/<AssetName>/runtime/`
+- old GUID/generated authored-output assumptions being removed
 
-Avoid tests requiring visible WPF windows.
+Do not attempt to run builds/tests in Codex. John will run builds/tests locally.

--- a/WindowsNetProjects/OasisEditor/README.md
+++ b/WindowsNetProjects/OasisEditor/README.md
@@ -1,1 +1,1 @@
-See AGENT.md and TASKS.md for development guidance.
+See AGENTS.md and 00_CURRENT_PRIORITY.md for development guidance.


### PR DESCRIPTION
Updates root OasisEditor guidance so Codex starts from the active AssetLayout workstream.

Changed:
- `README.md` now points to `AGENTS.md` and `00_CURRENT_PRIORITY.md`.
- `00_CURRENT_PRIORITY.md` now points to `Docs/AssetLayout/CODEX_START_PROMPT.md` and the folder-as-asset package redesign.

Not changed:
- `AGENTS.md` still needs thinning/updating, but write attempts to that agent-instruction file were blocked by the connector safety check in this environment.