### PR TITLE
Fix FML display overlay baking

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
@@ -151,4 +151,92 @@ public sealed class FmlDecodedLayoutAdapterTests
         Assert.Equal("0000_sublamp_1_mask_image.bmp", lampElement["BmpMaskImageFilename"]!.GetValue<string>());
         Assert.True(lampElement["Graphic"]!.GetValue<bool>());
     }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithFmlReelBandAndOverlay_MapsBandPrimaryAndOverlaySecondary()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Reel",
+              "Geometry": { "X": 10, "Y": 20, "Width": 30, "Height": 40, "Number": 2 },
+              "Images": {
+                "reel_band_gradient_image": { "Width": 16, "Height": 64, "BitsPerPixel": 32 },
+                "window_overlay_image": { "Width": 16, "Height": 16, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+        var imagePaths = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new(0, "reel_band_gradient_image")] = "reels/0000_reel_band_gradient_image.bmp",
+            [new(0, "window_overlay_image")] = "reels/0000_window_overlay_image.bmp"
+        };
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout", imagePaths);
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal("0000_reel_band_gradient_image.bmp", component["BandBmpImageFilename"]!.GetValue<string>());
+        Assert.True(component["HasOverlay"]!.GetValue<bool>());
+        Assert.Equal("0000_window_overlay_image.bmp", component["OverlayBmpImageFilename"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithFmlReelOnlyBand_DoesNotUseBandAsOverlay()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Reel",
+              "Geometry": { "X": 10, "Y": 20, "Width": 30, "Height": 40, "Number": 2 },
+              "Images": {
+                "reel_band_gradient_image": { "Width": 16, "Height": 64, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+        var imagePaths = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new(0, "reel_band_gradient_image")] = "reels/0000_reel_band_gradient_image.bmp"
+        };
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout", imagePaths);
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal("0000_reel_band_gradient_image.bmp", component["BandBmpImageFilename"]!.GetValue<string>());
+        Assert.False(component["HasOverlay"]!.GetValue<bool>());
+        Assert.Null(component["OverlayBmpImageFilename"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithFmlAlphaOverlay_MapsOverlay()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Alpha",
+              "Geometry": { "X": 10, "Y": 20, "Width": 30, "Height": 12, "Number": 0 },
+              "Images": {
+                "display_overlay": { "Width": 30, "Height": 12, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+        var imagePaths = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new(0, "display_overlay")] = "reels/0000_display_overlay.bmp"
+        };
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout", imagePaths);
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.True(component["HasOverlay"]!.GetValue<bool>());
+        Assert.Equal("0000_display_overlay.bmp", component["OverlayBmpImageFilename"]!.GetValue<string>());
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeImportAssetCopierTests.cs
@@ -440,6 +440,153 @@ public sealed class MfmeImportAssetCopierTests
         }
     }
 
+    [Fact]
+    public void CopyAssets_WithSevenSegmentWithoutOverlay_ClearsBackgroundRectAndSendsDisplayBehindBackground()
+    {
+        var extractRoot = CreateTempDirectory();
+        var projectRoot = CreateTempDirectory();
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(extractRoot, "background"));
+            CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 4, 4, _ => Color.FromArgb(255, 10, 20, 30));
+
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractRoot,
+                ProjectRootPath = projectRoot,
+                ProjectAssetsPath = Path.Combine(projectRoot, "Assets"),
+                CopyAssets = true
+            };
+
+            var extract = new MfmeLegacyExtractData
+            {
+                ExtractRootPath = extractRoot,
+                ManifestPath = Path.Combine(extractRoot, "layout.json"),
+                LayoutName = "layout",
+                Components = []
+            };
+
+            var elements = new[]
+            {
+                new PanelElementModel
+                {
+                    ObjectId = "bg",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    Width = 4,
+                    Height = 4,
+                    AssetPath = "background/bg.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "seven",
+                    Name = "7 Segment",
+                    Kind = PanelElementKind.SevenSegment,
+                    X = 1,
+                    Y = 1,
+                    Width = 2,
+                    Height = 1
+                }
+            };
+
+            var copier = new MfmeImportAssetCopier();
+            var result = copier.CopyAssets(context, extract, elements);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(PanelElementKind.SevenSegment, result.Elements[0].Kind);
+            Assert.Equal(PanelElementKind.Background, result.Elements[1].Kind);
+
+            var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
+            var backgroundPath = Path.Combine(projectRoot, "Assets", background.AssetPath!["Assets/".Length..]);
+            var pixels = ReadBgra32(backgroundPath, out var stride);
+
+            Assert.Equal(0, GetPixel(pixels, stride, 1, 1).A);
+            Assert.Equal(0, GetPixel(pixels, stride, 2, 1).A);
+            Assert.Equal(255, GetPixel(pixels, stride, 0, 0).A);
+        }
+        finally
+        {
+            Directory.Delete(extractRoot, recursive: true);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyAssets_WithAlphaOverlay_BakesOverlayIntoBackground()
+    {
+        var extractRoot = CreateTempDirectory();
+        var projectRoot = CreateTempDirectory();
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(extractRoot, "background"));
+            Directory.CreateDirectory(Path.Combine(extractRoot, "reels"));
+            CreatePng(Path.Combine(extractRoot, "background", "bg.png"), 3, 3, _ => Color.FromArgb(255, 10, 20, 30));
+            CreatePng(Path.Combine(extractRoot, "reels", "alpha-overlay.png"), 1, 1, _ => Color.FromArgb(200, 50, 60, 70));
+
+            var context = new MfmeImportContext
+            {
+                SourceExtractPath = extractRoot,
+                ProjectRootPath = projectRoot,
+                ProjectAssetsPath = Path.Combine(projectRoot, "Assets"),
+                CopyAssets = true
+            };
+
+            var extract = new MfmeLegacyExtractData
+            {
+                ExtractRootPath = extractRoot,
+                ManifestPath = Path.Combine(extractRoot, "layout.json"),
+                LayoutName = "layout",
+                Components = []
+            };
+
+            var elements = new[]
+            {
+                new PanelElementModel
+                {
+                    ObjectId = "bg",
+                    Name = "Background",
+                    Kind = PanelElementKind.Background,
+                    Width = 3,
+                    Height = 3,
+                    AssetPath = "background/bg.png"
+                },
+                new PanelElementModel
+                {
+                    ObjectId = "alpha",
+                    Name = "Alpha",
+                    Kind = PanelElementKind.Alpha,
+                    X = 1,
+                    Y = 1,
+                    Width = 1,
+                    Height = 1,
+                    SecondaryAssetPath = "reels/alpha-overlay.png"
+                }
+            };
+
+            var copier = new MfmeImportAssetCopier();
+            var result = copier.CopyAssets(context, extract, elements);
+
+            Assert.True(result.Succeeded);
+
+            var background = Assert.Single(result.Elements, element => element.Kind == PanelElementKind.Background);
+            var backgroundPath = Path.Combine(projectRoot, "Assets", background.AssetPath!["Assets/".Length..]);
+            var pixels = ReadBgra32(backgroundPath, out var stride);
+            var overlayPixel = GetPixel(pixels, stride, 1, 1);
+
+            Assert.Equal(200, overlayPixel.A);
+            Assert.Equal(50, overlayPixel.R);
+            Assert.Equal(60, overlayPixel.G);
+            Assert.Equal(70, overlayPixel.B);
+        }
+        finally
+        {
+            Directory.Delete(extractRoot, recursive: true);
+            Directory.Delete(projectRoot, recursive: true);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"oasis-mfme-copy-{Guid.NewGuid():N}");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -336,9 +336,8 @@ internal static class FmlDecodedLayoutAdapter
         }
 
         string? first = FindExportedImage(imagePaths, componentIndex, keys[0]);
