### PR TITLE
Harden Face asset package identity

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -13,6 +13,7 @@ public sealed class FaceDocumentRoundTripTests
         {
             Id = "face-1",
             Title = "Front Face",
+            AssetName = "Front Face Package",
             Summary = "Physical face summary",
             MaskLayer = new FaceMaskLayerModel
             {
@@ -118,6 +119,7 @@ public sealed class FaceDocumentRoundTripTests
         var savedContent = DocumentWorkspaceViewModel.BuildDocumentContent(document);
 
         Assert.True(FaceDocumentStorage.TryRead(savedContent, out var savedDocument));
+        Assert.Equal("Front Face Package", savedDocument.AssetName);
         Assert.Equal(FaceDocumentStorage.CurrentSchemaVersion, savedDocument.SchemaVersion);
         Assert.Equal("face-1", savedDocument.Id);
         Assert.Equal("Front Face", savedDocument.Title);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationSettingsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationSettingsTests.cs
@@ -69,6 +69,38 @@ public sealed class FaceGenerationSettingsTests
 
 
     [Fact]
+    public void Regenerate_UsesStableAssetNameWhenTitleChanges()
+    {
+        var projectDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceRegenerationTests-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(projectDirectory);
+            var existingFace = new FaceDocumentModel
+            {
+                Id = "face-1",
+                Title = "Renamed Face",
+                AssetName = "Stable Face",
+                SourcePanel2DDocumentId = "panel-doc",
+                SourceFaceShapeId = "shape-1",
+                SourceRegion = FaceSourceRegionModel.FromRect(new Rect(0, 0, 100, 100)),
+                GenerationSettings = FaceGenerationSettingsModel.Default
+            };
+
+            var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape(), projectDirectory, Path.Combine(projectDirectory, "Generated"));
+
+            Assert.Equal("Renamed Face", result.Document.Title);
+            Assert.Equal("Stable Face", result.Document.AssetName);
+            Assert.Equal("Assets/Faces/Stable Face/mask.png", result.Document.MaskLayer!.AssetPath);
+            Assert.True(File.Exists(Path.Combine(projectDirectory, "Assets", "Faces", "Stable Face", "mask.png")));
+            Assert.False(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Faces", "Renamed Face")));
+        }
+        finally
+        {
+            if (Directory.Exists(projectDirectory)) Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Regenerate_UsesExistingFaceSettingsWhenNoOverrideIsProvided()
     {
         var existingFace = new FaceDocumentModel

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -64,6 +64,30 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     }
 
     [Fact]
+    public void Export_UsesStableFaceAssetNameWhenTitleChanges_AndDoesNotOverwriteAuthoredAssets()
+    {
+        var authoredDirectory = Path.Combine(_assetsDirectory, "Faces", "Stable Face");
+        var authoredArtworkPath = Path.Combine(authoredDirectory, "artwork.png");
+        var authoredMaskPath = Path.Combine(authoredDirectory, "mask.png");
+        WriteSolidPng(authoredArtworkPath, 4, 4, SKColors.Red);
+        WriteSolidPng(authoredMaskPath, 4, 4, SKColors.White);
+        var artworkBefore = File.ReadAllBytes(authoredArtworkPath);
+        var maskBefore = File.ReadAllBytes(authoredMaskPath);
+
+        var document = CreateDocument("Assets/Faces/Stable Face/artwork.png", "Assets/Faces/Stable Face/mask.png", "Stable Face", "Renamed In Inspector");
+
+        var result = new FaceRuntimeExportService().Export(document, CreateProject());
+
+        Assert.Equal(Path.Combine(_generatedDirectory, "Faces", "Stable Face", "runtime"), result.OutputDirectory);
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Stable Face", "runtime", "artwork.png")));
+        Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Stable Face", "runtime", "mask.png")));
+        Assert.Equal("Generated/Faces/Stable Face/runtime/artwork.png", result.Document.RuntimeRenderAssets!.ArtworkPath);
+        Assert.Equal(artworkBefore, File.ReadAllBytes(authoredArtworkPath));
+        Assert.Equal(maskBefore, File.ReadAllBytes(authoredMaskPath));
+        Assert.False(Directory.Exists(Path.Combine(_generatedDirectory, "Faces", "Renamed In Inspector")));
+    }
+
+    [Fact]
     public void Export_WritesManifestArtworkAndMask_AndUpdatesDocumentRuntimeAssets()
     {
         var artworkPath = Path.Combine(_assetsDirectory, "artwork.png");
@@ -715,12 +739,13 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         };
     }
 
-    private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath)
+    private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath, string? assetName = null, string title = "Runtime Face")
     {
         return new FaceDocumentModel
         {
             Id = "face-runtime",
-            Title = "Runtime Face",
+            Title = title,
+            AssetName = assetName,
             SourceRegion = new FaceSourceRegionModel
             {
                 X = 0,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -4,6 +4,7 @@ public sealed class FaceDocumentModel
 {
     public string Id { get; init; } = Guid.NewGuid().ToString("N");
     public string Title { get; init; } = string.Empty;
+    public string? AssetName { get; init; }
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public string? SourcePanel2DDocumentPath { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -157,6 +157,7 @@ public static class FaceDocumentStorage
         {
             Id = string.IsNullOrWhiteSpace(file.Id) ? Guid.NewGuid().ToString("N") : file.Id.Trim(),
             Title = file.Title ?? string.Empty,
+            AssetName = string.IsNullOrWhiteSpace(file.AssetName) ? null : file.AssetName.Trim(),
             Summary = file.Summary,
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
             SourcePanel2DDocumentPath = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentPath) ? null : file.SourcePanel2DDocumentPath.Trim(),
@@ -192,6 +193,7 @@ public static class FaceDocumentStorage
             SchemaVersion = CurrentSchemaVersion,
             Id = string.IsNullOrWhiteSpace(model.Id) ? Guid.NewGuid().ToString("N") : model.Id.Trim(),
             Title = model.Title,
+            AssetName = string.IsNullOrWhiteSpace(model.AssetName) ? null : model.AssetName.Trim(),
             Summary = model.Summary,
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = string.IsNullOrWhiteSpace(model.SourcePanel2DDocumentPath) ? null : model.SourcePanel2DDocumentPath.Trim(),
@@ -759,6 +761,7 @@ public sealed record FaceDocumentFile
     public int SchemaVersion { get; init; } = FaceDocumentStorage.CurrentSchemaVersion;
     public string? Id { get; init; }
     public string? Title { get; init; }
+    public string? AssetName { get; init; }
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public string? SourcePanel2DDocumentPath { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -149,6 +149,7 @@ internal sealed class FaceGenerationService
         {
             Id = faceDocumentId,
             Title = resolvedFaceAssetName,
+            AssetName = resolvedFaceAssetName,
             Summary = $"Generated from Face Source Shape '{sourceShape.Name}' ({output.Width} x {output.Height}).",
             SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
             SourceFaceShapeId = NormalizeOptional(sourceShape.Id),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -83,7 +83,7 @@ internal sealed class FaceRegenerationService
             targetAspectRatio: targetAspectRatio,
             projectDirectory: projectDirectory,
             generatedDirectory: generatedDirectory,
-            faceAssetName: existingFace.Title,
+            faceAssetName: ResolveFaceAssetName(existingFace),
             generationSettings: settings,
             progress: progress.CreateChild(0.15, 0.45),
             sourcePanel2DDocumentPath: existingFace.SourcePanel2DDocumentPath);
@@ -145,6 +145,7 @@ internal sealed class FaceRegenerationService
         {
             Id = existingFace.Id,
             Title = existingFace.Title,
+            AssetName = ResolveFaceAssetName(existingFace),
             Summary = generated.Document.Summary ?? $"Regenerated from Face Source Shape.",
             SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = existingFace.SourcePanel2DDocumentPath,
@@ -168,6 +169,36 @@ internal sealed class FaceRegenerationService
             removedGeneratedElementCount,
             preservedManualElements.Count,
             generated);
+    }
+
+
+    private static string ResolveFaceAssetName(FaceDocumentModel faceDocument)
+    {
+        if (!string.IsNullOrWhiteSpace(faceDocument.AssetName))
+        {
+            return faceDocument.AssetName.Trim();
+        }
+
+        var packageAssetName = TryGetAssetNameFromFacePackagePath(faceDocument.MaskLayer?.AssetPath)
+            ?? faceDocument.Elements.OfType<FaceArtworkElement>().Select(element => TryGetAssetNameFromFacePackagePath(element.AssetPath)).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+        if (!string.IsNullOrWhiteSpace(packageAssetName))
+        {
+            return packageAssetName;
+        }
+
+        return string.IsNullOrWhiteSpace(faceDocument.Title) ? faceDocument.Id : faceDocument.Title.Trim();
+    }
+
+    private static string? TryGetAssetNameFromFacePackagePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        var normalized = ProjectAssetPathService.NormalizeProjectRelativePath(path.Trim());
+        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 4
+            && string.Equals(parts[0], "Assets", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(parts[1], "Faces", StringComparison.OrdinalIgnoreCase)
+            ? parts[2]
+            : null;
     }
 
     private static IReadOnlyList<FaceLayerModel> EnsureFaceMaskLayer(IReadOnlyList<FaceLayerModel> layers)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -88,6 +88,7 @@ public sealed class FaceRuntimeExportService
         {
             Id = faceDocument.Id,
             Title = faceDocument.Title,
+            AssetName = faceDocument.AssetName,
             Summary = faceDocument.Summary,
             SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
@@ -213,10 +214,39 @@ public sealed class FaceRuntimeExportService
             throw new IOException($"Project Generated directory points to a file: {generatedDirectory}");
         }
 
-        var faceName = string.IsNullOrWhiteSpace(faceDocument.Title)
+        var faceName = ResolveFaceAssetName(faceDocument);
+        return new ProjectAssetPathService().GetFaceRuntimeDirectory(project, faceName);
+    }
+
+    private static string ResolveFaceAssetName(FaceDocumentModel faceDocument)
+    {
+        if (!string.IsNullOrWhiteSpace(faceDocument.AssetName))
+        {
+            return faceDocument.AssetName.Trim();
+        }
+
+        var packageAssetName = TryGetAssetNameFromFacePackagePath(faceDocument.MaskLayer?.AssetPath)
+            ?? faceDocument.Elements.OfType<FaceArtworkElement>().Select(element => TryGetAssetNameFromFacePackagePath(element.AssetPath)).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+        if (!string.IsNullOrWhiteSpace(packageAssetName))
+        {
+            return packageAssetName;
+        }
+
+        return string.IsNullOrWhiteSpace(faceDocument.Title)
             ? (string.IsNullOrWhiteSpace(faceDocument.Id) ? Guid.NewGuid().ToString("N") : faceDocument.Id.Trim())
             : faceDocument.Title.Trim();
-        return new ProjectAssetPathService().GetFaceRuntimeDirectory(project, faceName);
+    }
+
+    private static string? TryGetAssetNameFromFacePackagePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        var normalized = ProjectAssetPathService.NormalizeProjectRelativePath(path.Trim());
+        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 4
+            && string.Equals(parts[0], "Assets", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(parts[1], "Faces", StringComparison.OrdinalIgnoreCase)
+            ? parts[2]
+            : null;
     }
 
     private static string ResolveExistingProjectPath(EditorProject project, string? projectPath, string description)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -209,6 +209,7 @@ public sealed class DocumentWorkspaceViewModel
             {
                 Id = faceDocument.Id,
                 Title = faceDocument.Title,
+                AssetName = faceDocument.AssetName,
                 Summary = faceDocument.Summary,
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
@@ -697,6 +698,10 @@ public sealed class DocumentWorkspaceViewModel
                 var title = string.IsNullOrWhiteSpace(faceDocument.Title)
                     ? Path.GetFileName(path)
                     : faceDocument.Title.Trim();
+                var assetName = string.IsNullOrWhiteSpace(faceDocument.AssetName)
+                    ? Path.GetFileName(Path.GetDirectoryName(path) ?? string.Empty)
+                    : faceDocument.AssetName.Trim();
+                faceDocument = faceDocument with { AssetName = string.IsNullOrWhiteSpace(assetName) ? null : assetName };
                 return new OpenDocumentData(summary, null, title, FaceDocumentStorage.Serialize(faceDocument));
             }
 
@@ -745,6 +750,7 @@ public sealed class DocumentWorkspaceViewModel
             {
                 Id = faceDocument.Id,
                 Title = document.Document.Title,
+                AssetName = faceDocument.AssetName,
                 Summary = document.ContentSummary,
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,


### PR DESCRIPTION
### Motivation

- Decouple an asset package's stable identity from the mutable `Title` to prevent runtime/regeneration output from drifting when users rename the document in the inspector.
- Ensure generated/regen outputs are written into the existing folder-as-asset package when available, and avoid overwriting authored `artwork.png`/`mask.png` except when explicitly regenerating.
- Preserve or infer stable package identity where practical so runtime export and generation use the package location rather than a transient title string.

### Description

- Add `AssetName` to `FaceDocumentModel` and round-trip it through `FaceDocumentStorage` so package identity is explicit in the face manifest (`asset.face`).
- Set `AssetName` during new Face creation in `FaceGenerationService` (`AssetName = resolvedFaceAssetName`) so newly-created packages carry a stable name separate from the display `Title`.
- Update regeneration to use `ResolveFaceAssetName(...)` (in `FaceRegenerationService`) so `faceAssetName` is derived from `AssetName` or inferred from authored package paths, preventing regeneration from creating a new package when the `Title` changed.
- Update runtime export to resolve runtime output using the package identity via `ResolveFaceAssetName(...)` (in `FaceRuntimeExportService`) so runtime output goes to `Generated/Faces/<AssetName>/runtime` when `AssetName` or package-derived paths exist.
- Preserve `AssetName` through open/save flows in `DocumentWorkspaceViewModel` by inferring an `assetName` from the manifest file path when missing and persisting it on save.
- Add focused tests: a round-trip test for `AssetName` in manifest serialization, a regeneration test verifying stable `AssetName` is used when `Title` changes, and a runtime-export test verifying generated runtime files are placed under `Generated/Faces/<AssetName>/runtime` and authored `Assets/Faces/<AssetName>/artwork.png` and `mask.png` are not overwritten by the export.

### Testing

- No automated tests were executed in this environment per project constraints; local verification is required.
- Added/updated automated tests to run locally: `FaceDocumentRoundTripTests.Serialize_AndOpen_RoundTripsFaceDocument`, `FaceGenerationSettingsTests.Regenerate_UsesStableAssetNameWhenTitleChanges`, and `FaceRuntimeExportServiceTests.Export_UsesStableFaceAssetNameWhenTitleChanges_AndDoesNotOverwriteAuthoredAssets`.
- Recommended local verification commands: `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj --filter "FaceGenerationSettingsTests|FaceRuntimeExportServiceTests|FaceDocumentRoundTripTests"` and then `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` for the full suite.
- `git diff --check` was run to ensure no whitespace errors; run the above tests locally and report any failures for iterative fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a44122c8fec8327bafdddb37d6db417)