### PR TITLE
Add live asset browser refresh

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1790,6 +1790,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 new EditorProgressRequest($"Saving {documentTitle}", "Saving document...", EditorProgressMode.Determinate, ShowDelay: TimeSpan.Zero),
                 (progress, _) => Task.Run(() => _documentSaveService.SaveDocument(current, savePath, LoadedProject, progress)));
             _documentWorkspace.ReplaceDocument(current, updatedDocument);
+            _assetBrowser.ScheduleRefreshFromDisk();
             StatusMessage = $"Saved document: {updatedDocument.Title}";
             AddOutputEntry($"Saved document to {savePath}", OutputLogStatus.Info);
         }
@@ -2548,6 +2549,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _activeDocumentContext.ClearAll();
         _machineRuntimeStates.ClearAll();
         PanelElementFactory.ProjectDirectoryPath = null;
+        _assetBrowser.Dispose();
 
         AssetBrowserItems.Clear();
         SelectedAsset = null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -1,12 +1,15 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace OasisEditor;
 
-public sealed class AssetBrowserViewModel
+public sealed class AssetBrowserViewModel : IDisposable
 {
     private readonly Func<EditorProject?> _loadedProjectAccessor;
     private readonly Action _selectionChanged;
@@ -16,6 +19,9 @@ public sealed class AssetBrowserViewModel
     private readonly Func<string, string?> _requestAssetRename;
     private AssetBrowserItemViewModel? _selectedAsset;
     private AssetDirectoryNodeViewModel? _selectedDirectory;
+    private FileSystemWatcher? _assetsWatcher;
+    private string? _watchedAssetsDirectory;
+    private readonly DispatcherTimer _refreshDebounceTimer;
     public event Action? StateChanged;
 
     public AssetBrowserViewModel(
@@ -32,10 +38,15 @@ public sealed class AssetBrowserViewModel
         _addOutputEntry = addOutputEntry;
         _openAsset = openAsset;
         _requestAssetRename = requestAssetRename;
+        _refreshDebounceTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(200)
+        };
+        _refreshDebounceTimer.Tick += OnRefreshDebounceTimerTick;
 
         AssetBrowserItems = new ObservableCollection<AssetBrowserItemViewModel>();
         AssetDirectoryTree = new ObservableCollection<AssetDirectoryNodeViewModel>();
-        RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowser, CanRefreshAssetBrowser);
+        RefreshAssetBrowserCommand = new RelayCommand(RefreshAssetBrowserPreservingState, CanRefreshAssetBrowser);
         OpenAssetCommand = new PaneItemCommand<object>(
             GetSelectedAssetContext,
             OpenAsset,
@@ -108,8 +119,14 @@ public sealed class AssetBrowserViewModel
 
     public void RefreshAssetBrowser()
     {
+        RefreshAssetBrowserPreservingState();
+    }
+
+    public void RefreshAssetBrowserPreservingState()
+    {
         var selectedDirectoryPath = SelectedDirectory?.FullPath;
         var selectedAssetPath = SelectedAsset?.FullPath;
+        var expandedDirectoryPaths = CaptureExpandedDirectoryPaths();
 
         var loadedProject = _loadedProjectAccessor();
         if (loadedProject is null)
@@ -119,6 +136,7 @@ public sealed class AssetBrowserViewModel
             SelectedDirectory = null;
             SelectedAsset = null;
             _notifyInspectorChanged();
+            StopWatchingAssetsDirectory();
             _addOutputEntry("Asset browser cleared (no project loaded).", OutputLogStatus.Info);
             return;
         }
@@ -129,14 +147,100 @@ public sealed class AssetBrowserViewModel
             Directory.CreateDirectory(assetDirectory);
         }
 
+        StartWatchingAssetsDirectory(assetDirectory);
+
         var rootNode = BuildDirectoryTree(assetDirectory, assetDirectory);
+        RestoreExpandedDirectoryPaths(rootNode, expandedDirectoryPaths);
         AssetDirectoryTree.Clear();
         AssetDirectoryTree.Add(rootNode);
-        SelectedDirectory = FindDirectoryByPath(rootNode, selectedDirectoryPath) ?? rootNode;
+        SelectedDirectory = FindDirectoryByPath(rootNode, selectedDirectoryPath)
+            ?? FindNearestExistingDirectory(rootNode, selectedDirectoryPath)
+            ?? rootNode;
         RestoreSelectedAsset(selectedAssetPath);
         _notifyInspectorChanged();
         _addOutputEntry($"Asset browser refreshed ({AssetBrowserItems.Count} items).", OutputLogStatus.Info);
         StateChanged?.Invoke();
