### PR TITLE
Map FML Button "Label" into Lamp DisplayText and add tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -149,6 +149,21 @@ public sealed class FmlToOasisMapperTests
     }
 
     [Fact]
+    public void Map_WithDecodedButtonUtf16Label_MapsToLampDisplayText()
+    {
+        var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
+        button.Strings["ButtonNumber"] = "1";
+        button.Strings["Label (UTF-16)"] = "START";
+
+        var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, element.Kind);
+        Assert.Equal("START", element.DisplayText);
+        Assert.Single(result.InputDefinitions);
+    }
+
+    [Fact]
     public void Map_WithLampSpecificTextAndLabel_PrefersLampSpecificText()
     {
         var lamp = new Lamp
@@ -161,6 +176,7 @@ public sealed class FmlToOasisMapperTests
         };
         lamp.Strings["OffText"] = "HOLD";
         lamp.Strings["Label"] = "START";
+        lamp.Strings["Label (UTF-16)"] = "COLLECT";
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -112,7 +112,7 @@ public sealed class FmlToOasisMapperTests
         lamp.Colours["Sublamp1Colour"] = "#112233FF";
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
         button.Strings["ButtonNumber"] = "1";
-        button.Strings["Text"] = "START";
+        button.Strings["Label"] = "START";
 
         var images = new Dictionary<FmlDecodedImageKey, string>
         {
@@ -128,6 +128,45 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal("#FF112233", graphicalLamp.OnColorHex);
         Assert.Contains(result.Elements, e => e.Kind == PanelElementKind.Lamp && e.DisplayNumber == 12 && e.DisplayText == "START");
         Assert.Single(result.InputDefinitions);
+    }
+
+    [Fact]
+    public void Map_WithButtonLabel_MapsToLampDisplayTextAndInputDefinition()
+    {
+        var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
+        button.Strings["ButtonNumber"] = "1";
+        button.Strings["Label"] = "START";
+
+        var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, element.Kind);
+        Assert.Equal(12, element.DisplayNumber);
+        Assert.Equal("START", element.DisplayText);
+        var input = Assert.Single(result.InputDefinitions);
+        Assert.Equal("1", input.ButtonNumber);
+        Assert.Equal(element.ObjectId, input.LinkedVisualElementId?.ToString("N"));
+    }
+
+    [Fact]
+    public void Map_WithLampSpecificTextAndLabel_PrefersLampSpecificText()
+    {
+        var lamp = new Lamp
+        {
+            X = 1,
+            Y = 2,
+            Width = 30,
+            Height = 40,
+            SublampTable = [new LampSublampTableEntry(1, 9)]
+        };
+        lamp.Strings["OffText"] = "HOLD";
+        lamp.Strings["Label"] = "START";
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, element.Kind);
+        Assert.Equal("HOLD", element.DisplayText);
     }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -110,7 +110,8 @@ internal sealed class FmlToOasisMapper
 
     private static IReadOnlyList<LampSublampTableEntry> GetSublamps(BaseComponent c) => c switch { Lamp l => l.SublampTable, Button b => b.SublampTable, Reel r => r.SublampTable, DiscReel d => d.SublampTable, PrismLamp p => Build(p.SubLamp1Number, p.SubLamp2Number), FlipReel f => Build(f.SubLamp1Number, f.SubLamp2Number, f.SubLamp3Number), _ => [] };
     private static LampSublampTableEntry[] Build(params uint[] values) => values.Select((v, i) => new LampSublampTableEntry(i + 1, unchecked((int)v))).ToArray();
