### PR TITLE
Fix asset browser folder icons

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetDirectoryNodeViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetDirectoryNodeViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Collections.Specialized;
 
 namespace OasisEditor;
 
@@ -13,6 +14,7 @@ public sealed class AssetDirectoryNodeViewModel : INotifyPropertyChanged
         DisplayPath = displayPath;
         FullPath = fullPath;
         Children = new ObservableCollection<AssetDirectoryNodeViewModel>();
+        Children.CollectionChanged += OnChildrenChanged;
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -20,6 +22,7 @@ public sealed class AssetDirectoryNodeViewModel : INotifyPropertyChanged
     public string DisplayPath { get; }
     public string FullPath { get; }
     public ObservableCollection<AssetDirectoryNodeViewModel> Children { get; }
+    public bool HasChildDirectories => Children.Count > 0;
 
     public bool IsExpanded
     {
@@ -34,6 +37,11 @@ public sealed class AssetDirectoryNodeViewModel : INotifyPropertyChanged
             _isExpanded = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
         }
+    }
+
+    private void OnChildrenChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasChildDirectories)));
     }
 
     public bool IsSelected

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -167,26 +167,59 @@
                     <HierarchicalDataTemplate DataType="{x:Type local:AssetDirectoryNodeViewModel}"
                                               ItemsSource="{Binding Children}">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Margin="0,0,6,0"
-                                       Foreground="{DynamicResource TextSecondaryBrush}">
-                                <TextBlock.Style>
-                                    <Style TargetType="{x:Type TextBlock}">
-                                        <Setter Property="Text" Value="📁" />
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Children.Count}" Value="0">
-                                                <Setter Property="Text" Value="🗀" />
-                                            </DataTrigger>
-                                            <MultiDataTrigger>
-                                                <MultiDataTrigger.Conditions>
-                                                    <Condition Binding="{Binding IsExpanded}" Value="True" />
-                                                    <Condition Binding="{Binding HasChildDirectories}" Value="True" />
-                                                </MultiDataTrigger.Conditions>
-                                                <Setter Property="Text" Value="📂" />
-                                            </MultiDataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
+                            <Grid Width="16"
+                                  Height="16"
+                                  Margin="0,1,6,0">
+                                <Canvas Width="16"
+                                        Height="16">
+                                    <Canvas.Style>
+                                        <Style TargetType="{x:Type Canvas}">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsExpanded}" Value="True" />
+                                                        <Condition Binding="{Binding HasChildDirectories}" Value="True" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Canvas.Style>
+                                    <Path Data="M1.5,5.5 H6 L7.5,7.5 H14.5 V14.5 H1.5 Z"
+                                          Stroke="{DynamicResource TextSecondaryBrush}"
+                                          StrokeThickness="1.4"
+                                          StrokeLineJoin="Round" />
+                                    <Path Data="M1.5,7.5 H14.5"
+                                          Stroke="{DynamicResource TextSecondaryBrush}"
+                                          StrokeThickness="1.4" />
+                                </Canvas>
+                                <Canvas Width="16"
+                                        Height="16">
+                                    <Canvas.Style>
+                                        <Style TargetType="{x:Type Canvas}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding IsExpanded}" Value="True" />
+                                                        <Condition Binding="{Binding HasChildDirectories}" Value="True" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Canvas.Style>
+                                    <Path Data="M1.5,6.5 H6 L7.5,4.5 H14.5 V7.5"
+                                          Stroke="{DynamicResource TextSecondaryBrush}"
+                                          StrokeThickness="1.4"
+                                          StrokeLineJoin="Round" />
+                                    <Path Data="M1.5,7.5 H15.5 L13.5,14.5 H1.5 Z"
+                                          Stroke="{DynamicResource TextSecondaryBrush}"
+                                          StrokeThickness="1.4"
+                                          StrokeLineJoin="Round" />
+                                </Canvas>
+                            </Grid>
                             <TextBlock Text="{Binding DisplayPath}" />
                         </StackPanel>
                     </HierarchicalDataTemplate>