+    }
+
+
+    public void ScheduleRefreshFromDisk()
+    {
+        var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+        if (dispatcher.CheckAccess())
+        {
+            RestartRefreshDebounceTimer();
+            return;
+        }
+
+        _ = dispatcher.BeginInvoke((Action)RestartRefreshDebounceTimer);
+    }
+
+    public void Dispose()
+    {
+        StopWatchingAssetsDirectory();
+        _refreshDebounceTimer.Stop();
+        _refreshDebounceTimer.Tick -= OnRefreshDebounceTimerTick;
+    }
+
+    private void StartWatchingAssetsDirectory(string assetsDirectory)
+    {
+        var fullAssetsDirectory = Path.GetFullPath(assetsDirectory);
+        if (_assetsWatcher is not null
+            && string.Equals(_watchedAssetsDirectory, fullAssetsDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        StopWatchingAssetsDirectory();
+
+        _assetsWatcher = new FileSystemWatcher(fullAssetsDirectory)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.DirectoryName
+                           | NotifyFilters.FileName
+                           | NotifyFilters.LastWrite
+                           | NotifyFilters.CreationTime
+        };
+        _assetsWatcher.Created += OnAssetsWatcherChanged;
+        _assetsWatcher.Deleted += OnAssetsWatcherChanged;
+        _assetsWatcher.Changed += OnAssetsWatcherChanged;
+        _assetsWatcher.Renamed += OnAssetsWatcherRenamed;
+        _assetsWatcher.EnableRaisingEvents = true;
+        _watchedAssetsDirectory = fullAssetsDirectory;
+    }
+
+    private void StopWatchingAssetsDirectory()
+    {
+        if (_assetsWatcher is null)
+        {
+            _watchedAssetsDirectory = null;
+            return;
+        }
+
+        _assetsWatcher.EnableRaisingEvents = false;
+        _assetsWatcher.Created -= OnAssetsWatcherChanged;
+        _assetsWatcher.Deleted -= OnAssetsWatcherChanged;
+        _assetsWatcher.Changed -= OnAssetsWatcherChanged;
+        _assetsWatcher.Renamed -= OnAssetsWatcherRenamed;
+        _assetsWatcher.Dispose();
+        _assetsWatcher = null;
+        _watchedAssetsDirectory = null;
+    }
+
+    private void OnAssetsWatcherChanged(object sender, FileSystemEventArgs e) => ScheduleRefreshFromDisk();
+
+    private void OnAssetsWatcherRenamed(object sender, RenamedEventArgs e) => ScheduleRefreshFromDisk();
+
+    private void RestartRefreshDebounceTimer()
+    {
+        _refreshDebounceTimer.Stop();
+        _refreshDebounceTimer.Start();
+    }
+
+    private void OnRefreshDebounceTimerTick(object? sender, EventArgs e)
+    {
+        _refreshDebounceTimer.Stop();
+        RefreshAssetBrowserPreservingState();
     }
 
     public void NotifyRefreshCommand()
@@ -422,7 +526,7 @@ public sealed class AssetBrowserViewModel
                 File.Move(asset.FullPath, targetPath);
             }
 
-            RefreshAssetBrowser();
+            RefreshAssetBrowserPreservingState();
             SelectDirectoryByPath(parentDirectory);
             SelectedAsset = AssetBrowserItems.FirstOrDefault(item =>
                 string.Equals(item.FullPath, targetPath, StringComparison.OrdinalIgnoreCase));
@@ -484,7 +588,7 @@ public sealed class AssetBrowserViewModel
                 _addOutputEntry($"Deleted file: {asset.DisplayPath}", OutputLogStatus.Info);
             }
 
-            RefreshAssetBrowser();
+            RefreshAssetBrowserPreservingState();
             SelectDirectoryByPath(selectedDirectoryPath ?? parentDirectory);
         }
         catch (Exception ex)
@@ -526,7 +630,69 @@ public sealed class AssetBrowserViewModel
         SelectedAsset = AssetBrowserItems.FirstOrDefault();
     }
 
