### PR TITLE
Add persistent FML import diagnostics

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using MfmeFmlDecoder.src.Model;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
@@ -1,0 +1,242 @@
+using System.Text;
+using System.Text.Json;
+using MfmeFmlDecoder.src.Model;
+using MfmeFmlDecoder.src.Model.Component;
+using OasisEditor.Features.LayoutImport;
+
+namespace OasisEditor.Features.FmlImport;
+
+internal sealed class FmlImportDiagnosticsWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public void WriteDecodedLayout(Layout layout, string stagingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        Directory.CreateDirectory(stagingDirectory);
+        File.WriteAllText(Path.Combine(stagingDirectory, "decoded-layout.json"), layout.ToJson(indented: true), Encoding.UTF8);
+    }
+
+    public void WriteMappedElements(
+        FmlToOasisMapResult mapResult,
+        Layout layout,
+        IReadOnlyDictionary<FmlDecodedImageKey, string> imagePaths,
+        string stagingDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(mapResult);
+        ArgumentNullException.ThrowIfNull(layout);
+        Directory.CreateDirectory(stagingDirectory);
+
+        var document = new
+        {
+            Elements = mapResult.Elements
+                .OrderBy(e => e.SourceComponentIndex ?? int.MaxValue)
+                .ThenBy(e => e.SourceElementIndex ?? int.MaxValue)
+                .ThenBy(e => e.Kind.ToString(), StringComparer.Ordinal)
+                .ThenBy(e => e.DisplayNumber ?? int.MaxValue)
+                .Select(e => new
+                {
+                    e.ObjectId,
+                    Kind = e.Kind.ToString(),
+                    e.Name,
+                    e.DisplayNumber,
+                    e.DisplayText,
+                    e.AssetPath,
+                    e.SecondaryAssetPath,
+                    Graphic = !string.IsNullOrWhiteSpace(e.AssetPath),
+                    e.OnColorHex,
+                    e.OffColorHex,
+                    e.TextColorHex,
+                    Bounds = new { e.X, e.Y, e.Width, e.Height },
+                    e.SourceComponentIndex,
+                    SourceDecoderType = TryGetComponent(layout, e.SourceComponentIndex)?.GetType().Name,
+                    e.SourceElementIndex,
+                    e.SharedSourceSetId,
+                    e.SharedSourceSetCount,
+                    e.SegmentDisplayType,
+                    e.ShowDecimalPoint,
+                    e.ShowCommaTail,
+                    e.TextBoxFontName,
+                    e.TextBoxFontStyle,
+                    e.TextBoxFontSize,
+                    e.IsReversed,
+                    e.Stops,
+                    e.VisibleScale,
+                    e.BandOffset,
+                    e.SourceBlend,
+                    e.ImportSource,
+                    Images = GetImagesForComponent(imagePaths, e.SourceComponentIndex)
+                }),
+            InputDefinitions = mapResult.InputDefinitions
+                .OrderBy(i => i.Name, StringComparer.Ordinal)
+                .ThenBy(i => i.ButtonNumber, StringComparer.Ordinal)
+                .Select(i => new
+                {
+                    i.Id,
+                    i.Name,
+                    Kind = i.Kind.ToString(),
+                    i.ButtonNumber,
+                    i.CoinInput,
+                    i.Inverted,
+                    i.RawMfmeShortcut,
+                    i.KeyboardShortcut,
+                    i.LinkedVisualElementId,
+                    i.MamePortTag,
+                    i.MameMask,
+                    i.Notes
+                }),
+            Warnings = mapResult.Warnings
+                .OrderBy(w => w.Code, StringComparer.Ordinal)
+                .ThenBy(w => w.Message, StringComparer.Ordinal)
+                .ThenBy(w => w.Context, StringComparer.Ordinal)
+                .ToArray(),
+            UnsupportedComponentTypes = mapResult.UnsupportedComponentTypes
+                .OrderBy(t => t, StringComparer.Ordinal)
+                .ToArray()
+        };
+
+        File.WriteAllText(Path.Combine(stagingDirectory, "mapped-elements.json"), JsonSerializer.Serialize(document, JsonOptions), Encoding.UTF8);
+    }
+
+    public void WriteReport(FmlImportDiagnosticsReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        Directory.CreateDirectory(report.StagingDirectory);
+        File.WriteAllText(Path.Combine(report.StagingDirectory, "import-diagnostics.txt"), BuildReport(report), Encoding.UTF8);
+    }
+
+    private static string BuildReport(FmlImportDiagnosticsReport report)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, "FML Import Diagnostics");
+        AppendLine(sb, "FML filename", Path.GetFileName(report.FmlPath));
+        AppendLine(sb, "FML path", report.FmlPath);
+        AppendLine(sb, "Import timestamp (UTC)", report.ImportTimestampUtc.ToString("O"));
+        AppendLine(sb, "Staging folder", report.StagingDirectory);
+        AppendLine(sb, "Elapsed decode time", FormatElapsed(report.DecodeElapsed));
+        AppendLine(sb, "Elapsed mapping time", FormatElapsed(report.MappingElapsed));
+        AppendLine(sb, "Elapsed asset copy time", FormatElapsed(report.AssetCopyElapsed));
+        AppendLine(sb, "Total import time", FormatElapsed(report.TotalElapsed));
+        sb.AppendLine();
+
+        AppendSection(sb, "Warnings and Errors");
+        AppendList(sb, "Decoder errors", report.DecoderErrors);
+        AppendList(sb, "Decoder warnings", report.DecoderWarnings);
+        AppendList(sb, "Mapper warnings", report.MapperWarnings.Select(FormatWarning));
+        AppendList(sb, "Asset copy warnings", report.AssetCopyWarnings.Select(FormatWarning));
+        sb.AppendLine();
+
+        AppendSection(sb, "Summary");
+        AppendList(sb, "Unsupported component summary", CountStrings(report.UnsupportedComponentTypes).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+        AppendList(sb, "Component counts by type", report.Layout is null ? [] : CountComponents(report.Layout).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+        AppendLine(sb, "Image count", report.ImagePaths.Count.ToString());
+        AppendList(sb, "Image filenames", report.ImagePaths.Values.OrderBy(v => v, StringComparer.Ordinal));
+        AppendList(sb, "Panel element counts", CountStrings(report.MapResult?.Elements.Select(e => e.Kind.ToString()) ?? []).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+        AppendLine(sb, "Input definition count", (report.MapResult?.InputDefinitions.Count ?? 0).ToString());
+        AppendLine(sb, "Imported asset count", report.ImportedAssetCount.ToString());
+        sb.AppendLine();
+
+        AppendSection(sb, "Mapped Elements");
+        if (report.MapResult is null)
+        {
+            sb.AppendLine("(mapping did not complete)");
+        }
+        else
+        {
+            foreach (var element in report.MapResult.Elements.OrderBy(e => e.SourceComponentIndex ?? int.MaxValue).ThenBy(e => e.SourceElementIndex ?? int.MaxValue).ThenBy(e => e.Kind.ToString(), StringComparer.Ordinal))
+            {
+                var component = TryGetComponent(report.Layout, element.SourceComponentIndex);
+                sb.AppendLine($"- Component {FormatNullable(element.SourceComponentIndex)} | Decoder type: {component?.GetType().Name ?? "(unknown)"} | Mapped element type: {element.Kind}");
+            }
+        }
+        sb.AppendLine();
+
+        AppendLampColourDiagnostics(sb, report);
+        return sb.ToString();
+    }
+
+    private static void AppendLampColourDiagnostics(StringBuilder sb, FmlImportDiagnosticsReport report)
+    {
+        AppendSection(sb, "Lamp Colour Diagnostics");
+        if (report.MapResult is null)
+        {
+            sb.AppendLine("(mapping did not complete)");
+            return;
+        }
+
+        var lamps = report.MapResult.Elements.Where(e => e.Kind == PanelElementKind.Lamp).OrderBy(e => e.SourceComponentIndex ?? int.MaxValue).ThenBy(e => e.SourceElementIndex ?? int.MaxValue).ToArray();
+        if (lamps.Length == 0)
+        {
+            sb.AppendLine("(none)");
+            return;
+        }
+
+        foreach (var lamp in lamps)
+        {
+            var component = TryGetComponent(report.Layout, lamp.SourceComponentIndex);
+            sb.AppendLine($"Component {FormatNullable(lamp.SourceComponentIndex)} / Element {FormatNullable(lamp.SourceElementIndex)}");
+            AppendLine(sb, "  Display number", lamp.DisplayNumber?.ToString() ?? "(none)");
+            AppendLine(sb, "  Display text", lamp.DisplayText ?? "(none)");
+            AppendList(sb, "  Decoded Colours dictionary", component?.Colours.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{kvp.Key}: {kvp.Value}") ?? []);
+            AppendLine(sb, "  Mapped OnColorHex", lamp.OnColorHex ?? "(none)");
+            AppendLine(sb, "  Mapped OffColorHex", lamp.OffColorHex ?? "(none)");
+            AppendLine(sb, "  Mapped TextColorHex", lamp.TextColorHex ?? "(none)");
+            AppendLine(sb, "  Mapped Graphic", (!string.IsNullOrWhiteSpace(lamp.AssetPath)).ToString());
+            AppendLine(sb, "  Mapped AssetPath", lamp.AssetPath ?? "(none)");
+            sb.AppendLine();
+        }
+    }
+
+    private static IReadOnlyList<string> GetImagesForComponent(IReadOnlyDictionary<FmlDecodedImageKey, string> imagePaths, int? componentIndex)
+        => componentIndex.HasValue
+            ? imagePaths.Where(kvp => kvp.Key.ComponentIndex == componentIndex.Value).OrderBy(kvp => kvp.Key.ImageName, StringComparer.Ordinal).Select(kvp => kvp.Value).ToArray()
+            : [];
+
+    private static BaseComponent? TryGetComponent(Layout? layout, int? index)
+        => layout is not null && index.HasValue && index.Value >= 0 && index.Value < layout.Components.Count ? layout.Components[index.Value] : null;
+
+    private static IReadOnlyDictionary<string, int> CountComponents(Layout layout)
+        => CountStrings(layout.Components.Select(c => c.GetType().Name));
+
+    private static IReadOnlyDictionary<string, int> CountStrings(IEnumerable<string> values)
+        => values.GroupBy(v => v, StringComparer.Ordinal).OrderBy(g => g.Key, StringComparer.Ordinal).ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+    private static string FormatWarning(LayoutImportWarning warning)
+        => string.IsNullOrWhiteSpace(warning.Context) ? $"{warning.Code}: {warning.Message}" : $"{warning.Code}: {warning.Message} ({warning.Context})";
+
+    private static string FormatElapsed(TimeSpan elapsed) => $"{elapsed.TotalMilliseconds:0.###} ms";
+    private static string FormatNullable(int? value) => value?.ToString() ?? "(none)";
+    private static void AppendHeader(StringBuilder sb, string value) { sb.AppendLine(value); sb.AppendLine(new string('=', value.Length)); }
+    private static void AppendSection(StringBuilder sb, string value) { sb.AppendLine(value); sb.AppendLine(new string('-', value.Length)); }
+    private static void AppendLine(StringBuilder sb, string key, string value) => sb.AppendLine($"{key}: {value}");
+    private static void AppendList(StringBuilder sb, string key, IEnumerable<string> values)
+    {
+        sb.AppendLine($"{key}:");
+        var ordered = values.OrderBy(v => v, StringComparer.Ordinal).ToArray();
+        if (ordered.Length == 0) sb.AppendLine("  (none)");
+        foreach (var value in ordered) sb.AppendLine($"  - {value}");
+    }
+}
+
+internal sealed class FmlImportDiagnosticsReport
+{
+    public required string FmlPath { get; init; }
+    public required DateTimeOffset ImportTimestampUtc { get; init; }
+    public required string StagingDirectory { get; init; }
+    public Layout? Layout { get; init; }
+    public FmlToOasisMapResult? MapResult { get; init; }
+    public IReadOnlyDictionary<FmlDecodedImageKey, string> ImagePaths { get; init; } = new Dictionary<FmlDecodedImageKey, string>();
+    public IReadOnlyList<string> DecoderErrors { get; init; } = [];
+    public IReadOnlyList<string> DecoderWarnings { get; init; } = [];
+    public IReadOnlyList<LayoutImportWarning> MapperWarnings { get; init; } = [];
+    public IReadOnlyList<LayoutImportWarning> AssetCopyWarnings { get; init; } = [];
+    public IReadOnlyList<string> UnsupportedComponentTypes { get; init; } = [];
+    public int ImportedAssetCount { get; init; }
+    public TimeSpan DecodeElapsed { get; init; }
+    public TimeSpan MappingElapsed { get; init; }
+    public TimeSpan AssetCopyElapsed { get; init; }
+    public TimeSpan TotalElapsed { get; init; }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -1,6 +1,5 @@
+using System.Diagnostics;
 using System.IO;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using MfmeFmlDecoder.Application;
 using MfmeFmlDecoder.src.Model;
 using MfmeFmlDecoder.src.Model.Component;
@@ -18,12 +17,14 @@ internal sealed class FmlImportService : IFmlImportService
     private readonly FmlDecoderService _decoderService;
     private readonly FmlToOasisMapper _mapper;
     private readonly LayoutImportAssetCopier _assetCopier;
+    private readonly FmlImportDiagnosticsWriter _diagnosticsWriter;
 
-    public FmlImportService(FmlDecoderService? decoderService = null, FmlToOasisMapper? mapper = null, LayoutImportAssetCopier? assetCopier = null)
+    public FmlImportService(FmlDecoderService? decoderService = null, FmlToOasisMapper? mapper = null, LayoutImportAssetCopier? assetCopier = null, FmlImportDiagnosticsWriter? diagnosticsWriter = null)
     {
         _decoderService = decoderService ?? new FmlDecoderService();
         _mapper = mapper ?? new FmlToOasisMapper();
         _assetCopier = assetCopier ?? new LayoutImportAssetCopier();
+        _diagnosticsWriter = diagnosticsWriter ?? new FmlImportDiagnosticsWriter();
     }
 
     public LayoutImportResult ImportFromFml(string fmlPath, string projectRootPath, string projectAssetsPath, bool copyAssets = true)
@@ -39,14 +40,35 @@ internal sealed class FmlImportService : IFmlImportService
             return Failure($"FML file was not found: '{fullFmlPath}'.");
         }
 
+        var importStartedUtc = DateTimeOffset.UtcNow;
+        var totalStopwatch = Stopwatch.StartNew();
+        var stagingDirectory = CreateStagingDirectory();
+        Directory.CreateDirectory(stagingDirectory);
+
         var diagnostics = new List<string>
         {
-            $"FML source path: {fullFmlPath}"
+            $"FML source path: {fullFmlPath}",
+            $"Persistent staging directory: {stagingDirectory}"
         };
 
+        var decodeStopwatch = Stopwatch.StartNew();
         var decodeResult = _decoderService.DecodeToLayout(fullFmlPath);
+        decodeStopwatch.Stop();
+
         if (!decodeResult.Succeeded)
         {
+            totalStopwatch.Stop();
+            _diagnosticsWriter.WriteReport(new FmlImportDiagnosticsReport
+            {
+                FmlPath = fullFmlPath,
+                ImportTimestampUtc = importStartedUtc,
+                StagingDirectory = stagingDirectory,
+                DecoderErrors = decodeResult.Errors,
+                DecoderWarnings = decodeResult.Warnings,
+                DecodeElapsed = decodeStopwatch.Elapsed,
+                TotalElapsed = totalStopwatch.Elapsed
+            });
+
             return new LayoutImportResult
             {
                 ImportedElements = [],
@@ -59,21 +81,79 @@ internal sealed class FmlImportService : IFmlImportService
             };
         }
 
-        var stagingDirectory = CreateStagingDirectory();
-        Directory.CreateDirectory(stagingDirectory);
-        var imagePaths = FmlDecodedAssetExporter.ExportImages(decodeResult.Layout!, stagingDirectory);
-        var mapResult = _mapper.Map(decodeResult.Layout!, imagePaths);
+        var layout = decodeResult.Layout!;
+        _diagnosticsWriter.WriteDecodedLayout(layout, stagingDirectory);
+        var imagePaths = FmlDecodedAssetExporter.ExportImages(layout, stagingDirectory);
 
-        diagnostics.Add($"Temp staging directory: {stagingDirectory}");
+        FmlToOasisMapResult mapResult;
+        var mappingStopwatch = Stopwatch.StartNew();
+        try
+        {
+            mapResult = _mapper.Map(layout, imagePaths);
+        }
+        catch (Exception ex)
+        {
+            mappingStopwatch.Stop();
+            totalStopwatch.Stop();
+            _diagnosticsWriter.WriteReport(new FmlImportDiagnosticsReport
+            {
+                FmlPath = fullFmlPath,
+                ImportTimestampUtc = importStartedUtc,
+                StagingDirectory = stagingDirectory,
+                Layout = layout,
+                ImagePaths = imagePaths,
+                DecoderWarnings = decodeResult.Warnings,
+                MapperWarnings = [new LayoutImportWarning("fml.mapping.exception", ex.Message)],
+                DecodeElapsed = decodeStopwatch.Elapsed,
+                MappingElapsed = mappingStopwatch.Elapsed,
+                TotalElapsed = totalStopwatch.Elapsed
+            });
+
+            return new LayoutImportResult
+            {
+                ImportedElements = [],
+                CopiedAssetRelativePaths = [],
+                InputDefinitions = [],
+                UnsupportedComponentTypes = [],
+                Warnings = decodeResult.Warnings.Select(w => new LayoutImportWarning("fml.decode.warning", w)).ToArray(),
+                Errors = [$"FML mapping failed: {ex.Message}"],
+                DebugDiagnostics = diagnostics
+            };
+        }
+        mappingStopwatch.Stop();
+        _diagnosticsWriter.WriteMappedElements(mapResult, layout, imagePaths, stagingDirectory);
+
         diagnostics.Add($"Generated image count: {imagePaths.Count}; image root: {stagingDirectory}; image paths: {FormatImagePaths(imagePaths.Values)}");
-        diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(decodeResult.Layout!.ToJson(indented: false)))}");
+        diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(layout))}");
 
