### PR TITLE
Implement folder-as-asset package layout

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -31,16 +31,16 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
             Title = "Runtime Face",
             RuntimeRenderAssets = new FaceRuntimeRenderAssetsModel
             {
-                ManifestPath = "Generated/Faces/face-runtime/runtime/face.runtime.json",
-                ArtworkPath = "Generated/Faces/face-runtime/runtime/artwork.png",
-                MaskPath = "Generated/Faces/face-runtime/runtime/mask.png",
-                TrayIdPath = "Generated/Faces/face-runtime/runtime/trayId.png",
-                LampIds0Path = "Generated/Faces/face-runtime/runtime/lampIds0.png",
-                LampWeights0Path = "Generated/Faces/face-runtime/runtime/lampWeights0.png",
+                ManifestPath = "Generated/Faces/Runtime Face/runtime/face.runtime.json",
+                ArtworkPath = "Generated/Faces/Runtime Face/runtime/artwork.png",
+                MaskPath = "Generated/Faces/Runtime Face/runtime/mask.png",
+                TrayIdPath = "Generated/Faces/Runtime Face/runtime/trayId.png",
+                LampIds0Path = "Generated/Faces/Runtime Face/runtime/lampIds0.png",
+                LampWeights0Path = "Generated/Faces/Runtime Face/runtime/lampWeights0.png",
                 LampIds1Path = null,
                 LampWeights1Path = null,
-                TrayIdDebugPath = "Generated/Faces/face-runtime/runtime/trayId_debug.png",
-                LampWeightsDebugPath = "Generated/Faces/face-runtime/runtime/lampWeights_debug.png",
+                TrayIdDebugPath = "Generated/Faces/Runtime Face/runtime/trayId_debug.png",
+                LampWeightsDebugPath = "Generated/Faces/Runtime Face/runtime/lampWeights_debug.png",
                 Width = 320,
                 Height = 240,
                 GeneratedUtc = generatedUtc
@@ -51,16 +51,16 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
 
         Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
         Assert.Equal(FaceDocumentStorage.CurrentSchemaVersion, file.SchemaVersion);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", file.RuntimeRenderAssets!.ArtworkPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/artwork.png", file.RuntimeRenderAssets!.ArtworkPath);
         Assert.Equal(320, file.RuntimeRenderAssets.Width);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/trayId_debug.png", file.RuntimeRenderAssets.TrayIdDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/trayId_debug.png", file.RuntimeRenderAssets.TrayIdDebugPath);
 
         var model = FaceDocumentStorage.ToModel(file);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", model.RuntimeRenderAssets!.ManifestPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", model.RuntimeRenderAssets.MaskPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/face.runtime.json", model.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/mask.png", model.RuntimeRenderAssets.MaskPath);
         Assert.Equal(240, model.RuntimeRenderAssets.Height);
         Assert.Equal(generatedUtc, model.RuntimeRenderAssets.GeneratedUtc);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights_debug.png", model.RuntimeRenderAssets.LampWeightsDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampWeights_debug.png", model.RuntimeRenderAssets.LampWeightsDebugPath);
     }
 
     [Fact]
@@ -83,14 +83,14 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.True(File.Exists(Path.Combine(result.OutputDirectory, "lampWeights0.png")));
         Assert.True(File.Exists(Path.Combine(result.OutputDirectory, "trayId_debug.png")));
         Assert.True(File.Exists(Path.Combine(result.OutputDirectory, "lampWeights_debug.png")));
-        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", result.Document.RuntimeRenderAssets!.ManifestPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", result.Document.RuntimeRenderAssets.ArtworkPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", result.Document.RuntimeRenderAssets.MaskPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/trayId.png", result.Document.RuntimeRenderAssets.TrayIdPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampIds0.png", result.Document.RuntimeRenderAssets.LampIds0Path);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights0.png", result.Document.RuntimeRenderAssets.LampWeights0Path);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/trayId_debug.png", result.Document.RuntimeRenderAssets.TrayIdDebugPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights_debug.png", result.Document.RuntimeRenderAssets.LampWeightsDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/face.runtime.json", result.Document.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/artwork.png", result.Document.RuntimeRenderAssets.ArtworkPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/mask.png", result.Document.RuntimeRenderAssets.MaskPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/trayId.png", result.Document.RuntimeRenderAssets.TrayIdPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampIds0.png", result.Document.RuntimeRenderAssets.LampIds0Path);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampWeights0.png", result.Document.RuntimeRenderAssets.LampWeights0Path);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/trayId_debug.png", result.Document.RuntimeRenderAssets.TrayIdDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampWeights_debug.png", result.Document.RuntimeRenderAssets.LampWeightsDebugPath);
         Assert.Equal(4, result.Document.RuntimeRenderAssets.Width);
         Assert.Equal(4, result.Document.RuntimeRenderAssets.Height);
 