-    private void SelectDirectoryByPath(string path)
+
+    private HashSet<string> CaptureExpandedDirectoryPaths()
+    {
+        var expandedDirectoryPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in AssetDirectoryTree)
+        {
+            CaptureExpandedDirectoryPathsRecursive(root, expandedDirectoryPaths);
+        }
+
+        return expandedDirectoryPaths;
+    }
+
+    private static void CaptureExpandedDirectoryPathsRecursive(
+        AssetDirectoryNodeViewModel node,
+        ISet<string> expandedDirectoryPaths)
+    {
+        if (node.IsExpanded)
+        {
+            expandedDirectoryPaths.Add(node.FullPath);
+        }
+
+        foreach (var child in node.Children)
+        {
+            CaptureExpandedDirectoryPathsRecursive(child, expandedDirectoryPaths);
+        }
+    }
+
+    private static void RestoreExpandedDirectoryPaths(
+        AssetDirectoryNodeViewModel node,
+        ISet<string> expandedDirectoryPaths)
+    {
+        node.IsExpanded = expandedDirectoryPaths.Contains(node.FullPath);
+        foreach (var child in node.Children)
+        {
+            RestoreExpandedDirectoryPaths(child, expandedDirectoryPaths);
+        }
+    }
+
+    private static AssetDirectoryNodeViewModel? FindNearestExistingDirectory(
+        AssetDirectoryNodeViewModel root,
+        string? requestedPath)
+    {
+        if (string.IsNullOrWhiteSpace(requestedPath))
+        {
+            return null;
+        }
+
+        var currentPath = requestedPath;
+        while (!string.IsNullOrWhiteSpace(currentPath))
+        {
+            var match = FindDirectoryByPath(root, currentPath);
+            if (match is not null)
+            {
+                return match;
+            }
+
+            currentPath = Path.GetDirectoryName(currentPath);
+        }
+
+        return null;
+    }
+
+    public void SelectDirectoryByPath(string path)
     {
         foreach (var root in AssetDirectoryTree)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -24,10 +24,6 @@
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource TextSecondaryBrush}"
                        Text="{Binding SelectedAssetDirectoryLabel, StringFormat=Folder: {0}}" />
-            <Button DockPanel.Dock="Right"
-                    Padding="10,4"
-                    Command="{Binding RefreshAssetBrowserCommand}"
-                    Content="Refresh" />
         </DockPanel>
 
         <Grid Grid.Row="1">


### PR DESCRIPTION
### Motivation

- Improve the Assets pane so new/renamed/deleted asset folders and files appear automatically without pressing Refresh. 
- Keep tree expansion and selection state when the tree is rebuilt to avoid disruptive UI collapses. 
- Ensure editor-side saves immediately surface in the Assets UI while also handling external filesystem changes.

### Description

- Added a debounced `FileSystemWatcher` that monitors the project `Assets` directory (with `IncludeSubdirectories = true` and `NotifyFilter` for directory/file/last-write/creation), and schedules UI refreshes on the dispatcher using a `DispatcherTimer` debounce (~200ms). 
- Introduced `ScheduleRefreshFromDisk()`, `StartWatchingAssetsDirectory()`, `StopWatchingAssetsDirectory()`, and `Dispose()` in `AssetBrowserViewModel`, and wired filesystem events to trigger a debounced refresh. 
- Replaced the destructive `RefreshAssetBrowser()` behavior with `RefreshAssetBrowserPreservingState()` which captures `SelectedDirectory`, `SelectedAsset`, and expanded directory paths before rebuilding the tree and restores matching nodes (or nearest existing ancestor) and the previously selected asset afterward. 
- Updated rename/delete flows to call the state-preserving refresh and added a non-destructive refresh call from `MainWindowViewModel.SaveSelectedDocument()` to surface editor-created asset package directories immediately. 
- Stop and dispose the watcher when no project is loaded and call `_assetBrowser.Dispose()` during project-close cleanup. 
- Removed the manual `Refresh` button from `AssetBrowserView.xaml` since automatic refresh is now provided.

### Testing

- No automated build/unit tests were executed in this environment because the session lacks the Windows/.NET/WPF toolchain (per project guidance); please run the test/build locally. 
- Performed repository checks (`git diff --check`, `git status`) and commit completed without whitespace or diff errors.
- Local manual verification recommended: open a project, expand an Assets folder (e.g. `Assets/Panel2D`), create/save a new asset, and confirm the new folder appears automatically in the tree and right pane, double-clicking opens it, external filesystem changes appear automatically, and project close disables the watcher without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a456b1b93e0832795717c7fdef5971b)