### PR TITLE
Fix FML color channel ordering and sublamp indexing in FML importer

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -1,6 +1,7 @@
 using MfmeFmlDecoder.src.Model;
 using MfmeFmlDecoder.src.Model.Component;
 using OasisEditor.Features.FmlImport;
+using System.Windows.Media;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -16,11 +17,11 @@ public sealed class FmlToOasisMapperTests
             Y = 20,
             Width = 30,
             Height = 40,
-            SublampTable = [new LampSublampTableEntry(0, 42)]
+            SublampTable = [new LampSublampTableEntry(1, 42)]
         };
         lamp.Strings["OffText"] = "HOLD";
-        lamp.Colours["Sublamp0Colour"] = "#11223344";
-        lamp.Fonts["Primary"] = new FontTagEntry(0, "Primary", "Arial", 12, 0, "Western", "#FF010203", 0);
+        lamp.Colours["Sublamp1Colour"] = "#0000FFFF";
+        lamp.Fonts["Primary"] = new FontTagEntry(0, "Primary", "Arial", 12, 0, "Western", "#0080C0FF", 0);
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
 
@@ -28,7 +29,10 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal(PanelElementKind.Lamp, element.Kind);
         Assert.Equal(42, element.DisplayNumber);
         Assert.Equal("HOLD", element.DisplayText);
-        Assert.Equal("#11223344", element.OnColorHex);
+        Assert.Equal("#FF0000FF", element.OnColorHex);
+        Assert.Equal("#FF0080C0", element.TextColorHex);
+        AssertOasisArgbChannels(element.OnColorHex, 255, 0, 0, 255);
+        AssertOasisArgbChannels(element.TextColorHex, 255, 0, 128, 192);
         Assert.Null(element.AssetPath);
         Assert.Null(element.SecondaryAssetPath);
         Assert.Equal("Arial", element.TextBoxFontName);
@@ -46,13 +50,13 @@ public sealed class FmlToOasisMapperTests
             Height = 4,
             SublampTable =
             [
-                new LampSublampTableEntry(0, 10),
-                new LampSublampTableEntry(1, 11),
-                new LampSublampTableEntry(2, -2)
+                new LampSublampTableEntry(1, 10),
+                new LampSublampTableEntry(2, 11),
+                new LampSublampTableEntry(3, -2)
             ]
         };
-        lamp.Colours["Sublamp0Colour"] = "#FF102030";
-        lamp.Colours["Sublamp1Colour"] = "#FF405060";
+        lamp.Colours["Sublamp1Colour"] = "#102030FF";
+        lamp.Colours["Sublamp2Colour"] = "#40506080";
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
 
@@ -60,7 +64,7 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal(10, result.Elements[0].DisplayNumber);
         Assert.Equal("#FF102030", result.Elements[0].OnColorHex);
         Assert.Equal(11, result.Elements[1].DisplayNumber);
-        Assert.Equal("#FF405060", result.Elements[1].OnColorHex);
+        Assert.Equal("#80405060", result.Elements[1].OnColorHex);
         Assert.Equal(result.Elements[0].SharedSourceSetId, result.Elements[1].SharedSourceSetId);
         Assert.All(result.Elements, element => Assert.Equal(2, element.SharedSourceSetCount));
     }
@@ -73,12 +77,12 @@ public sealed class FmlToOasisMapperTests
         reel.UInt32s["Stops"] = 20;
         reel.Booleans["Reverse"] = true;
         var sevenSeg = new SevenSeg { X = 3, Y = 4, Width = 50, Height = 12, Number = 7 };
-        sevenSeg.Colours["OnColour"] = "#FFAA0001";
+        sevenSeg.Colours["OnColour"] = "#AA0001FF";
         var alpha = new Alpha { X = 5, Y = 6, Width = 70, Height = 20 };
-        alpha.Colours["OnColour"] = "#FF00AA02";
+        alpha.Colours["OnColour"] = "#00AA02FF";
         var label = new Label { X = 7, Y = 8, Width = 90, Height = 24 };
         label.Strings["Caption"] = "HELLO";