@@ -136,23 +136,23 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var saved = new DocumentSaveService().SaveDocument(current, facePath, CreateProject());
 
         Assert.False(saved.IsDirty);
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "face.runtime.json")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "artwork.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "mask.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "trayId.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "lampIds0.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "lampWeights0.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "trayId_debug.png")));
-        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "face-runtime", "runtime", "lampWeights_debug.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "face.runtime.json")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "artwork.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "mask.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "trayId.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "lampIds0.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "lampWeights0.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "trayId_debug.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Runtime Face", "runtime", "lampWeights_debug.png")));
         Assert.True(FaceDocumentStorage.TryReadValidated(File.ReadAllText(facePath), out var persisted, out var error), error);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/face.runtime.json", persisted.RuntimeRenderAssets!.ManifestPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/artwork.png", persisted.RuntimeRenderAssets.ArtworkPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/mask.png", persisted.RuntimeRenderAssets.MaskPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/trayId.png", persisted.RuntimeRenderAssets.TrayIdPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampIds0.png", persisted.RuntimeRenderAssets.LampIds0Path);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights0.png", persisted.RuntimeRenderAssets.LampWeights0Path);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/trayId_debug.png", persisted.RuntimeRenderAssets.TrayIdDebugPath);
-        Assert.Equal("Generated/Faces/face-runtime/runtime/lampWeights_debug.png", persisted.RuntimeRenderAssets.LampWeightsDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/face.runtime.json", persisted.RuntimeRenderAssets!.ManifestPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/artwork.png", persisted.RuntimeRenderAssets.ArtworkPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/mask.png", persisted.RuntimeRenderAssets.MaskPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/trayId.png", persisted.RuntimeRenderAssets.TrayIdPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampIds0.png", persisted.RuntimeRenderAssets.LampIds0Path);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampWeights0.png", persisted.RuntimeRenderAssets.LampWeights0Path);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/trayId_debug.png", persisted.RuntimeRenderAssets.TrayIdDebugPath);
+        Assert.Equal("Generated/Faces/Runtime Face/runtime/lampWeights_debug.png", persisted.RuntimeRenderAssets.LampWeightsDebugPath);
     }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectAssetPathServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectAssetPathServiceTests.cs
@@ -1,0 +1,49 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class ProjectAssetPathServiceTests
+{
+    [Fact]
+    public void ResolvesFixedManifestAndFaceAuthoredAndRuntimePaths()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"OasisAssetPaths-{Guid.NewGuid():N}");
+        var project = new EditorProject
+        {
+            Name = "Test",
+            ProjectFilePath = Path.Combine(root, "Test.oasisproj"),
+            ProjectDirectory = root,
+            AssetsDirectory = Path.Combine(root, "Assets"),
+            MachinesDirectory = Path.Combine(root, "Machines"),
+            GeneratedDirectory = Path.Combine(root, "Generated")
+        };
+        var service = new ProjectAssetPathService();
+
+        Assert.Equal(Path.Combine(root, "Assets", "Panel2D", "Main Panel", "asset.panel2d"), service.GetPanel2DManifestPath(project, "Main Panel"));
+        Assert.Equal(Path.Combine(root, "Assets", "Faces", "Top Glass", "asset.face"), service.GetFaceManifestPath(project, "Top Glass"));
+        Assert.Equal(Path.Combine(root, "Assets", "Faces", "Top Glass", "artwork.png"), service.GetFaceArtworkPath(project, "Top Glass"));
+        Assert.Equal(Path.Combine(root, "Assets", "Faces", "Top Glass", "mask.png"), service.GetFaceMaskPath(project, "Top Glass"));
+        Assert.Equal(Path.Combine(root, "Assets", "Cabinet3D", "Vogue", "asset.cabinet3d"), service.GetCabinet3DManifestPath(project, "Vogue"));
+        Assert.Equal(Path.Combine(root, "Generated", "Faces", "Top Glass", "runtime"), service.GetFaceRuntimeDirectory(project, "Top Glass"));
+    }
+
+    [Fact]
+    public void EnsureUniqueAssetNameAddsPredictableSuffix()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"OasisAssetPaths-{Guid.NewGuid():N}");
+        var project = new EditorProject
+        {
+            Name = "Test",
+            ProjectFilePath = Path.Combine(root, "Test.oasisproj"),
+            ProjectDirectory = root,
+            AssetsDirectory = Path.Combine(root, "Assets"),
+            MachinesDirectory = Path.Combine(root, "Machines"),
+            GeneratedDirectory = Path.Combine(root, "Generated")
+        };
+        var service = new ProjectAssetPathService();
+        Directory.CreateDirectory(service.GetAssetPackageDirectory(project, EditorAssetType.Face, "Top Glass"));
+
+        Assert.Equal("Top Glass 2", service.EnsureUniqueAssetName(project, EditorAssetType.Face, "Top Glass"));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -94,6 +94,7 @@ internal sealed class FaceGenerationService
         double? targetAspectRatio = null,
         string? projectDirectory = null,
         string? generatedDirectory = null,
