### PR TITLE
Merge upstream FML decoder fixes into editor copy

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LabelParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LabelParser.cs
@@ -19,6 +19,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component
             { 0x02, new TagInfo(0x01, "Unknown 0x02", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x27, new TagInfo(0x00, "PrimaryFont", Array.Empty<byte>(), ValueRole.FONT) },
             { 0x38, new TagInfo(0x04, "Unknown 0x38", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
+            { 0x1C, new TagInfo(0x04, "Unknown 0x1C", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
         };
 
         public Label Parse(long componentOffset, uint componentId, byte[] data)
@@ -30,7 +31,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                 data,
                 normalizationRule: new GeometryAngleNormalization.Rule(
                     RewriteBytesAfterNormalizedAngle: new byte[] { 0x00, 0x01 },
-                    RewriteTriggerOffsetDelta: 5,
+                    RewriteTriggerOffsetDelta: 0,
                     ValidAngleOffsetDelta: 5));
 
             DumpRemaining(componentOffset, parseData, offset);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
@@ -109,10 +109,14 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                 { 0x07, new TagInfo(0x01, "Graphic", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
                 { 0x17, new TagInfo(0x01, "Blend", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
                 { 0x23, new TagInfo(0x01, "ClickAll", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+
+                // HACK
+                // TODO: I have no idea what these do, they don't appear on forms anywhere
+                // Might be related to the specific tech used
+                // Appear to be inferred my MFME and added to the FML.
                 { 0x5C, new TagInfo(0x14, "Unknown 0x5C", new byte[] { 0x00 }, ValueRole.RAW) },
                 { 0x5D, new TagInfo(0x14, "Unknown 0x5D", new byte[] { 0x00 }, ValueRole.RAW) },
                 { 0x5E, new TagInfo(0x14, "Unknown 0x5E", new byte[] { 0x00 }, ValueRole.RAW) },
-                //{ 0x5C, new TagInfo(0x04, "Unknown 0x5C", new byte[] { 0x00 }, ValueRole.UINT32) },
             });
 
         public Lamp Parse(long componentOffset, uint componentId, byte[] data)


### PR DESCRIPTION
### Motivation
- Bring two small but important fixes from the upstream MFME FML decoder snapshot into the Editor's vendored decoder to correct angle normalization behavior for labels and to recognise MFME-inferred lamp tags. 

### Description
- Applied upstream changes from `Upstream/mfme-fml-decoder-master/src/Decoder/Component/LabelParser.cs` by adding tag `0x1C` to the label tag map and changing `RewriteTriggerOffsetDelta` from `5` to `0` in the label angle normalization rule. 
- Applied upstream changes from `Upstream/mfme-fml-decoder-master/src/Decoder/Component/LampParser.cs` by documenting the unknown `0x5C/0x5D/0x5E` tags as raw (`ValueRole.RAW`) and removing the stale commented alternate `0x5C` entry while adding an explanatory comment block. 
- Kept changes strictly limited to the two matching vendor files under `OasisEditor/OasisEditor/FmlDecoder/Decoder/Component` and did not modify any Oasis-specific integration layers (for example `OasisEditor/Features/FmlImport` or editor wrapper/service APIs). 
- Resolved no conflicts during merge; edits were a one-to-one application of the upstream snapshot into the live copy and were committed as a focused update.

### Testing
- Verified the upstream commit touched `Upstream/mfme-fml-decoder-master/src/Decoder/Component/LabelParser.cs` and `Upstream/mfme-fml-decoder-master/src/Decoder/Component/LampParser.cs` and updated the matching live files at `OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LabelParser.cs` and `.../LampParser.cs` using `git diff` and `diff -u`. 
- Confirmed the repository `git status` is clean after committing the changes. 
- No automated build or unit tests were run in this environment per `WindowsNetProjects/OasisEditor/AGENTS.md` guidance that the Windows/.NET/WPF toolchain is unavailable, so local build and tests should be executed by a developer on a proper Windows/.NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ebdbcbfb8832791e8d835f688883c)