### PR TITLE
Refresh System6 native DLL API integration

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>net9.0-windows7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -54,8 +54,8 @@ public sealed class System6NativeBackendTests
             Assert.True(observedRun, "Expected the emulation pump to call Run while output polling was disabled.");
             Assert.Contains("Run:8000", library.Calls);
             Assert.DoesNotContain("LampsUpdate", library.Calls);
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("GetLampsOn:", StringComparison.Ordinal));
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("GetPosOut:", StringComparison.Ordinal));
+            Assert.DoesNotContain("GetOutputSnapshot", library.Calls);
+            
         }
         finally
         {
@@ -129,10 +129,10 @@ public sealed class System6NativeBackendTests
         await backend.StartAsync(request, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
 
-        Assert.Contains("SetCoinEnable:2:3:1", library.Calls);
-        Assert.Contains("SetCoinValue:2:3:10", library.Calls);
-        Assert.Contains("SetLockoutVal:2:3:4", library.Calls);
-        Assert.Contains("SetLockoutInvert:2:3:5", library.Calls);
+        Assert.Contains("SetCoinEnable:3:1", library.Calls);
+        Assert.Contains("SetCoinValue:3:10", library.Calls);
+        Assert.Contains("SetLockoutVal:3:4", library.Calls);
+        Assert.Contains("SetLockoutInvert:3:5", library.Calls);
         Assert.Contains("SetEnable:2:1", library.Calls);
         Assert.Contains("SetCounterIn:2:6", library.Calls);
         Assert.Contains("SetCounterOut:2:7", library.Calls);
@@ -283,12 +283,12 @@ public sealed class System6NativeBackendTests
             await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
             await backend.StopAsync(CancellationToken.None);
 
-            Assert.True(library.Calls.IndexOf("LampsUpdate") < library.Calls.IndexOf("GetLampsOn:0"));
+            Assert.Contains("GetOutputSnapshot", library.Calls);
             Assert.Contains(lampEvents, e => e.LampId == 0 && e.Value == 255);
             Assert.Contains(reelEvents, e => e.ReelId == 1 && e.Position == 86);
             Assert.Contains(reelEvents, e => e.ReelId == 2 && e.Position == 76);
-            Assert.Contains("GetPosOut:0", library.Calls);
-            Assert.Contains("GetPosOut:1", library.Calls);
+            Assert.Contains("GetOutputSnapshot", library.Calls);
+            
         }
         finally
         {
@@ -323,11 +323,7 @@ public sealed class System6NativeBackendTests
             Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoEnd:5:", StringComparison.Ordinal));
             Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoInvert:7:", StringComparison.Ordinal));
 
-            var getPosOutCalls = library.Calls.Where(call => call.StartsWith("GetPosOut:", StringComparison.Ordinal)).ToArray();
-            Assert.Equal(new[] { "GetPosOut:0", "GetPosOut:2", "GetPosOut:4" }, getPosOutCalls);
-            Assert.DoesNotContain("GetPosOut:1", library.Calls);
-            Assert.DoesNotContain("GetPosOut:3", library.Calls);
-            Assert.DoesNotContain("GetPosOut:5", library.Calls);
+            Assert.Contains("GetOutputSnapshot", library.Calls);
         }
         finally
         {
@@ -353,12 +349,10 @@ public sealed class System6NativeBackendTests
             await backend.StartAsync(CreateLaunchRequest([5, 255], rom1, rom2), CancellationToken.None);
             await backend.StopAsync(CancellationToken.None);
 
-            var getLampCalls = library.Calls.Where(call => call.StartsWith("GetLampsOn:", StringComparison.Ordinal)).ToArray();
-            Assert.Equal(new[] { "GetLampsOn:5", "GetLampsOn:255" }, getLampCalls);
+            Assert.Contains("GetOutputSnapshot", library.Calls);
             Assert.Contains(lampEvents, e => e.LampId == 5 && e.Value == 255);
             Assert.Contains(lampEvents, e => e.LampId == 255 && e.Value == 255);
-            Assert.DoesNotContain("GetLampsOn:0", library.Calls);
-            Assert.DoesNotContain("GetLampsOn:31", library.Calls);
+            
         }
         finally
         {
@@ -448,12 +442,7 @@ public sealed class System6NativeBackendTests
             await backend.StartAsync(request, CancellationToken.None);
             await backend.StopAsync(CancellationToken.None);
 
-            Assert.Contains("UpdateSegs", library.Calls);
-            Assert.Contains("GetSegsOn:32", library.Calls);
-            Assert.Contains("GetSegsOn:39", library.Calls);
-            Assert.Contains("GetSegsOn:80", library.Calls);
-            Assert.Contains("GetSegsOn:87", library.Calls);
-            Assert.DoesNotContain("GetSegsBright:32", library.Calls);
+            Assert.Contains("GetOutputSnapshot", library.Calls);
             Assert.Contains(segmentEvents, e => e.CellId == 2 && e.SegmentMask == 0x3F && e.OutputType == MameSegmentOutputType.Digit);
             Assert.Contains(segmentEvents, e => e.CellId == 5 && e.SegmentMask == 0x86 && e.OutputType == MameSegmentOutputType.Digit);
         }
@@ -524,7 +513,7 @@ public sealed class System6NativeBackendTests
             var brightnessEvent = Assert.Single(brightnessEvents);
             Assert.Equal(0, brightnessEvent.CellId);
             Assert.Equal(15d / 31d, brightnessEvent.NormalizedBrightness, precision: 6);
-            Assert.Contains("GetAlphaBrightness", library.Calls);
+            Assert.Contains("GetOutputSnapshot", library.Calls);
         }
         finally
         {
@@ -653,6 +642,58 @@ public sealed class System6NativeBackendTests
 
         public Dictionary<ushort, byte> SevenSegmentBrightness { get; } = new();
 
+        public uint GetOutputSnapshotSize() => (uint)Marshal.SizeOf<System6NativeOutputSnapshot>();
+
+        public System6NativeOutputSnapshot GetOutputSnapshot()
+        {
+            Calls.Add("GetOutputSnapshot");
+            var snapshot = new System6NativeOutputSnapshot
+            {
+                SizeBytes = (uint)Marshal.SizeOf<System6NativeOutputSnapshot>(),
+                Version = System6NativeOutputSnapshot.VersionValue,
+                MatrixLampCount = System6NativeOutputSnapshot.MatrixLampCapacity,
+                ReelCount = System6NativeOutputSnapshot.ReelCapacity,
+                AlphaSegmentedDisplayCount = AlphaSegmentPollingAvailable || AlphaBrightnessPollingAvailable ? 1u : 0u,
+                LedDisplayCount = SevenSegmentPollingAvailable ? System6NativeOutputSnapshot.LedDisplayCapacity : 0u
+            };
+
+            foreach (var (index, isOn) in GetLampsOnValues)
+            {
+                snapshot.SetMatrixLamp(index, new System6NativeLampState { OnOff = isOn ? (byte)1 : (byte)0, Brightness = isOn ? 1f : 0f });
+            }
+
+            foreach (var (index, position) in PositionOutputs)
+            {
+                snapshot.SetReelPosition(index, position);
+            }
+
+            if (AlphaSegmentPollingAvailable || AlphaBrightnessPollingAvailable)
+            {
+                var alpha = new System6NativeAlphaSegmentedState { Brightness = AlphaBrightnessPollingAvailable ? (float)System6NativeBackend.NormalizeSystem6AlphaBrightness(AlphaBrightness) : 1f };
+                unsafe
+                {
+                    foreach (var (index, segments) in AlphaSegments)
+                    {
+                        alpha.Segments[index] = (ushort)segments;
+                        AlphaSegmentIndices.Add(index);
+                    }
+                }
+                snapshot.SetAlphaSegmented(0, alpha);
+            }
+
+            foreach (var group in SevenSegmentCells.GroupBy(cell => cell.Key / 16))
+            {
+                uint mask = 0;
+                foreach (var cell in group.Where(cell => cell.Value))
+                {
+                    mask |= 1u << (cell.Key % 16);
+                }
+                snapshot.SetLedDisplay(group.Key, new System6NativeLedDisplayState { OnOff = mask, Brightness = 1f });
+            }
+
+            return snapshot;
+        }
+
         public byte Initialise()
         {
             Calls.Add("Initialise");
@@ -700,13 +741,13 @@ public sealed class System6NativeBackendTests
 
         public void SetPercent(byte percent) => Calls.Add($"SetPercent:{percent}");
 
-        public void SetCoinEnable(byte num, byte coin, byte coinEnable) => Calls.Add($"SetCoinEnable:{num}:{coin}:{coinEnable}");
+        public void SetCoinEnable(byte coin, byte coinEnable) => Calls.Add($"SetCoinEnable:{coin}:{coinEnable}");
 
-        public void SetCoinValue(byte num, byte coin, byte coinValue) => Calls.Add($"SetCoinValue:{num}:{coin}:{coinValue}");
+        public void SetCoinValue(byte coin, byte coinValue) => Calls.Add($"SetCoinValue:{coin}:{coinValue}");
 
-        public void SetLockoutVal(byte num, byte coin, byte lockoutValue) => Calls.Add($"SetLockoutVal:{num}:{coin}:{lockoutValue}");
+        public void SetLockoutVal(byte coin, byte lockoutValue) => Calls.Add($"SetLockoutVal:{coin}:{lockoutValue}");
 
-        public void SetLockoutInvert(byte num, byte coin, byte lockoutInvert) => Calls.Add($"SetLockoutInvert:{num}:{coin}:{lockoutInvert}");
+        public void SetLockoutInvert(byte coin, byte lockoutInvert) => Calls.Add($"SetLockoutInvert:{coin}:{lockoutInvert}");
 
         public void SetEnable(byte num, byte enable) => Calls.Add($"SetEnable:{num}:{enable}");
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -3,80 +3,30 @@ namespace OasisEditor;
 public interface ISystem6NativeLibrary : INativeCoreLibrary
 {
     byte Initialise();
-
     int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch);
-
     int LoadSoundRom(IReadOnlyList<string> soundRomPaths);
-
     void SetSteps(byte reelNum, byte steps);
-
     void SetOptoStart(byte reelNum, byte start);
-
     void SetOptoEnd(byte reelNum, byte end);
-
     void SetOptoInvert(byte reelNum, byte state);
-
     void Reset();
-
     int Run(int cycles);
-
     byte Shutdown();
-
-    bool IsLampsUpdateAvailable { get; }
-
-    string? LampsUpdateExportName { get; }
-
-    void LampsUpdate();
-
-    bool GetLampsOn(ushort lampIndex);
-
-    float GetLampBrightness(ushort lampIndex);
-
-    short GetPosOut(sbyte positionIndex);
-
-    bool IsAlphaSegmentPollingAvailable { get; }
-
-    int GetAlphaSegments(byte index);
-
-    bool IsAlphaBrightnessPollingAvailable { get; }
-
-    byte GetAlphaBrightness();
-
+    uint GetOutputSnapshotSize();
+    System6NativeOutputSnapshot GetOutputSnapshot();
     bool IsSetPercentAvailable { get; }
-
     void SetPercent(byte percent);
-
-    void SetCoinEnable(byte num, byte coin, byte coinEnable);
-
-    void SetCoinValue(byte num, byte coin, byte coinValue);
-
-    void SetLockoutVal(byte num, byte coin, byte lockoutValue);
-
-    void SetLockoutInvert(byte num, byte coin, byte lockoutInvert);
-
+    void SetCoinEnable(byte coin, byte coinEnable);
+    void SetCoinValue(byte coin, byte coinValue);
+    void SetLockoutVal(byte coin, byte lockoutValue);
+    void SetLockoutInvert(byte coin, byte lockoutInvert);
     void SetEnable(byte num, byte enable);
-
     void SetCounterIn(byte num, byte counterIn);
-
     void SetCounterOut(byte num, byte counterOut);
-
     void SetPortIndex(byte num, byte portIndex);
-
     void SetCoin(byte num, byte coin);
-
     void SetLevel(byte num, byte level);
-
     void SetFullLevel(byte num, byte fullLevel);
-
     void TurnSwitchOn(int switchIndex);
-
-    bool IsSevenSegmentPollingAvailable { get; }
-
-    void UpdateSegs();
-
-    int GetSegsOn(ushort index);
-
-    byte GetSegsBright(ushort index);
-
     void TurnSwitchOff(int switchIndex);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -158,11 +158,8 @@ public sealed class System6NativeBackend : IEmulationBackend
 
             _library = _libraryFactory(_libraryPath);
             LogStartupStage("native DLL loaded and exports bound");
-            LogStartupStage($"SYSTEM6GetAlphaSegments export {(_library.IsAlphaSegmentPollingAvailable ? "available" : "missing")}");
+            LogStartupStage($"GetOutputSnapshot size={_library.GetOutputSnapshotSize()} bytes");
             LogStartupStage($"SetPercent export {(_library.IsSetPercentAvailable ? "available" : "missing")}");
-            LogStartupStage($"SYSTEM6GetSegOn export {(_library.IsSevenSegmentPollingAvailable ? "available" : "missing")}");
-            LogStartupStage($"SYSTEM6UpdateLamps export {FormatOptionalExportStatus(_library.IsLampsUpdateAvailable, _library.LampsUpdateExportName)}");
-            LogStartupStage("SYSTEM6GetLampsOn export available");
             if (startupStage is System6StartupStage.LoadBindOnly)
             {
                 return CompleteStagedStartup();
@@ -174,7 +171,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                 LogStartupStage($"Initialise returned {initialiseResult}");
                 if (initialiseResult == 0)
                 {
-                    throw new InvalidOperationException("SYSTEM6Initialise returned failure.");
+                    throw new InvalidOperationException("Initialise returned failure.");
                 }
             }
             catch (Exception ex)
@@ -203,7 +200,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                 LogStartupStage($"LoadROM returned {loadRomResult}");
                 if (loadRomResult == 0)
                 {
-                    throw new InvalidOperationException("SYSTEM6LoadROM returned failure.");
+                    throw new InvalidOperationException("LoadROM returned failure.");
                 }
 
                 if (soundRomPaths.Any(path => !string.IsNullOrWhiteSpace(path)))
@@ -212,7 +209,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                     LogStartupStage($"LoadSoundROM returned {loadSoundRomResult}");
                     if (loadSoundRomResult == 0)
                     {
-                        throw new InvalidOperationException("SYSTEM6LoadSoundROM returned failure.");
+                        throw new InvalidOperationException("LoadSoundROM returned failure.");
                     }
                 }
                 else
@@ -730,10 +727,10 @@ public sealed class System6NativeBackend : IEmulationBackend
         {
             var num = checked((byte)coin.Num);
             var channel = checked((byte)coin.Coin);
-            library.SetCoinEnable(num, channel, checked((byte)coin.CoinEnable));
-            library.SetCoinValue(num, channel, checked((byte)coin.CoinValue));
-            library.SetLockoutVal(num, channel, checked((byte)coin.LockoutValue));
-            library.SetLockoutInvert(num, channel, checked((byte)coin.LockoutInvert));
+            library.SetCoinEnable(channel, checked((byte)coin.CoinEnable));
+            library.SetCoinValue(channel, checked((byte)coin.CoinValue));
+            library.SetLockoutVal(channel, checked((byte)coin.LockoutValue));
+            library.SetLockoutInvert(channel, checked((byte)coin.LockoutInvert));
             library.SetEnable(num, 1);
             library.SetCounterIn(num, checked((byte)coin.CounterIn));
             library.SetCounterOut(num, checked((byte)coin.CounterOut));
@@ -826,17 +823,18 @@ public sealed class System6NativeBackend : IEmulationBackend
         Debug.WriteLine($"System6 native backend output timing: pollHz={_outputPollsPerSecond}; PollOutputs={pollElapsed.TotalMilliseconds:0.00} ms; skippedVisualPolls={skippedPolls}; nativeCalls={nativeInvokeCount}.");
     }
 
-    private int PollOutputs(ISystem6NativeLibrary library)
+    private unsafe int PollOutputs(ISystem6NativeLibrary library)
     {
-        var nativeInvokeCount = 0;
-        nativeInvokeCount += PollLampOutputs(library);
-        nativeInvokeCount += PollReelOutputs(library);
-        nativeInvokeCount += PollAlphaDebugOutput(library);
-        nativeInvokeCount += PollSevenSegmentOutputs(library);
+        var snapshot = library.GetOutputSnapshot();
+        var nativeInvokeCount = 1;
+        nativeInvokeCount += PollLampOutputs(snapshot);
+        nativeInvokeCount += PollReelOutputs(snapshot);
+        nativeInvokeCount += PollAlphaOutputs(snapshot);
+        nativeInvokeCount += PollSevenSegmentOutputs(snapshot);
         return nativeInvokeCount;
     }
 
-    private int PollSevenSegmentOutputs(ISystem6NativeLibrary library)
+    private unsafe int PollSevenSegmentOutputs(System6NativeOutputSnapshot snapshot)
     {
         var displayIds = _configuredSevenSegmentDisplayIds;
         if (displayIds is null || displayIds.Count == 0)
@@ -844,84 +842,36 @@ public sealed class System6NativeBackend : IEmulationBackend
             return 0;
         }
 
-        if (!library.IsSevenSegmentPollingAvailable)
-        {
-            if (!_hasLoggedSevenSegmentUnavailable)
-            {
-                _hasLoggedSevenSegmentUnavailable = true;
-                Debug.WriteLine("[System6 7 Segment] SYSTEM6GetSegOn unavailable; seven-segment polling disabled.");
-            }
-
-            return 0;
-        }
-
-        var nativeInvokeCount = 0;
-        try
-        {
-            library.UpdateSegs();
-            nativeInvokeCount++;
-        }
-        catch (NotSupportedException)
-        {
-            // Some cores expose direct segment reads without an explicit update export.
-        }
-
         foreach (var displayId in displayIds)
         {
-            var baseIndex = GetNativeSevenSegmentBaseIndex(displayId);
-            var mask = 0;
-            for (var bit = 0; bit < SevenSegmentMaskBits; bit++)
+            if (displayId >= snapshot.LedDisplayCount || displayId >= System6NativeOutputSnapshot.LedDisplayCapacity)
             {
-                var nativeIndex = checked((ushort)(baseIndex + bit));
-                if (library.GetSegsOn(nativeIndex) != 0)
-                {
-                    mask |= 1 << bit;
-                }
-
-                nativeInvokeCount++;
+                continue;
             }
 
+            var ledDisplay = snapshot.GetLedDisplay(displayId);
+            var mask = unchecked((int)ledDisplay.OnOff);
             if (!_lastSevenSegmentMasks.TryGetValue(displayId, out var previous) || previous != mask)
             {
                 _lastSevenSegmentMasks[displayId] = mask;
-                if (_timingDiagnosticsEnabled)
-                {
-                    Debug.WriteLine($"[System6 7 Segment] display {displayId} nativeBase={baseIndex} mask=0x{mask:X2}");
-                }
-
                 SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(displayId, mask, MameSegmentOutputType.Digit));
             }
         }
 