+        string? faceAssetName = null,
         FaceGenerationSettingsModel? generationSettings = null,
         IEditorProgressReporter? progress = null,
         string? sourcePanel2DDocumentPath = null)
@@ -101,8 +102,13 @@ internal sealed class FaceGenerationService
         ArgumentNullException.ThrowIfNull(sourcePanel);
         ArgumentNullException.ThrowIfNull(sourceShape);
         var output = FaceSourceShapeTransformService.EstimateOutputSize(sourceShape, targetAspectRatio);
+        var pathService = new ProjectAssetPathService();
+        var resolvedFaceAssetName = pathService.SanitizePathSegment(string.IsNullOrWhiteSpace(faceAssetName) ? title : faceAssetName);
+        var faceArtworkPath = !string.IsNullOrWhiteSpace(projectDirectory)
+            ? pathService.GetFaceArtworkPath(CreatePathProject(projectDirectory, generatedDirectory), resolvedFaceAssetName)
+            : null;
         var region = FaceSourceRegionModel.FromRect(new Rect(0, 0, output.Width, output.Height));
-        var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, generatedDirectory);
+        var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, faceArtworkPath);
         var settings = (generationSettings ?? FaceGenerationSettingsModel.Default).Normalize();
         var faceDocumentId = Guid.NewGuid().ToString("N");
         progress?.Report(0.2, "Converting source-shape lamps...");
@@ -120,6 +126,7 @@ internal sealed class FaceGenerationService
             faceDocumentId,
             sourcePanel2DDocumentId,
             projectDirectory,
+            resolvedFaceAssetName,
             settings.MaskExtractionThreshold);
         var artwork = new FaceArtworkElement
         {
@@ -141,7 +148,7 @@ internal sealed class FaceGenerationService
         var document = new FaceDocumentModel
         {
             Id = faceDocumentId,
-            Title = string.IsNullOrWhiteSpace(title) ? "Generated Face" : title.Trim(),
+            Title = resolvedFaceAssetName,
             Summary = $"Generated from Face Source Shape '{sourceShape.Name}' ({output.Width} x {output.Height}).",
             SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
             SourceFaceShapeId = NormalizeOptional(sourceShape.Id),
@@ -174,6 +181,7 @@ internal sealed class FaceGenerationService
         string faceDocumentId,
         string? sourcePanel2DDocumentId,
         string? projectDirectory,
+        string faceAssetName,
         byte extractionThreshold)
     {
         if (string.IsNullOrWhiteSpace(projectDirectory) || faceWidth <= 0 || faceHeight <= 0)
@@ -225,7 +233,7 @@ internal sealed class FaceGenerationService
             });
         }
 
-        var assetPath = SaveSourceShapeMask(maskPixels, faceWidth, faceHeight, faceDocumentId, projectDirectory);
+        var assetPath = SaveSourceShapeMask(maskPixels, faceWidth, faceHeight, faceDocumentId, projectDirectory, faceAssetName);
         return new FaceMaskLayerModel
         {
             Id = "face-mask-layer",
@@ -303,7 +311,7 @@ internal sealed class FaceGenerationService
         return new SourceShapeMaskContribution(bounds, count);
     }
 
-    private static string SaveSourceShapeMask(byte[] maskPixels, int width, int height, string faceDocumentId, string projectDirectory)
+    private static string SaveSourceShapeMask(byte[] maskPixels, int width, int height, string faceDocumentId, string projectDirectory, string faceAssetName)
     {
         using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
         for (var y = 0; y < height; y++)
@@ -313,14 +321,30 @@ internal sealed class FaceGenerationService
             bitmap.SetPixel(x, y, new SKColor(value, value, value, value));
         }
 
