### PR TITLE
Remember MFME .FML import directory across Editor sessions

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -68,4 +68,34 @@ public sealed class EditorPreferencesSerializationTests
         Assert.Equal(string.Empty, preferences!.Mame.LocalRomSourceDirectory);
         Assert.Equal(".zip", preferences.Mame.LocalRomArchiveExtension);
     }
+
+    [Fact]
+    public void DeserializingLegacyPreferences_UsesEmptyMfmeFmlImportDirectory()
+    {
+        var json = """
+        {
+          "ThemePreference": 2
+        }
+        """;
+
+        var preferences = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(preferences);
+        Assert.Equal(string.Empty, preferences!.LastMfmeFmlImportDirectory);
+    }
+
+    [Fact]
+    public void SerializingPreferences_PreservesMfmeFmlImportDirectory()
+    {
+        var preferences = new EditorPreferences
+        {
+            LastMfmeFmlImportDirectory = "C:\\\\Layouts"
+        };
+
+        var json = JsonSerializer.Serialize(preferences);
+        var roundTripped = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal("C:\\\\Layouts", roundTripped!.LastMfmeFmlImportDirectory);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeFmlImportDirectoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeFmlImportDirectoryTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeFmlImportDirectoryTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ResolveMfmeFmlImportInitialDirectory_UsesProjectDirectory_WhenSavedDirectoryIsEmpty()
+    {
+        var projectDirectory = CreateDirectory("project");
+
+        var initialDirectory = MainWindowViewModel.ResolveMfmeFmlImportInitialDirectory(
+            string.Empty,
+            projectDirectory);
+
+        Assert.Equal(projectDirectory, initialDirectory);
+    }
+
+    [Fact]
+    public void ResolveMfmeFmlImportInitialDirectory_UsesSavedDirectory_WhenSavedDirectoryExists()
+    {
+        var projectDirectory = CreateDirectory("project");
+        var savedDirectory = CreateDirectory("fml-layouts");
+
+        var initialDirectory = MainWindowViewModel.ResolveMfmeFmlImportInitialDirectory(
+            savedDirectory,
+            projectDirectory);
+
+        Assert.Equal(savedDirectory, initialDirectory);
+    }
+
+    [Fact]
+    public void ResolveMfmeFmlImportInitialDirectory_UsesProjectDirectory_WhenSavedDirectoryIsMissing()
+    {
+        var projectDirectory = CreateDirectory("project");
+        var missingSavedDirectory = Path.Combine(_tempRoot, "deleted-layouts");
+
+        var initialDirectory = MainWindowViewModel.ResolveMfmeFmlImportInitialDirectory(
+            missingSavedDirectory,
+            projectDirectory);
+
+        Assert.Equal(projectDirectory, initialDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    private string CreateDirectory(string name)
+    {
+        var path = Path.Combine(_tempRoot, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -8,6 +8,7 @@ public sealed class EditorPreferences
     public NativeEmulationPreferences NativeEmulation { get; init; } = new();
     public OutputLogPreferences OutputLog { get; init; } = new();
     public FaceGenerationPreferences FaceGeneration { get; init; } = new();
+    public string LastMfmeFmlImportDirectory { get; init; } = string.Empty;
 
     public Dictionary<string, ProjectWindowState> ProjectWindowStates { get; init; } = new();
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -193,6 +193,7 @@ public partial class MainWindow : Window
             NativeEmulation = preferences.NativeEmulation,
             OutputLog = preferences.OutputLog,
             FaceGeneration = preferences.FaceGeneration,
+            LastMfmeFmlImportDirectory = preferences.LastMfmeFmlImportDirectory,
             ProjectWindowStates = states
         });
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool _debugOutputLamps;
     private bool _debugOutputStdIn;
     private bool _debugOutputStdOut;
+    private string _lastMfmeFmlImportDirectory = string.Empty;
     private FaceGenerationSettingsModel _defaultFaceGenerationSettings = FaceGenerationSettingsModel.Default;
     private bool _showFaceGenerationSettingsBeforeRegenerate = true;
     private string _mameValidationSummary = "Not validated.";
@@ -286,6 +287,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _debugOutputLamps = preferences.Mame.DebugOutputLamps;
             _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;
             _debugOutputStdOut = preferences.Mame.DebugOutputStdOut;
+            _lastMfmeFmlImportDirectory = preferences.LastMfmeFmlImportDirectory;
             _defaultFaceGenerationSettings = preferences.FaceGeneration.ToSettings();
             _showFaceGenerationSettingsBeforeRegenerate = preferences.FaceGeneration.ShowFaceGenerationSettingsBeforeRegenerate;
             _outputLog.ShowInfoLogs = preferences.OutputLog.ShowInfoLogs;
@@ -1678,13 +1680,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             Title = "Import MFME FML",
             Filter = "MFME FML Layout|*.fml|All Files|*.*",
-            InitialDirectory = LoadedProject.ProjectDirectory,
+            InitialDirectory = ResolveMfmeFmlImportInitialDirectory(
+                _lastMfmeFmlImportDirectory,
+                LoadedProject.ProjectDirectory),
             CheckFileExists = true
         };
 
         if (dialog.ShowDialog() != true)
         {
             return;
+        }
+
+        var selectedDirectory = Path.GetDirectoryName(dialog.FileName);
+        if (!string.IsNullOrWhiteSpace(selectedDirectory))
+        {
+            _lastMfmeFmlImportDirectory = selectedDirectory;
+            SavePreferences();
         }
 
         var activeDocument = SelectedDocument;
@@ -1807,6 +1818,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             EndEditorProgress();
             NotifyDocumentCommands();
         }
+    }
+
+    public static string ResolveMfmeFmlImportInitialDirectory(
+        string? lastMfmeFmlImportDirectory,
+        string projectDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(lastMfmeFmlImportDirectory)
+            && Directory.Exists(lastMfmeFmlImportDirectory))
+        {
+            return lastMfmeFmlImportDirectory;
+        }
+
+        return projectDirectory;
     }
 
     private void OpenAssetDocument(AssetBrowserItemViewModel? asset)