-        return nativeInvokeCount;
+        return 0;
     }
 
-    internal static int GetNativeSevenSegmentBaseIndex(int displayId)
-    {
-        // The native core exposes Seg7.On[256] as individual segment cells, not
-        // digit-level masks. Each digit occupies a 16-cell block; the first eight
-        // cells map to the canonical Oasis/MAME seven-segment bits.
-        return checked(displayId * NativeSevenSegmentCellStride);
-    }
+    internal static int GetNativeSevenSegmentBaseIndex(int displayId) => displayId;
 
-    private int PollLampOutputs(ISystem6NativeLibrary library)
+    private int PollLampOutputs(System6NativeOutputSnapshot snapshot)
     {
-        var nativeInvokeCount = 0;
-        LogLampPollingConfiguration(library);
-        if (library.IsLampsUpdateAvailable)
-        {
-            library.LampsUpdate();
-            nativeInvokeCount++;
-        }
-
         var changedDiagnostics = new List<string>();
-        foreach (var lampIndex in GetLampPollingIds())
+        var lampCount = (int)Math.Min(snapshot.MatrixLampCount, (uint)System6NativeOutputSnapshot.MatrixLampCapacity);
+        foreach (var lampIndex in GetLampPollingIds().Where(id => id < lampCount))
         {
-            var nativeLampIndex = checked((ushort)lampIndex);
-            var rawValue = library.GetLampsOn(nativeLampIndex) ? 1 : 0;
-            nativeInvokeCount++;
-            var isOn = rawValue != 0;
-            var value = isOn ? 255 : 0;
+            var lamp = snapshot.GetMatrixLamp(lampIndex);
+            var rawValue = lamp.OnOff != 0 ? 1 : 0;
+            var value = NormalizeLampBrightness(lamp);
             var diagnosticChanged = _lastLampRawValues[lampIndex] != rawValue;
             if (diagnosticChanged)
             {
@@ -935,7 +885,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
             if (diagnosticChanged && changedDiagnostics.Count < DiagnosticChangedLampSampleCount)
             {
-                changedDiagnostics.Add(FormatLampChangeDiagnostic(nativeLampIndex, lampIndex, rawValue, isOn, value));
+                changedDiagnostics.Add(FormatLampChangeDiagnostic((ushort)lampIndex, lampIndex, rawValue, value > 0, value));
             }
         }
 
@@ -944,7 +894,17 @@ public sealed class System6NativeBackend : IEmulationBackend
             Debug.WriteLine($"[System6 Lamps] changed: {string.Join("; ", changedDiagnostics)}");
         }
 
-        return nativeInvokeCount;
+        return 0;
+    }
+
+    private static int NormalizeLampBrightness(System6NativeLampState lamp)
+    {
+        if (lamp.Brightness > 0f)
+        {
+            return Math.Clamp((int)Math.Round(lamp.Brightness * 255f), 0, 255);
+        }
+
+        return lamp.OnOff != 0 ? 255 : 0;
     }
 
     private static string FormatLampChangeDiagnostic(ushort nativeLampIndex, int lampIndex, int rawValue, bool isOn, int value)
