### PR TITLE
Realtime Panel2D resize previews and resize-handle cursors

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
@@ -82,6 +82,144 @@ public sealed class PanelElementPreviewMutationServiceTests
         Assert.Equal(55, document.GetPanelElements().Single().Y);
     }
 
+
+    [Fact]
+    public void ResizePreview_UpdatesGeometryWithoutRecordingUndoHistoryOrDirtyingDocument()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Name = "Lamp 1",
+            Kind = PanelElementKind.Lamp,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var original = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        var resized = PanelElementModelCloner.Clone(original, x: 5, y: 15, width: 35, height: 45);
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", resized));
+
+        var element = document.GetPanelElements().Single();
+        Assert.Equal(5, element.X);
+        Assert.Equal(15, element.Y);
+        Assert.Equal(35, element.Width);
+        Assert.Equal(45, element.Height);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void PreviewedResizeCommand_RecordsSingleUndoableActionFromOriginalToFinalGeometry()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "reel-1",
+            Name = "Reel 1",
+            Kind = PanelElementKind.Reel,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var original = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        var previewed = PanelElementModelCloner.Clone(original, x: 5, y: 15, width: 35, height: 45);
+        var final = PanelElementModelCloner.Clone(original, x: 1, y: 2, width: 39, height: 58);
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "reel-1", previewed));
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "reel-1",
+            final,
+            original,
+            "Resize element");
+
+        document.CommandService.Execute(command);
+
+        Assert.Single(document.CommandService.History.Entries);
+        Assert.Equal(1, document.GetPanelElements().Single().X);
+        Assert.Equal(2, document.GetPanelElements().Single().Y);
+        Assert.Equal(39, document.GetPanelElements().Single().Width);
+        Assert.Equal(58, document.GetPanelElements().Single().Height);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Equal(10, document.GetPanelElements().Single().X);
+        Assert.Equal(20, document.GetPanelElements().Single().Y);
+        Assert.Equal(30, document.GetPanelElements().Single().Width);
+        Assert.Equal(40, document.GetPanelElements().Single().Height);
+
+        Assert.True(document.CommandService.TryRedo());
+        Assert.Equal(1, document.GetPanelElements().Single().X);
+        Assert.Equal(2, document.GetPanelElements().Single().Y);
+        Assert.Equal(39, document.GetPanelElements().Single().Width);
+        Assert.Equal(58, document.GetPanelElements().Single().Height);
+    }
+
+    [Fact]
+    public void PreviewedResizeCommand_NoOpFinalGeometryDoesNotRecordUndoHistory()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Name = "Lamp 1",
+            Kind = PanelElementKind.Lamp,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var original = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        var previewed = PanelElementModelCloner.Clone(original, x: 5, y: 15, width: 35, height: 45);
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", previewed));
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", original));
+
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            "lamp-1",
+            original,
+            original,
+            "Resize element");
+        document.CommandService.Execute(command);
+
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void CancelledResizePreview_RestoresOriginalWithoutRecordingUndoHistoryOrDirtyingDocument()
+    {
+        var document = CreateDocument(new PanelElementModel
+        {
+            ObjectId = "lamp-1",
+            Name = "Lamp 1",
+            Kind = PanelElementKind.Lamp,
+            X = 10,
+            Y = 20,
+            Width = 30,
+            Height = 40,
+            IsVisible = true
+        });
+        var original = PanelElementModelCloner.Clone(document.GetPanelElements().Single());
+        var previewed = PanelElementModelCloner.Clone(original, x: 5, y: 15, width: 35, height: 45);
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", previewed));
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "lamp-1", original));
+
+        var element = document.GetPanelElements().Single();
+        Assert.Equal(10, element.X);
+        Assert.Equal(20, element.Y);
+        Assert.Equal(30, element.Width);
+        Assert.Equal(40, element.Height);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
     private static DocumentTabViewModel CreateDocument(params PanelElementModel[] elements)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ResizeHandleCursorServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ResizeHandleCursorServiceTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class ResizeHandleCursorServiceTests
