### PR TITLE
Add System6 native streaming audio playback

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -34,6 +34,84 @@ public sealed class System6NativeBackendTests
     }
 
 
+
+    [Fact]
+    public async Task StartAsyncStartsAudioSinkWithNativeFormatAndStreamsPcm()
+    {
+        var library = new FakeSystem6NativeLibrary { AudioAvailable = true };
+        var sink = new FakeAudioSink();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
+
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+        var observedAudio = SpinWait.SpinUntil(() => sink.PushedBytes.Count > 0, TimeSpan.FromSeconds(1));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.True(observedAudio, "Expected the emulation pump to pull native audio and push PCM bytes.");
+        Assert.Equal(new EmulationAudioFormat(48000, 2, 16), sink.StartedFormats.Single());
+        Assert.Contains(100, sink.PushedSamples);
+        Assert.Contains(-100, sink.PushedSamples);
+    }
+
+    [Fact]
+    public async Task PauseResetAndStopClearAudioPlayback()
+    {
+        var library = new FakeSystem6NativeLibrary { AudioAvailable = true };
+        var sink = new FakeAudioSink();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
+
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+        await backend.PauseAsync(CancellationToken.None);
+        await backend.ResumeAsync(CancellationToken.None);
+        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.True(sink.ClearCount >= 3);
+        Assert.True(sink.StopCount >= 2);
+        Assert.True(sink.DisposeCalled);
+    }
+
+    [Fact]
+    public async Task StartAsyncContinuesWithoutAudioSinkWhenNativeAudioUnavailable()
+    {
+        var library = new FakeSystem6NativeLibrary { AudioAvailable = false };
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => throw new InvalidOperationException("Audio sink should not be created."));
+
+        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.DoesNotContain("GetAudioFormat", library.Calls);
+    }
+
+    [Fact]
+    public async Task StartAsyncFailsCleanlyForMalformedNativeAudioFormat()
+    {
+        var library = new FakeSystem6NativeLibrary
+        {
+            AudioAvailable = true,
+            AudioFormat = new System6NativeAudioFormat
+            {
+                SizeBytes = (uint)Marshal.SizeOf<System6NativeAudioFormat>(),
+                Version = System6NativeAudioFormat.VersionValue,
+                SampleRate = 0,
+                Channels = 2,
+                BitsPerSample = 16,
+                Format = System6NativeAudioFormat.PcmS16FormatValue
+            }
+        };
+        var sink = new FakeAudioSink();
+        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
+        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None));
+
+        Assert.Contains("audio format", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(library.DisposeCalled);
+        Assert.Empty(sink.StartedFormats);
+    }
+
     [Fact]
     public async Task StartAsyncWithOutputPollingDisabledRunsCoreWithoutPollingOutputs()
     {
@@ -596,6 +674,32 @@ public sealed class System6NativeBackendTests
         return (dllPath, rom1, rom2);
     }
 