@@ -952,19 +912,14 @@ public sealed class System6NativeBackend : IEmulationBackend
         return $"native {nativeLampIndex} -> lamp:{lampIndex} raw={rawValue.ToString(CultureInfo.InvariantCulture)} on={isOn.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()} value={value}";
     }
 
-    private int PollReelOutputs(ISystem6NativeLibrary library)
+    private int PollReelOutputs(System6NativeOutputSnapshot snapshot)
     {
-        var nativeInvokeCount = 0;
         LogReelPollingMapping();
-        foreach (var reelIndex in _enabledReelPollingIndices)
+        var reelCount = (int)Math.Min(snapshot.ReelCount, (uint)System6NativeOutputSnapshot.ReelCapacity);
+        foreach (var reelIndex in _enabledReelPollingIndices.Where(index => index < reelCount))
         {
-            // GetPosOut expects the same zero-based reel selector used by the
-            // native reel opto setup. Oasis machine references use the one-based
-            // display reel number, so translate only the emitted event ID.
-            var nativePositionSelector = checked((sbyte)reelIndex);
             var reelId = reelIndex + 1;
-            var rawPosition = library.GetPosOut(nativePositionSelector);
-            nativeInvokeCount++;
+            var rawPosition = snapshot.GetReelPosition(reelIndex);
             var position = NormalizeConfiguredNativeSystem6ReelPosition(reelIndex, rawPosition);
             if (_lastReelPositions[reelIndex] != position)
             {
@@ -973,9 +928,45 @@ public sealed class System6NativeBackend : IEmulationBackend
             }
         }
 
-        return nativeInvokeCount;
+        return 0;
     }
 
