### PR TITLE
Allow recursive asset folder deletion

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/AssetBrowserViewModel.cs
@@ -566,15 +566,8 @@ public sealed class AssetBrowserViewModel : IDisposable
                     return;
                 }
 
-                var hasChildren = Directory.EnumerateFileSystemEntries(asset.FullPath).Any();
-                if (hasChildren)
-                {
-                    _addOutputEntry($"Delete blocked: folder '{asset.DisplayPath}' is not empty.", OutputLogStatus.Warning);
-                    return;
-                }
-
-                Directory.Delete(asset.FullPath, recursive: false);
-                _addOutputEntry($"Deleted folder: {asset.DisplayPath}", OutputLogStatus.Info);
+                Directory.Delete(asset.FullPath, recursive: true);
+                _addOutputEntry($"Deleted folder and contents: {asset.DisplayPath}", OutputLogStatus.Info);
             }
             else
             {
@@ -588,13 +581,37 @@ public sealed class AssetBrowserViewModel : IDisposable
                 _addOutputEntry($"Deleted file: {asset.DisplayPath}", OutputLogStatus.Info);
             }
 
+            var directoryToSelect = ResolvePostDeleteDirectoryPath(
+                loadedProject.AssetsDirectory,
+                selectedDirectoryPath,
+                parentDirectory);
+
             RefreshAssetBrowserPreservingState();
-            SelectDirectoryByPath(selectedDirectoryPath ?? parentDirectory);
+            SelectDirectoryByPath(directoryToSelect);
         }
         catch (Exception ex)
         {
             _addOutputEntry($"Delete failed: {ex.Message}", OutputLogStatus.Warning);
         }
+    }
+
+    private static string ResolvePostDeleteDirectoryPath(
+        string assetsRoot,
+        string? selectedDirectoryPath,
+        string parentDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(selectedDirectoryPath)
+            && Directory.Exists(selectedDirectoryPath))
+        {
+            return selectedDirectoryPath;
+        }
+
+        if (Directory.Exists(parentDirectory))
+        {
+            return parentDirectory;
+        }
+
+        return assetsRoot;
     }
 
     private static string GetDirectoryDisplayPath(string assetsRoot, string directoryPath)


### PR DESCRIPTION
### Motivation

- Deleting folders in the Assets browser was blocked for non-empty directories which prevented convenient removal of a folder and its contents.
- Users can already rename and remove contents manually, so folder delete should remove the folder and its children recursively to match expected behavior.

### Description

- Removed the non-empty directory guard and changed folder deletion to `Directory.Delete(asset.FullPath, recursive: true)` so selected folders are deleted recursively.
- Updated the output log message to `Deleted folder and contents: <DisplayPath>` for clearer feedback after recursive deletion.
- Added `ResolvePostDeleteDirectoryPath` and used it to pick a sensible post-delete selection that prefers the previous selected directory, then the deleted folder’s parent, then the Assets root.
- Kept existing safety checks and behaviors including `IsPathInsideRoot` blocking, graceful handling when paths are missing, exception logging, and refreshing the asset browser after deletion.

### Testing

- Ran `git diff --check` which reported no whitespace or diff issues and succeeded.
- Verified repository state with `git status --short` showing the single modified file as expected.
- No build or unit tests were executed in this environment per repository guidance, so functional verification should be performed locally following the provided manual verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a45768a67988327a48632a8173b12ff)