### PR TITLE
Share MFME font resolution across text renderers

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
@@ -57,10 +57,12 @@ public sealed class LabelElementRendererTests
     {
         using var actualSurface = SKSurface.Create(new SKImageInfo(120, 48));
         actualSurface.Canvas.Clear(SKColors.Transparent);
-        var element = CreateLabel(displayText: "MFME", textColorHex: "#FFFFFFFF");
-        element.TextBoxFontName = "MFME";
-        element.TextBoxFontStyle = "Regular";
-        element.TextBoxFontSize = "14";
+        var element = CreateLabel(
+            displayText: "MFME",
+            textColorHex: "#FFFFFFFF",
+            textBoxFontName: "MFME",
+            textBoxFontStyle: "Regular",
+            textBoxFontSize: "14");
 
         new LabelElementRenderer().Render(new PanelElementRenderContext(actualSurface.Canvas, new PanelRuntimeState(), PanelViewportTransform.Identity), element);
 
@@ -105,7 +107,13 @@ public sealed class LabelElementRendererTests
         Assert.Null(exception);
     }
 
-    private static PanelElementModel CreateLabel(string displayText = "TEST", string? textColorHex = "#FFFFFFFF", int? lampNumber = null) => new()
+    private static PanelElementModel CreateLabel(
+        string displayText = "TEST",
+        string? textColorHex = "#FFFFFFFF",
+        int? lampNumber = null,
+        string? textBoxFontName = "Tahoma",
+        string? textBoxFontStyle = "Regular",
+        string? textBoxFontSize = "12") => new()
     {
         ObjectId = "label-1",
         Kind = PanelElementKind.Label,
@@ -115,9 +123,9 @@ public sealed class LabelElementRendererTests
         Height = 32,
         DisplayText = displayText,
         TextColorHex = textColorHex,
-        TextBoxFontName = "Tahoma",
-        TextBoxFontStyle = "Regular",
-        TextBoxFontSize = "12",
+        TextBoxFontName = textBoxFontName,
+        TextBoxFontStyle = textBoxFontStyle,
+        TextBoxFontSize = textBoxFontSize,
         LampNumber = lampNumber,
         IsVisible = true
     };

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
@@ -53,6 +53,41 @@ public sealed class LabelElementRendererTests
     }
 
     [Fact]
+    public void Render_BundledMfmeFont_MatchesSharedTypefaceRendering()
+    {
+        using var actualSurface = SKSurface.Create(new SKImageInfo(120, 48));
+        actualSurface.Canvas.Clear(SKColors.Transparent);
+        var element = CreateLabel(displayText: "MFME", textColorHex: "#FFFFFFFF");
+        element.TextBoxFontName = "MFME";
+        element.TextBoxFontStyle = "Regular";
+        element.TextBoxFontSize = "14";
+
+        new LabelElementRenderer().Render(new PanelElementRenderContext(actualSurface.Canvas, new PanelRuntimeState(), PanelViewportTransform.Identity), element);
+
+        using var expectedSurface = SKSurface.Create(new SKImageInfo(120, 48));
+        expectedSurface.Canvas.Clear(SKColors.Transparent);
+        using var textPaint = new SKPaint
+        {
+            Color = SKColors.White,
+            IsAntialias = true,
+            TextSize = (float)LampElementRenderer.ParseFontSize(element.TextBoxFontSize),
+            Typeface = MfmeTypefaceResolver.Resolve(element.TextBoxFontName, element.TextBoxFontStyle)
+        };
+        var bounds = SKRect.Create(0f, 0f, 120f, 48f);
+        var textBounds = LampElementRenderer.GetTextBounds(bounds);
+        var fontMetrics = textPaint.FontMetrics;
+        var lineHeight = Math.Max(1d, Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading));
+        var wrapWidth = LampElementRenderer.GetEffectiveWrapWidth(element.DisplayText, textBounds.Width, bounds.Width, textPaint);
+        var line = Assert.Single(LampElementRenderer.WrapTextToPixelWidth(element.DisplayText, wrapWidth, textPaint));
+        var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f ? Math.Abs(fontMetrics.Ascent) : textPaint.TextSize;
+        var x = textBounds.Left + ((textBounds.Width - line.Width) / 2d);
+        var y = textBounds.Top + ((textBounds.Height - lineHeight) / 2d) + baselineOffset;
+        expectedSurface.Canvas.DrawText(line.Text, (float)x, (float)y, textPaint);
+
+        Assert.Equal(ReadPixels(expectedSurface), ReadPixels(actualSurface));
+    }
+
+    [Fact]
     public void Render_InvalidFontAndColor_DoesNotThrow()
     {
         using var surface = SKSurface.Create(new SKImageInfo(80, 32));

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
@@ -78,7 +78,8 @@ public sealed class LabelElementRendererTests
         var bounds = SKRect.Create(0f, 0f, 120f, 48f);
         var textBounds = LampElementRenderer.GetTextBounds(bounds);
         var fontMetrics = textPaint.FontMetrics;
-        var lineHeight = Math.Max(1d, Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading));
+        var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);
+        var lineHeight = Math.Max(1d, measuredLineHeight > 0f ? measuredLineHeight : textPaint.TextSize * 1.2d);
         var wrapWidth = LampElementRenderer.GetEffectiveWrapWidth(element.DisplayText, textBounds.Width, bounds.Width, textPaint);
         var line = Assert.Single(LampElementRenderer.WrapTextToPixelWidth(element.DisplayText, wrapWidth, textPaint));
         var baselineOffset = Math.Abs(fontMetrics.Ascent) > 0f ? Math.Abs(fontMetrics.Ascent) : textPaint.TextSize;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LabelElementRendererTests.cs