+    private unsafe int PollAlphaOutputs(System6NativeOutputSnapshot snapshot)
+    {
+        if (snapshot.AlphaSegmentedDisplayCount == 0)
+        {
+            return 0;
+        }
+
+        var alpha = snapshot.GetAlphaSegmented(0);
+        var normalizedBrightness = Math.Clamp(alpha.Brightness, 0d, 1d);
+        if (!_lastAlphaBrightness.HasValue || Math.Abs(_lastAlphaBrightness.Value - normalizedBrightness) >= 0.000001d)
+        {
+            _lastAlphaBrightness = normalizedBrightness;
+            VfdBrightnessChanged?.Invoke(this, new MachineVfdBrightnessChangedEventArgs(0, normalizedBrightness));
+        }
+
+        var segments = new int[AlphaCellCount];
+        var mappedSegments = new int[AlphaCellCount];
+        for (var index = 0; index < segments.Length; index++)
+        {
+            segments[index] = alpha.Segments[index];
+            mappedSegments[index] = System6AlphaSegmentMapper.MapNativeMaskToOasisMask(segments[index]);
+        }
+
+        if (_lastAlphaSegments is not null && segments.SequenceEqual(_lastAlphaSegments))
+        {
+            return 0;
+        }
+
+        _lastAlphaSegments = segments;
+        for (var index = 0; index < segments.Length; index++)
+        {
+            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, mappedSegments[index], MameSegmentOutputType.NativeAlpha));
+        }
+
+        return 0;
+    }
 
     private void ResetConfiguredReelStepCounts()
     {
@@ -1046,22 +1037,6 @@ public sealed class System6NativeBackend : IEmulationBackend
         return (steps - positionWithinReel) % steps;
     }
 
-    private void LogLampPollingConfiguration(ISystem6NativeLibrary library)
-    {
-        if (_hasLoggedLampPollingConfiguration)
-        {
-            return;
-        }
-
-        _hasLoggedLampPollingConfiguration = true;
-        var lampIds = GetLampPollingIds();
-        var source = _configuredLampPollingIds is null ? $"fallback native lamps 0-{FallbackLampCount - 1}" : $"configured native lamp IDs ({lampIds.Count} total, range {lampIds.Min()}-{lampIds.Max()})";
-        Debug.WriteLine($"[System6 Lamps] SYSTEM6UpdateLamps export {FormatOptionalExportStatus(library.IsLampsUpdateAvailable, library.LampsUpdateExportName)}; SYSTEM6GetLampsOn export available; value source=SYSTEM6GetLampsOn; polling {source}");
-        var mappings = lampIds.Take(DiagnosticMappingSampleCount)
-            .Select(index => $"native {index} -> lamp:{index}");
-        Debug.WriteLine($"[System6 Lamps] mapping sample: {string.Join("; ", mappings)}");
-    }
-
     private void LogReelPollingMapping()
     {
         if (_hasLoggedReelPollingMapping)
@@ -1075,80 +1050,10 @@ public sealed class System6NativeBackend : IEmulationBackend
         Debug.WriteLine($"[System6 Reels] mapping sample: {string.Join("; ", mappings)}");
     }
 
-    private int PollAlphaDebugOutput(ISystem6NativeLibrary library)
-    {
-        var nativeInvokeCount = PollAlphaBrightnessOutput(library);
-
-        if (!library.IsAlphaSegmentPollingAvailable)
-        {
-            if (!_hasLoggedAlphaUnavailable)
-            {
-                _hasLoggedAlphaUnavailable = true;
-                Debug.WriteLine("[System6 Alpha] SYSTEM6GetAlphaSegments unavailable; alpha segment polling disabled.");
-            }
-
-            return nativeInvokeCount;
-        }
-
-        var segments = new int[AlphaCellCount];
-        var mappedSegments = new int[AlphaCellCount];
-        for (var index = 0; index < segments.Length; index++)
-        {
-            segments[index] = library.GetAlphaSegments(checked((byte)index));
-            nativeInvokeCount++;
-            mappedSegments[index] = System6AlphaSegmentMapper.MapNativeMaskToOasisMask(segments[index]);
-        }
-
-        if (_lastAlphaSegments is not null && segments.SequenceEqual(_lastAlphaSegments))
-        {
-            return nativeInvokeCount;
-        }
-
-        _lastAlphaSegments = segments;
-        if (_timingDiagnosticsEnabled)
-        {
-            Debug.WriteLine($"System6 alpha segs: {FormatAlphaSegments(segments)}");
-            Debug.WriteLine($"System6 alpha mapped segs: {FormatAlphaSegments(mappedSegments)}");
-        }
-
-        for (var index = 0; index < segments.Length; index++)
-        {
-            if (_timingDiagnosticsEnabled)
-            {
-                Debug.WriteLine($"System6 alpha cell {index} raw=0x{(segments[index] & 0xFFFF):X4} mapped=0x{(mappedSegments[index] & 0xFFFF):X4}");
-            }
-
-            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, mappedSegments[index], MameSegmentOutputType.NativeAlpha));
-        }
-
-        return nativeInvokeCount;
-    }
-
     internal static double NormalizeSystem6AlphaBrightness(byte rawBrightness)
     {
-        // SYSTEM6GetAlphaBright appears to report the same 0-31 VFD duty range that
-        // MAME exposes for Impact vfdduty outputs. The optional export gate handles
-        // unavailable data; raw 0 is a valid blank/fade-start value, not full brightness.
         const double maxSystem6AlphaDuty = 31d;
         return Math.Clamp(rawBrightness / maxSystem6AlphaDuty, 0d, 1d);
-    }
-
-    private int PollAlphaBrightnessOutput(ISystem6NativeLibrary library)
-    {
-        if (!library.IsAlphaBrightnessPollingAvailable)
-        {
-            return 0;
-        }
-
-        var normalizedBrightness = NormalizeSystem6AlphaBrightness(library.GetAlphaBrightness());
-        if (_lastAlphaBrightness.HasValue && Math.Abs(_lastAlphaBrightness.Value - normalizedBrightness) < 0.000001d)
-        {
-            return 1;
-        }
-
-        _lastAlphaBrightness = normalizedBrightness;
-        VfdBrightnessChanged?.Invoke(this, new MachineVfdBrightnessChangedEventArgs(0, normalizedBrightness));
-        return 1;
     }
 
     private void ResetCachedOutputState()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -8,201 +8,117 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6InitialiseDelegate _initialise;
     private readonly System6LoadRomDelegate _loadRom;
     private readonly System6LoadSoundRomDelegate _loadSoundRom;
