### PR TITLE
Add right-aligned submenu arrow indicator in EditorMenuItemStyle

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Styles/Menu.xaml
@@ -42,6 +42,12 @@
                                 CornerRadius="4">
                             <DockPanel LastChildFill="True"
                                        TextElement.Foreground="{TemplateBinding Foreground}">
+                                <TextBlock x:Name="SubmenuArrow"
+                                           DockPanel.Dock="Right"
+                                           Margin="16,0,0,0"
+                                           VerticalAlignment="Center"
+                                           Text=">"
+                                           Visibility="Collapsed" />
                                 <TextBlock x:Name="CheckGlyph"
                                            Width="16"
                                            Margin="0,0,4,0"
@@ -123,6 +129,9 @@
                             <Setter TargetName="SubMenuPopup"
                                     Property="Placement"
                                     Value="Right" />
+                            <Setter TargetName="SubmenuArrow"
+                                    Property="Visibility"
+                                    Value="Visible" />
                         </Trigger>
                         <Trigger Property="Role"
                                  Value="TopLevelItem">


### PR DESCRIPTION
### Motivation
- Make submenu nodes visually obvious by adding a right-aligned ">" indicator for menu items that open child submenus so items like File > Import are clearly identified as having children.

### Description
- Add a collapsed-by-default `TextBlock` named `SubmenuArrow` to the `EditorMenuItemStyle` `ControlTemplate` docked to the right and styled to inherit the template foreground and vertical alignment.
- Update the existing `Trigger` for `Role="SubmenuHeader"` to set `SubmenuArrow.Visibility` to `Visible` while keeping the existing submenu `Popup` placement behavior and all existing glyph/icon/header behavior unchanged.

### Testing
- No automated build or unit tests were run in this environment because the Codex environment does not contain the required Windows/.NET/WPF toolchain.  Local verification steps to run after pulling the change are: 1) Open the editor, 2) open the File menu, 3) confirm `New` and `Import` show a right-aligned `>`, 4) confirm `Save Asset`, `Close Project`, and `Exit` do not show a `>`, 5) confirm top-level menu headers like `File`, `Edit`, `Window` do not show a `>`, and 6) confirm child submenus still open in the correct direction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4565d3550c83278304d03fab066682)