@@ -75,7 +75,7 @@ public sealed class LabelElementRendererTests
             TextSize = (float)LampElementRenderer.ParseFontSize(element.TextBoxFontSize),
             Typeface = MfmeTypefaceResolver.Resolve(element.TextBoxFontName, element.TextBoxFontStyle)
         };
-        var bounds = SKRect.Create(0f, 0f, 120f, 48f);
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
         var textBounds = LampElementRenderer.GetTextBounds(bounds);
         var fontMetrics = textPaint.FontMetrics;
         var measuredLineHeight = Math.Abs(fontMetrics.Ascent) + Math.Abs(fontMetrics.Descent) + Math.Abs(fontMetrics.Leading);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeTypefaceResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MfmeTypefaceResolverTests.cs
@@ -1,0 +1,43 @@
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class MfmeTypefaceResolverTests
+{
+    [Fact]
+    public void Resolve_BundledMfmeFontByActualFamilyName_ReturnsBundledFamily()
+    {
+        var typeface = MfmeTypefaceResolver.Resolve("MFME", "Regular");
+
+        Assert.Equal("MFME", typeface.FamilyName, ignoreCase: true);
+        Assert.False(typeface.FontWeight >= (int)SKFontStyleWeight.SemiBold);
+    }
+
+    [Fact]
+    public void Resolve_RegularRequest_SelectsRegularBundledFace()
+    {
+        var typeface = MfmeTypefaceResolver.Resolve("MFME", "Regular");
+
+        Assert.Equal("MFME", typeface.FamilyName, ignoreCase: true);
+        Assert.False(typeface.FontWeight >= (int)SKFontStyleWeight.SemiBold);
+    }
+
+    [Fact]
+    public void Resolve_BoldRequest_SelectsBoldBundledFace()
+    {
+        var typeface = MfmeTypefaceResolver.Resolve("Lithograph", "Bold");
+
+        Assert.Equal("Lithograph", typeface.FamilyName, ignoreCase: true);
+        Assert.True(typeface.FontWeight >= (int)SKFontStyleWeight.SemiBold);
+    }
+
+    [Fact]
+    public void Resolve_MissingFamily_FallsBackSafely()
+    {
+        var exception = Record.Exception(() => MfmeTypefaceResolver.Resolve("Definitely Missing MFME Font", "Bold Italic"));
+
+        Assert.Null(exception);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
@@ -18,4 +18,9 @@
     <ProjectReference Include="..\OasisEditor\OasisEditor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\OasisEditor\MfmeFonts\*.ttf" Link="MfmeFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\OasisEditor\MfmeFonts\*.TTF" Link="MfmeFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LabelElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LabelElementRenderer.cs
@@ -1,12 +1,9 @@
-using System.Collections.Concurrent;
 using SkiaSharp;
 
 namespace OasisEditor.Rendering;
 
 internal sealed class LabelElementRenderer : IPanelElementRenderer
 {
-    private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
-
     public PanelElementKind Kind => PanelElementKind.Label;
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -33,7 +30,7 @@ internal sealed class LabelElementRenderer : IPanelElementRenderer
             Color = SkiaColorParser.ParseOrDefault(element.TextColorHex, SKColors.White),
             IsAntialias = true,
             TextSize = (float)LampElementRenderer.ParseFontSize(element.TextBoxFontSize),
-            Typeface = ResolveTypeface(element.TextBoxFontName, element.TextBoxFontStyle)
+            Typeface = MfmeTypefaceResolver.Resolve(element.TextBoxFontName, element.TextBoxFontStyle)
         };
 
         var textBounds = LampElementRenderer.GetTextBounds(bounds);
@@ -64,23 +61,4 @@ internal sealed class LabelElementRenderer : IPanelElementRenderer
         }
     }
 