-    private readonly System6SetStepsDelegate _setSteps;
-    private readonly System6SetOptoStartDelegate _setOptoStart;
-    private readonly System6SetOptoEndDelegate _setOptoEnd;
-    private readonly System6SetOptoInvertDelegate _setOptoInvert;
+    private readonly System6SetByteByteDelegate _setSteps;
+    private readonly System6SetByteByteDelegate _setOptoStart;
+    private readonly System6SetByteByteDelegate _setOptoEnd;
+    private readonly System6SetByteByteDelegate _setOptoInvert;
     private readonly System6ResetDelegate _reset;
     private readonly System6RunDelegate _run;
     private readonly System6ShutdownDelegate _shutdown;
-    private readonly System6GetLampsOnDelegate _getLampsOn;
-    private readonly System6LampsUpdateDelegate? _lampsUpdate;
-    private readonly string? _lampsUpdateExportName;
-    private readonly System6GetLampBrightnessDelegate _getLampBrightness;
-    private readonly System6GetPosOutDelegate _getPosOut;
-    private readonly System6GetAlphaSegmentsDelegate? _getAlphaSegments;
-    private readonly System6GetAlphaBrightnessDelegate? _getAlphaBrightness;
-    private readonly System6SetPercentDelegate? _setPercent;
-    private readonly System6UpdateSegsDelegate? _updateSegs;
-    private readonly System6GetSegsOnDelegate? _getSegsOn;
-    private readonly System6GetSegsBrightDelegate? _getSegsBright;
-    private readonly System6SetCoinEnableDelegate _setCoinEnable;
-    private readonly System6SetCoinValueDelegate _setCoinValue;
-    private readonly System6SetLockoutValDelegate _setLockoutVal;
-    private readonly System6SetLockoutInvertDelegate _setLockoutInvert;
-    private readonly System6SetEnableDelegate _setEnable;
-    private readonly System6SetCounterInDelegate _setCounterIn;
-    private readonly System6SetCounterOutDelegate _setCounterOut;
-    private readonly System6SetPortIndexDelegate _setPortIndex;
-    private readonly System6SetCoinDelegate _setCoin;
-    private readonly System6SetLevelDelegate _setLevel;
-    private readonly System6SetFullLevelDelegate _setFullLevel;
-    private readonly System6TurnSwitchOnDelegate _turnSwitchOn;
-    private readonly System6TurnSwitchOffDelegate _turnSwitchOff;
+    private readonly System6GetOutputSnapshotSizeDelegate _getOutputSnapshotSize;
+    private readonly System6GetOutputSnapshotDelegate _getOutputSnapshot;
+    private readonly System6SetByteDelegate? _setPercent;
+    private readonly System6SetByteByteDelegate _setCoinEnable;
+    private readonly System6SetByteByteDelegate _setCoinValue;
+    private readonly System6SetByteByteDelegate _setLockoutVal;
+    private readonly System6SetByteByteDelegate _setLockoutInvert;
+    private readonly System6SetByteByteDelegate _setEnable;
+    private readonly System6SetByteUIntDelegate _setCounterIn;
+    private readonly System6SetByteUIntDelegate _setCounterOut;
+    private readonly System6SetByteByteDelegate _setPortIndex;
+    private readonly System6SetByteByteDelegate _setCoin;
+    private readonly System6SetByteByteDelegate _setLevel;
+    private readonly System6SetByteByteDelegate _setFullLevel;
+    private readonly System6SetByteDelegate _turnSwitchOn;
+    private readonly System6SetByteDelegate _turnSwitchOff;
     private readonly List<IntPtr> _romPathBuffers = [];
 
-    public System6NativeLibrary(string libraryPath)
-        : this(new NativeLibraryLoader(libraryPath))
-    {
-    }
+    public System6NativeLibrary(string libraryPath) : this(new NativeLibraryLoader(libraryPath)) { }
 
     public System6NativeLibrary(NativeLibraryLoader loader)
     {
         _loader = loader ?? throw new ArgumentNullException(nameof(loader));
-
-        _initialise = _loader.BindExport<System6InitialiseDelegate>("SYSTEM6Initialise");
-        _loadRom = _loader.BindExport<System6LoadRomDelegate>("SYSTEM6LoadROM");
-        _loadSoundRom = _loader.BindExport<System6LoadSoundRomDelegate>("SYSTEM6LoadSoundROM");
-        _setSteps = _loader.BindExport<System6SetStepsDelegate>("SetSteps");
-        _setOptoStart = _loader.BindExport<System6SetOptoStartDelegate>("SetOptoStart");
-        _setOptoEnd = _loader.BindExport<System6SetOptoEndDelegate>("SetOptoEnd");
-        _setOptoInvert = _loader.BindExport<System6SetOptoInvertDelegate>("SetOptoInvert");
-        _reset = _loader.BindExport<System6ResetDelegate>("SYSTEM6Reset");
-        _run = _loader.BindExport<System6RunDelegate>("SYSTEM6Run");
-        _shutdown = _loader.BindExport<System6ShutdownDelegate>("SYSTEM6Shutdown");
-        _getLampsOn = _loader.BindExport<System6GetLampsOnDelegate>("SYSTEM6GetLampsOn");
-        (_lampsUpdate, _lampsUpdateExportName) = TryBindOptionalExportCandidate<System6LampsUpdateDelegate>("SYSTEM6UpdateLamps");
-        _getLampBrightness = _loader.BindExport<System6GetLampBrightnessDelegate>("SYSTEM6GetLampBrightness");
-        _getPosOut = _loader.BindExport<System6GetPosOutDelegate>("SYSTEM6GetPosOut");
-        _getAlphaSegments = TryBindOptionalExport<System6GetAlphaSegmentsDelegate>("SYSTEM6GetAlphaSegments");
-        _getAlphaBrightness = TryBindOptionalExport<System6GetAlphaBrightnessDelegate>("SYSTEM6GetAlphaBright");
-        _setPercent = TryBindOptionalExport<System6SetPercentDelegate>("SetPercent");
-        _updateSegs = TryBindOptionalExport<System6UpdateSegsDelegate>("SYSTEM6UpdateSegs");
-        _getSegsOn = TryBindOptionalExport<System6GetSegsOnDelegate>("SYSTEM6GetSegOn");
-        _getSegsBright = TryBindOptionalExport<System6GetSegsBrightDelegate>("SYSTEM6GetSegBright");
-        _setCoinEnable = _loader.BindExport<System6SetCoinEnableDelegate>("SYSTEM6SetCoinEnable");
-        _setCoinValue = _loader.BindExport<System6SetCoinValueDelegate>("SYSTEM6SetCoinValue");
-        _setLockoutVal = _loader.BindExport<System6SetLockoutValDelegate>("SYSTEM6SetLockoutVal");
-        _setLockoutInvert = _loader.BindExport<System6SetLockoutInvertDelegate>("SYSTEM6SetLockoutInvert");
-        _setEnable = _loader.BindExport<System6SetEnableDelegate>("SYSTEM6SetEnable");
-        _setCounterIn = _loader.BindExport<System6SetCounterInDelegate>("SYSTEM6SetCounterIn");
-        _setCounterOut = _loader.BindExport<System6SetCounterOutDelegate>("SYSTEM6SetCounterOut");
-        _setPortIndex = _loader.BindExport<System6SetPortIndexDelegate>("SYSTEM6SetPortIndex");
-        _setCoin = _loader.BindExport<System6SetCoinDelegate>("SYSTEM6SetCoin");
-        _setLevel = _loader.BindExport<System6SetLevelDelegate>("SYSTEM6SetLevel");
-        _setFullLevel = _loader.BindExport<System6SetFullLevelDelegate>("SYSTEM6SetFullLevel");
-        _turnSwitchOn = _loader.BindExport<System6TurnSwitchOnDelegate>("SYSTEM6TurnSwitchOn");
-        _turnSwitchOff = _loader.BindExport<System6TurnSwitchOffDelegate>("SYSTEM6TurnSwitchOff");
+        _initialise = _loader.BindExport<System6InitialiseDelegate>("Initialise");
+        _loadRom = _loader.BindExport<System6LoadRomDelegate>("LoadROM");
+        _loadSoundRom = _loader.BindExport<System6LoadSoundRomDelegate>("LoadSoundROM");
+        _setSteps = _loader.BindExport<System6SetByteByteDelegate>("SetSteps");
+        _setOptoStart = _loader.BindExport<System6SetByteByteDelegate>("SetOptoStart");
+        _setOptoEnd = _loader.BindExport<System6SetByteByteDelegate>("SetOptoEnd");
+        _setOptoInvert = _loader.BindExport<System6SetByteByteDelegate>("SetOptoInvert");
+        _reset = _loader.BindExport<System6ResetDelegate>("Reset");
+        _run = _loader.BindExport<System6RunDelegate>("Run");
+        _shutdown = _loader.BindExport<System6ShutdownDelegate>("Shutdown");
+        _getOutputSnapshotSize = _loader.BindExport<System6GetOutputSnapshotSizeDelegate>("GetOutputSnapshotSize");
+        _getOutputSnapshot = _loader.BindExport<System6GetOutputSnapshotDelegate>("GetOutputSnapshot");
+        _setPercent = TryBindOptionalExport<System6SetByteDelegate>("SetPercent");
+        _setCoinEnable = _loader.BindExport<System6SetByteByteDelegate>("SetCoinEnable");
+        _setCoinValue = _loader.BindExport<System6SetByteByteDelegate>("SetCoinValue");
+        _setLockoutVal = _loader.BindExport<System6SetByteByteDelegate>("SetLockoutVal");
+        _setLockoutInvert = _loader.BindExport<System6SetByteByteDelegate>("SetLockoutInvert");
+        _setEnable = _loader.BindExport<System6SetByteByteDelegate>("SetEnable");
+        _setCounterIn = _loader.BindExport<System6SetByteUIntDelegate>("SetCounterIn");
+        _setCounterOut = _loader.BindExport<System6SetByteUIntDelegate>("SetCounterOut");
+        _setPortIndex = _loader.BindExport<System6SetByteByteDelegate>("SetPortIndex");
+        _setCoin = _loader.BindExport<System6SetByteByteDelegate>("SetCoin");
+        _setLevel = _loader.BindExport<System6SetByteByteDelegate>("SetLevel");
+        _setFullLevel = _loader.BindExport<System6SetByteByteDelegate>("SetFullLevel");
+        _turnSwitchOn = _loader.BindExport<System6SetByteDelegate>("TurnSwitchOn");
+        _turnSwitchOff = _loader.BindExport<System6SetByteDelegate>("TurnSwitchOff");
     }
 
     public string LibraryPath => _loader.LibraryPath;
