### PR TITLE
Make Face packages the source of truth

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -8,12 +8,11 @@ public sealed class FaceDocumentRoundTripTests
     [Fact]
     public void Serialize_AndOpen_RoundTripsFaceDocument()
     {
-        const string path = "C:/Repo/Assets/sample.face";
+        const string path = "C:/Repo/Assets/Faces/Front Face/asset.face";
         var source = new FaceDocumentModel
         {
             Id = "face-1",
             Title = "Front Face",
-            AssetName = "Front Face Package",
             Summary = "Physical face summary",
             MaskLayer = new FaceMaskLayerModel
             {
@@ -119,7 +118,6 @@ public sealed class FaceDocumentRoundTripTests
         var savedContent = DocumentWorkspaceViewModel.BuildDocumentContent(document);
 
         Assert.True(FaceDocumentStorage.TryRead(savedContent, out var savedDocument));
-        Assert.Equal("Front Face Package", savedDocument.AssetName);
         Assert.Equal(FaceDocumentStorage.CurrentSchemaVersion, savedDocument.SchemaVersion);
         Assert.Equal("face-1", savedDocument.Id);
         Assert.Equal("Front Face", savedDocument.Title);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationSettingsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationSettingsTests.cs
@@ -69,7 +69,7 @@ public sealed class FaceGenerationSettingsTests
 
 
     [Fact]
-    public void Regenerate_UsesStableAssetNameWhenTitleChanges()
+    public void Regenerate_UsesFacePackageFolderNameWhenTitleChanges()
     {
         var projectDirectory = Path.Combine(Path.GetTempPath(), $"OasisFaceRegenerationTests-{Guid.NewGuid():N}");
         try
@@ -79,17 +79,15 @@ public sealed class FaceGenerationSettingsTests
             {
                 Id = "face-1",
                 Title = "Renamed Face",
-                AssetName = "Stable Face",
                 SourcePanel2DDocumentId = "panel-doc",
                 SourceFaceShapeId = "shape-1",
                 SourceRegion = FaceSourceRegionModel.FromRect(new Rect(0, 0, 100, 100)),
                 GenerationSettings = FaceGenerationSettingsModel.Default
             };
 
-            var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape(), projectDirectory, Path.Combine(projectDirectory, "Generated"));
+            var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape(), projectDirectory, Path.Combine(projectDirectory, "Generated"), documentPath: Path.Combine(projectDirectory, "Assets", "Faces", "Stable Face", "asset.face"));
 
             Assert.Equal("Renamed Face", result.Document.Title);
-            Assert.Equal("Stable Face", result.Document.AssetName);
             Assert.Equal("Assets/Faces/Stable Face/mask.png", result.Document.MaskLayer!.AssetPath);
             Assert.True(File.Exists(Path.Combine(projectDirectory, "Assets", "Faces", "Stable Face", "mask.png")));
             Assert.False(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Faces", "Renamed Face")));
@@ -118,7 +116,7 @@ public sealed class FaceGenerationSettingsTests
             }
         };
 
-        var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape());
+        var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape(), documentPath: "Assets/Faces/Face/asset.face");
 
         Assert.Equal(13, result.Document.GenerationSettings.MaskExtractionThreshold);
     }
@@ -144,7 +142,8 @@ public sealed class FaceGenerationSettingsTests
                 MaskExtractionThreshold = 31,
                 TrayBoundsInflationPercent = 0,
                 TrayBoundsPaddingPixels = 0
-            });
+            },
+            documentPath: "Assets/Faces/Face/asset.face");
 
         Assert.Equal(31, result.Document.GenerationSettings.MaskExtractionThreshold);
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -800,7 +800,6 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
 
 
 
-    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocumentWithLampWindows(params FaceLampWindowElement[] lampWindows)
     {
@@ -813,7 +812,6 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         };
     }
 
-    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocumentWithAuthoredTrayAndEmitter(
         FaceSourceRegionModel trayBounds,
@@ -857,7 +855,6 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         };
     }
 