-        label.Fonts["Primary"] = new FontTagEntry(0, "Primary", "Tahoma", 9, 0, "Western", "#FF010203", 0);
+        label.Fonts["Primary"] = new FontTagEntry(0, "Primary", "Tahoma", 9, 0, "Western", "#010203FF", 0);
 
         var images = new Dictionary<FmlDecodedImageKey, string>
         {
@@ -101,16 +105,16 @@ public sealed class FmlToOasisMapperTests
     [Fact]
     public void Map_WithGraphicalLampAndButton_PreservesAssetsAndInputDefinition()
     {
-        var lamp = new Lamp { X = 1, Y = 2, Width = 30, Height = 40, SublampTable = [new LampSublampTableEntry(0, 9)] };
-        lamp.Colours["Sublamp0Colour"] = "#FF112233";
-        var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(0, 12)] };
+        var lamp = new Lamp { X = 1, Y = 2, Width = 30, Height = 40, SublampTable = [new LampSublampTableEntry(1, 9)] };
+        lamp.Colours["Sublamp1Colour"] = "#112233FF";
+        var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
         button.Strings["ButtonNumber"] = "1";
         button.Strings["Text"] = "START";
 
         var images = new Dictionary<FmlDecodedImageKey, string>
         {
-            [new FmlDecodedImageKey(0, "Sublamp 0 Main")] = "lamps/lamp.bmp",
-            [new FmlDecodedImageKey(0, "Sublamp 0 Mask")] = "lamps/lamp-mask.bmp"
+            [new FmlDecodedImageKey(0, "Sublamp 1 Main")] = "lamps/lamp.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Mask")] = "lamps/lamp-mask.bmp"
         };
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp, button]), images);
@@ -132,6 +136,37 @@ public sealed class FmlToOasisMapperTests
 
         Assert.Empty(result.Elements);
         Assert.Contains(result.Warnings, warning => warning.Code == "fml.import.component.unsupported" && warning.Context == nameof(Border));
+    }
+
+    [Theory]
+    [InlineData("#0080C0FF", "#FF0080C0", 255, 0, 128, 192)]
+    [InlineData("#12345678", "#78123456", 0x78, 0x12, 0x34, 0x56)]
+    [InlineData("#123456", "#FF123456", 255, 0x12, 0x34, 0x56)]
+    public void ConvertDecoderRgbaToOasisArgb_ReordersChannels(string decoderValue, string expected, byte a, byte r, byte g, byte b)
+    {
+        var converted = FmlToOasisMapper.ConvertDecoderRgbaToOasisArgb(decoderValue);
+
+        Assert.Equal(expected, converted);
+        AssertOasisArgbChannels(converted, a, r, g, b);
+    }
+
+    [Theory]
+    [InlineData("#12345")]
+    [InlineData("#1234567890")]
+    [InlineData("#12345G")]
+    [InlineData("123456")]
+    public void ConvertDecoderRgbaToOasisArgb_RejectsMalformedValues(string decoderValue)
+    {
+        Assert.Null(FmlToOasisMapper.ConvertDecoderRgbaToOasisArgb(decoderValue));
+    }
+
+    private static void AssertOasisArgbChannels(string? value, byte a, byte r, byte g, byte b)
+    {
+        Assert.True(InspectorColorHex.TryParse(value, out Color color));
+        Assert.Equal(a, color.A);
+        Assert.Equal(r, color.R);
+        Assert.Equal(g, color.G);
+        Assert.Equal(b, color.B);
     }
 
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -21,6 +21,7 @@ public sealed class FmlToOasisMapperTests
         };
         lamp.Strings["OffText"] = "HOLD";
         lamp.Colours["Sublamp1Colour"] = "#0000FFFF";