-        string? overlay = keys.Select(key => new { Key = key, Path = FindExportedImage(imagePaths, componentIndex, key) })
-            .FirstOrDefault(entry => entry.Path is not null && !string.Equals(entry.Path, first, StringComparison.OrdinalIgnoreCase))
-            ?.Path;
+        string? reelBand = FindFirstImageByKeyRole(imagePaths, componentIndex, keys, IsReelBandImageKey) ?? first;
+        string? overlay = FindFirstImageByKeyRole(imagePaths, componentIndex, keys, IsOverlayImageKey);
 
         switch (MapType(type))
         {
@@ -350,16 +349,60 @@ internal static class FmlDecodedLayoutAdapter
                 legacy["LampElements"] = BuildLampElements(component, imagePaths, componentIndex, keys);
                 break;
             case "Reel":
-                legacy["BandBmpImageFilename"] = FileNameFromRelativePath(first);
+                legacy["BandBmpImageFilename"] = FileNameFromRelativePath(reelBand);
                 legacy["HasOverlay"] = overlay is not null;
                 legacy["OverlayBmpImageFilename"] = FileNameFromRelativePath(overlay);
                 break;
             case "Alpha":
             case "SevenSegment":
-                legacy["HasOverlay"] = first is not null;
-                legacy["OverlayBmpImageFilename"] = FileNameFromRelativePath(first);
+                legacy["HasOverlay"] = overlay is not null;
+                legacy["OverlayBmpImageFilename"] = FileNameFromRelativePath(overlay);
                 break;
         }