+{
+    [Theory]
+    [InlineData(ResizeHandleKind.Left, ResizeHandleCursorKind.SizeWE)]
+    [InlineData(ResizeHandleKind.Right, ResizeHandleCursorKind.SizeWE)]
+    [InlineData(ResizeHandleKind.Top, ResizeHandleCursorKind.SizeNS)]
+    [InlineData(ResizeHandleKind.Bottom, ResizeHandleCursorKind.SizeNS)]
+    [InlineData(ResizeHandleKind.TopLeft, ResizeHandleCursorKind.SizeNWSE)]
+    [InlineData(ResizeHandleKind.BottomRight, ResizeHandleCursorKind.SizeNWSE)]
+    [InlineData(ResizeHandleKind.TopRight, ResizeHandleCursorKind.SizeNESW)]
+    [InlineData(ResizeHandleKind.BottomLeft, ResizeHandleCursorKind.SizeNESW)]
+    [InlineData(ResizeHandleKind.None, ResizeHandleCursorKind.Arrow)]
+    public void GetCursorKind_MapsResizeHandlesToConventionalDirections(ResizeHandleKind handleKind, ResizeHandleCursorKind expected)
+    {
+        Assert.Equal(expected, ResizeHandleCursorService.GetCursorKind(handleKind));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ResizeHandleCursorServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ResizeHandleCursorServiceTests.cs
@@ -5,17 +5,20 @@ namespace OasisEditor.Tests;
 public sealed class ResizeHandleCursorServiceTests
 {
     [Theory]
-    [InlineData(ResizeHandleKind.Left, ResizeHandleCursorKind.SizeWE)]
-    [InlineData(ResizeHandleKind.Right, ResizeHandleCursorKind.SizeWE)]
-    [InlineData(ResizeHandleKind.Top, ResizeHandleCursorKind.SizeNS)]
-    [InlineData(ResizeHandleKind.Bottom, ResizeHandleCursorKind.SizeNS)]
-    [InlineData(ResizeHandleKind.TopLeft, ResizeHandleCursorKind.SizeNWSE)]
-    [InlineData(ResizeHandleKind.BottomRight, ResizeHandleCursorKind.SizeNWSE)]
-    [InlineData(ResizeHandleKind.TopRight, ResizeHandleCursorKind.SizeNESW)]
-    [InlineData(ResizeHandleKind.BottomLeft, ResizeHandleCursorKind.SizeNESW)]
-    [InlineData(ResizeHandleKind.None, ResizeHandleCursorKind.Arrow)]
-    public void GetCursorKind_MapsResizeHandlesToConventionalDirections(ResizeHandleKind handleKind, ResizeHandleCursorKind expected)
+    [InlineData((int)ResizeHandleKind.Left, (int)ResizeHandleCursorKind.SizeWE)]
+    [InlineData((int)ResizeHandleKind.Right, (int)ResizeHandleCursorKind.SizeWE)]
+    [InlineData((int)ResizeHandleKind.Top, (int)ResizeHandleCursorKind.SizeNS)]
+    [InlineData((int)ResizeHandleKind.Bottom, (int)ResizeHandleCursorKind.SizeNS)]
+    [InlineData((int)ResizeHandleKind.TopLeft, (int)ResizeHandleCursorKind.SizeNWSE)]
+    [InlineData((int)ResizeHandleKind.BottomRight, (int)ResizeHandleCursorKind.SizeNWSE)]
+    [InlineData((int)ResizeHandleKind.TopRight, (int)ResizeHandleCursorKind.SizeNESW)]
+    [InlineData((int)ResizeHandleKind.BottomLeft, (int)ResizeHandleCursorKind.SizeNESW)]
+    [InlineData((int)ResizeHandleKind.None, (int)ResizeHandleCursorKind.Arrow)]
+    public void GetCursorKind_MapsResizeHandlesToConventionalDirections(int handleKindValue, int expectedValue)
     {
+        var handleKind = (ResizeHandleKind)handleKindValue;
+        var expected = (ResizeHandleCursorKind)expectedValue;
+
         Assert.Equal(expected, ResizeHandleCursorService.GetCursorKind(handleKind));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -807,7 +807,9 @@ internal static class CanvasMutationCommands
                 return;
             }
 
-            _previousElement = PanelElementModelCloner.Clone(existing);
+            _previousElement = IsValidPreviewOriginal(existing)
+                ? PanelElementModelCloner.Clone(_previewOriginalElement!)
+                : PanelElementModelCloner.Clone(existing);
             elements[index] = PanelElementModelCloner.Clone(_updatedElement);
             var changedProperties = GetChangedProperties(existing, _updatedElement);
             var affectsHierarchy = changedProperties.HasFlag(PanelChangeProperties.Name)
@@ -818,6 +820,15 @@ internal static class CanvasMutationCommands
             _document.SetPanelElements(elements, CreateElementChange(_document, _objectId, changedProperties, affectsHierarchy: affectsHierarchy));
             _document.MarkDirty();
             WasExecuted = true;
+        }
+
+        private bool IsValidPreviewOriginal(PanelElementModel existing)
+        {
+            return _previewOriginalElement is not null
+                   && string.Equals(_previewOriginalElement.ObjectId, _objectId, StringComparison.Ordinal)
+                   && _previewOriginalElement.Kind == existing.Kind
+                   && PanelElementValidation.IsValidForInspectorUpdate(_previewOriginalElement)
+                   && !PanelElementModelComparer.AreEquivalent(_previewOriginalElement, _updatedElement);
         }
 
         public void Undo()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ResizeHandleCursorService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ResizeHandleCursorService.cs
@@ -1,0 +1,25 @@
+namespace OasisEditor;
+
+internal static class ResizeHandleCursorService
+{
+    public static ResizeHandleCursorKind GetCursorKind(ResizeHandleKind handleKind)
+    {
+        return handleKind switch
+        {
+            ResizeHandleKind.Left or ResizeHandleKind.Right => ResizeHandleCursorKind.SizeWE,
+            ResizeHandleKind.Top or ResizeHandleKind.Bottom => ResizeHandleCursorKind.SizeNS,
+            ResizeHandleKind.TopLeft or ResizeHandleKind.BottomRight => ResizeHandleCursorKind.SizeNWSE,
+            ResizeHandleKind.TopRight or ResizeHandleKind.BottomLeft => ResizeHandleCursorKind.SizeNESW,
+            _ => ResizeHandleCursorKind.Arrow
+        };
+    }
+}
+
+internal enum ResizeHandleCursorKind
+{
+    Arrow,
+    SizeWE,
+    SizeNS,
+    SizeNWSE,
+    SizeNESW
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml
@@ -18,7 +18,8 @@
                           MouseMove="OnEditSkiaSurfaceMouseMove"
                           MouseUp="OnEditSkiaSurfaceMouseUp"
                           MouseWheel="OnEditSkiaSurfaceMouseWheel"
-                          LostMouseCapture="OnEditSkiaSurfaceLostMouseCapture" />
+                          LostMouseCapture="OnEditSkiaSurfaceLostMouseCapture"
+                          MouseLeave="OnEditSkiaSurfaceMouseLeave" />
         </Border>
     </Grid>
 </UserControl>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -280,6 +280,7 @@ public partial class SkiaPanel2DEditView : UserControl
                 _isResizingSelection = true;
                 _resizeSourceElement = resizeElement;
                 _activeResizeHandle = resizeHandle;
+                EditSkiaSurface.Cursor = GetCursorForResizeHandle(resizeHandle);
                 _leftMouseDownStart = pointer;
                 _dragSelectionCurrent = pointer;
                 EditSkiaSurface.CaptureMouse();
@@ -340,7 +341,16 @@ public partial class SkiaPanel2DEditView : UserControl
 
             if (_isResizingSelection)
             {
-                RequestRender();
+                if (_shapeDragSource is not null)
+                {
+                    RequestRender();
+                }
+                else
+                {
+                    UpdateResizeSelectionPreview(_dragSelectionCurrent);
+                    EditSkiaSurface.Cursor = GetCursorForResizeHandle(_activeResizeHandle);
+                }
+
                 return;
             }
 
@@ -359,6 +369,7 @@ public partial class SkiaPanel2DEditView : UserControl
 
         if (!_isPanning || Document is null)
         {
+            UpdateHoverCursor(eventArgs.GetPosition(EditSkiaSurface));
             return;
         }
 
@@ -418,6 +429,7 @@ public partial class SkiaPanel2DEditView : UserControl
             _activeShapeCornerIndex = -1;
             _activeResizeHandle = ResizeHandleKind.None;
             EditSkiaSurface.ReleaseMouseCapture();
+            UpdateHoverCursor(eventArgs.GetPosition(EditSkiaSurface));
             RequestRender();
             eventArgs.Handled = true;
             return;
@@ -454,6 +466,19 @@ public partial class SkiaPanel2DEditView : UserControl
         if (_isPanning)
         {
             EndPan(releaseMouseCapture: false);
+        }
+
+        if (_isLeftMouseDown && _isResizingSelection && _shapeDragSource is null)
+        {
+            CancelActiveElementResizePreview();
+        }
+    }
+
+    private void OnEditSkiaSurfaceMouseLeave(object sender, MouseEventArgs eventArgs)
+    {
+        if (!_isPanning && !(_isLeftMouseDown && _isResizingSelection && _shapeDragSource is null))
+        {
+            EditSkiaSurface.Cursor = Cursors.Arrow;
         }
     }
 
@@ -710,8 +735,85 @@ public partial class SkiaPanel2DEditView : UserControl
         var start = viewport.ScreenToDocument(startScreenPoint);
         var end = viewport.ScreenToDocument(endScreenPoint);
         var updated = Panel2DResizeComputationService.ComputeResizedElement(_resizeSourceElement, _activeResizeHandle, start, end);
-        var command = CanvasMutationCommands.CreateUpdateElementCommand(document.DocumentId, document, _resizeSourceElement.ObjectId, updated, "Resize element");
+        var command = CanvasMutationCommands.CreateUpdateElementCommand(
+            document.DocumentId,
+            document,
+            _resizeSourceElement.ObjectId,
+            updated,
+            _resizeSourceElement,
+            "Resize element");
         document.CommandService.Execute(command);
+    }
+
+
+    private void UpdateResizeSelectionPreview(Point currentScreenPoint)
+    {
+        var document = Document;
+        if (document is null
+            || _resizeSourceElement is null
+            || _activeResizeHandle == ResizeHandleKind.None
+            || string.IsNullOrWhiteSpace(_resizeSourceElement.ObjectId))
+        {
+            return;
+        }
+
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        var start = viewport.ScreenToDocument(_leftMouseDownStart);
+        var current = viewport.ScreenToDocument(currentScreenPoint);
+        var updated = Panel2DResizeComputationService.ComputeResizedElement(_resizeSourceElement, _activeResizeHandle, start, current);
+        if (PanelElementPreviewMutationService.TryApplyPreview(document, _resizeSourceElement.ObjectId, updated))
+        {
+            RequestRender();
+        }
+    }
+
+    private void CancelActiveElementResizePreview()
+    {
+        var document = Document;
+        if (document is not null
+            && _resizeSourceElement is not null
+            && !string.IsNullOrWhiteSpace(_resizeSourceElement.ObjectId)
+            && PanelElementPreviewMutationService.TryApplyPreview(document, _resizeSourceElement.ObjectId, _resizeSourceElement))
+        {
+            RequestRender();
+        }
+
+        _isLeftMouseDown = false;
+        _isDragSelecting = false;
+        _isMovingSelection = false;
+        _isResizingSelection = false;
+        _resizeSourceElement = null;
+        _activeResizeHandle = ResizeHandleKind.None;
+        EditSkiaSurface.Cursor = Cursors.Arrow;
+    }
+
+    private void UpdateHoverCursor(Point screenPoint)
+    {
+        if (_isPanning || (_isLeftMouseDown && _isResizingSelection && _shapeDragSource is null))
+        {
+            return;
+        }
+
+        var document = Document;
+        if (document is not null && TryGetResizeHandleAtPoint(document, screenPoint, out var handleKind, out _))
+        {
+            EditSkiaSurface.Cursor = GetCursorForResizeHandle(handleKind);
+            return;
+        }
+
+        EditSkiaSurface.Cursor = Cursors.Arrow;
+    }
+
+    private static Cursor GetCursorForResizeHandle(ResizeHandleKind handleKind)
+    {
+        return ResizeHandleCursorService.GetCursorKind(handleKind) switch
+        {
+            ResizeHandleCursorKind.SizeWE => Cursors.SizeWE,
+            ResizeHandleCursorKind.SizeNS => Cursors.SizeNS,
+            ResizeHandleCursorKind.SizeNWSE => Cursors.SizeNWSE,
+            ResizeHandleCursorKind.SizeNESW => Cursors.SizeNESW,
+            _ => Cursors.Arrow
+        };
     }
 
     private bool TryGetResizeHandleAtPoint(DocumentTabViewModel document, Point screenPoint, out ResizeHandleKind handleKind, out PanelElementModel selectedElement)


### PR DESCRIPTION
### Motivation
- Provide immediate visual feedback while resizing Panel2D elements and show conventional resize cursors for each handle to match Windows UX expectations.
- Ensure the entire resize drag produces exactly one undoable change (no preview frames in history) and that cancelled or interrupted drags restore the original geometry.
- Avoid interfering with existing panning, move, and Face Source Shape corner-drag behaviours while keeping the view-layer logic small and focused.

### Description
- Added a small cursor mapping helper `ResizeHandleCursorService` and `ResizeHandleCursorKind` to map `ResizeHandleKind` to logical cursor directions, and converted those to WPF `Cursor` values in `SkiaPanel2DEditView` via `GetCursorForResizeHandle`.
- Implemented realtime resize preview in `SkiaPanel2DEditView.xaml.cs` with new helpers `UpdateResizeSelectionPreview(Point)`, `CancelActiveElementResizePreview()`, and `UpdateHoverCursor(Point)`, which call `Panel2DResizeComputationService.ComputeResizedElement(...)` and apply previews through `PanelElementPreviewMutationService.TryApplyPreview(...)` on every relevant `MouseMove`.
- Commit the final resize as a single undoable command using the overload `CanvasMutationCommands.CreateUpdateElementCommand(..., originalElement, "Resize element")` so Undo/Redo restore original and final geometries exactly.
- Wired hover and active cursor updates (including setting the cursor immediately at `MouseDown` on a handle and keeping the appropriate resize cursor while dragging), added a `MouseLeave` handler and lost-capture cancellation to avoid stale resize cursors and to restore original geometry when a drag is interrupted.
- Tests: extended `PanelElementPreviewMutationServiceTests` with focused cases for resize preview behaviour and final-command undo/redo/no-op/cancel semantics, and added `ResizeHandleCursorServiceTests` to verify handle→cursor mapping.

### Testing
- No automated tests were executed in this environment because the required Windows/.NET/WPF toolchain is not available here per project guidance, so no tests were run.
- New/updated automated tests added (to be run locally): `PanelElementPreviewMutationServiceTests` additions (`ResizePreview_UpdatesGeometryWithoutRecordingUndoHistoryOrDirtyingDocument`, `PreviewedResizeCommand_RecordsSingleUndoableActionFromOriginalToFinalGeometry`, `PreviewedResizeCommand_NoOpFinalGeometryDoesNotRecordUndoHistory`, `CancelledResizePreview_RestoresOriginalWithoutRecordingUndoHistoryOrDirtyingDocument`) and `ResizeHandleCursorServiceTests.GetCursorKind_MapsResizeHandlesToConventionalDirections`.
- Please run the OasisEditor test suite locally (for example with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests`) and verify the editor UI on Windows: cursors for all eight handles, continuous realtime resizing at multiple zoom levels, single Undo/Redo for a drag, and cancelled-resize behaviour restoring the original geometry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a52b3257ad88327905321cb906484e5)