+        lamp.Colours["OffImageColour"] = "#204060FF";
         lamp.Fonts["Primary"] = new FontTagEntry(0, "Primary", "Arial", 12, 0, "Western", "#0080C0FF", 0);
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
@@ -30,8 +31,10 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal(42, element.DisplayNumber);
         Assert.Equal("HOLD", element.DisplayText);
         Assert.Equal("#FF0000FF", element.OnColorHex);
+        Assert.Equal("#FF204060", element.OffColorHex);
         Assert.Equal("#FF0080C0", element.TextColorHex);
         AssertOasisArgbChannels(element.OnColorHex, 255, 0, 0, 255);
+        AssertOasisArgbChannels(element.OffColorHex, 255, 32, 64, 96);
         AssertOasisArgbChannels(element.TextColorHex, 255, 0, 128, 192);
         Assert.Null(element.AssetPath);
         Assert.Null(element.SecondaryAssetPath);
@@ -125,6 +128,72 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal("#FF112233", graphicalLamp.OnColorHex);
         Assert.Contains(result.Elements, e => e.Kind == PanelElementKind.Lamp && e.DisplayNumber == 12 && e.DisplayText == "START");
         Assert.Single(result.InputDefinitions);
+    }
+
+
+    [Theory]
+    [InlineData("OffImageColour", "#204060FF", "#FF204060", 255, 32, 64, 96)]
+    [InlineData("OffImageColor", "#20406080", "#80204060", 128, 32, 64, 96)]
+    public void Map_WithLampOffImageColorAliases_MapsOffColor(string key, string decoderValue, string expected, byte a, byte r, byte g, byte b)
+    {
+        var lamp = new Lamp
+        {
+            X = 1,
+            Y = 2,
+            Width = 30,
+            Height = 40,
+            SublampTable = [new LampSublampTableEntry(1, 9)]
+        };
+        lamp.Colours["Sublamp1Colour"] = "#0000FFFF";
+        lamp.Colours[key] = decoderValue;
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(expected, element.OffColorHex);
+        AssertOasisArgbChannels(element.OffColorHex, a, r, g, b);
+    }
+
+    [Fact]
+    public void Map_WithLampOffImageColour_PrefersDecoderKeyOverLegacyAliases()
+    {
+        var lamp = new Lamp
+        {
+            X = 1,
+            Y = 2,
+            Width = 30,
+            Height = 40,
+            SublampTable = [new LampSublampTableEntry(1, 9)]
+        };
+        lamp.Colours["Sublamp1Colour"] = "#0000FFFF";
+        lamp.Colours["OffImageColour"] = "#204060FF";
+        lamp.Colours["OffColour"] = "#010203FF";
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal("#FF204060", element.OffColorHex);
+    }
+
+    [Fact]
+    public void Map_WithMalformedLampOffImageColour_LeavesOffColorUnset()
+    {
+        var lamp = new Lamp
+        {
+            X = 1,
+            Y = 2,
+            Width = 30,
+            Height = 40,
+            SublampTable = [new LampSublampTableEntry(1, 9)]
+        };
+        lamp.Colours["Sublamp1Colour"] = "#0000FFFF";
+        lamp.Colours["OffImageColour"] = "#20406GFF";
+        lamp.Colours["OffColour"] = "#010203FF";
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Null(element.OffColorHex);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Windows.Media;
 using EditorCommands = OasisEditor.Commands;
 using Xunit;
 
@@ -332,6 +333,74 @@ public sealed class InspectorViewModelTests
         Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "On Color"));
         Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Off Color"));
         Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Text Color"));