-    private static SKTypeface ResolveTypeface(string? fontName, string? fontStyle)
-    {
-        var family = string.IsNullOrWhiteSpace(fontName) ? "Tahoma" : fontName.Trim();
-        var styleToken = string.IsNullOrWhiteSpace(fontStyle) ? "Regular" : fontStyle.Trim();
-        var cacheKey = $"{family}|{styleToken}";
-        return TypefaceCache.GetOrAdd(cacheKey, _ =>
-        {
-            var weight = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase)
-                ? SKFontStyleWeight.Bold
-                : SKFontStyleWeight.Normal;
-            var slant = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase)
-                ? SKFontStyleSlant.Italic
-                : SKFontStyleSlant.Upright;
-            var style = new SKFontStyle(weight, SKFontStyleWidth.Normal, slant);
-            return SKTypeface.FromFamilyName(family, style)
-                ?? SKTypeface.FromFamilyName("Tahoma", style)
-                ?? SKTypeface.Default;
-        });
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/LampElementRenderer.cs
@@ -9,7 +9,6 @@ namespace OasisEditor.Rendering;
 
 internal sealed class LampElementRenderer : IPanelElementRenderer
 {
-    private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<string, SKImage?> CachedLampImages = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<TextLayoutCacheKey, IReadOnlyList<PixelTextLine>> TextLayoutCache = new();
     private static readonly ConcurrentDictionary<TextVisualCacheKey, SKImage> TextVisualCache = new();
@@ -148,7 +147,7 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
             Color = textColor,
             IsAntialias = true,
             TextSize = (float)fontSize,
-            Typeface = ResolveTypeface(fontName, fontStyle)
+            Typeface = MfmeTypefaceResolver.Resolve(fontName, fontStyle)
         };
 
         var textBounds = GetTextBounds(localBounds);
@@ -300,87 +299,6 @@ internal sealed class LampElementRenderer : IPanelElementRenderer
         TextLayoutCache[cacheKey] = computed;
         return computed;
     }
