### PR TITLE
Align asset browser delete test with recursive folder deletion

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs
@@ -105,7 +105,7 @@ public sealed class AssetBrowserViewModelTests
     }
 
     [Fact]
-    public void DeleteAssetCommand_WhenFolderNotEmpty_BlocksDeletion()
+    public void DeleteAssetCommand_WhenFolderNotEmpty_DeletesFolderAndContents()
     {
         using var temp = new TempProjectDirectory();
         var folderPath = Path.Combine(temp.AssetsDirectory, "Art");
@@ -119,8 +119,8 @@ public sealed class AssetBrowserViewModelTests
         Assert.True(viewModel.DeleteAssetCommand.CanExecute(folderItem));
         viewModel.DeleteAssetCommand.Execute(folderItem);
 
-        Assert.True(Directory.Exists(folderPath));
-        Assert.Contains(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
+        Assert.False(Directory.Exists(folderPath));
+        Assert.DoesNotContain(viewModel.AssetBrowserItems, item => item.IsDirectory && item.DisplayPath == "Art");
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The asset browser implementation deletes selected folders and their contents recursively, so the test should expect deletion of non-empty folders rather than blocking it.

### Description
- Rename `DeleteAssetCommand_WhenFolderNotEmpty_BlocksDeletion` to `DeleteAssetCommand_WhenFolderNotEmpty_DeletesFolderAndContents` and update assertions to expect the folder to be removed (file: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/AssetBrowserViewModelTests.cs`).

### Testing
- No automated .NET tests were executed in this environment due to the missing Windows/.NET/WPF toolchain as noted in `AGENTS.md`; please run `dotnet test` locally to verify the updated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a46c685997c8327a859ac749a3a9567)