### PR TITLE
Fix folder-as-asset titles and Face first-save flow

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
@@ -1,5 +1,6 @@
 using OasisEditor;
 using OasisEditor.Automation;
+using OasisEditor.Features.CabinetEditor.Models;
 using Xunit;
 
 namespace OasisEditor.Tests;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
@@ -1,6 +1,7 @@
 using OasisEditor;
 using OasisEditor.Automation;
 using OasisEditor.Features.CabinetEditor.Models;
+using SkiaSharp;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -74,9 +75,75 @@ public sealed class AssetPackageLayoutBugTests : IDisposable
         Assert.True(File.Exists(Path.Combine(project.AssetsDirectory, "Faces", "Saved Face", "mask.png")));
     }
 
+
+    [Fact]
+    public void GenerateFaceFromSourceShape_WritesPendingArtworkWithSourcePixelsBeforeFirstSave()
+    {
+        var project = CreateProject();
+        var sourceArtworkPath = Path.Combine(project.AssetsDirectory, "source.png");
+        WriteSolidPng(sourceArtworkPath, 4, 4, SKColors.Red);
+        var panel = new Panel2DDocumentModel
+        {
+            Elements =
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "background",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    X = 0,
+                    Y = 0,
+                    Width = 4,
+                    Height = 4,
+                    AssetPath = "Assets/source.png"
+                }
+            ]
+        };
+        var sourceShape = new PanelFaceSourceShapeModel
+        {
+            Id = "shape",
+            Name = "Glass",
+            TopLeft = new FacePointModel { X = 0, Y = 0 },
+            TopRight = new FacePointModel { X = 4, Y = 0 },
+            BottomRight = new FacePointModel { X = 4, Y = 4 },
+            BottomLeft = new FacePointModel { X = 0, Y = 4 }
+        };
+        var pendingDirectory = Path.Combine(project.GeneratedDirectory, "Faces", "_unsaved", "pending-face");
+
+        var result = new FaceGenerationService().GenerateFromPanelFaceSourceShape(
+            panel,
+            sourceShape,
+            "Unsaved Face",
+            projectDirectory: project.ProjectDirectory,
+            generatedDirectory: project.GeneratedDirectory,
+            faceAssetName: "Unsaved Face",
+            faceAssetDirectory: pendingDirectory);
+
+        var artwork = Assert.IsType<FaceArtworkElement>(Assert.Single(result.Document.Elements.OfType<FaceArtworkElement>()));
+        var artworkPath = Path.Combine(project.ProjectDirectory, artwork.AssetPath!.Replace('/', Path.DirectorySeparatorChar));
+        Assert.StartsWith("Generated/Faces/_unsaved/pending-face/", artwork.AssetPath);
+        Assert.True(File.Exists(artworkPath));
+        using var bitmap = SKBitmap.Decode(artworkPath);
+        Assert.NotNull(bitmap);
+        Assert.Equal(SKColors.Red, bitmap.GetPixel(1, 1));
+        Assert.False(Directory.Exists(Path.Combine(project.AssetsDirectory, "Faces", "Unsaved Face")));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+
+    private static void WriteSolidPng(string path, int width, int height, SKColor color)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(color);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(path);
+        data.SaveTo(stream);
     }
 
     private EditorProject CreateProject()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetPackageLayoutBugTests.cs