-
     public Architecture ProcessArchitecture => _loader.ProcessArchitecture;
-
     public bool IsLoaded => _loader.IsLoaded;
-
     public byte Initialise() => _initialise();
 
     public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
     {
         var paths = AllocateRomPathSlots(programRomPaths);
-        return _loadRom(paths[0], paths[1], paths[2], paths[3], flashSwitch ? (byte)1 : (byte)0);
+        return checked((int)_loadRom(paths[0], paths[1], paths[2], paths[3]));
     }
 
     public int LoadSoundRom(IReadOnlyList<string> soundRomPaths)
     {
         var paths = AllocateRomPathSlots(soundRomPaths);
-        return _loadSoundRom(paths[0], paths[1], paths[2], paths[3]);
+        return checked((int)_loadSoundRom(paths[0], paths[1], paths[2], paths[3]));
     }
 
     public void SetSteps(byte reelNum, byte steps) => _setSteps(reelNum, steps);
-
     public void SetOptoStart(byte reelNum, byte start) => _setOptoStart(reelNum, start);
-
     public void SetOptoEnd(byte reelNum, byte end) => _setOptoEnd(reelNum, end);
-
     public void SetOptoInvert(byte reelNum, byte state) => _setOptoInvert(reelNum, state);
-
     public void Reset() => _reset();
-
-    public int Run(int cycles) => _run(cycles);
-
+    public int Run(int cycles) => _run(checked((uint)cycles));
     public byte Shutdown() => _shutdown();
+    public uint GetOutputSnapshotSize() => _getOutputSnapshotSize();
 
-    public bool IsLampsUpdateAvailable => _lampsUpdate is not null;
-
-    public string? LampsUpdateExportName => _lampsUpdateExportName;
-
-    public void LampsUpdate()
+    public System6NativeOutputSnapshot GetOutputSnapshot()
     {
-        var lampsUpdate = _lampsUpdate ?? throw new NotSupportedException("System6 native core does not export LampsUpdate.");
-        lampsUpdate();
-    }
+        var snapshot = new System6NativeOutputSnapshot();
+        var size = checked((uint)Marshal.SizeOf<System6NativeOutputSnapshot>());
+        var written = _getOutputSnapshot(ref snapshot, size);
+        if (written == 0 || snapshot.Version != System6NativeOutputSnapshot.VersionValue)
+        {
+            throw new InvalidOperationException($"OasisEmulator GetOutputSnapshot failed or returned unsupported snapshot version {snapshot.Version}.");
+        }
 
-    public bool GetLampsOn(ushort lampIndex) => _getLampsOn(lampIndex);
-
-    public float GetLampBrightness(ushort lampIndex) => _getLampBrightness(lampIndex);
-
-    public short GetPosOut(sbyte positionIndex) => _getPosOut(positionIndex);
-
-    public bool IsAlphaSegmentPollingAvailable => _getAlphaSegments is not null;
-
-    public int GetAlphaSegments(byte index)
-    {
-        var getAlphaSegments = _getAlphaSegments ?? throw new NotSupportedException("System6 native core does not export SYSTEM6GetAlphaSegments.");
-        return getAlphaSegments(index);
-    }
-
-    public bool IsAlphaBrightnessPollingAvailable => _getAlphaBrightness is not null;
-
-    public byte GetAlphaBrightness()
-    {
-        var getAlphaBrightness = _getAlphaBrightness ?? throw new NotSupportedException("System6 native core does not export SYSTEM6GetAlphaBright.");
-        return getAlphaBrightness();
+        return snapshot;
     }
 
     public bool IsSetPercentAvailable => _setPercent is not null;