-    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocumentWithAuthoredTrayAndEmitters(FaceSourceRegionModel trayBounds, params TestEmitter[] emitters)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -149,7 +149,8 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     {
         var artworkPath = Path.Combine(_assetsDirectory, "artwork.png");
         var maskPath = Path.Combine(_generatedDirectory, "source-mask.png");
-        var facePath = Path.Combine(_projectDirectory, "front.face");
+        var facePath = GetFaceManifestPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(facePath)!);
         WriteSolidPng(artworkPath, 4, 4, new SKColor(0, 255, 0, 192));
         WriteSolidPng(maskPath, 4, 4, SKColors.White);
         var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -74,9 +74,9 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var artworkBefore = File.ReadAllBytes(authoredArtworkPath);
         var maskBefore = File.ReadAllBytes(authoredMaskPath);
 
-        var document = CreateDocument("Assets/Faces/Stable Face/artwork.png", "Assets/Faces/Stable Face/mask.png", "Stable Face", "Renamed In Inspector");
+        var document = CreateDocument("Assets/Faces/Stable Face/artwork.png", "Assets/Faces/Stable Face/mask.png", "Renamed In Inspector");
 
-        var result = new FaceRuntimeExportService().Export(document, CreateProject());
+        var result = new FaceRuntimeExportService().Export(document, CreateProject(), GetFaceManifestPath("Stable Face"));
 
         Assert.Equal(Path.Combine(_generatedDirectory, "Faces", "Stable Face", "runtime"), result.OutputDirectory);
         Assert.True(File.Exists(Path.Combine(_generatedDirectory, "Faces", "Stable Face", "runtime", "artwork.png")));
@@ -97,7 +97,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
         var project = CreateProject();
 
-        var result = new FaceRuntimeExportService().Export(document, project);
+        var result = new FaceRuntimeExportService().Export(document, project, GetFaceManifestPath());
 
         Assert.True(File.Exists(result.ManifestPath));
         Assert.True(File.Exists(result.ArtworkPath));
@@ -269,7 +269,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         WriteSolidPng(maskPath, 4, 4, SKColors.White);
         var document = CreateDocument("Assets/missing.png", "Generated/source-mask.png");
 
-        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject()));
+        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject(), GetFaceManifestPath()));
         Assert.Contains("Artwork element", exception.Message);
     }
 
@@ -280,7 +280,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         WriteSolidPng(artworkPath, 4, 4, SKColors.Red);
         var document = CreateDocument("Assets/artwork.png", "Generated/missing-mask.png");
 
-        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject()));
+        var exception = Assert.Throws<FileNotFoundException>(() => new FaceRuntimeExportService().Export(document, CreateProject(), GetFaceManifestPath()));
         Assert.Contains("Face mask layer", exception.Message);
     }
 
@@ -739,13 +739,14 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         };
     }
 
-    private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath, string? assetName = null, string title = "Runtime Face")
+    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
+
+    private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath, string title = "Runtime Face")
     {
         return new FaceDocumentModel
         {
             Id = "face-runtime",
             Title = title,
-            AssetName = assetName,
             SourceRegion = new FaceSourceRegionModel
             {
                 X = 0,
@@ -799,6 +800,8 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
 
 
 
+    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
+
     private static FaceDocumentModel CreateDocumentWithLampWindows(params FaceLampWindowElement[] lampWindows)
     {
         return new FaceDocumentModel
@@ -809,6 +812,8 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
             Elements = lampWindows
         };
     }
+
+    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocumentWithAuthoredTrayAndEmitter(
         FaceSourceRegionModel trayBounds,
@@ -851,6 +856,8 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
             ]
         };
     }