+    private sealed class FakeAudioSink : IEmulationAudioSink
+    {
+        public List<EmulationAudioFormat> StartedFormats { get; } = new();
+        public List<byte[]> PushedBytes { get; } = new();
+        public List<short> PushedSamples { get; } = new();
+        public int ClearCount { get; private set; }
+        public int StopCount { get; private set; }
+        public bool DisposeCalled { get; private set; }
+
+        public void Start(EmulationAudioFormat format) => StartedFormats.Add(format);
+
+        public void PushPcm(ReadOnlySpan<byte> pcmBytes)
+        {
+            var copy = pcmBytes.ToArray();
+            PushedBytes.Add(copy);
+            for (var i = 0; i + 1 < copy.Length; i += 2)
+            {
+                PushedSamples.Add(BitConverter.ToInt16(copy, i));
+            }
+        }
+
+        public void Stop() => StopCount++;
+        public void Clear() => ClearCount++;
+        public void Dispose() => DisposeCalled = true;
+    }
+
     private sealed class FakeSystem6NativeLibrary : ISystem6NativeLibrary
     {
         public string LibraryPath => "C:/cores/system6.dll";
@@ -637,6 +741,20 @@ public sealed class System6NativeBackendTests
         public byte AlphaBrightness { get; set; } = 255;
 
         public bool SevenSegmentPollingAvailable { get; set; }
+
+        public bool AudioAvailable { get; set; }
+
+        public System6NativeAudioFormat AudioFormat { get; set; } = new()
+        {
+            SizeBytes = (uint)Marshal.SizeOf<System6NativeAudioFormat>(),
+            Version = System6NativeAudioFormat.VersionValue,
+            SampleRate = 48000,
+            Channels = 2,
+            BitsPerSample = 16,
+            Format = System6NativeAudioFormat.PcmS16FormatValue
+        };
+
+        public short[] AudioSamples { get; set; } = [100, -100, 200, -200];
 
         public Dictionary<ushort, bool> SevenSegmentCells { get; } = new();
 
@@ -827,6 +945,27 @@ public sealed class System6NativeBackendTests
         public void TurnSwitchOff(int switchIndex)
         {
             SwitchesTurnedOff.Add(switchIndex);
+        }
+
+        public bool IsAudioAvailable => AudioAvailable;
+
+        public System6NativeAudioFormat GetAudioFormat()
+        {
+            Calls.Add("GetAudioFormat");
+            return AudioFormat;
+        }
+
+        public uint FillAudioFrames(Span<short> interleavedStereoFrames, uint framesRequired)
+        {
+            Calls.Add($"FillAudioFrames:{framesRequired}");
+            if (!AudioAvailable || AudioSamples.Length == 0)
+            {
+                return 0;
+            }
+
+            var framesToWrite = Math.Min((int)framesRequired, AudioSamples.Length / 2);
+            AudioSamples.AsSpan(0, framesToWrite * 2).CopyTo(interleavedStereoFrames);
+            return (uint)framesToWrite;
         }
 
         public void Dispose()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -49,8 +49,8 @@ public sealed class System6NativeBackendTests
 
         Assert.True(observedAudio, "Expected the emulation pump to pull native audio and push PCM bytes.");
         Assert.Equal(new EmulationAudioFormat(48000, 2, 16), sink.StartedFormats.Single());
-        Assert.Contains(100, sink.PushedSamples);
-        Assert.Contains(-100, sink.PushedSamples);
+        Assert.Contains((short)100, sink.PushedSamples);
+        Assert.Contains((short)-100, sink.PushedSamples);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -31,7 +31,10 @@ public sealed class MamePreferences
 
 public sealed class NativeEmulationPreferences
 {
+    public const int DefaultAudioBufferLengthMilliseconds = 50;
+
     public string System6LibraryPath { get; init; } = string.Empty;
+    public int AudioBufferLengthMilliseconds { get; init; } = DefaultAudioBufferLengthMilliseconds;
 }
 
 public sealed class FaceGenerationPreferences

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
@@ -1,0 +1,11 @@
+namespace OasisEditor;
+
+public readonly record struct EmulationAudioFormat(int SampleRate, int Channels, int BitsPerSample);
+
+public interface IEmulationAudioSink : IDisposable
+{
+    void Start(EmulationAudioFormat format);
+    void PushPcm(ReadOnlySpan<byte> pcmBytes);
+    void Stop();
+    void Clear();
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -9,13 +9,16 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
 {
     private readonly Func<IEmulationBackend> _mameBackendFactory;
     private readonly Func<string?> _system6LibraryPathProvider;
+    private readonly Func<int> _system6AudioBufferLengthMillisecondsProvider;
 
     public EmulationBackendFactory(
         Func<IEmulationBackend> mameBackendFactory,
-        Func<string?> system6LibraryPathProvider)
+        Func<string?> system6LibraryPathProvider,
+        Func<int>? system6AudioBufferLengthMillisecondsProvider = null)
     {
         _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
         _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
+        _system6AudioBufferLengthMillisecondsProvider = system6AudioBufferLengthMillisecondsProvider ?? static () => NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -34,6 +37,13 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         var libraryPath = _system6LibraryPathProvider();
         return string.IsNullOrWhiteSpace(libraryPath)
             ? _mameBackendFactory()
-            : new System6NativeBackend(libraryPath);
+            : new System6NativeBackend(
+                libraryPath,
+                static path => new System6NativeLibrary(path),
+                60,
+                () => new NAudioEmulationAudioSink(NormalizeSystem6AudioBufferLengthMilliseconds(_system6AudioBufferLengthMillisecondsProvider())));
     }
+
+    private static int NormalizeSystem6AudioBufferLengthMilliseconds(int value)
+        => Math.Clamp(value, 10, 1000);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -18,7 +18,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     {
         _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
         _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
-        _system6AudioBufferLengthMillisecondsProvider = system6AudioBufferLengthMillisecondsProvider ?? static () => NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds;
+        _system6AudioBufferLengthMillisecondsProvider = system6AudioBufferLengthMillisecondsProvider ?? (() => NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds);
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -5,12 +5,21 @@ namespace OasisEditor;
 
 public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 {
-    private const int DesiredBufferMilliseconds = 200;
-    private const int DiscardThresholdMilliseconds = 250;
+    private readonly int _bufferLengthMilliseconds;
 
     private BufferedWaveProvider? _buffer;
     private WasapiOut? _output;
     private EmulationAudioFormat? _format;
+
+    public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
+    {
+        if (bufferLengthMilliseconds <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bufferLengthMilliseconds), bufferLengthMilliseconds, "Audio buffer length must be greater than zero.");
+        }
+
+        _bufferLengthMilliseconds = bufferLengthMilliseconds;
+    }
 
     public void Start(EmulationAudioFormat format)
     {
@@ -20,10 +29,10 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         var waveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
         _buffer = new BufferedWaveProvider(waveFormat)
         {
-            BufferDuration = TimeSpan.FromMilliseconds(DesiredBufferMilliseconds),
+            BufferDuration = TimeSpan.FromMilliseconds(_bufferLengthMilliseconds),
             DiscardOnBufferOverflow = true
         };
-        _output = new WasapiOut(AudioClientShareMode.Shared, DesiredBufferMilliseconds);
+        _output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
         _output.Init(_buffer);
         _output.Play();
         _format = format;
@@ -37,8 +46,8 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         }
 
         var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
-        var discardThresholdBytes = format.SampleRate * format.Channels * (format.BitsPerSample / 8) * DiscardThresholdMilliseconds / 1000;
-        if (_buffer.BufferedBytes > discardThresholdBytes)
+        var configuredBufferBytes = format.SampleRate * format.Channels * (format.BitsPerSample / 8) * _bufferLengthMilliseconds / 1000;
+        if (_buffer.BufferedBytes > configuredBufferBytes)
         {
             _buffer.ClearBuffer();
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -1,0 +1,69 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+
+namespace OasisEditor;
+
+public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
+{
+    private const int DesiredBufferMilliseconds = 200;
+    private const int DiscardThresholdMilliseconds = 250;
+
+    private BufferedWaveProvider? _buffer;
+    private WasapiOut? _output;
+    private EmulationAudioFormat? _format;
+
+    public void Start(EmulationAudioFormat format)
+    {
+        ValidateFormat(format);
+        Stop();
+
+        var waveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
+        _buffer = new BufferedWaveProvider(waveFormat)
+        {
+            BufferDuration = TimeSpan.FromMilliseconds(DesiredBufferMilliseconds),
+            DiscardOnBufferOverflow = true
+        };
+        _output = new WasapiOut(AudioClientShareMode.Shared, DesiredBufferMilliseconds);
+        _output.Init(_buffer);
+        _output.Play();
+        _format = format;
+    }
+
+    public void PushPcm(ReadOnlySpan<byte> pcmBytes)
+    {
+        if (pcmBytes.IsEmpty || _buffer is null)
+        {
+            return;
+        }
+
+        var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
+        var discardThresholdBytes = format.SampleRate * format.Channels * (format.BitsPerSample / 8) * DiscardThresholdMilliseconds / 1000;
+        if (_buffer.BufferedBytes > discardThresholdBytes)
+        {
+            _buffer.ClearBuffer();
+        }
+
+        var bytes = pcmBytes.ToArray();
+        _buffer.AddSamples(bytes, 0, bytes.Length);
+    }
+
+    public void Clear() => _buffer?.ClearBuffer();
+
+    public void Stop()
+    {
+        _output?.Stop();
+        _output?.Dispose();
+        _output = null;
+        _buffer = null;
+        _format = null;
+    }
+
+    public void Dispose() => Stop();
+
+    private static void ValidateFormat(EmulationAudioFormat format)
+    {
+        if (format.SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio sample rate must be greater than zero.");
+        if (format.Channels <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio channel count must be greater than zero.");
+        if (format.BitsPerSample != 16) throw new NotSupportedException($"Only 16-bit PCM audio is supported; native core reported {format.BitsPerSample} bits per sample.");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/ISystem6NativeLibrary.cs
@@ -29,4 +29,7 @@ public interface ISystem6NativeLibrary : INativeCoreLibrary
     void SetFullLevel(byte num, byte fullLevel);
     void TurnSwitchOn(int switchIndex);
     void TurnSwitchOff(int switchIndex);
+    bool IsAudioAvailable { get; }
+    System6NativeAudioFormat GetAudioFormat();
+    uint FillAudioFrames(Span<short> interleavedStereoFrames, uint framesRequired);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeAudioFormat.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeAudioFormat.cs
@@ -1,0 +1,17 @@
+using System.Runtime.InteropServices;
+
+namespace OasisEditor;
+
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+public struct System6NativeAudioFormat
+{
+    public const uint VersionValue = 1;
+    public const uint PcmS16FormatValue = 1;
+
+    public uint SizeBytes;
+    public uint Version;
+    public uint SampleRate;
+    public uint Channels;
+    public uint BitsPerSample;
+    public uint Format;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
@@ -40,6 +41,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     private readonly string _libraryPath;
     private readonly Func<string, ISystem6NativeLibrary> _libraryFactory;
+    private readonly Func<IEmulationAudioSink?> _audioSinkFactory;
     private readonly TimeSpan _emulationInterval;
     private readonly TimeSpan _pollInterval;
     private readonly int _emulationPumpHz;
@@ -70,9 +72,12 @@ public sealed class System6NativeBackend : IEmulationBackend
     private Task? _pollLoopTask;
     private EmulationBackendState _state = EmulationBackendState.Stopped;
     private DateTime _lastRunWarningUtc = DateTime.MinValue;
+    private IEmulationAudioSink? _audioSink;
+    private EmulationAudioFormat? _audioFormat;
+    private short[] _audioFrameBuffer = [];
 
     public System6NativeBackend(string libraryPath)
-        : this(libraryPath, static path => new System6NativeLibrary(path))
+        : this(libraryPath, static path => new System6NativeLibrary(path), DefaultOutputPollsPerSecond, static () => new NAudioEmulationAudioSink())
     {
     }
 
@@ -82,6 +87,11 @@ public sealed class System6NativeBackend : IEmulationBackend
     }
 
     public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory, int framesPerSecond)
+        : this(libraryPath, libraryFactory, framesPerSecond, static () => null)
+    {
+    }
+
+    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory, int framesPerSecond, Func<IEmulationAudioSink?> audioSinkFactory)
     {
         if (string.IsNullOrWhiteSpace(libraryPath))
         {
@@ -95,6 +105,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         _libraryPath = libraryPath;
         _libraryFactory = libraryFactory ?? throw new ArgumentNullException(nameof(libraryFactory));
+        _audioSinkFactory = audioSinkFactory ?? throw new ArgumentNullException(nameof(audioSinkFactory));
         _timingDiagnosticsEnabled = IsTimingDiagnosticsEnabled();
         _outputPollingEnabled = ResolveOutputPollingEnabled();
         _outputPollsPerSecond = ResolveOutputPollingRate(framesPerSecond);
@@ -240,6 +251,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             ResetCachedOutputState();
             ResetConfiguredReelStepCounts();
             ResetEnabledReelPollingIndices();
+            StartAudioIfAvailable(_library);
 
             try
             {
@@ -278,6 +290,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             {
                 _pollLoopTask = Task.Run(() => PollLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
             }
+            _audioSink?.Clear();
             SetState(EmulationBackendState.Running);
             return Task.CompletedTask;
         }
@@ -334,6 +347,7 @@ public sealed class System6NativeBackend : IEmulationBackend
             }
         }
 
+        StopAndDisposeAudio();
         ShutdownAndDisposeLibrary();
         _runLoopCancellation?.Dispose();
         _runLoopCancellation = null;
@@ -348,6 +362,8 @@ public sealed class System6NativeBackend : IEmulationBackend
         if (State is EmulationBackendState.Running)
         {
             SetState(EmulationBackendState.Paused);
+            _audioSink?.Clear();
+            _audioSink?.Stop();
         }
 
         return Task.CompletedTask;
@@ -358,6 +374,11 @@ public sealed class System6NativeBackend : IEmulationBackend
         cancellationToken.ThrowIfCancellationRequested();
         if (State is EmulationBackendState.Paused)
         {
+            _audioSink?.Clear();
+            if (_audioSink is not null && _audioFormat is { } audioFormat)
+            {
+                _audioSink.Start(audioFormat);
+            }
             SetState(EmulationBackendState.Running);
         }
 
@@ -374,6 +395,7 @@ public sealed class System6NativeBackend : IEmulationBackend
 
         var library = _library ?? throw new InvalidOperationException("System6 native backend cannot reset before it has started.");
         library.Reset();
+        _audioSink?.Clear();
         ResetCachedOutputState();
         return Task.CompletedTask;
     }
@@ -529,6 +551,7 @@ public sealed class System6NativeBackend : IEmulationBackend
                         Debug.WriteLine($"System6 native backend Run({cycles}) returned 0.");
                     }
 
+                    PullAudioFrames(library);
                     WarnIfEmulationTimingIsSlow(cycles, runElapsed, Stopwatch.GetTimestamp() - diagnosticsStartedAt, diagnosticsCycles, 0);
                     nextSliceTimestamp += _emulationIntervalTimestampTicks;
                     slicesRunThisLoop++;
@@ -1070,8 +1093,89 @@ public sealed class System6NativeBackend : IEmulationBackend
         _hasLoggedSevenSegmentUnavailable = false;
     }
 
+
+    private void StartAudioIfAvailable(ISystem6NativeLibrary library)
+    {
+        if (!library.IsAudioAvailable)
+        {
+            LogStartupStage("audio exports missing; playback disabled");
+            return;
+        }
+
+        var nativeFormat = library.GetAudioFormat();
+        var format = ValidateNativeAudioFormat(nativeFormat);
+        _audioSink = _audioSinkFactory();
+        if (_audioSink is null)
+        {
+            LogStartupStage("audio sink unavailable; playback disabled");
+            return;
+        }
+
+        _audioFormat = format;
+        _audioFrameBuffer = new short[Math.Max(1, (int)Math.Ceiling((double)format.SampleRate / _emulationPumpHz)) * format.Channels];
+        _audioSink.Start(format);
+        _audioSink.Clear();
+        LogStartupStage($"audio enabled: {format.SampleRate} Hz, {format.Channels} channels, {format.BitsPerSample}-bit PCM");
+    }
+
+    private static EmulationAudioFormat ValidateNativeAudioFormat(System6NativeAudioFormat nativeFormat)
+    {
+        if (nativeFormat.SampleRate is 0 || nativeFormat.Channels is 0 || nativeFormat.BitsPerSample is 0)
+        {
+            throw new InvalidOperationException($"OasisEmulator reported an invalid audio format: sampleRate={nativeFormat.SampleRate}, channels={nativeFormat.Channels}, bits={nativeFormat.BitsPerSample}.");
+        }
+
+        if (nativeFormat.Format != System6NativeAudioFormat.PcmS16FormatValue || nativeFormat.BitsPerSample != 16)
+        {
+            throw new NotSupportedException($"OasisEmulator reported unsupported audio format {nativeFormat.Format} with {nativeFormat.BitsPerSample} bits per sample; only PCM signed 16-bit is supported.");
+        }
+
+        if (nativeFormat.Channels > 8 || nativeFormat.SampleRate > 384000)
+        {
+            throw new InvalidOperationException($"OasisEmulator reported an unreasonable audio format: sampleRate={nativeFormat.SampleRate}, channels={nativeFormat.Channels}.");
+        }
+
+        return new EmulationAudioFormat(checked((int)nativeFormat.SampleRate), checked((int)nativeFormat.Channels), checked((int)nativeFormat.BitsPerSample));
+    }
+
+    private void PullAudioFrames(ISystem6NativeLibrary library)
+    {
+        if (_audioSink is null || _audioFormat is not { } format || _audioFrameBuffer.Length == 0)
+        {
+            return;
+        }
+
+        var framesRequested = checked((uint)(_audioFrameBuffer.Length / format.Channels));
+        var framesWritten = library.FillAudioFrames(_audioFrameBuffer, framesRequested);
+        if (framesWritten == 0)
+        {
+            return;
+        }
+
+        var clampedFrames = Math.Min(framesWritten, framesRequested);
+        var bytesWritten = checked((int)clampedFrames * format.Channels * (format.BitsPerSample / 8));
+        _audioSink.PushPcm(MemoryMarshal.AsBytes(_audioFrameBuffer.AsSpan(0, bytesWritten / sizeof(short))));
+    }
+
+    private void StopAndDisposeAudio()
+    {
+        var sink = _audioSink;
+        _audioSink = null;
+        _audioFormat = null;
+        _audioFrameBuffer = [];
+        if (sink is null)
+        {
+            return;
+        }
+
+        sink.Clear();
+        sink.Stop();
+        sink.Dispose();
+    }
+
     private void CleanupLibraryAfterFailedStart()
     {
+        StopAndDisposeAudio();
         ShutdownAndDisposeLibrary();
         _runLoopCancellation?.Dispose();
         _runLoopCancellation = null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeLibrary.cs
@@ -31,6 +31,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     private readonly System6SetByteByteDelegate _setFullLevel;
     private readonly System6SetByteDelegate _turnSwitchOn;
     private readonly System6SetByteDelegate _turnSwitchOff;
+    private readonly System6GetAudioFormatDelegate? _getAudioFormat;
+    private readonly System6FillAudioFramesDelegate? _fillAudioFrames;
     private readonly List<IntPtr> _romPathBuffers = [];
 
     public System6NativeLibrary(string libraryPath) : this(new NativeLibraryLoader(libraryPath)) { }
@@ -64,6 +66,8 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
         _setFullLevel = _loader.BindExport<System6SetByteByteDelegate>("SetFullLevel");
         _turnSwitchOn = _loader.BindExport<System6SetByteDelegate>("TurnSwitchOn");
         _turnSwitchOff = _loader.BindExport<System6SetByteDelegate>("TurnSwitchOff");
+        _getAudioFormat = TryBindOptionalExport<System6GetAudioFormatDelegate>("GetAudioFormat");
+        _fillAudioFrames = TryBindOptionalExport<System6FillAudioFramesDelegate>("FillAudioFrames");
     }
 
     public string LibraryPath => _loader.LibraryPath;
@@ -121,6 +125,42 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     public void TurnSwitchOn(int switchIndex) => _turnSwitchOn(checked((byte)switchIndex));
     public void TurnSwitchOff(int switchIndex) => _turnSwitchOff(checked((byte)switchIndex));
 
+    public bool IsAudioAvailable => _getAudioFormat is not null && _fillAudioFrames is not null;
+
+    public System6NativeAudioFormat GetAudioFormat()
+    {
+        if (_getAudioFormat is null)
+        {
+            throw new NotSupportedException("OasisEmulator does not export GetAudioFormat.");
+        }
+
+        var format = new System6NativeAudioFormat();
+        var size = checked((uint)Marshal.SizeOf<System6NativeAudioFormat>());
+        var written = _getAudioFormat(ref format, size);
+        if (written == 0 || format.Version != System6NativeAudioFormat.VersionValue)
+        {
+            throw new InvalidOperationException($"OasisEmulator GetAudioFormat failed or returned unsupported audio format version {format.Version}.");
+        }
+
+        return format;
+    }
+
+    public uint FillAudioFrames(Span<short> interleavedStereoFrames, uint framesRequired)
+    {
+        if (_fillAudioFrames is null)
+        {
+            throw new NotSupportedException("OasisEmulator does not export FillAudioFrames.");
+        }
+
+        unsafe
+        {
+            fixed (short* buffer = interleavedStereoFrames)
+            {
+                return _fillAudioFrames(buffer, framesRequired);
+            }
+        }
+    }
+
     public void Dispose()
     {
         FreeRomPathBuffers();
@@ -163,4 +203,6 @@ public sealed class System6NativeLibrary : ISystem6NativeLibrary
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteDelegate(byte value);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteByteDelegate(byte first, byte second);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate void System6SetByteUIntDelegate(byte first, uint second);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public delegate uint System6GetAudioFormatDelegate(ref System6NativeAudioFormat outBuffer, uint outBufferSize);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)] public unsafe delegate uint System6FillAudioFramesDelegate(short* outInterleavedStereo, uint framesRequired);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -41,6 +41,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameLuaPluginPath = string.Empty;
     private string _mameCommandLineOverrides = string.Empty;
     private string _system6NativeLibraryPath = string.Empty;
+    private int _system6AudioBufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds;
     private string _mameRomDownloadBaseUrl = MameRomDownloadService.DefaultDownloadRootUrl;
     private string _mameRomArchiveExtension = MameRomDownloadService.DefaultArchiveExtension;
     private string _mameLocalRomSourceDirectory = string.Empty;
@@ -269,6 +270,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameLuaPluginPath = MameRuntimePaths.ResolveBundledLuaPluginSourcePath();
             _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
             _system6NativeLibraryPath = preferences.NativeEmulation.System6LibraryPath;
+            _system6AudioBufferLengthMilliseconds = NormalizeSystem6AudioBufferLengthMilliseconds(preferences.NativeEmulation.AudioBufferLengthMilliseconds);
             _mameRomDownloadBaseUrl = preferences.Mame.RomDownloadBaseUrl;
             _mameRomArchiveExtension = preferences.Mame.RomArchiveExtension;
             _mameLocalRomSourceDirectory = preferences.Mame.LocalRomSourceDirectory;
@@ -360,7 +362,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 _mameProcessRunner,
                 () => SelectedFruitMachinePlatform,
                 input => LoadedProject?.InputDefinitions.FirstOrDefault(definition => string.Equals(definition.Id, input.Id, StringComparison.OrdinalIgnoreCase))),
-            () => System6NativeLibraryPath);
+            () => System6NativeLibraryPath,
+            () => System6AudioBufferLengthMilliseconds);
 
         _mameEmulationService.StateChanged += (_, state) =>
         {
@@ -638,6 +641,18 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameLuaPluginPath => _mameLuaPluginPath;
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
     public string System6NativeLibraryPath { get => _system6NativeLibraryPath; set { if (SetProperty(ref _system6NativeLibraryPath, value)) SavePreferences(); } }
+    public int System6AudioBufferLengthMilliseconds
+    {
+        get => _system6AudioBufferLengthMilliseconds;
+        set
+        {
+            var normalized = NormalizeSystem6AudioBufferLengthMilliseconds(value);
+            if (SetProperty(ref _system6AudioBufferLengthMilliseconds, normalized))
+            {
+                SavePreferences();
+            }
+        }
+    }
     public string MameRomDownloadBaseUrl
     {
         get => _mameRomDownloadBaseUrl;
@@ -2345,6 +2360,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             AddOutputEntry($"Failed to remove cached MAME version: {ex.Message}", OutputLogStatus.Warning);
         }
     }