-
-    public bool IsSevenSegmentPollingAvailable => _getSegsOn is not null;
-
-    public void UpdateSegs()
-    {
-        var updateSegs = _updateSegs ?? throw new NotSupportedException("System6 native core does not export SYSTEM6UpdateSegs.");
-        updateSegs();
-    }
-
-    public int GetSegsOn(ushort index)
-    {
-        var getSegsOn = _getSegsOn ?? throw new NotSupportedException("System6 native core does not export SYSTEM6GetSegOn.");
-        return getSegsOn(index);
-    }
-
-    public byte GetSegsBright(ushort index)
-    {
-        var getSegsBright = _getSegsBright ?? throw new NotSupportedException("System6 native core does not export SYSTEM6GetSegBright.");
-        return getSegsBright(index);
-    }
-
-    public void SetPercent(byte percent)
-    {
-        var setPercent = _setPercent ?? throw new NotSupportedException("System6 native core does not export SetPercent.");
-        setPercent(percent);
-    }
-
-    public void SetCoinEnable(byte num, byte coin, byte coinEnable) => _setCoinEnable(num, coin, coinEnable);
-
-    public void SetCoinValue(byte num, byte coin, byte coinValue) => _setCoinValue(num, coin, coinValue);
-
-    public void SetLockoutVal(byte num, byte coin, byte lockoutValue) => _setLockoutVal(num, coin, lockoutValue);
-
-    public void SetLockoutInvert(byte num, byte coin, byte lockoutInvert) => _setLockoutInvert(num, coin, lockoutInvert);
-
+    public void SetPercent(byte percent) => (_setPercent ?? throw new NotSupportedException("OasisEmulator does not export SetPercent."))(percent);
+    public void SetCoinEnable(byte coin, byte coinEnable) => _setCoinEnable(coin, coinEnable);
+    public void SetCoinValue(byte coin, byte coinValue) => _setCoinValue(coin, coinValue);
+    public void SetLockoutVal(byte coin, byte lockoutValue) => _setLockoutVal(coin, lockoutValue);
+    public void SetLockoutInvert(byte coin, byte lockoutInvert) => _setLockoutInvert(coin, lockoutInvert);
     public void SetEnable(byte num, byte enable) => _setEnable(num, enable);
-
     public void SetCounterIn(byte num, byte counterIn) => _setCounterIn(num, counterIn);
-
     public void SetCounterOut(byte num, byte counterOut) => _setCounterOut(num, counterOut);
-
     public void SetPortIndex(byte num, byte portIndex) => _setPortIndex(num, portIndex);
-
     public void SetCoin(byte num, byte coin) => _setCoin(num, coin);
-
     public void SetLevel(byte num, byte level) => _setLevel(num, level);
-
     public void SetFullLevel(byte num, byte fullLevel) => _setFullLevel(num, fullLevel);
-
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(checked((byte)switchIndex));
-
     public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(checked((byte)switchIndex));
 
     public void Dispose()
@@ -211,51 +127,19 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _loader.Dispose();
     }
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte System6InitialiseDelegate();
-
-    private TDelegate? TryBindOptionalExport<TDelegate>(string exportName)
-        where TDelegate : Delegate
-    {
-        var (export, _) = TryBindOptionalExportCandidate<TDelegate>(exportName);
-        return export;
-    }
-
-    private (TDelegate? Export, string? ExportName) TryBindOptionalExportCandidate<TDelegate>(params string[] exportNames)
-        where TDelegate : Delegate
-    {
-        foreach (var exportName in exportNames)
-        {
-            if (_loader.TryBindExport<TDelegate>(exportName, out var export))
-            {
-                return (export, exportName);
-            }
-        }
-
-        System.Diagnostics.Debug.WriteLine($"System6 native optional exports {string.Join("/", exportNames)} unavailable in '{_loader.LibraryPath}'.");
-        return (null, null);
-    }
+    private TDelegate? TryBindOptionalExport<TDelegate>(string exportName) where TDelegate : Delegate
+        => _loader.TryBindExport<TDelegate>(exportName, out var export) ? export : null;
 
     private IntPtr[] AllocateRomPathSlots(IReadOnlyList<string> romPaths)
     {
-        // Keep ANSI path buffers alive for the lifetime of the native core.
-        // Some legacy System6 DLLs retain the char* values passed to LoadROM
-        // and read them later during Reset/Run rather than copying immediately.
-
         var paths = new[] { IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero };
         for (var i = 0; i < paths.Length; i++)
         {
             var path = i < romPaths.Count ? romPaths[i] : string.Empty;
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                paths[i] = IntPtr.Zero;
-                continue;
-            }
-
+            if (string.IsNullOrWhiteSpace(path)) continue;
             paths[i] = Marshal.StringToHGlobalAnsi(path);
             _romPathBuffers.Add(paths[i]);
         }
-
         return paths;
     }
 
