### PR TITLE
Add decoded FML layout diagnostics

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -59,9 +59,13 @@ internal sealed class FmlImportService : IFmlImportService
 
         var stagingDirectory = CreateStagingDirectory();
         Directory.CreateDirectory(stagingDirectory);
+        var decodedLayoutPath = Path.Combine(stagingDirectory, "decoded-layout.json");
         var manifestPath = Path.Combine(stagingDirectory, "layout.json");
         var imagePaths = FmlDecodedAssetExporter.ExportImages(decodeResult.Layout!, stagingDirectory);
         var decodedJson = decodeResult.Layout!.ToJson(indented: true);
+        File.WriteAllText(
+            decodedLayoutPath,
+            decodedJson);
         var adaptedManifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(
             decodedJson,
             Path.GetFileNameWithoutExtension(fullFmlPath),
@@ -71,6 +75,7 @@ internal sealed class FmlImportService : IFmlImportService
             adaptedManifestJson);
 
         diagnostics.Add($"Temp staging directory: {stagingDirectory}");
+        diagnostics.Add($"Decoded layout JSON path: {decodedLayoutPath}");
         diagnostics.Add($"Generated layout JSON path: {manifestPath}");
         diagnostics.Add($"Generated image count: {imagePaths.Count}; image root: {stagingDirectory}; image paths: {FormatImagePaths(imagePaths.Values)}");
         diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(decodedJson))}");


### PR DESCRIPTION
### Motivation
- Provide visibility into the raw decoded `.FML` `Layout` JSON so we can determine whether Width/Height swaps originate in the `FmlDecoder` or in the Oasis adapter.

### Description
- Write the decoder output directly to `decoded-layout.json` in the staging directory using `decodeResult.Layout!.ToJson(indented: true)` before calling the adapter, while keeping the adapted manifest written to `layout.json`, and add a diagnostic entry `Decoded layout JSON path: ...` alongside the existing `Generated layout JSON path: ...`.

### Testing
- Ran `git diff --check` which reported no issues; build/tests were not executed in this environment per `AGENTS.md` guidance (requires local Windows/.NET/WPF toolchain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4d49a31ff8832798f43023d79d0948)