### PR TITLE
Add draggable splitter to Assets browser panes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml
@@ -28,9 +28,9 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="1.5*" />
+                <ColumnDefinition Width="*" MinWidth="120" />
+                <ColumnDefinition Width="6" />
+                <ColumnDefinition Width="1.5*" MinWidth="160" />
             </Grid.ColumnDefinitions>
 
             <TreeView Grid.Column="0"
@@ -226,6 +226,29 @@
                 </TreeView.Resources>
             </TreeView>
 
+            <GridSplitter Grid.Column="1"
+                          Width="6"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          Background="Transparent"
+                          ResizeBehavior="PreviousAndNext"
+                          ResizeDirection="Columns"
+                          ShowsPreview="True"
+                          KeyboardIncrement="8"
+                          DragIncrement="1"
+                          Cursor="SizeWE"
+                          ToolTip="Drag to resize the asset folder tree and contents panes">
+                <GridSplitter.Template>
+                    <ControlTemplate TargetType="{x:Type GridSplitter}">
+                        <Border Background="{TemplateBinding Background}">
+                            <Border Width="1"
+                                    HorizontalAlignment="Center"
+                                    Background="{DynamicResource BorderSubtleBrush}" />
+                        </Border>
+                    </ControlTemplate>
+                </GridSplitter.Template>
+            </GridSplitter>
+
             <Border Grid.Column="2"
                     BorderBrush="{DynamicResource BorderSubtleBrush}"
                     BorderThickness="1"
@@ -237,7 +260,9 @@
                              MouseDoubleClick="OnAssetListMouseDoubleClick"
                              Background="Transparent"
                              BorderThickness="0"
-                             Foreground="{DynamicResource TextPrimaryBrush}">
+                             Foreground="{DynamicResource TextPrimaryBrush}"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <ListBox.ContextMenu>
                             <ContextMenu Style="{StaticResource EditorContextMenuStyle}">
                                 <MenuItem Header="Open"


### PR DESCRIPTION
### Motivation

- Allow users to resize the left folder tree and right content panes in the Assets browser by dragging a divider, matching a Unity-style editor workflow while keeping the editor layout simple. 

### Description

- Added a `GridSplitter` in `WindowsNetProjects/OasisEditor/OasisEditor/Views/AssetBrowserView.xaml` between the left `TreeView` and right `ListBox` so the divider can be dragged horizontally, using `ResizeBehavior="PreviousAndNext"` and `ResizeDirection="Columns"` with `ShowsPreview="True"`.
- Enforced sensible minimum widths by setting `MinWidth="120"` on the left column and `MinWidth="160"` on the right column so neither pane can collapse entirely during resizing.
- Applied a small visual template for the splitter (subtle center line) and kept `Cursor="SizeWE"` and `KeyboardIncrement`/`DragIncrement` for usable keyboard and mouse adjustments.
- Prevented horizontal scrollbars by leaving the left `TreeView` with `ScrollViewer.HorizontalScrollBarVisibility="Disabled"` and adding `ScrollViewer.HorizontalScrollBarVisibility="Disabled"` to the right `ListBox`, while preserving vertical scrolling behavior with `ScrollViewer.VerticalScrollBarVisibility="Auto"`.

### Testing

- No automated tests were run in this environment per project guidance and repository constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a457c91a64c8327ae30a7721ead3feb)