+    }
+
+
+    [Fact]
+    public void InspectorPropertyRows_SelectedLamp_InitializesOffColorStringAndPicker()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40,
+                    OffColorHex = "#FF204060"
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("lamp-1", "lamp", 10, 20, 30, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var row = Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Off Color"));
+        Assert.Equal("#204060", row.HexValue);
+        Assert.Equal(255, row.SelectedColor.A);
+        Assert.Equal(32, row.SelectedColor.R);
+        Assert.Equal(64, row.SelectedColor.G);
+        Assert.Equal(96, row.SelectedColor.B);
+
+        row.SelectedColor = Color.FromArgb(255, 1, 2, 3);
+
+        Assert.Equal("#010203", row.HexValue);
+        Assert.Equal("#010203", selectedDocument.GetPanelElements().Single().OffColorHex);
+    }
+
+    [Fact]
+    public void InspectorPropertyRows_SelectedLamp_WithUnsetOffColor_DocumentsBlankOptionalColor()
+    {
+        var selectedDocument = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        selectedDocument.SetPanelElements(
+            [
+                new PanelElementModel
+                {
+                    ObjectId = "lamp-1",
+                    Name = "Lamp",
+                    Kind = PanelElementKind.Lamp,
+                    X = 10,
+                    Y = 20,
+                    Width = 30,
+                    Height = 40
+                }
+            ]);
+
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(selectedDocument);
+        context.SetPanelSelection(selectedDocument.DocumentId, new PanelSelectionInfo("lamp-1", "lamp", 10, 20, 30, 40));
+        var viewModel = CreateInspectorViewModel(selectedDocument, context, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var row = Assert.IsType<InspectorColorPropertyViewModel>(viewModel.InspectorPropertyRows.Single(x => x.DisplayName == "Off Color"));
+        Assert.Equal(string.Empty, row.HexValue);
+        Assert.Equal(Colors.White, row.SelectedColor);
     }
 
     private static InspectorViewModel CreateInspectorViewModel(

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LampElementRendererTests.cs
@@ -79,4 +79,64 @@ public sealed class LampElementRendererTests
 
         Assert.True(wrapWidth < measured);
     }
+    [Fact]
+    public void Render_TextLampAtZeroIntensity_UsesStoredOffColor()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(24, 24));
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetLampIntensity("lamp-1", 0d);
+        var element = new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Kind = PanelElementKind.Lamp,
+            X = 0,
+            Y = 0,
+            Width = 24,
+            Height = 24,
+            DisplayText = "HI",
+            OnColorHex = "#FFFFFFFF",
+            OffColorHex = "#FF204060",
+            TextColorHex = "#FFFFFFFF",
+            TextBoxFontSize = "8"
+        };
+
+        new LampElementRenderer().Render(new PanelElementRenderContext(surface.Canvas, runtimeState, PanelViewportTransform.Identity), element);
+
+        using var image = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(image);
+        var pixel = bitmap.GetPixel(1, 1);
+        Assert.Equal(32, pixel.Red);
+        Assert.Equal(64, pixel.Green);
+        Assert.Equal(96, pixel.Blue);
+        Assert.Equal(255, pixel.Alpha);
+    }
+
+    [Fact]
+    public void Render_LampAtZeroIntensity_WithNoOffColor_UsesDefensiveRendererFallback()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(16, 16));
+        var runtimeState = new PanelRuntimeState();
+        runtimeState.SetLampIntensity("lamp-1", 0d);
+        var element = new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Kind = PanelElementKind.Lamp,
+            X = 0,
+            Y = 0,
+            Width = 16,
+            Height = 16,
+            OnColorHex = "#FFFFFFFF"
+        };
+
+        new LampElementRenderer().Render(new PanelElementRenderContext(surface.Canvas, runtimeState, PanelViewportTransform.Identity), element);
+
+        using var image = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(image);
+        var pixel = bitmap.GetPixel(1, 1);
+        Assert.Equal(40, pixel.Red);
+        Assert.Equal(0, pixel.Green);
+        Assert.Equal(0, pixel.Blue);
+        Assert.Equal(255, pixel.Alpha);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -152,6 +152,39 @@ public sealed class Panel2DRoundTripTests
         Assert.Equal("layout.json#lamp-8", element.ImportSource.Reference);
     }
 
