### PR TITLE
Merge refreshed MFME FML decoder fixes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BorderParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BorderParser.cs
@@ -1,0 +1,54 @@
+using MfmeFmlDecoder.Model;
+using MfmeFmlDecoder.src.Decoder.Component.Core;
+using MfmeFmlDecoder.src.Model.Component;
+using System;
+using static MfmeFmlDecoder.src.Decoder.Component.Core.ExtendedTagParser;
+
+namespace MfmeFmlDecoder.src.Decoder.Component
+{
+    internal sealed class BorderParser : ComponentParserBase<Border>
+    {
+        private ComponentTagMap componentTagMap = new ComponentTagMap
+        {
+            // TODO: TOTAL HACK -- we need to do a proper job here
+            { 0x0A, new TagInfo(0x01, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x0B, new TagInfo(0x01, "Unknown 0x0B", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x37, new TagInfo(0x04, "Unknown 0x37", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x36, new TagInfo(0x00, "Overlay Image", Array.Empty<byte>(), ValueRole.BITMAP) },
+            
+            { 0x3B, new TagInfo(0x04, "Unknown 0x3B", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x06, new TagInfo(0x08, "Unknown 0x06", new byte[] { 0x00 }, ValueRole.RAW) },
+
+
+
+        }.WithNestedTagBlock(new ComponentTagMap
+        {
+            { 0x03, new TagInfo(0x00, "Border Image", Array.Empty<byte>(), ValueRole.BITMAP) },
+            { 0x01, new TagInfo(0x04, "Unknown 0x01", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+            { 0x05, new TagInfo(0x04, "Unknown 0x05", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+            { 0x06, new TagInfo(0x08, "Unknown 0x06", new byte[] { 0x00 }, ValueRole.RAW) },
+            { 0xCA, new TagInfo(0x04, "Unknown 0xCA", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x4D, new TagInfo(0x04, "Unknown 0x4D", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x22, new TagInfo(0x04, "Unknown 0x4D", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x27, new TagInfo(0x04, "Unknown 0x27", Array.Empty<byte>(), ValueRole.UINT32) },
+
+        });
+
+        public Border Parse(long componentOffset, uint componentId, byte[] data)
+        {
+            var (component, offset, parseData) = ParseBase(componentOffset, componentId, data);
+
+            var parseOptions = WithComponentTagLogging(Options.Default);
+            var parseResult = ParseExtendedTags(component, componentTagMap, parseData, offset, parseOptions);
+            
+            ApplyExtendedTags(component, parseResult);
+            return component;
+        }
+
+        private void ApplyExtendedTags(Border component, ParseResult parseResult)
+        {
+
+            ApplyExtendedTagsByReflection(component, parseResult, componentTagMap);
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/GeometryParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/GeometryParser.cs
@@ -67,13 +67,13 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         offset += 4;
                         break;
 
-                    case 0x03: // Width
-                        width = BitConverter.ToUInt32(data, (int)offset);
+                    case 0x03: // Height
+                        height = BitConverter.ToUInt32(data, (int)offset);
                         offset += 4;
                         break;
 
-                    case 0x04: // Height
-                        height = BitConverter.ToUInt32(data, (int)offset);
+                    case 0x04: // Width
+                        width = BitConverter.ToUInt32(data, (int)offset);
                         offset += 4;
                         break;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
@@ -109,6 +109,10 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                 { 0x07, new TagInfo(0x01, "Graphic", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
                 { 0x17, new TagInfo(0x01, "Blend", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
                 { 0x23, new TagInfo(0x01, "ClickAll", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+                { 0x5C, new TagInfo(0x14, "Unknown 0x5C", new byte[] { 0x00 }, ValueRole.RAW) },
+                { 0x5D, new TagInfo(0x14, "Unknown 0x5D", new byte[] { 0x00 }, ValueRole.RAW) },
+                { 0x5E, new TagInfo(0x14, "Unknown 0x5E", new byte[] { 0x00 }, ValueRole.RAW) },
+                //{ 0x5C, new TagInfo(0x04, "Unknown 0x5C", new byte[] { 0x00 }, ValueRole.UINT32) },
             });
 
         public Lamp Parse(long componentOffset, uint componentId, byte[] data)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/Border.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/Border.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MfmeFmlDecoder.src.Model.Component
+{
+    internal class Border : BaseComponent
+    {
+        // TODO: Add attributes
+    }
+}
+


### PR DESCRIPTION
### Motivation
- Bring the vendor copy of the MFME FML decoder up to date with the refreshed upstream snapshot to pick up bugfixes and tag map updates.
- Preserve Oasis-specific import integration and the Editor wrapper while minimizing local edits inside the vendor `FmlDecoder` folder.
- Keep the decoder code copy-friendly and avoid importing upstream test binaries or `Program.cs` into the Editor project.

### Description
- Updated geometry tag handling in `FmlDecoder/Decoder/Component/Core/GeometryParser.cs` so tag `0x03` maps to height and tag `0x04` maps to width to match upstream.
- Added upstream tag entries for raw lamp data in `FmlDecoder/Decoder/Component/LampParser.cs` for tags `0x5C`, `0x5D`, and `0x5E`.
- Added upstream `Border` component/model files `FmlDecoder/Decoder/Component/BorderParser.cs` and `FmlDecoder/Model/Component/Border.cs` as vendor code without wiring any Oasis-specific changes into them.
- Preserved Oasis-only integrations and wrappers such as `Features/FmlImport/FmlImportService.cs`, `FmlDecoder/Application/FmlDecoderService.cs`, and the File > Import menu binding, and intentionally excluded upstream tests and `Program.cs`.

### Testing
- Ran `git diff --check` which returned clean results after the merge.
- Compared the upstream `mfme-fml-decoder-master/src` snapshot to `OasisEditor/OasisEditor/FmlDecoder` with `diff -qr` and validated that remaining differences are Oasis-only wrapper files or intentionally excluded upstream test/`Program.cs` files.
- Note: no build or unit tests were executed in this environment per repository instructions because the Windows/.NET/WPF toolchain is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e89cb7c1c8327ab61e15a2eedefac)