-    private static string? LampText(BaseComponent c) => Str(c, "OffText") ?? Str(c, "On1Text") ?? Str(c, "On2Text") ?? Str(c, "On3Text") ?? Str(c, "Label") ?? Text(c);
+    private static string? LampText(BaseComponent c) => Str(c, "OffText") ?? Str(c, "On1Text") ?? Str(c, "On2Text") ?? Str(c, "On3Text") ?? ButtonLabelText(c) ?? Text(c);
+    private static string? ButtonLabelText(BaseComponent c) => Str(c, "Label") ?? Str(c, "Label (UTF-16)");
     private static string? Text(BaseComponent c) => Str(c, "Text") ?? Str(c, "Caption") ?? Str(c, "TextBoxText");
     private static FontTagEntry? Font(BaseComponent c) => c.Fonts.Values.FirstOrDefault(f => f.Role.Contains("off", StringComparison.OrdinalIgnoreCase)) ?? c.Fonts.Values.FirstOrDefault();
     private static string? FontStyle(FontTagEntry? font) => font is null ? null : font.FontStyle == 1 ? "Bold" : "Regular";

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -110,7 +110,7 @@ internal sealed class FmlToOasisMapper
 
     private static IReadOnlyList<LampSublampTableEntry> GetSublamps(BaseComponent c) => c switch { Lamp l => l.SublampTable, Button b => b.SublampTable, Reel r => r.SublampTable, DiscReel d => d.SublampTable, PrismLamp p => Build(p.SubLamp1Number, p.SubLamp2Number), FlipReel f => Build(f.SubLamp1Number, f.SubLamp2Number, f.SubLamp3Number), _ => [] };
     private static LampSublampTableEntry[] Build(params uint[] values) => values.Select((v, i) => new LampSublampTableEntry(i + 1, unchecked((int)v))).ToArray();
-    private static string? LampText(BaseComponent c) => Str(c, "OffText") ?? Str(c, "On1Text") ?? Str(c, "On2Text") ?? Str(c, "On3Text") ?? Text(c);
+    private static string? LampText(BaseComponent c) => Str(c, "OffText") ?? Str(c, "On1Text") ?? Str(c, "On2Text") ?? Str(c, "On3Text") ?? Str(c, "Label") ?? Text(c);
     private static string? Text(BaseComponent c) => Str(c, "Text") ?? Str(c, "Caption") ?? Str(c, "TextBoxText");
     private static FontTagEntry? Font(BaseComponent c) => c.Fonts.Values.FirstOrDefault(f => f.Role.Contains("off", StringComparison.OrdinalIgnoreCase)) ?? c.Fonts.Values.FirstOrDefault();
     private static string? FontStyle(FontTagEntry? font) => font is null ? null : font.FontStyle == 1 ? "Bold" : "Regular";


### PR DESCRIPTION
### Motivation
- FML `Button` components decode their label into the `Strings["Label"]` key but the lamp-like mapping ignored that key, causing imported button lamps to lack display text.
- The change should preserve existing lamp-specific precedence (`OffText`, `On1Text`, `On2Text`, `On3Text`) while making decoded button labels appear on generated Oasis lamps.

### Description
- Added `Str(c, "Label")` to the `LampText(...)` precedence chain so decoded button `Label` values are used for lamp `DisplayText` after lamp-specific text fields and before generic aliases. (edited `WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs`)
- Updated the existing graphical button test to use the decoder-accurate key by replacing `button.Strings["Text"]` with `button.Strings["Label"]` in `FmlToOasisMapperTests`. (edited `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs`)
- Added regression tests `Map_WithButtonLabel_MapsToLampDisplayTextAndInputDefinition` and `Map_WithLampSpecificTextAndLabel_PrefersLampSpecificText` to verify label mapping, input definition generation, and precedence behavior. (edited `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs`)
- Changes are localized to lamp-text mapping and test coverage only and do not alter parser tag names, input numbering, or other lamp/checkbox/prism-lamp import logic.

### Testing
- Repository quick-check: `git diff --check` passed in this environment.
- No unit tests were executed here due to the environment's lack of the Windows/.NET/WPF toolchain per `AGENTS.md`; automated tests should be run locally with `dotnet test --filter FmlToOasisMapperTests` and/or `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and are expected to pass after this change.
- The new/updated tests verify that a `Button` with `Strings["Label"]` becomes a `PanelElementKind.Lamp` with `DisplayText`, that an input definition is still created, and that lamp-specific text keys take precedence over `Label`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5296f0c7008327b8b34c07b9bfacef)