+
+    private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocumentWithAuthoredTrayAndEmitters(FaceSourceRegionModel trayBounds, params TestEmitter[] emitters)
     {
@@ -912,10 +919,10 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var document = CreateDocument("Assets/progress-artwork.png", "Generated/progress-mask.png");
         var project = CreateProject();
         var service = new FaceRuntimeExportService();
-        var baseline = service.Export(document, project);
+        var baseline = service.Export(document, project, GetFaceManifestPath());
         var progress = new RecordingEditorProgressReporter();
 
-        var result = service.Export(document, project, progress);
+        var result = service.Export(document, project, GetFaceManifestPath(), progress);
 
         Assert.Equal(baseline.Document.RuntimeRenderAssets!.ManifestPath, result.Document.RuntimeRenderAssets!.ManifestPath);
         Assert.Equal(baseline.Document.RuntimeRenderAssets.ArtworkPath, result.Document.RuntimeRenderAssets.ArtworkPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -69,7 +69,7 @@ public sealed class DocumentSaveService : IDocumentSaveService
         if (current.Document.DocumentType == EditorDocumentType.Face && project is not null)
         {
             progress.Report(0.15, "Exporting Face runtime assets...");
-            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, current.Document.FilePath, progress.CreateChild(0.15, 0.75));
+            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, savePath, progress.CreateChild(0.15, 0.75));
             faceDocumentJson = FaceDocumentStorage.Serialize(exportResult.Document);
             contentSource = new DocumentTabViewModel(
                 current.Document,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -69,7 +69,7 @@ public sealed class DocumentSaveService : IDocumentSaveService
         if (current.Document.DocumentType == EditorDocumentType.Face && project is not null)
         {
             progress.Report(0.15, "Exporting Face runtime assets...");
-            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, progress.CreateChild(0.15, 0.75));
+            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, current.Document.FilePath, progress.CreateChild(0.15, 0.75));
             faceDocumentJson = FaceDocumentStorage.Serialize(exportResult.Document);
             contentSource = new DocumentTabViewModel(
                 current.Document,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentModel.cs
@@ -4,7 +4,6 @@ public sealed class FaceDocumentModel
 {
     public string Id { get; init; } = Guid.NewGuid().ToString("N");
     public string Title { get; init; } = string.Empty;
-    public string? AssetName { get; init; }
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public string? SourcePanel2DDocumentPath { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -157,7 +157,6 @@ public static class FaceDocumentStorage
         {
             Id = string.IsNullOrWhiteSpace(file.Id) ? Guid.NewGuid().ToString("N") : file.Id.Trim(),
             Title = file.Title ?? string.Empty,
-            AssetName = string.IsNullOrWhiteSpace(file.AssetName) ? null : file.AssetName.Trim(),
             Summary = file.Summary,
             SourcePanel2DDocumentId = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentId) ? null : file.SourcePanel2DDocumentId.Trim(),
             SourcePanel2DDocumentPath = string.IsNullOrWhiteSpace(file.SourcePanel2DDocumentPath) ? null : file.SourcePanel2DDocumentPath.Trim(),
@@ -193,7 +192,6 @@ public static class FaceDocumentStorage
             SchemaVersion = CurrentSchemaVersion,
             Id = string.IsNullOrWhiteSpace(model.Id) ? Guid.NewGuid().ToString("N") : model.Id.Trim(),
             Title = model.Title,
-            AssetName = string.IsNullOrWhiteSpace(model.AssetName) ? null : model.AssetName.Trim(),
             Summary = model.Summary,
             SourcePanel2DDocumentId = model.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = string.IsNullOrWhiteSpace(model.SourcePanel2DDocumentPath) ? null : model.SourcePanel2DDocumentPath.Trim(),
@@ -761,7 +759,6 @@ public sealed record FaceDocumentFile
     public int SchemaVersion { get; init; } = FaceDocumentStorage.CurrentSchemaVersion;
     public string? Id { get; init; }
     public string? Title { get; init; }
-    public string? AssetName { get; init; }
     public string? Summary { get; init; }
     public string? SourcePanel2DDocumentId { get; init; }
     public string? SourcePanel2DDocumentPath { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -149,7 +149,6 @@ internal sealed class FaceGenerationService
         {
             Id = faceDocumentId,
             Title = resolvedFaceAssetName,
-            AssetName = resolvedFaceAssetName,
             Summary = $"Generated from Face Source Shape '{sourceShape.Name}' ({output.Width} x {output.Height}).",
             SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
             SourceFaceShapeId = NormalizeOptional(sourceShape.Id),

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRegenerationService.cs
@@ -38,7 +38,8 @@ internal sealed class FaceRegenerationService
         string? projectDirectory = null,
         string? generatedDirectory = null,
         FaceGenerationSettingsModel? generationSettings = null,
-        IEditorProgressReporter? progress = null)
+        IEditorProgressReporter? progress = null,
+        string? documentPath = null)
     {
         ArgumentNullException.ThrowIfNull(existingFace);
         ArgumentNullException.ThrowIfNull(sourcePanel);
@@ -83,7 +84,7 @@ internal sealed class FaceRegenerationService
             targetAspectRatio: targetAspectRatio,
             projectDirectory: projectDirectory,
             generatedDirectory: generatedDirectory,
-            faceAssetName: ResolveFaceAssetName(existingFace),
+            faceAssetName: ResolveFaceAssetName(documentPath),
             generationSettings: settings,
             progress: progress.CreateChild(0.15, 0.45),
             sourcePanel2DDocumentPath: existingFace.SourcePanel2DDocumentPath);
@@ -145,7 +146,6 @@ internal sealed class FaceRegenerationService
         {
             Id = existingFace.Id,
             Title = existingFace.Title,
-            AssetName = ResolveFaceAssetName(existingFace),
             Summary = generated.Document.Summary ?? $"Regenerated from Face Source Shape.",
             SourcePanel2DDocumentId = existingFace.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = existingFace.SourcePanel2DDocumentPath,
@@ -172,33 +172,15 @@ internal sealed class FaceRegenerationService
     }
 
 
-    private static string ResolveFaceAssetName(FaceDocumentModel faceDocument)
+    private static string ResolveFaceAssetName(string? documentPath)
     {
-        if (!string.IsNullOrWhiteSpace(faceDocument.AssetName))
+        var assetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(documentPath ?? string.Empty, EditorAssetType.Face);
+        if (string.IsNullOrWhiteSpace(assetName))
         {
-            return faceDocument.AssetName.Trim();
+            throw new InvalidOperationException("Face regeneration requires a Face package manifest path: Assets/Faces/<AssetName>/asset.face.");
         }
 
-        var packageAssetName = TryGetAssetNameFromFacePackagePath(faceDocument.MaskLayer?.AssetPath)
-            ?? faceDocument.Elements.OfType<FaceArtworkElement>().Select(element => TryGetAssetNameFromFacePackagePath(element.AssetPath)).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
-        if (!string.IsNullOrWhiteSpace(packageAssetName))
-        {
-            return packageAssetName;
-        }
-
-        return string.IsNullOrWhiteSpace(faceDocument.Title) ? faceDocument.Id : faceDocument.Title.Trim();
-    }
-
-    private static string? TryGetAssetNameFromFacePackagePath(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        var normalized = ProjectAssetPathService.NormalizeProjectRelativePath(path.Trim());
-        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length >= 4
-            && string.Equals(parts[0], "Assets", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(parts[1], "Faces", StringComparison.OrdinalIgnoreCase)
-            ? parts[2]
-            : null;
+        return assetName;
     }
 
     private static IReadOnlyList<FaceLayerModel> EnsureFaceMaskLayer(IReadOnlyList<FaceLayerModel> layers)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -29,7 +29,7 @@ public sealed class FaceRuntimeExportService
         Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
     };
 
-    public FaceRuntimeExportResult Export(FaceDocumentModel faceDocument, EditorProject project, IEditorProgressReporter? progress = null)
+    public FaceRuntimeExportResult Export(FaceDocumentModel faceDocument, EditorProject project, string? documentPath = null, IEditorProgressReporter? progress = null)
     {
         ArgumentNullException.ThrowIfNull(faceDocument);
         ArgumentNullException.ThrowIfNull(project);
@@ -43,7 +43,7 @@ public sealed class FaceRuntimeExportService
 
         var width = ResolveRuntimeWidth(faceDocument);
         var height = ResolveRuntimeHeight(faceDocument);
-        var outputDirectory = ResolveRuntimeOutputDirectory(faceDocument, project);
+        var outputDirectory = ResolveRuntimeOutputDirectory(project, documentPath);
         Directory.CreateDirectory(outputDirectory);
 
         if (!Directory.Exists(outputDirectory))
@@ -88,7 +88,6 @@ public sealed class FaceRuntimeExportService
         {
             Id = faceDocument.Id,
             Title = faceDocument.Title,
-            AssetName = faceDocument.AssetName,
             Summary = faceDocument.Summary,
             SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
             SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
@@ -201,7 +200,7 @@ public sealed class FaceRuntimeExportService
         File.Copy(sourcePath, outputPath, overwrite: true);
     }
 
-    private static string ResolveRuntimeOutputDirectory(FaceDocumentModel faceDocument, EditorProject project)
+    private static string ResolveRuntimeOutputDirectory(EditorProject project, string? documentPath)
     {
         if (string.IsNullOrWhiteSpace(project.GeneratedDirectory))
         {
@@ -214,39 +213,13 @@ public sealed class FaceRuntimeExportService
             throw new IOException($"Project Generated directory points to a file: {generatedDirectory}");
         }
 
-        var faceName = ResolveFaceAssetName(faceDocument);
+        var faceName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(documentPath ?? string.Empty, EditorAssetType.Face);
+        if (string.IsNullOrWhiteSpace(faceName))
+        {
+            throw new InvalidOperationException("Face runtime export requires a Face package manifest path: Assets/Faces/<AssetName>/asset.face.");
+        }
+
         return new ProjectAssetPathService().GetFaceRuntimeDirectory(project, faceName);
-    }
-
-    private static string ResolveFaceAssetName(FaceDocumentModel faceDocument)
-    {
-        if (!string.IsNullOrWhiteSpace(faceDocument.AssetName))
-        {
-            return faceDocument.AssetName.Trim();
-        }
-
-        var packageAssetName = TryGetAssetNameFromFacePackagePath(faceDocument.MaskLayer?.AssetPath)
-            ?? faceDocument.Elements.OfType<FaceArtworkElement>().Select(element => TryGetAssetNameFromFacePackagePath(element.AssetPath)).FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
-        if (!string.IsNullOrWhiteSpace(packageAssetName))
-        {
-            return packageAssetName;
-        }
-
-        return string.IsNullOrWhiteSpace(faceDocument.Title)
-            ? (string.IsNullOrWhiteSpace(faceDocument.Id) ? Guid.NewGuid().ToString("N") : faceDocument.Id.Trim())
-            : faceDocument.Title.Trim();
-    }
-
-    private static string? TryGetAssetNameFromFacePackagePath(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        var normalized = ProjectAssetPathService.NormalizeProjectRelativePath(path.Trim());
-        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length >= 4
-            && string.Equals(parts[0], "Assets", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(parts[1], "Faces", StringComparison.OrdinalIgnoreCase)
-            ? parts[2]
-            : null;
     }
 
     private static string ResolveExistingProjectPath(EditorProject project, string? projectPath, string description)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
@@ -51,6 +51,18 @@ public sealed class ProjectAssetPathService
     public string GetFaceMaskPath(EditorProject project, string assetName) => Path.Combine(GetAssetPackageDirectory(project, EditorAssetType.Face, assetName), FaceMaskFileName);
     public string GetFaceRuntimeDirectory(EditorProject project, string assetName) => Path.Combine(project.GeneratedDirectory, "Faces", SanitizePathSegment(assetName), FaceRuntimeExportService.RuntimeDirectoryName);
 
+    public static string? GetPackageAssetNameFromManifestPath(string manifestPath, EditorAssetType assetType)
+    {
+        if (string.IsNullOrWhiteSpace(manifestPath)) return null;
+        var fullPath = Path.GetFullPath(manifestPath);
+        if (!string.Equals(Path.GetFileName(fullPath), GetManifestFileName(assetType), StringComparison.OrdinalIgnoreCase)) return null;
+        var packageDirectory = Path.GetDirectoryName(fullPath);
+        var typeDirectory = packageDirectory is null ? null : Path.GetDirectoryName(packageDirectory);
+        if (string.IsNullOrWhiteSpace(packageDirectory) || string.IsNullOrWhiteSpace(typeDirectory)) return null;
+        if (!string.Equals(Path.GetFileName(typeDirectory), GetAssetTypeFolderName(assetType), StringComparison.OrdinalIgnoreCase)) return null;
+        return Path.GetFileName(packageDirectory);
+    }
+
     public string EnsureUniqueAssetName(EditorProject project, EditorAssetType assetType, string requestedName)
     {
         var safe = SanitizePathSegment(requestedName);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -60,6 +60,28 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         _faceDocumentModel = FaceDocumentStorage.TryRead(faceDocumentJson, out var faceDocumentFile)
             ? FaceDocumentStorage.ToModel(faceDocumentFile)
             : new FaceDocumentModel();
+        if (document.DocumentType == EditorDocumentType.Face)
+        {
+            _faceDocumentModel = new FaceDocumentModel
+            {
+                Id = _faceDocumentModel.Id,
+                Title = document.Title,
+                Summary = _faceDocumentModel.Summary,
+                SourcePanel2DDocumentId = _faceDocumentModel.SourcePanel2DDocumentId,
+                SourcePanel2DDocumentPath = _faceDocumentModel.SourcePanel2DDocumentPath,
+                SourceFaceShapeId = _faceDocumentModel.SourceFaceShapeId,
+                AssignedCabinetFaceTargetId = _faceDocumentModel.AssignedCabinetFaceTargetId,
+                SourceRegion = _faceDocumentModel.SourceRegion,
+                LastRegeneratedAtUtc = _faceDocumentModel.LastRegeneratedAtUtc,
+                GenerationSettings = _faceDocumentModel.GenerationSettings,
+                RuntimeRenderAssets = _faceDocumentModel.RuntimeRenderAssets,
+                MaskLayer = _faceDocumentModel.MaskLayer,
+                Trays = _faceDocumentModel.Trays,
+                LampEmitters = _faceDocumentModel.LampEmitters,
+                Layers = _faceDocumentModel.Layers,
+                Elements = _faceDocumentModel.Elements
+            };
+        }
         _cabinetDocumentModel = CabinetDocumentStorage.TryRead(cabinetDocumentJson, out var cabinetDocument)
             ? cabinetDocument
             : CabinetDocument.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -181,9 +181,9 @@ public sealed class DocumentWorkspaceViewModel
             generationSettings: generationSettings,
             progress: progress.CreateChild(0.0, 0.8),
             sourcePanel2DDocumentPath: sourceDocument.FilePath);
-        var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, progress.CreateChild(0.8, 0.95));
-        var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
         var manifestPath = pathService.GetFaceManifestPath(loadedProject, title);
+        var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, manifestPath, progress.CreateChild(0.8, 0.95));
+        var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
         System.IO.File.WriteAllText(manifestPath, faceJson);
         var faceEditorDocument = EditorDocument.CreateFromFile(manifestPath, generatedFaceDocument.Summary ?? "Generated Face document.", title);
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
@@ -194,11 +194,11 @@ public sealed class DocumentWorkspaceViewModel
         return document;
     }
 
-    private FaceDocumentModel ExportRuntimeAssetsForPreview(FaceDocumentModel faceDocument, EditorProject loadedProject, IEditorProgressReporter? progress = null)
+    private FaceDocumentModel ExportRuntimeAssetsForPreview(FaceDocumentModel faceDocument, EditorProject loadedProject, string documentPath, IEditorProgressReporter? progress = null)
     {
         try
         {
-            var exportResult = _faceRuntimeExportService.Export(faceDocument, loadedProject, progress);
+            var exportResult = _faceRuntimeExportService.Export(faceDocument, loadedProject, documentPath, progress);
             _addOutputEntry($"Generated runtime face preview textures for '{faceDocument.Title}'.", OutputLogStatus.Info);
             return exportResult.Document;
         }
@@ -209,7 +209,6 @@ public sealed class DocumentWorkspaceViewModel
             {
                 Id = faceDocument.Id,
                 Title = faceDocument.Title,
-                AssetName = faceDocument.AssetName,
                 Summary = faceDocument.Summary,
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
@@ -302,10 +301,11 @@ public sealed class DocumentWorkspaceViewModel
             loadedProject.ProjectDirectory,
             loadedProject.GeneratedDirectory,
             generationSettings,
-            progress.CreateChild(0.0, 0.8));
+            progress.CreateChild(0.0, 0.8),
+            selectedDocument.FilePath);
 
         progress.Report(0.8, "Exporting regenerated runtime preview assets...");
-        var regeneratedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, progress.CreateChild(0.8, 0.95));
+        var regeneratedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, selectedDocument.FilePath, progress.CreateChild(0.8, 0.95));
 
         progress.Report(0.95, "Updating Face document...");
 
@@ -695,14 +695,16 @@ public sealed class DocumentWorkspaceViewModel
                 var summary = string.IsNullOrWhiteSpace(faceDocument.Summary)
                     ? "Face document opened."
                     : faceDocument.Summary.Trim();
-                var title = string.IsNullOrWhiteSpace(faceDocument.Title)
-                    ? Path.GetFileName(path)
-                    : faceDocument.Title.Trim();
-                var assetName = string.IsNullOrWhiteSpace(faceDocument.AssetName)
-                    ? Path.GetFileName(Path.GetDirectoryName(path) ?? string.Empty)
-                    : faceDocument.AssetName.Trim();
-                faceDocument = faceDocument with { AssetName = string.IsNullOrWhiteSpace(assetName) ? null : assetName };
-                return new OpenDocumentData(summary, null, title, FaceDocumentStorage.Serialize(faceDocument));
+                var assetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(path, EditorAssetType.Face);
+                if (string.IsNullOrWhiteSpace(assetName))
+                {
+                    return new OpenDocumentData(
+                        "Failed to open face document: Face manifests must be stored as Assets/Faces/<AssetName>/asset.face.",
+                        null,
+                        Path.GetFileName(path));
+                }
+
+                return new OpenDocumentData(summary, null, assetName, FaceDocumentStorage.Serialize(faceDocument));
             }
 
             return new OpenDocumentData(
@@ -750,7 +752,6 @@ public sealed class DocumentWorkspaceViewModel
             {
                 Id = faceDocument.Id,
                 Title = document.Document.Title,
-                AssetName = faceDocument.AssetName,
                 Summary = document.ContentSummary,
                 SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
                 SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,


### PR DESCRIPTION
### Motivation
- Enforce the folder-as-asset model so the package folder name (Assets/Faces/<AssetName>/) is the single user-facing Face name and source of truth. 
- Remove the legacy duplicate mutable `AssetName`/title semantics that permitted divergent user-visible names and runtime path inference. 
- Simplify runtime/export/regeneration logic by resolving asset identity from the manifest/package path and drop fallbacks for pre-package layouts.

### Description
- Removed the persisted/mutable `AssetName` field from the Face model and storage (`FaceDocumentModel`, `FaceDocumentFile`, `FaceDocumentStorage`) so the model no longer carries a duplicate asset name. 
- Added package-name resolution helper `ProjectAssetPathService.GetPackageAssetNameFromManifestPath(...)` and updated asset/path services to treat `Assets/Faces/<AssetName>/asset.face` as the canonical Face manifest location. 
- Updated runtime/export and regeneration flows to accept and require the manifest/document path and derive `Generated/Faces/<AssetName>/runtime/` from the package folder name rather than from a mutable title or legacy inference (`FaceRuntimeExportService`, `FaceRegenerationService`, `FaceGenerationService`). 
- Updated document open/save and preview flows to require package manifests, to pass the manifest path into export/regeneration, and to reject non-package Face manifests; updated tests to assume only the new package layout (`DocumentWorkspaceViewModel`, `DocumentTabViewModel`, and related automation). 

### Testing
- No automated tests were executed in this environment per repository policy. 
- Unit tests were updated to assume the package layout; run the project test suite locally and verify the modified Face tests: `OasisEditor.Tests/FaceRuntimeExportServiceTests`, `OasisEditor.Tests/FaceGenerationSettingsTests`, `OasisEditor.Tests/FaceDocumentRoundTripTests`, and `OasisEditor.Tests/ProjectAssetPathServiceTests`. 
- Expected local verification: run `dotnet test` (Windows/.NET environment) and confirm the above Face tests and the full test suite pass with the package-only assumptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4416cb1a648327b6d188d96c8ab859)