-        var relative = System.IO.Path.Combine("Generated", "Faces", $"{faceDocumentId}-face-source-shape-mask.png");
-        var path = System.IO.Path.Combine(projectDirectory, relative);
+        var pathService = new ProjectAssetPathService();
+        var project = CreatePathProject(projectDirectory, null);
+        var path = pathService.GetFaceMaskPath(project, faceAssetName);
+        var relative = pathService.ToProjectRelativePath(project, path);
         System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
         using var image = SKImage.FromBitmap(bitmap);
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);
         using var stream = System.IO.File.Create(path);
         data.SaveTo(stream);
-        return relative.Replace(System.IO.Path.DirectorySeparatorChar, '/');
+        return ProjectAssetPathService.NormalizeProjectRelativePath(relative);
+    }
+
+    private static EditorProject CreatePathProject(string projectDirectory, string? generatedDirectory)
+    {
+        var root = System.IO.Path.GetFullPath(projectDirectory);
+        return new EditorProject
+        {
+            Name = System.IO.Path.GetFileName(root),
+            ProjectFilePath = System.IO.Path.Combine(root, $"{System.IO.Path.GetFileName(root)}.oasisproj"),
+            ProjectDirectory = root,
+            AssetsDirectory = System.IO.Path.Combine(root, "Assets"),
+            MachinesDirectory = System.IO.Path.Combine(root, "Machines"),
+            GeneratedDirectory = string.IsNullOrWhiteSpace(generatedDirectory) ? System.IO.Path.Combine(root, "Generated") : generatedDirectory
+        };
     }
 
     private FaceLampWindowElement? CreateLampWindowFromSourceShape(PanelElementModel sourceElement, PanelFaceSourceShapeModel sourceShape, int faceWidth, int faceHeight, string? projectDirectory)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -83,6 +83,7 @@ internal sealed class FaceRegenerationService
             targetAspectRatio,
             projectDirectory,
             generatedDirectory,
+            existingFace.Title,
             settings,
             progress.CreateChild(0.15, 0.45),
             existingFace.SourcePanel2DDocumentPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -78,15 +78,15 @@ internal sealed class FaceRegenerationService
             sourcePanel,
             sourceShape,
             existingFace.Title,
-            existingFace.SourcePanel2DDocumentId,
-            existingFace.AssignedCabinetFaceTargetId,
-            targetAspectRatio,
-            projectDirectory,
-            generatedDirectory,
-            existingFace.Title,
-            settings,
-            progress.CreateChild(0.15, 0.45),
-            existingFace.SourcePanel2DDocumentPath);
+            sourcePanel2DDocumentId: existingFace.SourcePanel2DDocumentId,
+            assignedCabinetFaceTargetId: existingFace.AssignedCabinetFaceTargetId,
+            targetAspectRatio: targetAspectRatio,
+            projectDirectory: projectDirectory,
+            generatedDirectory: generatedDirectory,
+            faceAssetName: existingFace.Title,
+            generationSettings: settings,
+            progress: progress.CreateChild(0.15, 0.45),
+            sourcePanel2DDocumentPath: existingFace.SourcePanel2DDocumentPath);
 
         progress.Report(0.45, "Correlating regenerated elements...");
         var existingGeneratedByKey = existingFace.Elements

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -213,8 +213,10 @@ public sealed class FaceRuntimeExportService
             throw new IOException($"Project Generated directory points to a file: {generatedDirectory}");
         }
 
-        var safeFaceId = SanitizePathSegment(string.IsNullOrWhiteSpace(faceDocument.Id) ? Guid.NewGuid().ToString("N") : faceDocument.Id.Trim());
-        return Path.Combine(generatedDirectory, "Faces", safeFaceId, RuntimeDirectoryName);
+        var faceName = string.IsNullOrWhiteSpace(faceDocument.Title)
+            ? (string.IsNullOrWhiteSpace(faceDocument.Id) ? Guid.NewGuid().ToString("N") : faceDocument.Id.Trim())
+            : faceDocument.Title.Trim();
+        return new ProjectAssetPathService().GetFaceRuntimeDirectory(project, faceName);
     }
 
     private static string ResolveExistingProjectPath(EditorProject project, string? projectPath, string description)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSourceShapeTransformService.cs