@@ -1,0 +1,98 @@
+using OasisEditor;
+using OasisEditor.Automation;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class AssetPackageLayoutBugTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"OasisAssetPackageBugTests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void CreateProject_DoesNotCreateLegacyAssetPlaceholderFolders()
+    {
+        var projectDirectory = new ProjectScaffolder().CreateProject("PackageProject", _root);
+
+        Assert.False(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Audio")));
+        Assert.False(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Fonts")));
+        Assert.False(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Images")));
+        Assert.True(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Panel2D")));
+        Assert.True(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Faces")));
+        Assert.True(Directory.Exists(Path.Combine(projectDirectory, "Assets", "Cabinet3D")));
+    }
+
+    [Theory]
+    [InlineData("Assets/Panel2D/Main Panel/asset.panel2d", "Main Panel")]
+    [InlineData("Assets/Faces/Top Glass/asset.face", "Top Glass")]
+    [InlineData("Assets/Cabinet3D/Vogue/asset.cabinet3d", "Vogue")]
+    public void CreateFromFile_ForPackageManifest_UsesEnclosingFolderAsTitle(string relativePath, string expectedTitle)
+    {
+        var path = Path.Combine(_root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        var document = EditorDocument.CreateFromFile(path, "Opened.");
+
+        Assert.Equal(expectedTitle, document.Title);
+    }
+
+    [Fact]
+    public void BuildOpenDocumentData_ForPackageManifests_UsesEnclosingFolderAsTitle()
+    {
+        var panelJson = Panel2DDocumentStorage.Serialize("Internal Title", "Panel summary", [], []);
+        var faceJson = FaceDocumentStorage.Serialize(FaceDocumentStorage.CreateEmpty("Internal Face"));
+        var cabinetJson = CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("model.glb"));
+
+        Assert.Equal("Main Panel", DocumentWorkspaceViewModel.BuildOpenDocumentData(Path.Combine(_root, "Assets", "Panel2D", "Main Panel", "asset.panel2d"), panelJson).PanelTitle);
+        Assert.Equal("Top Glass", DocumentWorkspaceViewModel.BuildOpenDocumentData(Path.Combine(_root, "Assets", "Faces", "Top Glass", "asset.face"), faceJson).PanelTitle);
+        Assert.Equal("Vogue", DocumentWorkspaceViewModel.BuildOpenDocumentData(Path.Combine(_root, "Assets", "Cabinet3D", "Vogue", "asset.cabinet3d"), cabinetJson).PanelTitle);
+    }
+
+    [Fact]
+    public void SaveDocument_ForUnsavedGeneratedFace_CreatesFacePackageFilesAndUsesPackageTitle()
+    {
+        var project = CreateProject();
+        var faceDocument = new FaceDocumentModel
+        {
+            Title = "Temporary Face",
+            SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 2, Height = 2 },
+            Elements =
+            [
+                new FaceArtworkElement { ObjectId = "art", Name = "Artwork", Width = 2, Height = 2 }
+            ]
+        };
+        var current = new DocumentTabViewModel(
+            EditorDocument.CreateFaceStub("Temporary Face").MarkDirty(),
+            faceDocumentJson: FaceDocumentStorage.Serialize(faceDocument));
+        var savePath = Path.Combine(project.AssetsDirectory, "Faces", "Saved Face", "asset.face");
+
+        var saved = new DocumentSaveService().SaveDocument(current, savePath, project);
+
+        Assert.Equal("Saved Face", saved.Title);
+        Assert.False(saved.Document.IsUntitled);
+        Assert.True(File.Exists(Path.Combine(project.AssetsDirectory, "Faces", "Saved Face", "asset.face")));
+        Assert.True(File.Exists(Path.Combine(project.AssetsDirectory, "Faces", "Saved Face", "artwork.png")));
+        Assert.True(File.Exists(Path.Combine(project.AssetsDirectory, "Faces", "Saved Face", "mask.png")));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private EditorProject CreateProject()
+    {
+        Directory.CreateDirectory(_root);
+        var assets = Path.Combine(_root, "Assets");
+        var generated = Path.Combine(_root, "Generated");
+        Directory.CreateDirectory(assets);
+        Directory.CreateDirectory(generated);
+        return new EditorProject
+        {
+            Name = "Test",
+            ProjectFilePath = Path.Combine(_root, "Test.oasisproj"),
+            ProjectDirectory = _root,
+            AssetsDirectory = assets,
+            MachinesDirectory = Path.Combine(_root, "Machines"),
+            GeneratedDirectory = generated
+        };
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyPanelCommandServiceTests.cs
@@ -50,9 +50,9 @@ public sealed class HierarchyPanelCommandServiceTests
         Assert.Equal(2, document.GetPanelElements().Count);
 
         var savedContent = DocumentWorkspaceViewModel.BuildDocumentContent(document);
-        var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData("C:/Repo/TestProject/Assets/panel.panel2d", savedContent);
+        var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData("C:/Repo/TestProject/Assets/Panel2D/Panel/asset.panel2d", savedContent);
         var reopened = new DocumentTabViewModel(
-            EditorDocument.CreateFromFile("C:/Repo/TestProject/Assets/panel.panel2d", openData.Summary, openData.PanelTitle),
+            EditorDocument.CreateFromFile("C:/Repo/TestProject/Assets/Panel2D/Panel/asset.panel2d", openData.Summary, openData.PanelTitle),
             openData.PanelLayoutJson);
 
         Assert.Equal(2, reopened.GetPanelElements().Count);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -9,7 +9,7 @@ public sealed class Panel2DRoundTripTests
     [Fact]
     public void BuildOpenDocumentData_AndBuildDocumentContent_RoundTripExistingPanelFile()
     {
-        const string path = "C:/Repo/Assets/sample.panel2d";
+        const string path = "C:/Repo/Assets/Panel2D/Sample Panel/asset.panel2d";
         var sourceJson = """
         {
           "SchemaVersion": 1,
@@ -77,13 +77,13 @@ public sealed class Panel2DRoundTripTests
     [Fact]
     public void BuildOpenDocumentData_WithInvalidPanelJson_ReturnsClearErrorSummary()
     {
-        const string path = "C:/Repo/Assets/bad.panel2d";
+        const string path = "C:/Repo/Assets/Panel2D/Bad Panel/asset.panel2d";
         const string invalidJson = "{ not valid json";
 
         var openData = DocumentWorkspaceViewModel.BuildOpenDocumentData(path, invalidJson);
 
         Assert.Null(openData.PanelLayoutJson);
-        Assert.Equal("bad.panel2d", openData.PanelTitle);
+        Assert.Equal("asset.panel2d", openData.PanelTitle);
         Assert.Contains("Malformed JSON", openData.Summary);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Automation/MfmeImportAndDocumentSaveServices.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using OasisEditor.Features.MfmeImport;
 using OasisEditor.Progress;
+using SkiaSharp;
 
 namespace OasisEditor.Automation;
 
@@ -69,7 +70,8 @@ public sealed class DocumentSaveService : IDocumentSaveService
         if (current.Document.DocumentType == EditorDocumentType.Face && project is not null)
         {
             progress.Report(0.15, "Exporting Face runtime assets...");
-            var exportResult = _faceRuntimeExportService.Export(current.GetFaceDocument(), project, savePath, progress.CreateChild(0.15, 0.75));
+            var faceWithAuthoredAssets = EnsureFaceAuthoredPackageAssets(current.GetFaceDocument(), project, savePath);
+            var exportResult = _faceRuntimeExportService.Export(faceWithAuthoredAssets, project, savePath, progress.CreateChild(0.15, 0.75));
             faceDocumentJson = FaceDocumentStorage.Serialize(exportResult.Document);
             contentSource = new DocumentTabViewModel(
                 current.Document,
@@ -115,4 +117,121 @@ public sealed class DocumentSaveService : IDocumentSaveService
         progress.Report(1.0, "Document saved.");
         return savedDocument;
     }
+
+    private static FaceDocumentModel EnsureFaceAuthoredPackageAssets(FaceDocumentModel faceDocument, EditorProject project, string savePath)
+    {
+        var assetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(savePath, EditorAssetType.Face);
+        if (string.IsNullOrWhiteSpace(assetName))
+        {
+            return faceDocument;
+        }
+
+        var pathService = new ProjectAssetPathService();
+        var artworkPath = pathService.GetFaceArtworkPath(project, assetName);
+        var maskPath = pathService.GetFaceMaskPath(project, assetName);
+        Directory.CreateDirectory(Path.GetDirectoryName(savePath)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(artworkPath)!);
+
+        CopyOrCreatePng(project, faceDocument.Elements.OfType<FaceArtworkElement>().FirstOrDefault()?.AssetPath, artworkPath, faceDocument);
+        CopyOrCreatePng(project, faceDocument.MaskLayer?.AssetPath, maskPath, faceDocument);
+
+        var artworkRelative = pathService.ToProjectRelativePath(project, artworkPath);
+        var maskRelative = pathService.ToProjectRelativePath(project, maskPath);
+        var elements = faceDocument.Elements.Select(element => element is FaceArtworkElement artwork
+            ? new FaceArtworkElement
+            {
+                ObjectId = artwork.ObjectId,
+                Name = artwork.Name,
+                X = artwork.X,
+                Y = artwork.Y,
+                Width = artwork.Width,
+                Height = artwork.Height,
+                IsVisible = artwork.IsVisible,
+                IsLocked = artwork.IsLocked,
+                LinkedMachineObjectReference = artwork.LinkedMachineObjectReference,
+                LinkedPanel2DElementId = artwork.LinkedPanel2DElementId,
+                AssetPath = artworkRelative,
+                SourcePanel2DDocumentId = artwork.SourcePanel2DDocumentId,
+                SourceRegion = artwork.SourceRegion,
+                Provenance = artwork.Provenance
+            }
+            : element).ToArray();
+        var maskLayer = faceDocument.MaskLayer is null
+            ? new FaceMaskLayerModel
+            {
+                Id = "face-mask-layer",
+                Name = "Face Mask",
+                AssetPath = maskRelative,
+                SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+                SourceRegion = faceDocument.SourceRegion,
+                Width = Math.Max(1, (int)Math.Ceiling(faceDocument.SourceRegion?.Width ?? 1)),
+                Height = Math.Max(1, (int)Math.Ceiling(faceDocument.SourceRegion?.Height ?? 1)),
+                GeneratedUtc = DateTime.UtcNow,
+                Contributions = []
+            }
+            : new FaceMaskLayerModel
+            {
+                Id = faceDocument.MaskLayer.Id,
+                Name = faceDocument.MaskLayer.Name,
+                AssetPath = maskRelative,
+                SourcePanel2DDocumentId = faceDocument.MaskLayer.SourcePanel2DDocumentId,
+                SourceRegion = faceDocument.MaskLayer.SourceRegion,
+                ExtractionThreshold = faceDocument.MaskLayer.ExtractionThreshold,
+                GeneratedUtc = faceDocument.MaskLayer.GeneratedUtc,
+                Width = faceDocument.MaskLayer.Width,
+                Height = faceDocument.MaskLayer.Height,
+                Contributions = faceDocument.MaskLayer.Contributions
+            };
+
+        return new FaceDocumentModel
+        {
+            Id = faceDocument.Id,
+            Title = assetName,
+            Summary = faceDocument.Summary,
+            SourcePanel2DDocumentId = faceDocument.SourcePanel2DDocumentId,
+            SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
+            SourceFaceShapeId = faceDocument.SourceFaceShapeId,
+            AssignedCabinetFaceTargetId = faceDocument.AssignedCabinetFaceTargetId,
+            SourceRegion = faceDocument.SourceRegion,
+            LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
+            GenerationSettings = faceDocument.GenerationSettings,
+            RuntimeRenderAssets = faceDocument.RuntimeRenderAssets,
+            MaskLayer = maskLayer,
+            Trays = faceDocument.Trays,
+            LampEmitters = faceDocument.LampEmitters,
+            Layers = faceDocument.Layers,
+            Elements = elements
+        };
+    }
+
+    private static void CopyOrCreatePng(EditorProject project, string? sourceAssetPath, string destinationPath, FaceDocumentModel faceDocument)
+    {
+        var sourcePath = ResolveExistingProjectPath(project, sourceAssetPath);
+        if (!string.IsNullOrWhiteSpace(sourcePath) && File.Exists(sourcePath))
+        {
+            if (!string.Equals(Path.GetFullPath(sourcePath), Path.GetFullPath(destinationPath), StringComparison.OrdinalIgnoreCase))
+            {
+                File.Copy(sourcePath, destinationPath, overwrite: true);
+            }
+            return;
+        }
+
+        var width = Math.Max(1, (int)Math.Ceiling(faceDocument.SourceRegion?.Width ?? 1));
+        var height = Math.Max(1, (int)Math.Ceiling(faceDocument.SourceRegion?.Height ?? 1));
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(SKColors.Transparent);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(destinationPath);
+        data.SaveTo(stream);
+    }
+
+    private static string? ResolveExistingProjectPath(EditorProject project, string? assetPath)
+    {
+        if (string.IsNullOrWhiteSpace(assetPath)) return null;
+        return Path.IsPathRooted(assetPath)
+            ? assetPath
+            : Path.GetFullPath(Path.Combine(project.ProjectDirectory, assetPath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentModel.cs
@@ -133,9 +133,12 @@ public sealed class EditorDocument
             documentType = EditorDocumentType.Generic;
         }
 
-        var resolvedTitle = string.IsNullOrWhiteSpace(title)
-            ? System.IO.Path.GetFileName(filePath)
-            : title.Trim();
+        var packageTitle = ProjectAssetPathService.GetDocumentTitleFromManifestPath(filePath);
+        var resolvedTitle = !string.IsNullOrWhiteSpace(packageTitle)
+            ? packageTitle
+            : string.IsNullOrWhiteSpace(title)
+                ? System.IO.Path.GetFileName(filePath)
+                : title.Trim();
 
         return new EditorDocument(
             resolvedTitle,
@@ -148,9 +151,12 @@ public sealed class EditorDocument
 
     public EditorDocument SaveAs(string filePath, string summary)
     {
-        var resolvedTitle = IsUntitled
-            ? System.IO.Path.GetFileName(filePath)
-            : Title;
+        var packageTitle = ProjectAssetPathService.GetDocumentTitleFromManifestPath(filePath);
+        var resolvedTitle = !string.IsNullOrWhiteSpace(packageTitle)
+            ? packageTitle
+            : IsUntitled
+                ? System.IO.Path.GetFileName(filePath)
+                : Title;
         return CreateFromFile(filePath, summary, resolvedTitle);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -95,6 +95,7 @@ internal sealed class FaceGenerationService
         string? projectDirectory = null,
         string? generatedDirectory = null,
         string? faceAssetName = null,
+        string? faceAssetDirectory = null,
         FaceGenerationSettingsModel? generationSettings = null,
         IEditorProgressReporter? progress = null,
         string? sourcePanel2DDocumentPath = null)
@@ -104,9 +105,7 @@ internal sealed class FaceGenerationService
         var output = FaceSourceShapeTransformService.EstimateOutputSize(sourceShape, targetAspectRatio);
         var pathService = new ProjectAssetPathService();
         var resolvedFaceAssetName = pathService.SanitizePathSegment(string.IsNullOrWhiteSpace(faceAssetName) ? title : faceAssetName);
-        var faceArtworkPath = !string.IsNullOrWhiteSpace(projectDirectory)
-            ? pathService.GetFaceArtworkPath(CreatePathProject(projectDirectory, generatedDirectory), resolvedFaceAssetName)
-            : null;
+        var faceArtworkPath = ResolveFaceAuthoredAssetPath(projectDirectory, generatedDirectory, faceAssetDirectory, resolvedFaceAssetName, ProjectAssetPathService.FaceArtworkFileName);
         var region = FaceSourceRegionModel.FromRect(new Rect(0, 0, output.Width, output.Height));
         var assetPath = FaceSourceShapeTransformService.TryGenerateBackground(sourcePanel, sourceShape, output.Width, output.Height, projectDirectory, faceArtworkPath);
         var settings = (generationSettings ?? FaceGenerationSettingsModel.Default).Normalize();
@@ -127,6 +126,7 @@ internal sealed class FaceGenerationService
             sourcePanel2DDocumentId,
             projectDirectory,
             resolvedFaceAssetName,
+            ResolveFaceAuthoredAssetPath(projectDirectory, generatedDirectory, faceAssetDirectory, resolvedFaceAssetName, ProjectAssetPathService.FaceMaskFileName),
             settings.MaskExtractionThreshold);
         var artwork = new FaceArtworkElement
         {
@@ -182,6 +182,7 @@ internal sealed class FaceGenerationService
         string? sourcePanel2DDocumentId,
         string? projectDirectory,
         string faceAssetName,
+        string? outputPath,
         byte extractionThreshold)
     {
         if (string.IsNullOrWhiteSpace(projectDirectory) || faceWidth <= 0 || faceHeight <= 0)
@@ -233,7 +234,7 @@ internal sealed class FaceGenerationService
             });
         }
 
-        var assetPath = SaveSourceShapeMask(maskPixels, faceWidth, faceHeight, faceDocumentId, projectDirectory, faceAssetName);
+        var assetPath = SaveSourceShapeMask(maskPixels, faceWidth, faceHeight, projectDirectory, faceAssetName, outputPath);
         return new FaceMaskLayerModel
         {
             Id = "face-mask-layer",
@@ -311,7 +312,7 @@ internal sealed class FaceGenerationService
         return new SourceShapeMaskContribution(bounds, count);
     }
 
-    private static string SaveSourceShapeMask(byte[] maskPixels, int width, int height, string faceDocumentId, string projectDirectory, string faceAssetName)
+    private static string SaveSourceShapeMask(byte[] maskPixels, int width, int height, string projectDirectory, string faceAssetName, string? outputPath = null)
     {
         using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
         for (var y = 0; y < height; y++)
@@ -323,7 +324,7 @@ internal sealed class FaceGenerationService
 
         var pathService = new ProjectAssetPathService();
         var project = CreatePathProject(projectDirectory, null);
-        var path = pathService.GetFaceMaskPath(project, faceAssetName);
+        var path = string.IsNullOrWhiteSpace(outputPath) ? pathService.GetFaceMaskPath(project, faceAssetName) : outputPath;
         var relative = pathService.ToProjectRelativePath(project, path);
         System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
         using var image = SKImage.FromBitmap(bitmap);
@@ -331,6 +332,26 @@ internal sealed class FaceGenerationService
         using var stream = System.IO.File.Create(path);
         data.SaveTo(stream);
         return ProjectAssetPathService.NormalizeProjectRelativePath(relative);
+    }
+
+
+    private static string? ResolveFaceAuthoredAssetPath(string? projectDirectory, string? generatedDirectory, string? faceAssetDirectory, string faceAssetName, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(projectDirectory))
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(faceAssetDirectory))
+        {
+            return System.IO.Path.Combine(faceAssetDirectory, fileName);
+        }
+
+        var pathService = new ProjectAssetPathService();
+        var project = CreatePathProject(projectDirectory, generatedDirectory);
+        return string.Equals(fileName, ProjectAssetPathService.FaceMaskFileName, StringComparison.OrdinalIgnoreCase)
+            ? pathService.GetFaceMaskPath(project, faceAssetName)
+            : pathService.GetFaceArtworkPath(project, faceAssetName);
     }
 
     private static EditorProject CreatePathProject(string projectDirectory, string? generatedDirectory)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectAssetPathService.cs
@@ -63,6 +63,18 @@ public sealed class ProjectAssetPathService
         return Path.GetFileName(packageDirectory);
     }
 
+
+    public static string? GetDocumentTitleFromManifestPath(string manifestPath)
+    {
+        foreach (var assetType in Enum.GetValues<EditorAssetType>())
+        {
+            var assetName = GetPackageAssetNameFromManifestPath(manifestPath, assetType);
+            if (!string.IsNullOrWhiteSpace(assetName)) return assetName;
+        }
+
+        return null;
+    }
+
     public string EnsureUniqueAssetName(EditorProject project, EditorAssetType assetType, string requestedName)
     {
         var safe = SanitizePathSegment(requestedName);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ProjectScaffolder.cs
@@ -8,9 +8,6 @@ public sealed class ProjectScaffolder
     private static readonly string[] ProjectFolders =
     [
         "Assets",
-        "Assets/Images",
-        "Assets/Audio",
-        "Assets/Fonts",
         "Assets/Panel2D",
         "Assets/Cabinet3D",
         "Assets/Faces",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -166,6 +166,7 @@ public sealed class DocumentWorkspaceViewModel
             : (target.Corners[1] - target.Corners[0]).Length / Math.Max(0.0001, (target.Corners[3] - target.Corners[0]).Length);
         progress ??= NoOpEditorProgressReporter.Instance;
         var title = string.IsNullOrWhiteSpace(faceAssetName) ? $"{sourceDocument.Title} Face" : faceAssetName.Trim();
+        var pendingFaceAssetDirectory = Path.Combine(loadedProject.GeneratedDirectory, "Faces", "_unsaved", Guid.NewGuid().ToString("N"));
         var result = _faceGenerationService.GenerateFromPanelFaceSourceShape(
             sourceDocument.GetPanelDocument(),
             shape,
@@ -173,9 +174,10 @@ public sealed class DocumentWorkspaceViewModel
             sourcePanel2DDocumentId: sourceDocument.DocumentId.ToString("N"),
             assignedCabinetFaceTargetId: target?.Id,
             targetAspectRatio: targetAspect,
-            projectDirectory: null,
-            generatedDirectory: null,
+            projectDirectory: loadedProject.ProjectDirectory,
+            generatedDirectory: loadedProject.GeneratedDirectory,
             faceAssetName: title,
+            faceAssetDirectory: pendingFaceAssetDirectory,
             generationSettings: generationSettings,
             progress: progress.CreateChild(0.0, 0.8),
             sourcePanel2DDocumentPath: sourceDocument.FilePath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentWorkspaceViewModel.cs
@@ -165,9 +165,7 @@ public sealed class DocumentWorkspaceViewModel
             ? (double?)null
             : (target.Corners[1] - target.Corners[0]).Length / Math.Max(0.0001, (target.Corners[3] - target.Corners[0]).Length);
         progress ??= NoOpEditorProgressReporter.Instance;
-        var pathService = new ProjectAssetPathService();
-        var title = pathService.EnsureUniqueAssetName(loadedProject, EditorAssetType.Face, string.IsNullOrWhiteSpace(faceAssetName) ? $"{sourceDocument.Title} Face" : faceAssetName);
-        pathService.CreateAssetPackageDirectory(loadedProject, EditorAssetType.Face, title);
+        var title = string.IsNullOrWhiteSpace(faceAssetName) ? $"{sourceDocument.Title} Face" : faceAssetName.Trim();
         var result = _faceGenerationService.GenerateFromPanelFaceSourceShape(
             sourceDocument.GetPanelDocument(),
             shape,
@@ -175,17 +173,15 @@ public sealed class DocumentWorkspaceViewModel
             sourcePanel2DDocumentId: sourceDocument.DocumentId.ToString("N"),
             assignedCabinetFaceTargetId: target?.Id,
             targetAspectRatio: targetAspect,
-            projectDirectory: loadedProject.ProjectDirectory,
-            generatedDirectory: loadedProject.GeneratedDirectory,
+            projectDirectory: null,
+            generatedDirectory: null,
             faceAssetName: title,
             generationSettings: generationSettings,
             progress: progress.CreateChild(0.0, 0.8),
             sourcePanel2DDocumentPath: sourceDocument.FilePath);
-        var manifestPath = pathService.GetFaceManifestPath(loadedProject, title);
-        var generatedFaceDocument = ExportRuntimeAssetsForPreview(result.Document, loadedProject, manifestPath, progress.CreateChild(0.8, 0.95));
+        var generatedFaceDocument = result.Document;
         var faceJson = FaceDocumentStorage.Serialize(generatedFaceDocument);
-        System.IO.File.WriteAllText(manifestPath, faceJson);
-        var faceEditorDocument = EditorDocument.CreateFromFile(manifestPath, generatedFaceDocument.Summary ?? "Generated Face document.", title);
+        var faceEditorDocument = EditorDocument.CreateFaceStub(title).MarkDirty();
         var document = CreateDocumentTab(faceEditorDocument, faceDocumentJson: faceJson);
         ExecuteDocumentMutation(new OpenDocumentTabMutationCommand(this, document));
         _setStatusMessage($"Generated face document from Face Source Shape '{shape.Name}'.");
@@ -659,7 +655,16 @@ public sealed class DocumentWorkspaceViewModel
                 }
 
                 var summary = "Cabinet 3D document opened.";
-                return new OpenDocumentData(summary, null, Path.GetFileName(path), CabinetDocumentJson: CabinetDocumentStorage.Serialize(cabinetDocument));
+                var assetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(path, EditorAssetType.Cabinet3D);
+                if (string.IsNullOrWhiteSpace(assetName))
+                {
+                    return new OpenDocumentData(
+                        "Failed to open cabinet document: Cabinet3D manifests must be stored as Assets/Cabinet3D/<AssetName>/asset.cabinet3d.",
+                        null,
+                        Path.GetFileName(path));
+                }
+
+                return new OpenDocumentData(summary, null, assetName, CabinetDocumentJson: CabinetDocumentStorage.Serialize(cabinetDocument));
             }
 
             return new OpenDocumentData(
@@ -675,10 +680,16 @@ public sealed class DocumentWorkspaceViewModel
                 var summary = string.IsNullOrWhiteSpace(panelDocument.Summary)
                     ? "Panel document opened."
                     : panelDocument.Summary.Trim();
-                var title = string.IsNullOrWhiteSpace(panelDocument.Title)
-                    ? Path.GetFileName(path)
-                    : panelDocument.Title.Trim();
-                return new OpenDocumentData(summary, Panel2DDocumentStorage.Serialize(panelDocument.Title, panelDocument.Summary, panelDocument.Elements, panelDocument.FaceSourceShapes), title);
+                var assetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(path, EditorAssetType.Panel2D);
+                if (string.IsNullOrWhiteSpace(assetName))
+                {
+                    return new OpenDocumentData(
+                        "Failed to open panel document: Panel2D manifests must be stored as Assets/Panel2D/<AssetName>/asset.panel2d.",
+                        null,
+                        Path.GetFileName(path));
+                }
+
+                return new OpenDocumentData(summary, Panel2DDocumentStorage.Serialize(assetName, panelDocument.Summary, panelDocument.Elements, panelDocument.FaceSourceShapes), assetName);
             }
 
             return new OpenDocumentData(


### PR DESCRIPTION
### Motivation

- Remove legacy placeholder asset folders from new project scaffolding and enforce the folder-as-asset model where the asset folder name is the single user-facing asset name.
- Ensure fixed manifest filenames (`asset.panel2d`, `asset.face`, `asset.cabinet3d`) are treated as internal manifests and the enclosing folder name is used as the document/tab title.
- Prevent creating a final named Face package when generating a Face from a Face Source Shape and instead create an unsaved Face document that only writes package files on first save.

### Description

- Removed legacy scaffolding entries `Assets/Images`, `Assets/Audio`, and `Assets/Fonts` from `ProjectScaffolder` so new projects only create active package roots `Assets/Panel2D`, `Assets/Faces`, and `Assets/Cabinet3D`.
- Added `ProjectAssetPathService.GetDocumentTitleFromManifestPath(...)` to centralize resolving a user-facing title from package manifest paths and used it in `DocumentModel` so package manifests use the enclosing folder as the document title.
- Updated `DocumentWorkspaceViewModel.BuildOpenDocumentData(...)` to require manifests for Panel2D/Face/Cabinet3D to follow the package layout and to set the tab title from the package folder name.
- Changed Face generation from a Face Source Shape to open a dirty, unsaved Face stub tab (no package created) and moved package creation to the save path flow.
- Implemented `EnsureFaceAuthoredPackageAssets(...)` inside the document save service that, when saving a Face manifest into `Assets/Faces/<AssetName>/asset.face`, creates the package directory and authored PNGs (`artwork.png`, `mask.png`) and rewrites authored asset paths into the manifest before runtime export and final save.
- Added unit tests `OasisEditor.Tests/AssetPackageLayoutBugTests.cs` covering: new-project scaffolding no longer creates legacy folders, manifest-open title resolution uses the enclosing folder, BuildOpenDocumentData package title behavior, and first-save of a generated Face creates the `asset.face`, `artwork.png`, and `mask.png` files.

### Testing

- Added automated tests: `OasisEditor.Tests/AssetPackageLayoutBugTests.cs` to validate scaffolding, package title resolution, and Face first-save package output, but no test runner was executed in this environment.
- No CI or `dotnet test` was run inside Codex per repository policy; run the unit test suite locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` to verify and ensure all tests pass.
- Manual verification recommended: create a new project via the launcher, confirm `Assets/Audio`, `Assets/Fonts`, and `Assets/Images` are not created, open package manifests for Panel2D/Face/Cabinet3D and confirm the tab title is the package folder name, generate a Face from a Face Source Shape (should open unsaved tab), then perform first-save and confirm `Assets/Faces/<AssetName>/asset.face`, `artwork.png`, and `mask.png` are created and the saved document title equals the package folder name.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a441f11eff48327aedcf4b1dfde05d7)