### PR TITLE
Clean up editor asset menus

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -49,32 +49,24 @@
                 </Style>
             </Menu.Resources>
             <MenuItem Header="_File">
-                <MenuItem Header="New _Panel2D Stub"
-                          Command="{Binding OpenPanel2DStubCommand}" />
-                <MenuItem Header="New _Face Stub"
-                          Command="{Binding OpenFaceStubCommand}" />
-                <MenuItem Header="Add Face Source _Shape"
-                          Command="{Binding AddFaceSourceShapeCommand}" />
-                <MenuItem Header="Create Face from Face Source _Shape"
-                          Command="{Binding GenerateFaceFromSourceShapeCommand}" />
-                <MenuItem Header="_Regenerate Face from Source Shape"
-                          Command="{Binding RegenerateFaceCommand}" />
-                <MenuItem Header="_Validate Face"
-                          Command="{Binding ValidateFaceCommand}" />
-                <MenuItem Header="Open Source _Panel2D"
-                          Command="{Binding OpenSourcePanel2DCommand}" />
-                <MenuItem Header="New _Cabinet3D Stub"
-                          Command="{Binding OpenCabinet3DStubCommand}" />
-                <MenuItem Header="New _Machine Stub"
-                          Command="{Binding OpenMachineStubCommand}" />
+                <MenuItem Header="_New">
+                    <MenuItem Header="_Panel2D"
+                              Command="{Binding OpenPanel2DStubCommand}" />
+                    <MenuItem Header="_Face"
+                              Command="{Binding OpenFaceStubCommand}" />
+                    <MenuItem Header="_Cabinet3D"
+                              Command="{Binding OpenCabinet3DStubCommand}" />
+                    <MenuItem Header="_Machine"
+                              Command="{Binding OpenMachineStubCommand}" />
+                </MenuItem>
                 <Separator />
-                <MenuItem Header="Open _Document"
+                <MenuItem Header="Open _Asset"
                           Command="{Binding OpenDocumentCommand}" />
                 <MenuItem Header="_Import">
                     <MenuItem Header="_MFME Extract..."
                               Command="{Binding ImportMfmeExtractCommand}" />
                 </MenuItem>
-                <MenuItem Header="_Save Document"
+                <MenuItem Header="_Save Asset"
                           Command="{Binding SaveSelectedDocumentCommand}" />
                 <MenuItem Header="_Close Project"
                           Command="{Binding CloseProjectCommand}" />
@@ -92,6 +84,8 @@
                           Command="{Binding GenerateFaceFromSourceShapeCommand}" />
                 <MenuItem Header="_Regenerate from Source Shape"
                           Command="{Binding RegenerateFaceCommand}" />
+                <MenuItem Header="_Validate Face"
+                          Command="{Binding ValidateFaceCommand}" />
             </MenuItem>
             <MenuItem Header="_Edit">
                 <MenuItem Header="{Binding UndoMenuHeader}"


### PR DESCRIPTION
### Motivation
- Align the editor UI with the folder-as-asset model by consolidating File menu item placement and using user-facing `Asset` terminology instead of `Document` where appropriate.
- Remove obsolete and duplicate File menu entries so face-related actions live under the dedicated `Face` menu and the New workflow is grouped.

### Description
- Updated `WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml` to add a top-level `File > New` submenu with `Panel2D`, `Face`, `Cabinet3D`, and `Machine` items bound to the existing `OpenPanel2DStubCommand`, `OpenFaceStubCommand`, `OpenCabinet3DStubCommand`, and `OpenMachineStubCommand` respectively.
- Removed the old `New * Stub` entries and removed `Create Face from Face Source Shape` and `Regenerate Face from Source Shape` from the `File` menu so they remain only under the `Face` menu.
- Moved `Validate Face` into the `Face` menu and added a `MenuItem` bound to the existing `ValidateFaceCommand`.
- Renamed visible `File` menu labels `Open Document` → `Open Asset` and `Save Document` → `Save Asset` while preserving existing command bindings and without renaming any internal classes or commands.

### Testing
- Ran `git diff --check` to validate whitespace and diff issues and it passed.
- Verified the menu label and removal changes using ripgrep patterns against `MainWindow.xaml`, confirming the new `Header="_New"`, `Open _Asset`, and `_Save Asset` entries and the removed legacy headers.
- Committed the change (`Clean up editor asset menus`) and did not run WPF builds or unit tests per repository constraints and the instructions not to run build/test tooling in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a455bfeec288327afe8507f07104e36)