@@ -21,7 +21,7 @@ internal static class FaceSourceShapeTransformService
         return new FaceSourceShapeOutputSize(Math.Max(1, (int)Math.Ceiling(sourceWidth)), Math.Max(1, (int)Math.Ceiling(sourceHeight)));
     }
 
-    public static string? TryGenerateBackground(Panel2DDocumentModel panel, PanelFaceSourceShapeModel shape, int width, int height, string? projectDirectory, string? generatedDirectory)
+    public static string? TryGenerateBackground(Panel2DDocumentModel panel, PanelFaceSourceShapeModel shape, int width, int height, string? projectDirectory, string? outputPath = null)
     {
         var background = panel.Elements.FirstOrDefault(e => e.Kind == PanelElementKind.Background && !string.IsNullOrWhiteSpace(e.AssetPath));
         if (background is null || string.IsNullOrWhiteSpace(projectDirectory)) return null;
@@ -43,8 +43,10 @@ internal static class FaceSourceShapeTransformService
             var py = panelPoint.Y - background.Y;
             output.SetPixel(x, y, SampleBicubic(source, px / Math.Max(1d, background.Width) * source.Width, py / Math.Max(1d, background.Height) * source.Height));
         }
-        var relative = Path.Combine("Generated", "Faces", $"face-source-shape-{Guid.NewGuid():N}.png");
-        var path = Path.Combine(projectDirectory, relative);
+        var path = string.IsNullOrWhiteSpace(outputPath)
+            ? Path.Combine(projectDirectory, "Generated", "Faces", $"face-source-shape-{Guid.NewGuid():N}.png")
+            : outputPath;
+        var relative = Path.GetRelativePath(projectDirectory, path);
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         using var image = SKImage.FromBitmap(output);
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1174,7 +1174,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 new EditorProgressRequest("Creating Face", "Creating Face from Face Source Shape...", EditorProgressMode.Determinate),
                 (progress, _) =>
                 {
-                    _documentWorkspace.GenerateFaceFromSelectedFaceSourceShape(_defaultFaceGenerationSettings, progress);
+                    _documentWorkspace.GenerateFaceFromSelectedFaceSourceShape(null, _defaultFaceGenerationSettings, progress);
                     return Task.CompletedTask;
                 });
         }
@@ -1299,6 +1299,17 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
+        var faceNameDialog = new HierarchyRenameDialog("New Face", "Create Face Asset", "Face asset name")
+        {
+            Owner = _ownerWindow
+        };
+
+        if (faceNameDialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var faceAssetName = faceNameDialog.NameText;
         _defaultFaceGenerationSettings = generateDialog.Settings;
         SavePreferences();
         try
@@ -1307,7 +1318,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 new EditorProgressRequest("Creating Face", "Creating Face from Face Source Shape...", EditorProgressMode.Determinate),
                 (progress, _) =>
                 {
-                    _documentWorkspace.GenerateFaceFromSelectedFaceSourceShape(generateDialog.Settings, progress);
+                    _documentWorkspace.GenerateFaceFromSelectedFaceSourceShape(faceAssetName, generateDialog.Settings, progress);
                     return Task.CompletedTask;
                 });
         }
@@ -1801,21 +1812,37 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             defaultName = Path.GetFileNameWithoutExtension(selectedDocument.FilePath);
         }
 
-        var (defaultExtension, filter) = selectedDocument?.Document.DocumentType switch
+        if (selectedDocument?.Document.DocumentType is EditorDocumentType.Panel2D or EditorDocumentType.Cabinet3D or EditorDocumentType.Face)
         {
-            EditorDocumentType.Face => (".face", "Face|*.face|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*"),
-            EditorDocumentType.Cabinet3D => (".cabinet3d", "Cabinet 3D|*.cabinet3d|Face|*.face|Panel 2D|*.panel2d|Machine|*.machine|All Files|*.*"),
-            EditorDocumentType.Machine => (".machine", "Machine|*.machine|Face|*.face|Panel 2D|*.panel2d|Cabinet 3D|*.cabinet3d|All Files|*.*"),
-            _ => (".panel2d", "Panel 2D|*.panel2d|Face|*.face|Cabinet 3D|*.cabinet3d|Machine|*.machine|All Files|*.*")
-        };
+            var nameDialog = new HierarchyRenameDialog(defaultName, "Save Asset", "Asset name")
+            {
+                Owner = _ownerWindow
+            };
+
+            if (nameDialog.ShowDialog() != true)
+            {
+                return null;
+            }
+
+            var pathService = new ProjectAssetPathService();
+            var assetType = selectedDocument.Document.DocumentType switch
+            {
+                EditorDocumentType.Face => EditorAssetType.Face,
+                EditorDocumentType.Cabinet3D => EditorAssetType.Cabinet3D,
+                _ => EditorAssetType.Panel2D
+            };
+            var assetName = pathService.EnsureUniqueAssetName(LoadedProject, assetType, nameDialog.NameText);
+            pathService.CreateAssetPackageDirectory(LoadedProject, assetType, assetName);
+            return pathService.GetAssetManifestPath(LoadedProject, assetType, assetName);
+        }
 
         var dialog = new SaveFileDialog
         {
             Title = "Save Document",
             InitialDirectory = LoadedProject.AssetsDirectory,
-            FileName = $"{defaultName}{defaultExtension}",
-            DefaultExt = defaultExtension,
-            Filter = filter
+            FileName = $"{defaultName}.machine",
+            DefaultExt = ".machine",
+            Filter = "Machine|*.machine|All Files|*.*"
         };
 
         return dialog.ShowDialog() == true ? dialog.FileName : null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