@@ -224,19 +257,51 @@
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Margin="0,0,6,0"
-                                               Foreground="{DynamicResource TextSecondaryBrush}">
-                                        <TextBlock.Style>
-                                            <Style TargetType="{x:Type TextBlock}">
-                                                <Setter Property="Text" Value="📄" />
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsDirectory}" Value="True">
-                                                        <Setter Property="Text" Value="📁" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
+                                    <Grid Width="16"
+                                          Height="16"
+                                          Margin="0,1,6,0">
+                                        <Canvas Width="16"
+                                                Height="16">
+                                            <Canvas.Style>
+                                                <Style TargetType="{x:Type Canvas}">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsDirectory}" Value="True">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Canvas.Style>
+                                            <Path Data="M3.5,1.5 H10.5 L14.5,5.5 V14.5 H3.5 Z"
+                                                  Stroke="{DynamicResource TextSecondaryBrush}"
+                                                  StrokeThickness="1.4"
+                                                  StrokeLineJoin="Round" />
+                                            <Path Data="M10.5,1.5 V5.5 H14.5"
+                                                  Stroke="{DynamicResource TextSecondaryBrush}"
+                                                  StrokeThickness="1.4"
+                                                  StrokeLineJoin="Round" />
+                                        </Canvas>
+                                        <Canvas Width="16"
+                                                Height="16">
+                                            <Canvas.Style>
+                                                <Style TargetType="{x:Type Canvas}">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsDirectory}" Value="True">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Canvas.Style>
+                                            <Path Data="M1.5,5.5 H6 L7.5,7.5 H14.5 V14.5 H1.5 Z"
+                                                  Stroke="{DynamicResource TextSecondaryBrush}"
+                                                  StrokeThickness="1.4"
+                                                  StrokeLineJoin="Round" />
+                                            <Path Data="M1.5,7.5 H14.5"
+                                                  Stroke="{DynamicResource TextSecondaryBrush}"
+                                                  StrokeThickness="1.4" />
+                                        </Canvas>
+                                    </Grid>
                                     <TextBlock Text="{Binding DisplayPath}" />
                                 </StackPanel>
                             </DataTemplate>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -176,12 +176,13 @@
                                             <DataTrigger Binding="{Binding Children.Count}" Value="0">
                                                 <Setter Property="Text" Value="🗀" />
                                             </DataTrigger>
-                                            <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsExpanded}" Value="True" />
+                                                    <Condition Binding="{Binding HasChildDirectories}" Value="True" />
+                                                </MultiDataTrigger.Conditions>
                                                 <Setter Property="Text" Value="📂" />
-                                            </DataTrigger>
-                                            <DataTrigger Binding="{Binding IsExpanded}" Value="True">
-                                                <Setter Property="Text" Value="📂" />
-                                            </DataTrigger>
+                                            </MultiDataTrigger>
                                         </Style.Triggers>
                                     </Style>
                                 </TextBlock.Style>


### PR DESCRIPTION
### Motivation
- Fix inconsistent folder icon behavior so tree folders only show an open glyph when actually expanded and non-empty, and ensure the right-side flat list always shows a closed folder icon.

### Description
- Remove the selection-driven open-folder DataTrigger from `AssetBrowserView.xaml` and replace it with a `MultiDataTrigger` that shows the open-folder glyph only when `IsExpanded == true` and `HasChildDirectories == true`.
- Add `HasChildDirectories` to `AssetDirectoryNodeViewModel` and subscribe to `Children.CollectionChanged` so the view is notified when child presence changes.
- Preserve the right-pane `ListBox` item template so directories always render with the closed-folder glyph and are not bound to selection or expansion state.
- Modified files: `WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml` and `WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetDirectoryNodeViewModel.cs`.

### Testing
- Ran `git diff --check` which produced no issues.
- No build or unit tests were executed because the WPF/.NET toolchain is unavailable in this environment per project guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4571d05dbc8327b98cd8ced94e94fb)