+        var assetCopyStopwatch = Stopwatch.StartNew();
         var assetResult = _assetCopier.CopyAssetsFromStaging(
             stagingDirectory,
             Path.GetFileNameWithoutExtension(fullFmlPath),
             projectAssetsPath,
             copyAssets,
             mapResult.Elements);
+        assetCopyStopwatch.Stop();
+        totalStopwatch.Stop();
+
+        _diagnosticsWriter.WriteReport(new FmlImportDiagnosticsReport
+        {
+            FmlPath = fullFmlPath,
+            ImportTimestampUtc = importStartedUtc,
+            StagingDirectory = stagingDirectory,
+            Layout = layout,
+            MapResult = mapResult,
+            ImagePaths = imagePaths,
+            DecoderWarnings = decodeResult.Warnings,
+            MapperWarnings = mapResult.Warnings,
+            AssetCopyWarnings = assetResult.Warnings,
+            UnsupportedComponentTypes = mapResult.UnsupportedComponentTypes,
+            ImportedAssetCount = assetResult.CopiedAssetRelativePaths.Count,
+            DecodeElapsed = decodeStopwatch.Elapsed,
+            MappingElapsed = mappingStopwatch.Elapsed,
+            AssetCopyElapsed = assetCopyStopwatch.Elapsed,
+            TotalElapsed = totalStopwatch.Elapsed
+        });
 
         return new LayoutImportResult
         {
@@ -106,31 +186,11 @@ internal sealed class FmlImportService : IFmlImportService
         return paths.Length == 0 ? "(none)" : string.Join(", ", paths);
     }
 