@@ -1,0 +1,66 @@
+using System.IO;
+
+namespace OasisEditor;
+
+public enum EditorAssetType
+{
+    Panel2D,
+    Face,
+    Cabinet3D
+}
+
+public sealed class ProjectAssetPathService
+{
+    public const string Panel2DManifestFileName = "asset.panel2d";
+    public const string FaceManifestFileName = "asset.face";
+    public const string Cabinet3DManifestFileName = "asset.cabinet3d";
+    public const string FaceArtworkFileName = "artwork.png";
+    public const string FaceMaskFileName = "mask.png";
+
+    public string SanitizePathSegment(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Asset name is required.", nameof(name));
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitized = new string(name.Trim().Select(ch => invalid.Contains(ch) || char.IsControl(ch) ? '-' : ch).ToArray());
+        sanitized = string.Join(" ", sanitized.Split(' ', StringSplitOptions.RemoveEmptyEntries)).Trim('.', ' ');
+        if (string.IsNullOrWhiteSpace(sanitized) || sanitized is "." or "..") throw new ArgumentException("Asset name does not contain any safe path characters.", nameof(name));
+        return sanitized;
+    }
+
+    public string ToProjectRelativePath(EditorProject project, string absolutePath)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
+        return NormalizeProjectRelativePath(Path.GetRelativePath(project.ProjectDirectory, Path.GetFullPath(absolutePath)));
+    }
+
+    public string ResolveProjectRelativePath(EditorProject project, string relativePath)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+        return Path.IsPathRooted(relativePath) ? Path.GetFullPath(relativePath) : Path.GetFullPath(Path.Combine(project.ProjectDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    public string GetAssetTypeDirectory(EditorProject project, EditorAssetType assetType) => Path.Combine(project.AssetsDirectory, GetAssetTypeFolderName(assetType));
+    public string GetAssetPackageDirectory(EditorProject project, EditorAssetType assetType, string assetName) => Path.Combine(GetAssetTypeDirectory(project, assetType), SanitizePathSegment(assetName));
+    public string GetAssetManifestPath(EditorProject project, EditorAssetType assetType, string assetName) => Path.Combine(GetAssetPackageDirectory(project, assetType, assetName), GetManifestFileName(assetType));
+    public string GetPanel2DManifestPath(EditorProject project, string assetName) => GetAssetManifestPath(project, EditorAssetType.Panel2D, assetName);
+    public string GetFaceManifestPath(EditorProject project, string assetName) => GetAssetManifestPath(project, EditorAssetType.Face, assetName);
+    public string GetCabinet3DManifestPath(EditorProject project, string assetName) => GetAssetManifestPath(project, EditorAssetType.Cabinet3D, assetName);
+    public string GetFaceArtworkPath(EditorProject project, string assetName) => Path.Combine(GetAssetPackageDirectory(project, EditorAssetType.Face, assetName), FaceArtworkFileName);
+    public string GetFaceMaskPath(EditorProject project, string assetName) => Path.Combine(GetAssetPackageDirectory(project, EditorAssetType.Face, assetName), FaceMaskFileName);
+    public string GetFaceRuntimeDirectory(EditorProject project, string assetName) => Path.Combine(project.GeneratedDirectory, "Faces", SanitizePathSegment(assetName), FaceRuntimeExportService.RuntimeDirectoryName);
+
+    public string EnsureUniqueAssetName(EditorProject project, EditorAssetType assetType, string requestedName)
+    {
+        var safe = SanitizePathSegment(requestedName);
+        var candidate = safe;
+        for (var suffix = 2; Directory.Exists(GetAssetPackageDirectory(project, assetType, candidate)); suffix++) candidate = $"{safe} {suffix}";
+        return candidate;
+    }
+
+    public DirectoryInfo CreateAssetPackageDirectory(EditorProject project, EditorAssetType assetType, string assetName) => Directory.CreateDirectory(GetAssetPackageDirectory(project, assetType, assetName));
+    public static string NormalizeProjectRelativePath(string path) => path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+    private static string GetAssetTypeFolderName(EditorAssetType assetType) => assetType switch { EditorAssetType.Panel2D => "Panel2D", EditorAssetType.Face => "Faces", EditorAssetType.Cabinet3D => "Cabinet3D", _ => throw new ArgumentOutOfRangeException(nameof(assetType), assetType, null) };
+    private static string GetManifestFileName(EditorAssetType assetType) => assetType switch { EditorAssetType.Panel2D => Panel2DManifestFileName, EditorAssetType.Face => FaceManifestFileName, EditorAssetType.Cabinet3D => Cabinet3DManifestFileName, _ => throw new ArgumentOutOfRangeException(nameof(assetType), assetType, null) };
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
@@ -13,6 +13,7 @@ public sealed class ProjectScaffolder
         "Assets/Fonts",
         "Assets/Panel2D",
         "Assets/Cabinet3D",
+        "Assets/Faces",
         "Machines",
         "Generated",
         "Generated/Build",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -177,7 +177,6 @@ public sealed class DocumentWorkspaceViewModel
             targetAspect,
             loadedProject.ProjectDirectory,
             loadedProject.GeneratedDirectory,
-            title,
             generationSettings,
             progress.CreateChild(0.0, 0.8),
             sourceDocument.FilePath);
@@ -300,7 +299,6 @@ public sealed class DocumentWorkspaceViewModel
             sourcePanelDocument.GetPanelDocument(),
             loadedProject.ProjectDirectory,
             loadedProject.GeneratedDirectory,
-            title,
             generationSettings,
             progress.CreateChild(0.0, 0.8));
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -172,14 +172,15 @@ public sealed class DocumentWorkspaceViewModel
             sourceDocument.GetPanelDocument(),
             shape,
             title,