+
+    [Fact]
+    public void Serialize_AndRead_RoundTripsLampOffColorHexWithoutReconversion()
+    {
+        var json = Panel2DDocumentStorage.Serialize(
+            "Panel",
+            "Panel with imported lamp off color",
+            [
+                new PanelElementFile
+                {
+                    ObjectId = "lamp-off-color",
+                    Name = "Lamp",
+                    Kind = "lamp",
+                    X = 1,
+                    Y = 2,
+                    Width = 30,
+                    Height = 40,
+                    OnColorHex = "#FF0000FF",
+                    OffColorHex = "#FF204060",
+                    TextColorHex = "#FFFFFFFF"
+                }
+            ]);
+
+        Assert.True(Panel2DDocumentStorage.TryReadValidated(json, out var parsed, out var error), error);
+
+        var model = Panel2DDocumentStorage.ToModel(parsed);
+        var element = Assert.Single(model.Elements);
+        Assert.Equal("#FF204060", element.OffColorHex);
+
+        var storageElement = Assert.Single(Panel2DDocumentStorage.ToStorageElements(model));
+        Assert.Equal("#FF204060", storageElement.OffColorHex);
+    }
+
     [Fact]
     public void Serialize_WithNativeElementMetadata_WritesSchemaVersion2()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -105,15 +105,37 @@ internal sealed class FmlToOasisMapper
     private static PanelElementModel MapLabel(BaseComponent c, int index) { var font = Font(c); return new PanelElementModel { ObjectId = Guid.NewGuid().ToString("N"), Name = "Label", Kind = PanelElementKind.Label, X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height), DisplayText = Text(c), TextBoxFontName = font?.FontName, TextBoxFontStyle = FontStyle(font), TextBoxFontSize = font?.FontSize.ToString(CultureInfo.InvariantCulture), TextColorHex = TextColor(c), ImportSource = Source(c, index) }; }
 
     private static IReadOnlyList<LampSublampTableEntry> GetSublamps(BaseComponent c) => c switch { Lamp l => l.SublampTable, Button b => b.SublampTable, Reel r => r.SublampTable, DiscReel d => d.SublampTable, PrismLamp p => Build(p.SubLamp1Number, p.SubLamp2Number), FlipReel f => Build(f.SubLamp1Number, f.SubLamp2Number, f.SubLamp3Number), _ => [] };
-    private static LampSublampTableEntry[] Build(params uint[] values) => values.Select((v, i) => new LampSublampTableEntry(i, unchecked((int)v))).ToArray();
+    private static LampSublampTableEntry[] Build(params uint[] values) => values.Select((v, i) => new LampSublampTableEntry(i + 1, unchecked((int)v))).ToArray();
     private static string? LampText(BaseComponent c) => Str(c, "OffText") ?? Str(c, "On1Text") ?? Str(c, "On2Text") ?? Str(c, "On3Text") ?? Text(c);
     private static string? Text(BaseComponent c) => Str(c, "Text") ?? Str(c, "Caption") ?? Str(c, "TextBoxText");
     private static FontTagEntry? Font(BaseComponent c) => c.Fonts.Values.FirstOrDefault(f => f.Role.Contains("off", StringComparison.OrdinalIgnoreCase)) ?? c.Fonts.Values.FirstOrDefault();
     private static string? FontStyle(FontTagEntry? font) => font is null ? null : font.FontStyle == 1 ? "Bold" : "Regular";
