### PR TITLE
Ensure FML imports produce Reel VisibleScale by mapping ReelHeight into legacy manifest

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using OasisEditor.Features.MfmeImport;
 using OasisEditor.Features.FmlImport;
 using Xunit;
 
@@ -239,4 +241,85 @@ public sealed class FmlDecodedLayoutAdapterTests
         Assert.True(component["HasOverlay"]!.GetValue<bool>());
         Assert.Equal("0000_display_overlay.bmp", component["OverlayBmpImageFilename"]!.GetValue<string>());
     }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithFmlReelHeight_MapsLegacyHeightForSharedVisibleScaleCalculation()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Reel",
+              "Geometry": { "X": 10, "Y": 20, "Width": 30, "Height": 40, "Number": 2 },
+              "Values": { "Stops": 24, "ReelHeight": 100 },
+              "Reversed": false
+            }
+          ]
+        }
+        """;
+
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout");
+
+        var component = JsonNode.Parse(manifestJson)!["Components"]!.AsArray()[0]!.AsObject();
+        Assert.Equal(24, component["Stops"]!.GetValue<int>());
+        Assert.Equal(100, component["Height"]!.GetValue<int>());
+        Assert.Null(component["VisibleScale"]);
+    }
+
+    [Fact]
+    public void ToMfmeExtractManifestJson_WithFmlReelHeight_ProducesVisibleScaleThroughLegacyMapper()
+    {
+        const string decodedJson = """
+        {
+          "Components": [
+            {
+              "Type": "Reel",
+              "Geometry": { "X": 10, "Y": 20, "Width": 30, "Height": 40, "Number": 2 },
+              "Values": { "Stops": 24, "ReelHeight": 100 },
+              "Reversed": false,
+              "Images": {
+                "reel_band_gradient_image": { "Width": 16, "Height": 64, "BitsPerPixel": 32 }
+              }
+            }
+          ]
+        }
+        """;
+        var imagePaths = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new(0, "reel_band_gradient_image")] = "reels/0000_reel_band_gradient_image.bmp"
+        };
+        var manifestJson = FmlDecodedLayoutAdapter.ToMfmeExtractManifestJson(decodedJson, "layout", imagePaths);
+        using var document = JsonDocument.Parse(manifestJson);
+        var component = document.RootElement.GetProperty("Components")[0];
+        var overlayBmpImageFilename = component.TryGetProperty("OverlayBmpImageFilename", out var overlayElement)
+            ? overlayElement.GetString()
+            : null;
+        var legacyReel = new MfmeLegacyReelComponent(
+            new MfmeLegacyPoint(
+                component.GetProperty("Position").GetProperty("X").GetInt32(),
+                component.GetProperty("Position").GetProperty("Y").GetInt32()),
+            new MfmeLegacyPoint(
+                component.GetProperty("Size").GetProperty("X").GetInt32(),
+                component.GetProperty("Size").GetProperty("Y").GetInt32()),
+            component.GetProperty("Number").GetInt32(),
+            component.GetProperty("Stops").GetInt32(),
+            component.GetProperty("Reversed").GetBoolean(),
+            component.GetProperty("Height").GetInt32(),
+            component.GetProperty("BandBmpImageFilename").GetString(),
+            component.GetProperty("HasOverlay").GetBoolean(),
+            overlayBmpImageFilename);
+        var mapper = new MfmeToOasisComponentMapper();
+
+        var result = mapper.Map(new MfmeLegacyExtractData
+        {
+            ExtractRootPath = "C:/extract",
+            ManifestPath = "C:/extract/layout.json",
+            LayoutName = "layout",
+            Components = [legacyReel]
+        });
+
+        var reel = Assert.Single(result.Elements);
+        Assert.Equal(100d / 50d / 24d, reel.VisibleScale);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -226,7 +226,7 @@ internal static class FmlDecodedLayoutAdapter
         CopyValue(component, legacy, "Reversed", "Reversed");
         CopyValue(component, legacy, "Reverse", "Reversed");
         CopyValue(component, legacy, "Stops", "Stops");
-        CopyValue(component, legacy, "Height", "Height");
+        CopyReelHeight(component, legacy, type);
         CopyValue(component, legacy, "ButtonNumber", "ButtonNumberAsString");
         CopyValue(component, legacy, "Button", "ButtonNumberAsString");
         CopyColor(component, legacy, "Colour", "TextColor");
@@ -295,6 +295,20 @@ internal static class FmlDecodedLayoutAdapter
         if (value is not null && !target.ContainsKey(targetName))
         {
             target[targetName] = JsonNode.Parse(value.ToJsonString());
+        }
+    }
+
+    private static void CopyReelHeight(JsonObject source, JsonObject target, string type)
+    {
+        if (!string.Equals(MapType(type), "Reel", StringComparison.Ordinal) || target.ContainsKey("Height"))
+        {
+            return;
+        }
+
+        var reelHeight = FindValue(source, "ReelHeight") ?? FindValue(source, "Height");
+        if (reelHeight is not null)
+        {
+            target["Height"] = JsonNode.Parse(reelHeight.ToJsonString());
         }
     }
 


### PR DESCRIPTION
### Motivation
- FML-imported reels were ending up with `VisibleScale = 0` because the decoded FML `ReelHeight` was not being provided to the legacy MFME mapping path that calculates `VisibleScale`.
- The visible-scale value is expected to be derived by the existing legacy mapper logic (`Height / 50d / Stops`) rather than computed inside the FML adapter.
- The goal is to make both import paths share the same calculation path and avoid duplicating visible-scale logic.

### Description
- Added `CopyReelHeight` to `FmlDecodedLayoutAdapter` and replaced the direct `Height` copy with a call to `CopyReelHeight` so `ReelHeight` (falling back to `Height`) is copied into the legacy manifest only for reel types (`WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs`).
- The existing legacy mapper (`MfmeToOasisComponentMapper`) is reused unchanged to compute `VisibleScale = (Height / 50d) / Stops` when `Stops > 0` so no FML-specific visible-scale computation was introduced (`WindowsNetProjects/OasisEditor/OasisEditor/Features/MfmeImport/MfmeToOasisComponentMapper.cs`).
- Added tests that exercise the adapter-to-legacy flow and validate that `ReelHeight` becomes the legacy `Height`, that `VisibleScale` is not directly copied into the manifest, and that the legacy mapper produces the expected visible-scale value (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecodedLayoutAdapterTests.cs`).

### Testing
- Added unit tests: `ToMfmeExtractManifestJson_WithFmlReelHeight_MapsLegacyHeightForSharedVisibleScaleCalculation` and `ToMfmeExtractManifestJson_WithFmlReelHeight_ProducesVisibleScaleThroughLegacyMapper` (no automated test runner was executed in this environment).
- Per repository guidance the test suite was not executed here because the environment lacks the required Windows/.NET/WPF toolchain, so no test run results are available; these tests should be run locally with `dotnet test` and are expected to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e9ff689b08327bd16383570ec418e)