-
-    private static SKTypeface ResolveTypeface(string? fontName, string? fontStyle)
-    {
-        var family = string.IsNullOrWhiteSpace(fontName) ? "Tahoma" : fontName.Trim();
-        var styleToken = string.IsNullOrWhiteSpace(fontStyle) ? "Regular" : fontStyle.Trim();
-        var cacheKey = $"{family}|{styleToken}";
-        if (TypefaceCache.TryGetValue(cacheKey, out var cached))
-        {
-            return cached;
-        }
-
-        var weight = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase)
-            ? SKFontStyleWeight.Bold
-            : SKFontStyleWeight.Normal;
-        var slant = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase)
-            ? SKFontStyleSlant.Italic
-            : SKFontStyleSlant.Upright;
-        var style = new SKFontStyle(weight, SKFontStyleWidth.Normal, slant);
-
-        if (TryResolveMfmeTypeface(family, styleToken, out var mfmeTypeface))
-        {
-            TypefaceCache[cacheKey] = mfmeTypeface;
-            return mfmeTypeface;
-        }
-
-        var resolved = SKTypeface.FromFamilyName(family, style)
-            ?? SKTypeface.FromFamilyName("Tahoma", style)
-            ?? SKTypeface.Default;
-        TypefaceCache[cacheKey] = resolved;
-        return resolved;
-    }
-
-    private static bool TryResolveMfmeTypeface(string family, string styleToken, out SKTypeface typeface)
-    {
-        var fontsDirectory = Path.Combine(AppContext.BaseDirectory, "MfmeFonts");
-        if (!Directory.Exists(fontsDirectory))
-        {
-            typeface = null!;
-            return false;
-        }
-
-        var wantsBold = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase);
-        foreach (var fontPath in Directory.EnumerateFiles(fontsDirectory, "*.ttf"))
-        {
-            SKTypeface? candidate = null;
-            try
-            {
-                candidate = SKTypeface.FromFile(fontPath);
-            }
-            catch
-            {
-                continue;
-            }
-
-            if (candidate is null)
-            {
-                continue;
-            }
-
-            var familyMatches = string.Equals(candidate.FamilyName, family, StringComparison.OrdinalIgnoreCase);
-            if (!familyMatches)
-            {
-                candidate.Dispose();
-                continue;
-            }
-
-            var isBoldFace = candidate.FontWeight >= (int)SKFontStyleWeight.SemiBold;
-            if (wantsBold != isBoldFace)
-            {
-                candidate.Dispose();
-                continue;
-            }
-
-            typeface = candidate;
-            return true;
-        }
-
-        typeface = null!;
-        return false;
-    }
-
 
     private static bool TryGetLampImage(string? assetPath, out SKImage image)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/MfmeTypefaceResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/MfmeTypefaceResolver.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using System.IO;
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal static class MfmeTypefaceResolver
+{
+    private const string DefaultFamily = "Tahoma";
+    private const string DefaultStyle = "Regular";
+    private static readonly ConcurrentDictionary<string, SKTypeface> TypefaceCache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Lazy<IReadOnlyList<BundledTypeface>> BundledTypefaces = new(LoadBundledTypefaces, isThreadSafe: true);
+
+    public static SKTypeface Resolve(string? fontName, string? fontStyle)
+    {
+        var family = NormalizeFamily(fontName);
+        var styleToken = NormalizeStyle(fontStyle);
+        var cacheKey = $"{family}|{styleToken}";
+
+        return TypefaceCache.GetOrAdd(cacheKey, _ => ResolveUncached(family, styleToken));
+    }
+
+    private static SKTypeface ResolveUncached(string family, string styleToken)
+    {
+        var style = CreateFontStyle(styleToken);
+        if (TryResolveBundledTypeface(family, styleToken, out var bundledTypeface))
+        {
+            return bundledTypeface;
+        }
+
+        return SKTypeface.FromFamilyName(family, style)
+            ?? SKTypeface.FromFamilyName(DefaultFamily, style)
+            ?? SKTypeface.Default;
+    }
+
+    private static bool TryResolveBundledTypeface(string family, string styleToken, out SKTypeface typeface)
+    {
+        var wantsBold = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase);
+        var wantsItalic = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase);
+        BundledTypeface? compatible = null;
+
+        foreach (var candidate in BundledTypefaces.Value)
+        {
+            if (!string.Equals(candidate.FamilyName, family, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (candidate.IsBold != wantsBold)
+            {
+                continue;
+            }
+
+            compatible ??= candidate;
+            if (candidate.IsItalic == wantsItalic)
+            {
+                typeface = candidate.Typeface;
+                return true;
+            }
+        }
+
+        if (compatible is not null)
+        {
+            typeface = compatible.Typeface;
+            return true;
+        }
+
+        typeface = null!;
+        return false;
+    }
+
+    private static IReadOnlyList<BundledTypeface> LoadBundledTypefaces()
+    {
+        var fontsDirectory = Path.Combine(AppContext.BaseDirectory, "MfmeFonts");
+        if (!Directory.Exists(fontsDirectory))
+        {
+            return [];
+        }
+
+        var bundledTypefaces = new List<BundledTypeface>();
+        IEnumerable<string> fontPaths;
+        try
+        {
+            fontPaths = Directory.EnumerateFiles(fontsDirectory)
+                .Where(path => string.Equals(Path.GetExtension(path), ".ttf", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+        catch
+        {
+            return bundledTypefaces;
+        }
+
+        foreach (var fontPath in fontPaths)
+        {
+            SKTypeface? candidate = null;
+            try
+            {
+                candidate = SKTypeface.FromFile(fontPath);
+                if (candidate is null || string.IsNullOrWhiteSpace(candidate.FamilyName))
+                {
+                    candidate?.Dispose();
+                    continue;
+                }
+
+                bundledTypefaces.Add(new BundledTypeface(
+                    candidate.FamilyName,
+                    candidate.FontWeight >= (int)SKFontStyleWeight.SemiBold,
+                    candidate.FontSlant == SKFontStyleSlant.Italic || candidate.FontSlant == SKFontStyleSlant.Oblique,
+                    candidate));
+                candidate = null;
+            }
+            catch
+            {
+                // Ignore invalid or unreadable bundled fonts; fallback resolution remains safe.
+            }
+            finally
+            {
+                candidate?.Dispose();
+            }
+        }
+
+        return bundledTypefaces;
+    }
+
+    private static SKFontStyle CreateFontStyle(string styleToken)
+    {
+        var weight = styleToken.Contains("Bold", StringComparison.OrdinalIgnoreCase)
+            ? SKFontStyleWeight.Bold
+            : SKFontStyleWeight.Normal;
+        var slant = styleToken.Contains("Italic", StringComparison.OrdinalIgnoreCase)
+            ? SKFontStyleSlant.Italic
+            : SKFontStyleSlant.Upright;
+
+        return new SKFontStyle(weight, SKFontStyleWidth.Normal, slant);
+    }
+
+    private static string NormalizeFamily(string? fontName) =>
+        string.IsNullOrWhiteSpace(fontName) ? DefaultFamily : fontName.Trim();
+
+    private static string NormalizeStyle(string? fontStyle) =>
+        string.IsNullOrWhiteSpace(fontStyle) ? DefaultStyle : fontStyle.Trim();
+
+    private sealed record BundledTypeface(string FamilyName, bool IsBold, bool IsItalic, SKTypeface Typeface);
+}


### PR DESCRIPTION
### Motivation
- Label text rendered with `SKTypeface.FromFamilyName()` could not resolve fonts bundled in `MfmeFonts`, causing Label text to fallback to system fonts while Lamp and Button text used bundled faces.
- The goal is to centralise MFME font resolution so Lamp, Button and Label renderers use the same bundled-font lookup, caching and safe fallback order.

### Description
- Added `OasisEditor/Rendering/MfmeTypefaceResolver.cs` which caches resolved `SKTypeface` instances, enumerates bundled `MfmeFonts` once, matches family name case-insensitively, selects faces by bold/italic compatibility, ignores unreadable files, disposes rejected candidates, and preserves the fallback order: bundled MFME → installed family via `SKTypeface.FromFamilyName` → `Tahoma` → `SKTypeface.Default`.
- Replaced Lamp and Label local resolution with the shared call `MfmeTypefaceResolver.Resolve(...)` and removed the duplicated per-renderer cache/lookup code paths.
- Added `OasisEditor.Tests/MfmeTypefaceResolverTests.cs` with focused regression tests for bundled family lookup, regular and bold face selection, and safe fallback for missing families.
- Extended `LabelElementRendererTests` with a `Render_BundledMfmeFont_MatchesSharedTypefaceRendering` test and updated the test project file to copy `MfmeFonts` into test output so tests do not rely on system-installed fonts.

### Testing
- Automated tests added: `MfmeTypefaceResolverTests` (4 facts) and an additional Label renderer regression (`Render_BundledMfmeFont_MatchesSharedTypefaceRendering`) integrated into `LabelElementRendererTests`.
- The test project was configured to copy `MfmeFonts/*.ttf` into the test output to ensure deterministic bundled-font resolution without system font dependencies.
- No tests or builds were executed in this environment due to the repository's `AGENTS.md` constraints and the unavailable Windows/.NET/WPF toolchain here, so automated tests must be run locally (for example `dotnet test OasisEditor.Tests` and `dotnet build OasisEditor`).
- Please run the added test suite locally; the changes are narrowly scoped to font resolution and should not affect unrelated renderer behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a52ab4c3fc083279653a8c13d1f249a)