+
+    private static int NormalizeSystem6AudioBufferLengthMilliseconds(int value)
+        => Math.Clamp(value, 10, 1000);
+
     private void SavePreferences()
     {
         var existingPreferences = _preferencesStore.Load();
@@ -2368,7 +2387,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             },
             NativeEmulation = new NativeEmulationPreferences
             {
-                System6LibraryPath = System6NativeLibraryPath
+                System6LibraryPath = System6NativeLibraryPath,
+                AudioBufferLengthMilliseconds = System6AudioBufferLengthMilliseconds
             },
             FaceGeneration = FaceGenerationPreferences.FromSettings(
                 _defaultFaceGenerationSettings,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisEditor.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="HelixToolkit.Wpf" Version="3.1.2" />
     <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.6" />
     <PackageReference Include="PixiEditor.ColorPicker" Version="3.4.2.3" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
     <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.8" />
   </ItemGroup>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -137,6 +137,14 @@
                 <TextBlock FontSize="18" FontWeight="SemiBold" Text="Native Emulation" />
                 <TextBlock Margin="0,16,0,4" Text="System6 native core DLL path" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding System6NativeLibraryPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <TextBlock Margin="0,16,0,4" Text="Audio Buffer Length (ms)" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBox Width="120"
+                         HorizontalAlignment="Left"
+                         Text="{Binding System6AudioBufferLengthMilliseconds, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                <TextBlock Margin="0,4,0,0"
+                           TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="Playback buffering for native System6 audio. Lower values reduce latency; higher values can help if audio crackles." />
                 <TextBlock Margin="0,8,0,0"
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource TextSecondaryBrush}"