-    private static string? TextColor(BaseComponent c) => Font(c)?.TextColour ?? Color(c, "TextColour") ?? Color(c, "TextColor") ?? Color(c, "Colour") ?? Color(c, "Color");
-    private static string? SublampColor(BaseComponent c, int i) => Color(c, $"Sublamp{i}Colour") ?? Color(c, $"Sublamp{i}Color") ?? Color(c, $"On{i + 1}Colour") ?? Color(c, $"On{i + 1}Color");
-    private static string? Color(BaseComponent c, string key) => c.Colours.TryGetValue(key, out var value) ? NormalizeColor(value) : null;
-    private static string? NormalizeColor(string? value) { if (string.IsNullOrWhiteSpace(value)) return null; var v = value.Trim(); if (v.StartsWith('#') && (v.Length == 7 || v.Length == 9)) return v.Length == 7 ? $"#FF{v[1..]}" : v; return v; }
+    private static string? TextColor(BaseComponent c) => ConvertDecoderRgbaToOasisArgb(Font(c)?.TextColour) ?? Color(c, "TextColour") ?? Color(c, "TextColor") ?? Color(c, "Colour") ?? Color(c, "Color");
+    private static string? SublampColor(BaseComponent c, int i)
+    {
+        var oneBasedIndex = Math.Max(1, i);
+        return Color(c, $"Sublamp{oneBasedIndex}Colour")
+            ?? Color(c, $"Sublamp{oneBasedIndex}Color")
+            ?? Color(c, $"On{oneBasedIndex}Colour")
+            ?? Color(c, $"On{oneBasedIndex}Color")
+            ?? (i == 0 ? Color(c, "Sublamp0Colour") ?? Color(c, "Sublamp0Color") : null);
+    }
+    private static string? Color(BaseComponent c, string key) => c.Colours.TryGetValue(key, out var value) ? ConvertDecoderRgbaToOasisArgb(value) : null;
+
+    /// <summary>
+    /// Converts FML decoder color strings (#RRGGBB or #RRGGBBAA) to Oasis/WPF-compatible #AARRGGBB.
+    /// </summary>
+    internal static string? ConvertDecoderRgbaToOasisArgb(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        var hex = value.Trim();
+        if (!hex.StartsWith('#')) return null;
+        hex = hex[1..];
+        if (hex.Length != 6 && hex.Length != 8) return null;
+        if (!hex.All(static c => Uri.IsHexDigit(c))) return null;
+        hex = hex.ToUpperInvariant();
+        return hex.Length == 6 ? $"#FF{hex}" : $"#{hex[6..8]}{hex[..6]}";
+    }
     private static string? Str(BaseComponent c, string key) => c.Strings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value.Trim() : null;
     private static uint? UInt(BaseComponent c, string key) => c.UInt32s.TryGetValue(key, out var v) ? v : null;
     private static double? Double(BaseComponent c, string key) => c.Floats.TryGetValue(key, out var f) ? f : c.UInt32s.TryGetValue(key, out var u) ? u : null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -9,6 +9,10 @@ internal sealed class FmlToOasisMapper
 {
     private const int UndefinedSublampNumber = -2;
     private const string ImportSourceFormat = "FML";
+    private const string LampOffImageColourKey = "OffImageColour";
+    private const string LampOffImageColorKey = "OffImageColor";
+    private const string OffColourKey = "OffColour";
+    private const string OffColorKey = "OffColor";
 
     public FmlToOasisMapResult Map(Layout layout, IReadOnlyDictionary<FmlDecodedImageKey, string> exportedImages)
     {
@@ -82,7 +86,7 @@ internal sealed class FmlToOasisMapper
                 X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height), DisplayNumber = displayNumber,
                 AssetPath = main, SecondaryAssetPath = main is null ? null : mask,
                 OnColorHex = SublampColor(c, entry.SublampIndex) ?? Color(c, "OnColour") ?? Color(c, "OnColor") ?? Color(c, "Colour") ?? Color(c, "Color"),
-                OffColorHex = Color(c, "OffColour") ?? Color(c, "OffColor"), TextColorHex = TextColor(c),
+                OffColorHex = LampOffColor(c), TextColorHex = TextColor(c),
                 DisplayText = LampText(c), TextBoxFontName = font?.FontName ?? "Tahoma", TextBoxFontStyle = FontStyle(font), TextBoxFontSize = font?.FontSize.ToString(CultureInfo.InvariantCulture) ?? "8",
                 SourceComponentIndex = index, SourceElementIndex = entry.SublampIndex, SharedSourceSetId = sharedSetId, SharedSourceSetCount = entries.Length, ImportSource = Source(c, index, displayNumber)
             });