@@ -263,118 +147,20 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     {
         foreach (var buffer in _romPathBuffers)
         {
-            if (buffer != IntPtr.Zero)
-            {
-                Marshal.FreeHGlobal(buffer);
-            }
+            if (buffer != IntPtr.Zero) Marshal.FreeHGlobal(buffer);
         }
-
         _romPathBuffers.Clear();
     }
 
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6LoadRomDelegate(
-        IntPtr romPath1,
-        IntPtr romPath2,
-        IntPtr romPath3,
-        IntPtr romPath4,
-        byte flashSwitch);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6LoadSoundRomDelegate(
-        IntPtr romPath1,
-        IntPtr romPath2,
-        IntPtr romPath3,
-        IntPtr romPath4);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetStepsDelegate(byte reelNum, byte steps);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetOptoStartDelegate(byte reelNum, byte start);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetOptoEndDelegate(byte reelNum, byte end);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetOptoInvertDelegate(byte reelNum, byte state);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6ResetDelegate();
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6RunDelegate(int cycles);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte System6ShutdownDelegate();
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6LampsUpdateDelegate();
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    [return: MarshalAs(UnmanagedType.I1)]
-    public delegate bool System6GetLampsOnDelegate(ushort lampIndex);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate float System6GetLampBrightnessDelegate(ushort lampIndex);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate short System6GetPosOutDelegate(sbyte positionIndex);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6GetAlphaSegmentsDelegate(byte index);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte System6GetAlphaBrightnessDelegate();
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetPercentDelegate(byte percent);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6UpdateSegsDelegate();
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int System6GetSegsOnDelegate(ushort index);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte System6GetSegsBrightDelegate(ushort index);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetCoinEnableDelegate(byte num, byte coin, byte coinEnable);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetCoinValueDelegate(byte num, byte coin, byte coinValue);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetLockoutValDelegate(byte num, byte coin, byte lockoutValue);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetLockoutInvertDelegate(byte num, byte coin, byte lockoutInvert);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetEnableDelegate(byte num, byte enable);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetCounterInDelegate(byte num, byte counterIn);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetCounterOutDelegate(byte num, byte counterOut);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetPortIndexDelegate(byte num, byte portIndex);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetCoinDelegate(byte num, byte coin);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetLevelDelegate(byte num, byte level);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6SetFullLevelDelegate(byte num, byte fullLevel);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6TurnSwitchOnDelegate(byte switchIndex);
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void System6TurnSwitchOffDelegate(byte switchIndex);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate byte System6InitialiseDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate uint System6LoadRomDelegate(IntPtr romPath1, IntPtr romPath2, IntPtr romPath3, IntPtr romPath4);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate uint System6LoadSoundRomDelegate(IntPtr romPath1, IntPtr romPath2, IntPtr romPath3, IntPtr romPath4);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6ResetDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate int System6RunDelegate(uint cycles);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate byte System6ShutdownDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate uint System6GetOutputSnapshotSizeDelegate();
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate uint System6GetOutputSnapshotDelegate(ref System6NativeOutputSnapshot outBuffer, uint outBufferSize);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteDelegate(byte value);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteByteDelegate(byte first, byte second);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteUIntDelegate(byte first, uint second);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6OutputSnapshot.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6OutputSnapshot.cs
@@ -1,0 +1,183 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+// Mirrors PA2CoreInterface.h from johnparker007/OasisEmulator (PA2_OUTPUT_SNAPSHOT_VERSION = 1).
+// The native header uses #pragma pack(push, 4); keep these layouts in sync with that ABI.
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public struct System6NativeLampState
+{
+    public byte OnOff;
+    public byte Reserved0;
+    public byte Reserved1;
+    public byte Reserved2;
+    public float Brightness;
+    public float FilamentR;
+    public float FilamentG;
+    public float FilamentB;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public struct System6NativeReelState
+{
+    public int Position;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public unsafe struct System6NativeAlphaSegmentedState
+{
+    public fixed ushort Segments[System6NativeOutputSnapshot.AlphaCharacterCount];
+    public fixed byte DotComma[System6NativeOutputSnapshot.AlphaCharacterCount];
+    public float Brightness;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public struct System6NativeLedDisplayState
+{
+    public uint OnOff;
+    public float Brightness;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public unsafe struct System6NativeOutputSnapshot
+{
+    public const uint VersionValue = 1;
+    public const int MatrixLampCapacity = 512;
+    public const int ReelCapacity = 8;
+    public const int AlphaDisplayCapacity = 2;
+    public const int AlphaCharacterCount = 16;
+    public const int LedDisplayCapacity = 40;
+
+    public uint SizeBytes;
+    public uint Version;
+    public uint MatrixLampCount;
+    public uint DirectLampCount;
+    public uint FloLampCount;
+    public uint PrismLampCount;
+    public uint LedCount;
+    public uint TriacLampCount;
+    public uint FluorescentLampCount;
+    public uint DiscoLampCount;
+    public uint ReelCount;
+    public uint AlphaSegmentedDisplayCount;
+    public uint AlphaDotDisplayCount;
+    public uint LedDisplayCount;
+    public uint ElectronicMechCount;
+    public uint MechanicalMechCount;
+    public uint CoinEntryLampCount;
+    public uint MeterCount;
+    public uint TubeCount;
+    public uint DipCount;
+    public uint HopperCount;
+
+    public fixed byte MatrixLamps[MatrixLampCapacity * 20];
+    public fixed byte DirectLamps[32 * 20];
+    public fixed byte FloLamps[4 * 20];
+    public fixed byte PrismLamps[16 * 20];
+    public fixed byte Leds[512 * 20];
+    public fixed byte TriacLamps[32 * 20];
+    public fixed byte FluorescentLamps[8 * 20];
+    public fixed byte DiscoLamps[64 * 20];
+    public fixed int Reels[ReelCapacity];
+    public fixed byte AlphaSegmented[AlphaDisplayCapacity * 52];
+    public fixed byte AlphaDot[AlphaDisplayCapacity * 100];
+    public fixed byte LedDisplays[LedDisplayCapacity * 8];
+    public fixed byte Remaining[464];
+
+
+    public int GetReelPosition(int index)
+    {
+        if ((uint)index >= ReelCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (int* ptr = Reels)
+            {
+                return ptr[index];
+            }
+        }
+    }
+
+    public void SetReelPosition(int index, int position)
+    {
+        if ((uint)index >= ReelCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (int* ptr = Reels)
+            {
+                ptr[index] = position;
+            }
+        }
+    }
+
+    public System6NativeLampState GetMatrixLamp(int index)
+    {
+        if ((uint)index >= MatrixLampCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = MatrixLamps)
+            {
+                return *(System6NativeLampState*)(ptr + (index * sizeof(System6NativeLampState)));
+            }
+        }
+    }
+
+    public void SetMatrixLamp(int index, System6NativeLampState value)
+    {
+        if ((uint)index >= MatrixLampCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = MatrixLamps)
+            {
+                *(System6NativeLampState*)(ptr + (index * sizeof(System6NativeLampState))) = value;
+            }
+        }
+    }
+
+    public System6NativeAlphaSegmentedState GetAlphaSegmented(int index)
+    {
+        if ((uint)index >= AlphaDisplayCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = AlphaSegmented)
+            {
+                return *(System6NativeAlphaSegmentedState*)(ptr + (index * sizeof(System6NativeAlphaSegmentedState)));
+            }
+        }
+    }
+
+    public void SetAlphaSegmented(int index, System6NativeAlphaSegmentedState value)
+    {
+        if ((uint)index >= AlphaDisplayCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = AlphaSegmented)
+            {
+                *(System6NativeAlphaSegmentedState*)(ptr + (index * sizeof(System6NativeAlphaSegmentedState))) = value;
+            }
+        }
+    }
+
+    public System6NativeLedDisplayState GetLedDisplay(int index)
+    {
+        if ((uint)index >= LedDisplayCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = LedDisplays)
+            {
+                return *(System6NativeLedDisplayState*)(ptr + (index * sizeof(System6NativeLedDisplayState)));
+            }
+        }
+    }
+
+    public void SetLedDisplay(int index, System6NativeLedDisplayState value)
+    {
+        if ((uint)index >= LedDisplayCapacity) throw new ArgumentOutOfRangeException(nameof(index));
+        unsafe
+        {
+            fixed (byte* ptr = LedDisplays)
+            {
+                *(System6NativeLedDisplayState*)(ptr + (index * sizeof(System6NativeLedDisplayState))) = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Update the editor's System6 native backend to use the refreshed OasisEmulator C ABI that exposes a batched output snapshot instead of many legacy per-output exports. 
- Improve performance and clarity by polling a single snapshot for lamps, reels, alpha/VFD and LED/7-seg outputs and keep the existing editor event model intact. 
- Remove obsolete legacy export probing and adapt coin/ROM/load/run bindings to match the new DLL.

### Description
- Rebound native bindings to the new OasisEmulator exports and signatures: `Initialise`, `LoadROM`, `LoadSoundROM`, `Reset`, `Run(uint)`, `Shutdown`, `GetOutputSnapshotSize`, `GetOutputSnapshot`, `TurnSwitchOn`, `TurnSwitchOff`, and the updated coin setters. (files changed: `System6NativeLibrary.cs`, `ISystem6NativeLibrary.cs`)
- Added managed interop for the PA2/PA2Core output snapshot (packed structs and accessors) in `System6OutputSnapshot.cs` and mapped its fields into the editor model (lamps, reels, alpha/segments, LED displays). 
- Reworked `System6NativeBackend` to poll a single `GetOutputSnapshot()` each output poll and to translate snapshot state into existing events: `LampChanged`, `ReelChanged`, `SegmentChanged`, `VfdBrightnessChanged` while preserving the `IEmulationBackend` lifecycle (Start/Pause/Resume/Reset/Stop) and editor pump loop. 
- Updated the in-test fake and tests to produce/consume snapshot-driven data and adjusted coin-API-related assertions and plumbing; enabled `AllowUnsafeBlocks` for tests to construct fixed-buffer snapshot data. 
- Removed legacy optional-per-export polling logic (per-lamp/pos/alpha/seg calls) and startup-stage probes that are no longer needed with the snapshot API.

### Testing
- Unit tests were updated (notably `System6NativeBackendTests.cs`) to exercise snapshot-driven lamp, reel, alpha and seven-seg behaviors and the adjusted coin setter signatures.
- An attempt to run the test suite with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore` failed in this environment because `dotnet` is not installed, so no automated tests were executed here (error: `dotnet: command not found`).
- Please run the editor test suite locally (e.g. `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj`) to verify all tests pass and to validate the DLL can be started/stopped and that inputs/outputs flow as expected with the locally-built OasisEmulator DLL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a48227028688327af53c6ad659a22e6)