-    private static IReadOnlyDictionary<string, int> CountDecodedTypes(string decodedJson)
-        => CountComponentsByProperty(decodedJson, "Type");
-
-
-    private static IReadOnlyDictionary<string, int> CountComponentsByProperty(
-        string json,
-        string propertyName,
-        Func<string, string>? normalize = null)
-    {
-        var root = JsonNode.Parse(json)?.AsObject();
-        if (root?["Components"] is not JsonArray components)
-        {
-            return new Dictionary<string, int>();
-        }
-
-        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (var component in components.OfType<JsonObject>())
-        {
-            var key = component[propertyName]?.GetValue<string>() ?? "(missing)";
-            key = normalize?.Invoke(key) ?? key;
-            counts[key] = counts.TryGetValue(key, out var count) ? count + 1 : 1;
-        }
-
-        return counts;
-    }
+    private static IReadOnlyDictionary<string, int> CountDecodedTypes(Layout layout)
+        => layout.Components
+            .GroupBy(component => component.GetType().Name, StringComparer.Ordinal)
+            .OrderBy(group => group.Key, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
 
     private static string FormatCounts(IReadOnlyDictionary<string, int> counts)
         => counts.Count == 0


### PR DESCRIPTION
### Motivation
- Provide persistent, human-readable diagnostics for the new direct FML import pipeline so decoder output, mapper output and asset export stages can be inspected without a debugger. 
- Make the staging folder part of the normal developer workflow to aid debugging of issues such as missing lamp `OffColor` values.

### Description
- Create a new helper `FmlImportDiagnosticsWriter` that writes `decoded-layout.json` (using the decoder's `Layout.ToJson(indented: true)`), `mapped-elements.json` (indented JSON with mapped element fields and image paths) and `import-diagnostics.txt` (human-readable report including timings, warnings, counts and lamp colour diagnostics).
- Wire diagnostics into `FmlImportService` so a persistent staging folder is created before decode and is used for all diagnostics and exported images, and ensure diagnostics are written on both success and failure paths (decode or mapping failures still produce diagnostics).
- Preserve existing image export behavior (bitmap bytes remain as separate files under `lamps/`, `reels/`, `background/`) and keep diagnostics deterministic by sorting component lists, image names, dictionary keys and warnings where practical.
- Include timing measurements for decode, mapping and asset-copy phases and include mapper warnings, asset copy warnings and a per-element summary (decoder type -> mapped element type) in `import-diagnostics.txt`.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it succeeded. 
- No .NET build or unit tests were executed in this environment per project guidance (local Windows/.NET tooling required); please run the solution tests and perform an FML import locally to verify the staging folder contains `decoded-layout.json`, `mapped-elements.json`, `import-diagnostics.txt` and the exported images.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a525fcbea688327bf0a447cf6294590)