-            sourceDocument.DocumentId.ToString("N"),
-            target?.Id,
-            targetAspect,
-            loadedProject.ProjectDirectory,
-            loadedProject.GeneratedDirectory,
-            generationSettings,
-            progress.CreateChild(0.0, 0.8),
-            sourceDocument.FilePath);
+            sourcePanel2DDocumentId: sourceDocument.DocumentId.ToString("N"),
+            assignedCabinetFaceTargetId: target?.Id,
+            targetAspectRatio: targetAspect,
+            projectDirectory: loadedProject.ProjectDirectory,
+            generatedDirectory: loadedProject.GeneratedDirectory,
+            faceAssetName: title,
+            generationSettings: generationSettings,
+            progress: progress.CreateChild(0.0, 0.8),
+            sourcePanel2DDocumentPath: sourceDocument.FilePath);
         var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, progress.CreateChild(0.8, 0.95));
         var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
         var manifestPath = pathService.GetFaceManifestPath(loadedProject, title);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -151,7 +151,7 @@ public sealed class DocumentWorkspaceViewModel
     }
 
 
-    public DocumentTabViewModel? GenerateFaceFromSelectedFaceSourceShape(FaceGenerationSettingsModel? generationSettings = null, IEditorProgressReporter? progress = null)
+    public DocumentTabViewModel? GenerateFaceFromSelectedFaceSourceShape(string? faceAssetName = null, FaceGenerationSettingsModel? generationSettings = null, IEditorProgressReporter? progress = null)
     {
         var sourceDocument = _getSelectedDocument();
         var loadedProject = _getLoadedProject();
@@ -165,7 +165,9 @@ public sealed class DocumentWorkspaceViewModel
             ? (double?)null
             : (target.Corners[1] - target.Corners[0]).Length / Math.Max(0.0001, (target.Corners[3] - target.Corners[0]).Length);
         progress ??= NoOpEditorProgressReporter.Instance;
-        var title = $"{sourceDocument.Title} Face";
+        var pathService = new ProjectAssetPathService();
+        var title = pathService.EnsureUniqueAssetName(loadedProject, EditorAssetType.Face, string.IsNullOrWhiteSpace(faceAssetName) ? $"{sourceDocument.Title} Face" : faceAssetName);
+        pathService.CreateAssetPackageDirectory(loadedProject, EditorAssetType.Face, title);
         var result = _faceGenerationService.GenerateFromPanelFaceSourceShape(
             sourceDocument.GetPanelDocument(),
             shape,
@@ -175,12 +177,15 @@ public sealed class DocumentWorkspaceViewModel
             targetAspect,
             loadedProject.ProjectDirectory,
             loadedProject.GeneratedDirectory,
+            title,
             generationSettings,
             progress.CreateChild(0.0, 0.8),
             sourceDocument.FilePath);
         var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, progress.CreateChild(0.8, 0.95));
         var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