### PR DESCRIPTION
### Motivation
- The native OasisEmulator DLL now exposes a PCM audio stream instead of owning playback; the Editor must consume that stream during native System 6 emulation. 
- Keep platform-specific playback (NAudio/WASAPI) isolated to the Editor and avoid leaking audio device types into shared emulation abstractions. 
- Provide a testable, minimal integration that the future Unity-based runtime can reuse (same PCM stream contract) without taking NAudio dependencies.

### Description
- Added a small audio abstraction: `EmulationAudioFormat` and `IEmulationAudioSink` with `Start`, `PushPcm`, `Stop`, `Clear`, and `Dispose` to decouple playback from the native backend. 
- Implemented an Editor-only NAudio sink `NAudioEmulationAudioSink` that uses `BufferedWaveProvider` + `WasapiOut` (shared mode), targets ~200ms buffer, discards on overflow, validates 16-bit PCM, and handles clear/stop/dispose lifecycle. 
- Extended the native wrapper ABI: added `System6NativeAudioFormat` (managed mirror), updated `ISystem6NativeLibrary` with `IsAudioAvailable`, `GetAudioFormat()` and `FillAudioFrames(Span<short>, uint)`, and bound optional exports `GetAudioFormat` and `FillAudioFrames` in `System6NativeLibrary`. 
- Integrated audio into `System6NativeBackend`: discover/validate native audio format during startup (`StartAudioIfAvailable`), create/start an audio sink via an injectable `Func<IEmulationAudioSink?>` factory, pull frames from the DLL on the emulation run loop (`PullAudioFrames` after each `Run`), and push PCM bytes to the sink; clear/stop/dispose the sink on pause/reset/stop/failure. 
- Made audio sink creation injectable for tests and added simple buffering policy (frame buffer sized to an emulation slice), format validation (reject malformed/unsupported formats), and safety guards so absence of audio exports leaves backend functional. 
- Added Editor project dependency on `NAudio` only (no NAudio types appear in shared backend contracts). 
- Tests: added unit tests in `System6NativeBackendTests` that use a `FakeAudioSink` and an updated `FakeSystem6NativeLibrary` to verify sink start/format, PCM delivery, pause/reset/stop clearing, behavior when native audio is unavailable, and handling of malformed native audio formats.

### Testing
- Unit tests added: `StartAsyncStartsAudioSinkWithNativeFormatAndStreamsPcm`, `PauseResetAndStopClearAudioPlayback`, `StartAsyncContinuesWithoutAudioSinkWhenNativeAudioUnavailable`, and `StartAsyncFailsCleanlyForMalformedNativeAudioFormat` (all use a fake `IEmulationAudioSink` and do not require a real audio device). 
- No automated builds or tests were executed in this agent environment because the workspace lacks the Windows/.NET/WPF toolchain; tests should be run locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` and a local build of the updated OasisEmulator DLL to verify live audio playback. 
- Recommended local verification: `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, then `dotnet test ...` and run the Editor with the locally built OasisEmulator DLL to confirm audible playback and correct behavior across start/pause/resume/reset/stop cycles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a482c22eb6c83278576cacf42f4bfde)