### PR TITLE
Update System6 alpha snapshot test to assert snapshot-based behavior

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -484,9 +484,16 @@ public sealed class System6NativeBackendTests
             await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
             await backend.StopAsync(CancellationToken.None);
 
-            Assert.Equal(Enumerable.Range(0, 16).ToArray(), library.AlphaSegmentIndices);
-            Assert.Contains(segmentEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001 && e.OutputType == MameSegmentOutputType.NativeAlpha);
-            Assert.Contains(segmentEvents, e => e.CellId == 1 && e.SegmentMask == 0x2002 && e.OutputType == MameSegmentOutputType.NativeAlpha);
+            var nativeAlphaEvents = segmentEvents
+                .Where(e => e.OutputType == MameSegmentOutputType.NativeAlpha)
+                .OrderBy(e => e.CellId)
+                .ToArray();
+
+            Assert.Contains("GetOutputSnapshot", library.Calls);
+            Assert.Equal(16, nativeAlphaEvents.Length);
+            Assert.Equal(Enumerable.Range(0, 16).ToArray(), nativeAlphaEvents.Select(e => e.CellId).ToArray());
+            Assert.Contains(nativeAlphaEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001);
+            Assert.Contains(nativeAlphaEvents, e => e.CellId == 1 && e.SegmentMask == 0x2002);
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- The System6 backend now reads alpha data via `GetOutputSnapshot()` and `System6NativeOutputSnapshot.AlphaSegmented` instead of calling `GetAlphaSegments(0..15)`, so the existing test's expectation that the fake library recorded polled indices `0..15` is stale.
- Update the test to assert observable snapshot-driven behavior (snapshot call and emitted `NativeAlpha` events) without changing production code.

### Description
- Replaced the stale assertion on `library.AlphaSegmentIndices` with assertions that `GetOutputSnapshot` was called by checking `library.Calls`.
- Added assertions that the startup snapshot produced 16 `MameSegmentOutputType.NativeAlpha` `SegmentChanged` events with cell ids `0..15` and that cell `0` emits mask `0x0001` and cell `1` emits mask `0x2002` (mapped value).
- Kept all other test setup intact and only modified `StartAsyncOneRunOnlyPollsAlphaSegmentsAndPublishesNativeAlphaSegmentMasks` in `System6NativeBackendTests.cs`.

### Testing
- Attempted to run the System6 native backend test class via `dotnet test --filter FullyQualifiedName~OasisEditor.Tests.System6NativeBackendTests`, but `dotnet` is not available in this execution environment so the tests could not be executed here.
- `git diff --check` was run and the change was committed locally as `Update System6 alpha snapshot test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a483673cfb883279547c5ee056592c0)