-        var faceEditorDocument = EditorDocument.CreateFaceStub(title).WithContentSummary(generatedFaceDocument.Summary ?? "Generated Face document.");
+        var manifestPath = pathService.GetFaceManifestPath(loadedProject, title);
+        System.IO.File.WriteAllText(manifestPath, faceJson);
+        var faceEditorDocument = EditorDocument.CreateFromFile(manifestPath, generatedFaceDocument.Summary ?? "Generated Face document.", title);
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Generated face document from Face Source Shape '{shape.Name}'.");
@@ -295,6 +300,7 @@ public sealed class DocumentWorkspaceViewModel
             sourcePanelDocument.GetPanelDocument(),
             loadedProject.ProjectDirectory,
             loadedProject.GeneratedDirectory,
+            title,
             generationSettings,
             progress.CreateChild(0.0, 0.8));
 


### PR DESCRIPTION
### Motivation

- Move the editor to a folder-as-asset storage model so the asset folder is the asset and manifests inside packages are fixed filenames (no `<Name>.face/.panel2d/.cabinet3d`).
- Keep authored/user-editable content under `Assets/` and disposable runtime/export output under `Generated/` so authored `artwork.png`/`mask.png` are protected from runtime exports.
- Centralize path construction and sanitization to avoid ad-hoc string paths scattered across generation/export/save code.

### Description

- Added a centralized path/service `ProjectAssetPathService` with APIs to sanitize names, resolve package directories, return fixed manifest paths (`asset.face`, `asset.panel2d`, `asset.cabinet3d`), authored face paths (`artwork.png`, `mask.png`), and runtime directories (`Generated/Faces/<AssetName>/runtime/`).
- Updated Face creation flow to prompt / ensure a unique face asset name, create `Assets/Faces/<AssetName>/`, write the face manifest to `Assets/Faces/<AssetName>/asset.face`, and save authored `artwork.png` and `mask.png` into that package via changes in `DocumentWorkspaceViewModel` and `FaceGenerationService`.
- Kept per-lamp transformed masks out of authored packages by redirecting composite authored mask and artwork into the Face package and keeping per-lamp intermediates as generated/disposable outputs.
- Changed `FaceRuntimeExportService` to resolve runtime output via the new service so runtime exports go to `Generated/Faces/<AssetName>/runtime/` and no longer overwrite authored `Assets` files.
- Updated save/first-save UI behavior to create package manifests for Panel2D/Face/Cabinet3D assets (via `MainWindowViewModel.PromptSavePath`) and preserved the GLB protection behavior for Cabinet3D models.
- Project scaffolding now ensures `Assets/Faces` exists and a new unit test `ProjectAssetPathServiceTests` was added; `FaceRuntimeExportServiceTests` was updated to match the new runtime path expectations.

### Testing

- No automated tests were executed in this Codex environment per `AGENTS.md` and project constraints; please run the test suite locally (for example `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests`).
- Added unit test `OasisEditor.Tests/ProjectAssetPathServiceTests` that validates manifest, authored, and runtime path resolution and deterministic collision suffix behavior.
- Updated `OasisEditor.Tests/FaceRuntimeExportServiceTests` to assert runtime outputs under `Generated/Faces/<AssetName>/runtime/` instead of GUID-only folders.
- Recommended local verification: run `dotnet test` and exercise WPF flows to create/save Panel2D/Face/Cabinet3D assets and confirm files appear at `Assets/Panel2D/<Name>/asset.panel2d`, `Assets/Faces/<Name>/asset.face + artwork.png + mask.png`, and `Generated/Faces/<Name>/runtime/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a440ad1f38c8327a6625448171928e6)