### PR TITLE
Prefer decoded FML background image dimensions

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
@@ -7,6 +7,81 @@ namespace OasisEditor.Tests;
 public sealed class FmlDecodedLayoutAdapterTests
 {
     [Fact]
+    public void ToMfmeExtractManifestJson_WithBackgroundImageDimensions_UsesImageSize()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Background",
+              "Geometry": { "X": 0, "Y": 0, "Width": 1069, "Height": 965, "Number": 0 },
+              "Images": {
+                "background_image": { "Width": 1071, "Height": 990, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout");
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal(0, component["Position"]!["X"]!.GetValue<int>());
+        Assert.Equal(0, component["Position"]!["Y"]!.GetValue<int>());
+        Assert.Equal(1071, component["Size"]!["X"]!.GetValue<int>());
+        Assert.Equal(990, component["Size"]!["Y"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithBackgroundWithoutImageDimensions_UsesGeometrySize()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Background",
+              "Geometry": { "X": 12, "Y": 34, "Width": 1069, "Height": 965, "Number": 0 }
+            }
+          ]
+        }
+        """;
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout");
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal(12, component["Position"]!["X"]!.GetValue<int>());
+        Assert.Equal(34, component["Position"]!["Y"]!.GetValue<int>());
+        Assert.Equal(1069, component["Size"]!["X"]!.GetValue<int>());
+        Assert.Equal(965, component["Size"]!["Y"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithInvalidBackgroundImageDimensions_UsesGeometrySize()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Background",
+              "Geometry": { "X": 12, "Y": 34, "Width": 1069, "Height": 965, "Number": 0 },
+              "Images": {
+                "background_image": { "Width": 0, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout");
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal(12, component["Position"]!["X"]!.GetValue<int>());
+        Assert.Equal(34, component["Position"]!["Y"]!.GetValue<int>());
+        Assert.Equal(1069, component["Size"]!["X"]!.GetValue<int>());
+        Assert.Equal(965, component["Size"]!["Y"]!.GetValue<int>());
+    }
+
+    [Fact]
     public void ToMfmeExtractManifestJson_WithFmlLampImages_MapsLampElementNumberAndBitmapFilenames()
     {
         const string decodedJson = """

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -209,8 +209,8 @@ internal static class FmlDecodedLayoutAdapter
             },
             ["Size"] = new JsonObject
             {
-                ["X"] = Math.Max(1, ReadNumber(component, "Geometry", "Width")),
-                ["Y"] = Math.Max(1, ReadNumber(component, "Geometry", "Height"))
+                ["X"] = Math.Max(1, ReadComponentWidth(component, type)),
+                ["Y"] = Math.Max(1, ReadComponentHeight(component, type))
             }
         };
 
@@ -252,6 +252,40 @@ internal static class FmlDecodedLayoutAdapter
 
     private static int ReadNumber(JsonObject component, string objectName, string propertyName)
         => component[objectName] is JsonObject obj && obj[propertyName] is JsonValue value && value.TryGetValue<double>(out var number)
+            ? (int)Math.Round(number)
+            : 0;
+
+    private static int ReadComponentWidth(JsonObject component, string type)
+        => ReadComponentSize(component, type, "Width");
+
+    private static int ReadComponentHeight(JsonObject component, string type)
+        => ReadComponentSize(component, type, "Height");
+
+    private static int ReadComponentSize(JsonObject component, string type, string propertyName)
+    {
+        if (string.Equals(MapType(type), "Background", StringComparison.Ordinal))
+        {
+            var backgroundImageWidth = ReadBackgroundImageSize(component, "Width");
+            var backgroundImageHeight = ReadBackgroundImageSize(component, "Height");
+            if (backgroundImageWidth > 0 && backgroundImageHeight > 0)
+            {
+                return string.Equals(propertyName, "Width", StringComparison.Ordinal)
+                    ? backgroundImageWidth
+                    : backgroundImageHeight;
+            }
+        }
+
+        return ReadGeometrySize(component, propertyName);
+    }
+
+    private static int ReadGeometrySize(JsonObject component, string propertyName)
+        => ReadNumber(component, "Geometry", propertyName);
+
+    private static int ReadBackgroundImageSize(JsonObject component, string propertyName)
+        => component["Images"] is JsonObject images
+            && images["background_image"] is JsonObject backgroundImage
+            && backgroundImage[propertyName] is JsonValue value
+            && value.TryGetValue<double>(out var number)
             ? (int)Math.Round(number)
             : 0;
 


### PR DESCRIPTION
### Motivation
- Background components adapted from decoded FML should use the actual decoded image dimensions when present so imported Oasis Panel2D backgrounds match the source artwork rather than always using Geometry sizes.

### Description
- Prefer `Images.background_image.Width`/`Height` for `Background` component `Size.X`/`Size.Y`, falling back to `Geometry.Width`/`Geometry.Height` when image dimensions are missing/invalid or <= 0, while preserving `Position.X`/`Position.Y` from `Geometry.X`/`Geometry.Y`.
- Added helper methods `ReadComponentWidth`, `ReadComponentHeight`, `ReadComponentSize`, `ReadGeometrySize`, and `ReadBackgroundImageSize` to centralize size selection logic and keep existing `Math.Max(1, ...)` non-zero behavior.
- Kept other component sizing and lamp/reel/alpha/seven-segment behavior unchanged except for using the shared helper for size resolution.
- Files changed: `OasisEditor/Features/FmlImport/FmlImportService.cs` and `OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs` (added three tests).

### Testing
- Added three unit tests in `OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs` that verify: image-dimension preference, fallback to geometry when image is missing, and fallback when image dimensions are invalid; these tests were not executed in this environment.
- Ran repository checks: `git diff --check` passed in the workspace.
- Note: `dotnet test` / solution build was not run here due to environment constraints; please run `dotnet test OasisEditor.Tests` locally to validate all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e8f9c3b3083279fc7ed495d158292)