+    }
+
+    private static string? FindFirstImageByKeyRole(
+        IReadOnlyDictionary<FmlDecodedImageKey, string> imagePaths,
+        int componentIndex,
+        IEnumerable<string> imageKeys,
+        Func<string, bool> matchesRole)
+    {
+        foreach (var imageKey in imageKeys)
+        {
+            if (!matchesRole(imageKey))
+            {
+                continue;
+            }
+
+            var path = FindExportedImage(imagePaths, componentIndex, imageKey);
+            if (path is not null)
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsReelBandImageKey(string imageKey)
+    {
+        var normalizedKey = NormalizeImageKey(imageKey);
+        return normalizedKey.Contains("band", StringComparison.Ordinal)
+            || normalizedKey.Contains("gradient", StringComparison.Ordinal)
+            || normalizedKey.Contains("strip", StringComparison.Ordinal)
+            || normalizedKey.Contains("reel_image", StringComparison.Ordinal)
+            || normalizedKey.EndsWith("reel", StringComparison.Ordinal);
+    }
+
+    private static bool IsOverlayImageKey(string imageKey)
+    {
+        var normalizedKey = NormalizeImageKey(imageKey);
+        return normalizedKey.Contains("overlay", StringComparison.Ordinal)
+            || normalizedKey.Contains("over_lay", StringComparison.Ordinal)
+            || normalizedKey.Contains("window", StringComparison.Ordinal)
+            || normalizedKey.Contains("cutout", StringComparison.Ordinal)
+            || normalizedKey.Contains("cut_out", StringComparison.Ordinal)
+            || normalizedKey.Contains("mask_overlay", StringComparison.Ordinal);
     }
 
     private static string? FindExportedImage(IReadOnlyDictionary<FmlDecodedImageKey, string> imagePaths, int componentIndex, string imageName)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -69,7 +69,7 @@ internal static class MfmeBackgroundOverlayPostProcessor
 
     private static bool IsBackgroundCutoutDisplay(PanelElementModel element)
     {
-        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix;
+        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.SevenSegment or PanelElementKind.VfdDotMatrix;
     }
 
     private static void CopyOverlayIntoBackground(PixelBuffer backgroundImage, PanelElementModel background, PanelElementModel overlayElement, PixelBuffer overlayImage)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeExtractManifestParser.cs
@@ -280,12 +280,17 @@ internal static class MfmeExtractManifestParser
                 return true;
 
             case "extractcomponentsevensegment":
-                parsedComponent = new MfmeLegacySevenSegmentComponent(
-                    position,
-                    size,
-                    ReadInt(component, "Number"),
-                    ReadColor(component, "SegmentOnColor"));
-                return true;
+                {
+                    var overlayBmpImageFilename = ReadString(component, "OverlayBmpImageFilename") ?? ReadString(component, "BmpImageFilename");
+                    parsedComponent = new MfmeLegacySevenSegmentComponent(
+                        position,
+                        size,
+                        ReadInt(component, "Number"),
+                        ReadColor(component, "SegmentOnColor"),
+                        ReadBool(component, "HasOverlay") || !string.IsNullOrWhiteSpace(overlayBmpImageFilename),
+                        overlayBmpImageFilename);
+                    return true;
+                }
 
             case "extractcomponentalpha":
             case "extractcomponentalphanew":

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeImportAssetCopier.cs
@@ -215,7 +215,7 @@ internal sealed class MfmeImportAssetCopier
 
     private static bool IsBackgroundCutoutDisplay(PanelElementModel element)
     {
-        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.VfdDotMatrix;
+        return element.Kind is PanelElementKind.Reel or PanelElementKind.Alpha or PanelElementKind.SevenSegment or PanelElementKind.VfdDotMatrix;
     }
 
     private static PanelElementModel CloneWithAssetPath(PanelElementModel element, string? assetPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeLegacyExtractComponentDtos.cs
@@ -95,7 +95,9 @@ internal sealed record MfmeLegacySevenSegmentComponent(
     MfmeLegacyPoint Position,
     MfmeLegacyPoint Size,
     int Number,
-    MfmeLegacyColor? SegmentOnColor)
+    MfmeLegacyColor? SegmentOnColor,
+    bool HasOverlay = false,
+    string? OverlayBmpImageFilename = null)
     : MfmeLegacyComponentBase(
         "SevenSegment",
         Position,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs
@@ -312,6 +312,9 @@ internal sealed class MfmeToOasisComponentMapper
             Width = component.Size.X,
             Height = component.Size.Y,
             DisplayNumber = component.Number,
+            SecondaryAssetPath = component.HasOverlay
+                ? BuildExtractRelativePath("reels", component.OverlayBmpImageFilename)
+                : null,
             OnColorHex = ToHex(component.SegmentOnColor),
             ImportSource = CreateImportSource($"{component.SourceType}:{component.Number}")
         };


### PR DESCRIPTION
### Motivation

- FML `.FML` imports were not matching the legacy MFME Extract overlay/cutout behavior because the wrong decoded image was being used as the overlay and segment/seven-seg displays were not participating in background cutouts.
- The goal is to adapt the FML-to-legacy manifest so the existing MFME import pipeline and `MfmeBackgroundOverlayPostProcessor` can handle overlays/cutouts unchanged.

### Description

- Updated `FmlDecodedLayoutAdapter.CopyImageReferences(...)` to select a reel band/gradient image for the legacy primary reel field and to prefer image keys that indicate overlays/windows/cutouts for the legacy secondary overlay field via new helpers `FindFirstImageByKeyRole`, `IsReelBandImageKey`, and `IsOverlayImageKey` in `FmlImportService.cs`.
- Carried seven-segment overlay metadata through the legacy DTO and parser by extending `MfmeLegacySevenSegmentComponent` with `HasOverlay` and `OverlayBmpImageFilename`, and updated `MfmeExtractManifestParser` and `MfmeToOasisComponentMapper` to preserve `SecondaryAssetPath` for seven-segment displays.
- Included `PanelElementKind.SevenSegment` in the background cutout/display ordering and baking logic by updating `IsBackgroundCutoutDisplay` in `MfmeImportAssetCopier.cs` and `MfmeBackgroundOverlayPostProcessor.cs` so seven-segment elements punch transparent rects or bake overlays like reels and alpha displays.
- Added regression unit tests to validate: reel band vs overlay selection, reel-only band not being used as overlay, alpha overlay mapping, seven-segment transparent cutout behavior, and alpha overlay baking in `FmlDecodedLayoutAdapterTests.cs` and `MfmeImportAssetCopierTests.cs`.

### Testing

- No automated tests were executed in this environment because the environment lacks the required Windows/.NET/WPF toolchain as noted in `AGENTS.md`.
- Added automated tests: `FmlDecodedLayoutAdapterTests.ToMfmeExtractManifestJson_WithFmlReelBandAndOverlay_MapsBandPrimaryAndOverlaySecondary`, `FmlDecodedLayoutAdapterTests.ToMfmeExtractManifestJson_WithFmlReelOnlyBand_DoesNotUseBandAsOverlay`, `FmlDecodedLayoutAdapterTests.ToMfmeExtractManifestJson_WithFmlAlphaOverlay_MapsOverlay`, `MfmeImportAssetCopierTests.CopyAssets_WithSevenSegmentWithoutOverlay_ClearsBackgroundRectAndSendsDisplayBehindBackground`, and `MfmeImportAssetCopierTests.CopyAssets_WithAlphaOverlay_BakesOverlayIntoBackground` which should be run locally with `dotnet test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e9ce93c808327b5fcee7c48437fc7)