@@ -2527,6 +2551,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _preferencesStore.Save(new EditorPreferences
         {
             ThemePreference = SelectedThemePreference,
+            LastMfmeFmlImportDirectory = _lastMfmeFmlImportDirectory,
             Mame = new MamePreferences
             {
                 Version = MameVersion,


### PR DESCRIPTION
### Motivation

- Improve UX by remembering the last folder used for `File > Import > MFME .FML...` so users don't repeatedly navigate to the same directory.
- Make the remembered folder Editor-wide (not per-project) and persist it in the existing preferences store so it survives restarts.

### Description

- Added an editor preference property `LastMfmeFmlImportDirectory` to `EditorPreferences` to store the saved folder path.
- Loaded `LastMfmeFmlImportDirectory` into `MainWindowViewModel` state and preserved it when saving preferences via `SavePreferences()` and when window placement is saved in `MainWindow.xaml.cs`.
- Updated the MFME FML import flow to set the `OpenFileDialog.InitialDirectory` using a new helper `ResolveMfmeFmlImportInitialDirectory(last, projectDir)`, which returns the saved directory if it exists or falls back to `LoadedProject.ProjectDirectory` otherwise.
- After a successful file selection the code saves `Path.GetDirectoryName(dialog.FileName)` into `_lastMfmeFmlImportDirectory` and calls `SavePreferences()` to persist the choice.
- Added unit tests covering JSON (de)serialization for the new preference and tests for `ResolveMfmeFmlImportInitialDirectory` to verify fallback behaviors for empty, existing, and missing saved directories.

### Testing

- No automated test suite was executed in this environment per project `AGENTS.md` guidance (the Windows/.NET/WPF toolchain is not available here), but unit tests were added: `EditorPreferencesSerializationTests` updates and `MfmeFmlImportDirectoryTests` for the resolver helper.
- The added tests are standard `xUnit` tests and should be run locally with `dotnet test` on a machine with the required toolchain; they were not run here and therefore have no pass/fail result in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e962f72488327a39a8a01d0a006af)