@@ -111,6 +115,7 @@ internal sealed class FmlToOasisMapper
     private static FontTagEntry? Font(BaseComponent c) => c.Fonts.Values.FirstOrDefault(f => f.Role.Contains("off", StringComparison.OrdinalIgnoreCase)) ?? c.Fonts.Values.FirstOrDefault();
     private static string? FontStyle(FontTagEntry? font) => font is null ? null : font.FontStyle == 1 ? "Bold" : "Regular";
     private static string? TextColor(BaseComponent c) => ConvertDecoderRgbaToOasisArgb(Font(c)?.TextColour) ?? Color(c, "TextColour") ?? Color(c, "TextColor") ?? Color(c, "Colour") ?? Color(c, "Color");
+    private static string? LampOffColor(BaseComponent c) => FirstPresentColor(c, LampOffImageColourKey, LampOffImageColorKey, OffColourKey, OffColorKey);
     private static string? SublampColor(BaseComponent c, int i)
     {
         var oneBasedIndex = Math.Max(1, i);
@@ -121,6 +126,18 @@ internal sealed class FmlToOasisMapper
             ?? (i == 0 ? Color(c, "Sublamp0Colour") ?? Color(c, "Sublamp0Color") : null);
     }
     private static string? Color(BaseComponent c, string key) => c.Colours.TryGetValue(key, out var value) ? ConvertDecoderRgbaToOasisArgb(value) : null;
+    private static string? FirstPresentColor(BaseComponent c, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (c.Colours.TryGetValue(key, out var value))
+            {
+                return ConvertDecoderRgbaToOasisArgb(value);
+            }
+        }
+
+        return null;
+    }
 
     /// <summary>
     /// Converts FML decoder color strings (#RRGGBB or #RRGGBBAA) to Oasis/WPF-compatible #AARRGGBB.


### PR DESCRIPTION
### Motivation

- Imported lamp and font colors from the FML decoder were appearing with zero alpha in the Inspector because decoder strings are emitted as `#RRGGBBAA` while Oasis/WPF expects `#AARRGGBB`.
- The direct mapper previously passed 8-digit decoder strings through unchanged, producing incorrect channel ordering in the application UI.
- Sublamp table/key handling used zero-based indexing in parts of the mapper while the decoder and decoded keys are one-based, causing mispaired sublamp colors.

### Description

- Added an explicit conversion helper `ConvertDecoderRgbaToOasisArgb` that converts `#RRGGBB` to `#FFRRGGBB` and `#RRGGBBAA` to `#AARRGGBB`, uppercases the output, and returns `null` for malformed inputs.
- Replaced the old `NormalizeColor` pass-through with `ConvertDecoderRgbaToOasisArgb` and applied it to all mapper color lookups including component colour dictionaries and `FontTagEntry.TextColour` use-sites.
- Adjusted sublamp handling to use one-based decoder keys (e.g. `Sublamp1Colour`) and updated the `Build`/sublamp-indexing logic to produce one-based `LampSublampTableEntry` indices while retaining a fallback for legacy `Sublamp0*` fixtures.
- Added and updated unit tests in `FmlToOasisMapperTests` to cover opaque blue, the reported cyan-blue case, non-opaque alpha reordering, six-digit RGB, font text color conversion, malformed inputs, and multi-sublamp pairing/keys.

### Testing

- Added automated unit tests exercising `ConvertDecoderRgbaToOasisArgb` and mapper behavior, but they were not run in this environment and are included in `OasisEditor.Tests/FmlToOasisMapperTests.cs`.
- Ran repository static checks and formatting verification (`git diff --check`) which passed in this environment.
- Attempted `dotnet build` and `dotnet test` but they could not be executed here because the `dotnet` toolchain is not available in this execution environment, so local build/test is required to validate the new tests and runtime behavior on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a525685f3888327bfccc453b4dd1b9f)