### PR TITLE
Add phased multi-selection refactor planning docs

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/Selection/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/CODEX_START_PROMPT.md
@@ -1,0 +1,116 @@
+# Codex Start Prompt - Multi-Selection Refactor
+
+You are working in the connected Oasis repository.
+
+Repository:
+
+`johnparker007/Oasis`
+
+Focus area:
+
+`WindowsNetProjects/OasisEditor`
+
+## First Step
+
+Read these files in full:
+
+- `WindowsNetProjects/OasisEditor/Docs/Selection/MULTI_SELECTION_CONTEXT.md`
+- `WindowsNetProjects/OasisEditor/Docs/Selection/TASK_01_SELECTION_FOUNDATION_AND_TRANSFORM_LOCK.md`
+
+Then inspect the current implementation, especially:
+
+- `OasisEditor/ViewModels/DocumentTabViewModel.cs`
+- `OasisEditor/ActiveDocumentContextService.cs`
+- `OasisEditor/ViewModels/HierarchyViewModel.cs`
+- `OasisEditor/Views/HierarchyView.xaml`
+- `OasisEditor/Views/HierarchyView.xaml.cs`
+- `OasisEditor/ViewModels/InspectorViewModel.cs`
+- `OasisEditor/Views/SkiaPanel2DEditView.xaml.cs`
+- `OasisEditor/Views/SkiaFaceEditView.xaml.cs`
+- `OasisEditor/Panel2DSelectionNotificationService.cs`
+- `OasisEditor/CanvasMutationCommands.cs`
+- `OasisEditor/FaceMutationCommands.cs`
+- relevant selection, preview mutation, serialization, and test files discovered from those entry points
+
+## Task To Start
+
+Implement only:
+
+`TASK_01_SELECTION_FOUNDATION_AND_TRANSFORM_LOCK.md`
+
+Do not begin Task 02 or later tasks in the same PR.
+
+## Core Requirements
+
+- Replace the singular-selection foundation with a document-local ordered selection state capable of holding multiple stable object identities.
+- Track selected items, a primary item, and a hierarchy range anchor separately.
+- Keep compatibility shims only where needed to avoid unnecessary Task 01 churn.
+- Make selection changes explicitly observable so Panel2D and Face canvases redraw when hierarchy-driven selection changes.
+- Fix the current Panel2D hierarchy-selection outline refresh regression.
+- Remove the old behaviour where `IsLocked` prevents hit-testing or selection.
+- Replace the old ambiguous lock with clearly named transform-lock semantics.
+- Transform-locked components must remain selectable and Inspector-visible.
+- Transform lock must govern moving/resizing only; it must not make components unselectable.
+- Newly created or imported background components should default to transform locked where appropriate.
+- Preserve existing serialized assets safely. Do not silently reinterpret arbitrary existing locked elements without an explicit compatibility strategy.
+- Keep Panel2D, Face, hierarchy, and Inspector single-selection behaviour working while establishing the new foundation.
+- Keep selection document-local across tab switching.
+
+## Constraints
+
+- Do not implement viewport Ctrl-click or rectangle multiselect yet.
+- Do not implement hierarchy Ctrl/Shift multiselect yet.
+- Do not implement Inspector mixed values yet.
+- Do not implement group move or group resize yet.
+- Do not implement bulk delete yet.
+- Do not redesign context menus.
+- Do not make Face Source Shapes ordinary component multiselections.
+- Do not use copied X/Y/Width/Height values as selection identity.
+- Avoid reflection-driven Inspector or model mutation systems.
+- Keep changes small enough to review and diagnose.
+- Preserve undo/redo behaviour.
+- Keep all existing tests passing and add focused tests for the new state and lock semantics.
+
+## Expected Design Direction
+
+Use stable selection identity such as domain/kind plus object ID. The exact type names may vary to fit repository conventions, but the architecture must provide the equivalent of:
+
+- ordered selected item identities
+- primary selected identity
+- hierarchy anchor identity
+- replace/add/remove/toggle/clear operations
+- pruning of identities whose objects no longer exist
+- one selection-changed notification path consumed by hierarchy, Inspector, and both canvases
+
+Do not let views maintain independent authoritative selection collections.
+
+## Verification
+
+Run the relevant OasisEditor build and test suite available in the repository.
+
+Add tests covering at least:
+
+- replace/add/remove/toggle/clear selection state operations
+- primary and anchor behaviour
+- document-local selection retention
+- stale-selection pruning
+- transform-locked items remain selectable
+- transform-locked items are rejected by move/resize eligibility
+- legacy selection compatibility, if retained
+- Panel2D redraw notification when selection changes from the hierarchy path
+
+## Completion Report
+
+When Task 01 is complete, report:
+
+- files added
+- files modified
+- tests added or updated
+- commands/tests run and results
+- old `IsLocked` behaviour removed
+- transform-lock compatibility or migration decisions
+- any deviations from the task document
+- manual checks the user should perform
+- confirmation that Task 02 was not started
+
+Stop after Task 01 so the user can test it and the PR can be reviewed before further work.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/MULTI_SELECTION_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/MULTI_SELECTION_CONTEXT.md
@@ -1,0 +1,359 @@
+# Multi-Selection and Shared Selection Architecture Context
+
+## Purpose
+
+This document defines the planned selection-system refactor for Oasis Editor.
+
+The goal is to introduce a consistent Unity-style multi-selection workflow across:
+
+- Panel2D edit views
+- Face edit views
+- Hierarchy tree views
+- Inspector editing
+- Move and delete commands
+- Undo and redo
+
+The work should be implemented in numbered phases. Each phase should be completed, tested by the user, and reviewed before the next phase begins.
+
+## Current Problem
+
+The Editor currently treats selection as one nullable `PanelSelectionInfo`.
+
+That single-selection assumption is embedded in:
+
+- `DocumentTabViewModel.HierarchySelectedPanelSelection`
+- `ActiveDocumentContextService.ActivePanelSelection`
+- `HierarchyViewModel`
+- `InspectorViewModel`
+- Panel2D selection outlines
+- Face selection outlines
+- Panel2D move and resize handling
+- Hierarchy delete and context commands
+
+Panel2D and Face selection behaviour has also drifted apart.
+
+Panel2D currently supports click selection, rectangle selection, movement, and resize. Face currently has a more limited click-selection path. Both views should eventually present the same core selection behaviour.
+
+There is also a current Panel2D bug: selecting an element from the Hierarchy updates the logical selection but does not immediately redraw the Panel2D selection outline. The selected element can still be dragged, confirming that the state changed but the viewport was not invalidated.
+
+## Core Architectural Decision
+
+Introduce one authoritative, document-scoped selection state.
+
+The Hierarchy, Inspector, Panel2D view, and Face view must all read and update the same selection state. Do not maintain separate parallel selection collections for different UI surfaces.
+
+Suggested conceptual shape:
+
+```csharp
+public sealed class DocumentSelectionState
+{
+    public IReadOnlyList<EditorSelectionItem> Items { get; }
+    public EditorSelectionItem? PrimaryItem { get; }
+    public EditorSelectionItem? AnchorItem { get; }
+}
+```
+
+The exact names may change to fit project conventions.
+
+### Selection Identity
+
+Selection items should identify objects using stable identity rather than copied bounds.
+
+Suggested conceptual shape:
+
+```csharp
+public readonly record struct EditorSelectionItem(
+    EditorSelectionDomain Domain,
+    string ObjectId);
+```
+
+Possible domains include:
+
+- Panel element
+- Face element
+- Panel Face Source Shape
+- Face mask layer
+
+Do not rely on copied X, Y, Width, or Height values as the authoritative selection state. Resolve the current model when geometry or properties are needed.
+
+### Primary Selection
+
+The selection state must track a primary item separately from the selected set.
+
+The primary item is normally the last item clicked or focused. It is useful for:
+
+- Inspector titles and type decisions
+- Hierarchy keyboard focus
+- Context-menu behaviour later
+- Single-item resize handles
+- Distinguishing one selection outline from the rest
+
+### Hierarchy Range Anchor
+
+The selection state or hierarchy selection controller must track an anchor item for Shift-range selection.
+
+The anchor is distinct from the primary item, although they will often be the same.
+
+## Document Scope
+
+Selection belongs to a document.
+
+Each open document should retain its own selection state. Switching tabs must restore that document's selection rather than transferring IDs from another document.
+
+When document content changes:
+
+- Remove selections whose objects no longer exist.
+- Preserve surviving selections.
+- Preserve the primary item when it still exists.
+- Choose a deterministic replacement primary item when necessary.
+
+## Required Selection Operations
+
+Selection changes should be expressed as explicit operations rather than scattered collection mutations.
+
+At minimum, support:
+
+- Replace selection
+- Add item
+- Add range or collection
+- Remove item
+- Toggle item
+- Clear selection
+- Set primary item
+- Set hierarchy anchor
+- Reconcile selection after model changes
+
+Selection changes must raise a dedicated notification that causes all relevant UI surfaces to refresh.
+
+## Viewport Selection Behaviour
+
+### Click
+
+- Click an unselected component: replace the selection with that component.
+- Click a selected component: keep the complete selection.
+- Ctrl-click an unselected component: add it and make it primary.
+- Ctrl-click a selected component: remove only that component.
+- Click empty space without Ctrl: clear selection.
+- Ctrl-click empty space: preserve the selection.
+
+Keeping the full selection when clicking an already-selected component is required so a group drag can begin without collapsing the group.
+
+### Rectangle Selection
+
+- Rectangle without Ctrl: replace the selection with all matching eligible components.
+- Ctrl+rectangle: add matching components.
+- Ctrl+rectangle never toggles or removes already-selected components.
+- Shift modifiers in the viewport are deferred.
+
+Use a shared, tested geometry rule. For the initial implementation, select components whose bounds are fully enclosed by the rectangle. This avoids a large background or artwork element being selected merely because the rectangle crosses it.
+
+Special non-rectangular editing objects such as Panel Face Source Shapes may retain their existing specialised selection behaviour unless a task explicitly includes them.
+
+### Gesture Priority
+
+Pointer interaction should resolve in this order:
+
+1. Special editing handle, such as a Face Source Shape corner
+2. Single-selection resize handle
+3. Drag on a selected, transform-unlocked component
+4. Potential click selection
+5. Rectangle selection after the drag threshold is exceeded
+
+## Multi-Selection Rendering
+
+- Draw an outline around every selected component.
+- Draw the primary item's outline with a visually stronger treatment.
+- Show resize handles only when exactly one transformable component is selected.
+- Do not implement group resizing in this work.
+- Ensure selection changes from the Hierarchy immediately invalidate Panel2D and Face viewports.
+
+## Group Movement
+
+Dragging any selected, transform-unlocked component should move the selected transform-unlocked group by the same document-space delta.
+
+Implementation requirements:
+
+- Capture immutable original models or bounds at drag start.
+- Calculate all previews from the original state.
+- Do not accumulate preview deltas from already-mutated preview models.
+- Commit the group move as one undoable command.
+- Cancel or lost-capture handling must restore all previewed models.
+- Locked items may remain selected but do not move.
+- Dragging a locked selected item must not initiate group movement.
+
+## Transform Lock
+
+The old `IsLocked` behaviour is not wanted.
+
+Current observed behaviour prevents a locked component from being selected after the user clicks away. Remove that old selection-exclusion behaviour.
+
+Replace the concept with an explicit transform lock:
+
+- Prefer a model/property name such as `IsTransformLocked`.
+- Inspector label: `Lock Transform`.
+- A transform-locked component remains selectable.
+- It remains inspectable.
+- Non-transform properties remain editable.
+- It cannot be moved or resized in the viewport.
+- Transform fields in the Inspector should be disabled or rejected for locked items according to the multi-edit rules.
+
+Preserve asset compatibility where practical. If persisted data currently uses `IsLocked`, introduce a deliberate migration or serialization compatibility mapping rather than silently breaking existing assets.
+
+Background components should default to transform locked when newly created or imported. Do not automatically rewrite every existing background on each load.
+
+## Hierarchy Behaviour
+
+The WPF `TreeView` is single-selection by default, so multi-selection must be represented by view-model state rather than relying on native `TreeViewItem.IsSelected` as the authoritative source.
+
+Required behaviour:
+
+- Click: replace selection.
+- Ctrl-click: toggle one component.
+- Shift-click: select the continuous visible range from the anchor to the clicked item.
+- Ctrl+Shift-click: add the continuous visible range.
+- Range selection uses currently visible hierarchy rows.
+- Descendants hidden inside collapsed groups are not included.
+- Group nodes do not become component selections in the initial implementation.
+- Programmatic selection from a viewport must update all matching hierarchy row visuals.
+
+The native TreeView selection may be retained only for keyboard focus/navigation if useful.
+
+## Inspector Multi-Edit
+
+The Inspector should aggregate selected component properties.
+
+A property has one of these conceptual states:
+
+- Common value
+- Mixed value
+- Unavailable
+
+Do not store the dash character as a value. The UI may display `-` for a mixed numeric or text field, but the internal state must explicitly represent a mixed value.
+
+For boolean properties, use an indeterminate three-state checkbox for mixed values.
+
+### Same-Type Selection
+
+When all selected elements have the same concrete type:
+
+- Show common/base properties.
+- Show meaningful type-specific properties.
+- Show a common value when all values match.
+- Show mixed state when values differ.
+- Entering a value applies it to every eligible selected item.
+
+### Mixed-Type Selection
+
+Initially show only safe common properties:
+
+- X
+- Y
+- Width
+- Height
+- Visible
+- Lock Transform
+
+Do not bulk-edit Name in the initial mixed-type implementation.
+
+### Transform Editing
+
+X, Y, Width, and Height edits are absolute assignments.
+
+For example, if selected items have different Y values and the user enters `10`, all eligible selected items receive Y = 10.
+
+Do not add relative-expression syntax in this work.
+
+A multi-object Inspector edit must be committed as one undoable command.
+
+## Bulk Delete
+
+Delete should operate on all selected deletable components.
+
+Requirements:
+
+- One delete action removes the selected set.
+- One undo restores the complete set.
+- Preserve deterministic ordering when restoring.
+- Ignore or reject non-deletable selection domains explicitly.
+- After deletion, reconcile the selection state.
+- Hierarchy Delete-key behaviour and any existing viewport Delete-key path should use the same bulk-delete command.
+
+## Shared Logic and View-Specific Logic
+
+Share domain logic between Panel2D and Face, including:
+
+- Selection state
+- Selection mutation operations
+- Modifier interpretation
+- Rectangle bounds matching
+- Group move computation
+- Bulk mutation commands
+- Inspector aggregation
+- Selection outline styling helpers where practical
+
+Do not force the complete Panel2D and Face WPF controls into one inheritance hierarchy during this refactor. Their current gesture and rendering responsibilities differ. Keep view-specific event adapters thin and route them into shared services.
+
+## Undo and Preview Requirements
+
+Multi-object operations must be atomic from the user's perspective.
+
+One user action should create one undo entry for:
+
+- Group move
+- Multi-object Inspector edit
+- Bulk delete
+
+Preview mutations must not become separate command-history entries.
+
+## Deferred Work
+
+Do not include the following in this core selection work:
+
+- Group resize or scale
+- Alignment and distribution tools
+- Duplicate or copy/paste workflows
+- Full context-menu redesign
+- Multi-selection context-menu command matrices
+- Shift selection in Panel2D or Face viewports
+- Rectangle-selection toggle behaviour
+- Relative Inspector expressions such as `+=10`
+- Selecting hierarchy group nodes as component groups
+- Cross-document selections
+
+A minimal right-click preservation rule may be added only if required to prevent the new selection state being accidentally collapsed, but context-menu redesign remains separate.
+
+## Testing Expectations
+
+Add focused unit tests for:
+
+- Replace, add, remove, toggle, and clear operations
+- Primary and anchor behaviour
+- Selection reconciliation after deletion
+- Rectangle enclosure matching
+- Modifier interpretation
+- Group move calculations
+- Locked-item movement exclusion
+- Inspector common and mixed value aggregation
+- Atomic bulk update commands
+- Atomic bulk delete and undo restoration
+- Hierarchy visible-range calculation
+
+Add view-model or integration tests where practical for:
+
+- Hierarchy-to-viewport selection refresh
+- Viewport-to-hierarchy multi-selection sync
+- Document tab selection isolation
+- Panel2D and Face parity
+
+## Delivery Process
+
+Implement one numbered task at a time.
+
+For each task:
+
+1. Read this context file and the current numbered task.
+2. Inspect the current implementation before changing code.
+3. Keep the change focused on that task.
+4. Run relevant targeted tests and the full test suite where practical.
+5. Report files changed, tests run, deviations, risks, and manual test instructions.
+6. Stop and wait for user testing and review before starting the next task.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_01_SELECTION_FOUNDATION_AND_TRANSFORM_LOCK.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_01_SELECTION_FOUNDATION_AND_TRANSFORM_LOCK.md
@@ -1,0 +1,106 @@
+# Task 01 - Selection Foundation and Transform Lock
+
+## Goal
+
+Introduce the document-scoped selection foundation, fix current selection refresh behaviour, and replace the unwanted old lock semantics with an explicit transform lock.
+
+Do not implement user-facing multi-select gestures yet.
+
+## Required Work
+
+### Central Selection State
+
+Create the authoritative document-scoped selection state described in `MULTI_SELECTION_CONTEXT.md`.
+
+It must support:
+
+- Ordered selected items
+- Primary item
+- Hierarchy range anchor
+- Replace, add, remove, toggle, clear, and reconcile operations
+- Dedicated selection-change notifications
+- Per-document selection isolation
+
+Use stable object identity and a selection domain. Do not use copied geometry as authoritative selection state.
+
+### Compatibility Bridge
+
+Existing code currently expects one `HierarchySelectedPanelSelection` / active selection.
+
+Provide a temporary compatibility path where useful, but new code must treat the selection state as authoritative. The compatibility property should represent the primary item only and should not become a second source of truth.
+
+Document any temporary compatibility members so they can be removed after later tasks migrate all consumers.
+
+### Fix Current Panel2D Refresh Bug
+
+Selecting a Panel2D element from the Hierarchy must immediately redraw its viewport selection outline.
+
+Use the new dedicated selection notification rather than adding more ad hoc redraw conditions where practical.
+
+### Replace Old Lock Semantics
+
+Remove the behaviour where `IsLocked` prevents an element from being selected.
+
+Introduce explicit transform-lock semantics:
+
+- Prefer `IsTransformLocked` in runtime/model APIs.
+- Inspector label should eventually be `Lock Transform`.
+- Locked elements remain selectable and inspectable.
+- Locked elements cannot be moved or resized.
+- Non-transform properties remain editable.
+
+Preserve persisted asset compatibility. If the serialized property is currently named `IsLocked`, add an intentional compatibility mapping or migration. Do not silently drop existing values.
+
+Newly created/imported background components should default to transform locked. Existing assets must not be rewritten on every load.
+
+### Selection Reconciliation
+
+Add a service or method that removes stale selection identities after document structure changes while preserving surviving selections and the primary item when possible.
+
+## Out of Scope
+
+- Ctrl-click and rectangle multi-selection
+- Hierarchy multi-selection
+- Inspector multi-edit
+- Group movement
+- Bulk delete
+- Group resize
+- Context-menu redesign
+
+## Tests
+
+Add tests covering:
+
+- Selection replace/add/remove/toggle/clear
+- Primary item updates
+- Anchor updates
+- Duplicate prevention
+- Per-document isolation
+- Reconciliation after selected objects are removed
+- Locked elements remain selectable
+- Locked elements are rejected by move/resize eligibility checks
+- Existing serialized lock data remains compatible
+- Hierarchy-originated selection invalidates Panel2D rendering through the new notification path where practical
+
+## Manual Test Checklist
+
+- Select a Panel2D item in the Hierarchy and confirm the outline appears immediately.
+- Enable Lock Transform, click away, then reselect the component from both viewport and Hierarchy.
+- Confirm the component remains inspectable.
+- Confirm a locked component cannot be moved or resized.
+- Confirm a newly created/imported background starts transform locked.
+- Reopen an existing asset containing old lock data and confirm the lock value is preserved.
+
+## Completion Report
+
+Report:
+
+- Files added and modified
+- New selection-state API
+- Compatibility members retained
+- Lock serialization/migration approach
+- Tests added and run
+- Manual tests requested
+- Deviations or risks
+
+Stop after Task 01 for user testing and review.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_02_PANEL2D_MULTI_SELECTION_AND_GROUP_MOVE.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_02_PANEL2D_MULTI_SELECTION_AND_GROUP_MOVE.md
@@ -1,0 +1,113 @@
+# Task 02 - Panel2D Multi-Selection and Group Move
+
+## Goal
+
+Implement multi-selection interaction, rendering, and atomic group movement in the Panel2D viewport using the selection foundation from Task 01.
+
+## Required Behaviour
+
+### Click Selection
+
+- Click an unselected element: replace selection.
+- Click a selected element: preserve the full selection.
+- Ctrl-click an unselected element: add it and make it primary.
+- Ctrl-click a selected element: remove only it.
+- Click empty space without Ctrl: clear selection.
+- Ctrl-click empty space: preserve selection.
+
+### Rectangle Selection
+
+- Rectangle without Ctrl replaces the selection.
+- Ctrl+rectangle adds matching elements.
+- Ctrl+rectangle never removes or toggles existing elements.
+- Use full-enclosure bounds matching for the initial implementation.
+- Do not add Shift viewport behaviour.
+
+### Gesture Priority
+
+Preserve Face Source Shape corner editing and single-element resize behaviour.
+
+Resolve pointer gestures in this order:
+
+1. Face Source Shape corner handle
+2. Single-selection resize handle
+3. Drag on a selected transform-unlocked element
+4. Click candidate
+5. Rectangle selection after threshold
+
+A selected transform-locked background must not capture a move drag. Dragging over it should still allow rectangle selection to begin.
+
+### Rendering
+
+- Draw an outline for every selected Panel2D element.
+- Give the primary selection a stronger visual treatment.
+- Show resize handles only when exactly one transform-unlocked resizable element is selected.
+- Do not implement group resize.
+- Keep Face Source Shape visuals and handles working.
+
+### Group Move
+
+Dragging any selected transform-unlocked element moves all selected transform-unlocked Panel2D elements by the same document-space delta.
+
+Requirements:
+
+- Capture immutable originals at drag start.
+- Preview all moved elements from those originals.
+- Cancel/lost capture restores every previewed element.
+- Commit one atomic undoable command.
+- One undo restores the entire group.
+- Selected locked elements remain selected but do not move.
+- Dragging a locked selected element does not initiate group movement.
+
+Extract shared move computation and bulk mutation infrastructure suitable for later Face reuse.
+
+## Selection Eligibility
+
+Retain existing hit-test ordering and cycling semantics where they remain useful, but adapt them to selection sets.
+
+Do not include Panel Face Source Shapes in ordinary rectangular component multi-selection unless the existing architecture makes that safe and explicit. Preserve their specialised single-selection editing path.
+
+## Out of Scope
+
+- Face viewport parity
+- Hierarchy Ctrl/Shift selection
+- Inspector multi-edit
+- Bulk delete
+- Group resize
+- Context-menu redesign
+
+## Tests
+
+Add tests for:
+
+- Click replace/add/remove behaviour
+- Ctrl-click toggle behaviour
+- Empty-space behaviour
+- Rectangle replace and Ctrl-add
+- Full-enclosure rectangle rule
+- Background/locked element drag eligibility
+- Group move delta calculation
+- Locked member exclusion
+- Preview cancellation
+- Atomic command undo/redo
+- Primary outline and resize-handle eligibility logic where practical
+
+## Manual Test Checklist
+
+- Select several Panel2D components using Ctrl-click.
+- Remove one using Ctrl-click.
+- Replace the set by clicking another element.
+- Draw a rectangle to replace selection.
+- Ctrl-draw a rectangle to add elements.
+- Drag any selected unlocked element and confirm the unlocked group moves together.
+- Undo once and confirm the whole group returns.
+- Include a locked background in the selection and confirm it remains stationary.
+- Start a rectangle drag over a selected locked background.
+- Confirm single-selection resize still works and multi-selection resize handles are absent.
+- Confirm Face Source Shape corner editing still works.
+
+## Completion Report
+
+Report files changed, shared services introduced, tests run, manual tests requested, and any interaction deviations.
+
+Stop after Task 02 for user testing and review.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_03_FACE_MULTI_SELECTION_PARITY.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_03_FACE_MULTI_SELECTION_PARITY.md
@@ -1,0 +1,87 @@
+# Task 03 - Face Multi-Selection Parity
+
+## Goal
+
+Bring the Face edit viewport onto the shared selection and transform infrastructure established by Tasks 01 and 02.
+
+The user-facing selection model should be consistent between Panel2D and Face wherever the asset types allow it.
+
+## Required Behaviour
+
+Implement in the Face viewport:
+
+- Click replacement selection
+- Ctrl-click add/remove selection
+- Empty-space clear/preserve behaviour
+- Rectangle replacement selection
+- Ctrl+rectangle additive selection
+- Full-enclosure rectangle matching
+- Multi-selection outlines with a distinct primary item
+- Atomic group movement
+- Transform-lock enforcement
+- Single-selection resize only, if Face resize is already supported or can be added without broad unrelated work
+
+If Face does not currently have a reliable resize implementation, do not add group resize and do not force resize into this task. Preserve the agreed scope and report the limitation.
+
+## Shared Infrastructure
+
+Reuse the shared services introduced for Panel2D:
+
+- Selection mutation operations
+- Modifier interpretation
+- Rectangle bounds matching
+- Group move computation
+- Bulk update commands
+- Preview cancellation patterns
+- Selection outline styling helpers where practical
+
+Do not copy the Panel2D interaction implementation into Face under different names.
+
+Do not force both views into one large base control. Keep WPF event handling view-specific and thin.
+
+## Face-Specific Considerations
+
+- Preserve artwork rendering.
+- Preserve runtime display rendering.
+- Preserve mask-layer and special Face selection behaviour.
+- Ensure large artwork/background elements can be transform locked and remain selectable.
+- Ensure a locked selected artwork/background does not block starting a rectangle selection.
+- Keep right-click add behaviour working; do not redesign context menus.
+
+## Out of Scope
+
+- Hierarchy Ctrl/Shift selection
+- Inspector multi-edit
+- Bulk delete
+- Group resize
+- Context-menu redesign
+- Alignment/distribution
+
+## Tests
+
+Add tests for Face equivalents of:
+
+- Click and Ctrl-click transitions
+- Rectangle replace/add
+- Group move computation and atomic undo
+- Locked item exclusion
+- Selection rendering eligibility
+- Selection state synchronization
+- Panel2D/Face shared-service parity
+
+## Manual Test Checklist
+
+- Select multiple Face elements with Ctrl-click.
+- Replace and clear selections.
+- Select with a rectangle and add with Ctrl+rectangle.
+- Move a selected group and undo it in one step.
+- Include a transform-locked artwork/background and confirm it remains stationary and selectable.
+- Begin rectangle selection over a locked artwork/background.
+- Confirm selection changes from elsewhere redraw immediately.
+- Confirm existing Face artwork and runtime display rendering remains correct.
+
+## Completion Report
+
+Report files changed, reused shared services, any Face-specific divergence, tests run, and manual tests requested.
+
+Stop after Task 03 for user testing and review.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_04_HIERARCHY_MULTI_SELECTION.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_04_HIERARCHY_MULTI_SELECTION.md
@@ -1,0 +1,98 @@
+# Task 04 - Hierarchy Multi-Selection
+
+## Goal
+
+Implement component multi-selection in the Hierarchy and synchronize it bidirectionally with Panel2D and Face viewports.
+
+## Required Behaviour
+
+### Mouse Selection
+
+- Click a component row: replace selection.
+- Ctrl-click a component row: toggle that item.
+- Shift-click: select the continuous visible range from the hierarchy anchor.
+- Ctrl+Shift-click: add the continuous visible range.
+- Clicking a group row must not add the group to the component selection set.
+- Preserve expand/collapse behaviour.
+
+### Visible Range
+
+Range selection must use the flattened list of currently visible hierarchy rows.
+
+- Include expanded descendants.
+- Exclude descendants hidden by collapsed ancestors.
+- Exclude non-selectable group rows from the resulting component selection.
+- Keep ordering deterministic.
+
+### WPF TreeView Handling
+
+Do not use native `TreeViewItem.IsSelected` as the authoritative multi-selection state.
+
+Use `HierarchyItemViewModel.IsSelected` or an equivalent explicit visual-state property for every selected row.
+
+The native TreeView selection may remain as keyboard focus/navigation support, but it must not clear the document selection set unexpectedly.
+
+### Synchronization
+
+- Viewport multi-selection updates all matching hierarchy row visuals.
+- Hierarchy multi-selection immediately redraws Panel2D or Face selection outlines.
+- Switching documents restores each document's own hierarchy selection visuals.
+- Hierarchy refresh/rebuild preserves surviving selections and expansion state.
+- Deleted or missing items are removed from selection through reconciliation.
+
+### Keyboard Navigation
+
+Preserve existing Delete and F2 behaviour where applicable, but do not implement bulk delete in this task. Ensure keyboard focus changes do not collapse the multi-selection accidentally.
+
+## Context Menus
+
+Do not redesign Hierarchy context menus.
+
+Minimal preservation rule:
+
+- Right-click an already-selected component: preserve the current selection.
+- Right-click an unselected component: replace selection with that component before opening the existing menu.
+
+Only implement this rule if required to prevent regressions; do not add new multi-selection menu commands.
+
+## Out of Scope
+
+- Inspector multi-edit
+- Bulk delete
+- Group nodes as selectable component collections
+- Drag-and-drop reordering of multiple hierarchy items
+- Context-menu command redesign
+
+## Tests
+
+Add tests for:
+
+- Visible-row flattening
+- Shift range selection
+- Ctrl+Shift additive range
+- Collapsed descendant exclusion
+- Group-row exclusion
+- Anchor and primary updates
+- Viewport-to-hierarchy synchronization
+- Hierarchy-to-viewport synchronization
+- Selection preservation across hierarchy refresh
+- Per-document selection restoration
+- Right-click preservation rule if implemented
+
+## Manual Test Checklist
+
+- Ctrl-select separate Panel2D hierarchy rows.
+- Shift-select a continuous visible range.
+- Collapse a group and confirm hidden descendants are not selected by a range.
+- Use Ctrl+Shift to add another range.
+- Repeat in a Face document.
+- Select several elements in a viewport and confirm all hierarchy rows highlight.
+- Select several hierarchy rows and confirm all viewport outlines appear immediately.
+- Switch tabs and confirm each document restores its own selection.
+- Confirm expand/collapse, F2, and existing context menus still behave sensibly.
+
+## Completion Report
+
+Report files changed, TreeView strategy, range algorithm, tests run, manual tests requested, and any focus/navigation compromises.
+
+Stop after Task 04 for user testing and review.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_05_INSPECTOR_MULTI_EDIT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_05_INSPECTOR_MULTI_EDIT.md
@@ -1,0 +1,135 @@
+# Task 05 - Inspector Multi-Edit
+
+## Goal
+
+Implement Unity-style Inspector aggregation and atomic multi-object editing for selected Panel2D and Face components.
+
+## Property State Model
+
+Represent each property as one of:
+
+- Common value
+- Mixed value
+- Unavailable
+
+Do not use `-` as the internal value. The UI may display a dash for a mixed numeric or text field.
+
+Use a three-state checkbox for mixed boolean values.
+
+## Inspector Titles
+
+Use useful aggregate titles, for example:
+
+- `3 Lamps`
+- `4 Reel Displays`
+- `5 Components`
+
+The exact text may follow existing naming conventions.
+
+## Same-Type Selection
+
+When all selected components have the same concrete type:
+
+- Show common/base fields.
+- Show meaningful type-specific fields.
+- Show a common value when all selected values match.
+- Show mixed state when values differ.
+- Committing a value applies it to every eligible selected component.
+
+Retain explicit property descriptors/builders rather than introducing broad reflection-based editing.
+
+## Mixed-Type Selection
+
+Initially show only these safe common fields:
+
+- X
+- Y
+- Width
+- Height
+- Visible
+- Lock Transform
+
+Do not show bulk Name editing for mixed types.
+
+## Transform Lock Rules
+
+- `Lock Transform` remains editable across selections.
+- Mixed lock values use an indeterminate checkbox.
+- Transform fields should not mutate transform-locked items.
+- Clearly define and test whether a transform edit applies only to unlocked selected items or is rejected when any selected item is locked.
+
+Preferred initial behaviour: apply transform edits to unlocked eligible items and leave locked items unchanged, matching viewport group movement. The Inspector should communicate this consistently and avoid silent ambiguity where practical.
+
+## Editing Semantics
+
+- X, Y, Width, and Height edits are absolute assignments.
+- Entering a value into a mixed field sets that value on all eligible selected items.
+- Width and Height retain positive-value validation.
+- One committed field edit creates one undo entry.
+- One undo restores every affected object.
+- Do not add relative syntax such as `+=10`.
+
+## Refresh Behaviour
+
+The Inspector must refresh when:
+
+- Selection membership changes
+- Primary selection changes where title/type display depends on it
+- Any selected object's relevant property changes
+- Undo/redo changes selected objects
+- A selected object is deleted
+
+Avoid rebuilding every row unnecessarily during high-frequency move previews. Preserve or improve the current suppression/throttling behaviour.
+
+## Special Selection Domains
+
+Preserve existing single-selection Inspector support for:
+
+- Panel Face Source Shapes
+- Face mask layers
+- Document-level Face properties
+- Asset Browser inspection
+
+Do not force unsupported special-domain combinations into multi-edit. Show a clear read-only summary when the selection combination is unsupported.
+
+## Out of Scope
+
+- Relative expressions
+- Alignment/distribution
+- Group resize
+- Context-menu redesign
+- Bulk rename
+- Cross-domain Face Source Shape/component multi-edit
+
+## Tests
+
+Add tests for:
+
+- Common numeric/text values
+- Mixed numeric/text values
+- Mixed boolean values
+- Same-type type-specific rows
+- Mixed-type base rows only
+- Absolute assignment to multiple objects
+- Locked-item transform exclusion
+- Atomic undo/redo
+- Validation failures without partial mutation
+- Refresh after selected-object changes
+- Existing single-selection special-domain Inspector behaviour
+
+## Manual Test Checklist
+
+- Select two lamps with equal X and confirm the common value appears.
+- Give them different Y values and confirm mixed state appears.
+- Enter a Y value and confirm both update.
+- Undo once and confirm both return.
+- Test mixed Visible and Lock Transform checkboxes.
+- Select mixed component types and confirm only common base fields appear.
+- Include a transform-locked component and confirm transform edits follow the documented rule.
+- Confirm single-selection Face Source Shape, mask-layer, document, and asset inspection still work.
+
+## Completion Report
+
+Report property aggregation design, files changed, supported same-type fields, mixed-type behaviour, lock handling, tests run, and manual tests requested.
+
+Stop after Task 05 for user testing and review.

--- a/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_06_BULK_DELETE_AND_INTEGRATION_HARDENING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/Selection/TASK_06_BULK_DELETE_AND_INTEGRATION_HARDENING.md
@@ -1,0 +1,142 @@
+# Task 06 - Bulk Delete and Integration Hardening
+
+## Goal
+
+Complete the core multi-selection feature by making Delete operate atomically on selected components and hardening selection behaviour across undo/redo, document changes, and existing editor workflows.
+
+## Bulk Delete
+
+Implement one shared bulk-delete path for selected deletable components.
+
+Requirements:
+
+- Delete removes all selected deletable components.
+- One user action creates one undo entry.
+- One undo restores the complete set.
+- Restore original ordering and hierarchy placement deterministically.
+- Redo removes the same set again.
+- Reconcile selection after deletion.
+- Do not delete unsupported special selection domains accidentally.
+- If a selection mixes deletable and non-deletable domains, handle this explicitly and consistently.
+
+Use the same command path from:
+
+- Hierarchy Delete key
+- Any existing viewport Delete key handling
+- Existing delete command bindings that represent component deletion
+
+Do not add a new context-menu redesign.
+
+## Integration Hardening
+
+Review and fix selection behaviour for:
+
+- Undo and redo after group move
+- Undo and redo after Inspector multi-edit
+- Undo and redo after bulk delete
+- Document reload or structure refresh
+- Hierarchy rebuild
+- Switching between open documents
+- Closing a selected document
+- Deleting the primary item
+- Deleting the hierarchy anchor
+- Selection changes during active preview gestures
+- Lost mouse capture and cancelled drags
+- Locked and hidden components
+
+## Compatibility Cleanup
+
+Review temporary single-selection compatibility members introduced in Task 01.
+
+- Remove them where all consumers have migrated.
+- Retain only compatibility that is still required for persisted data or clearly documented external behaviour.
+- Ensure there is still one authoritative selection state.
+
+Review old `IsLocked` names and behaviour:
+
+- Remove obsolete selection-exclusion code.
+- Keep only intentional persisted-data compatibility.
+- Ensure UI and runtime terminology consistently use `Lock Transform` / `IsTransformLocked` where applicable.
+
+## Behaviour Consistency Review
+
+Confirm Panel2D and Face agree on:
+
+- Click selection
+- Ctrl-click selection
+- Empty-space behaviour
+- Rectangle replace/add
+- Primary selection rendering
+- Group move
+- Transform-lock handling
+- Selection clearing after deletion
+
+Confirm Hierarchy and Inspector remain synchronized with both views.
+
+## Performance Review
+
+Test representative larger documents.
+
+Avoid:
+
+- Rebuilding the full hierarchy on every mouse move
+- Rebuilding all Inspector rows on every preview frame
+- Creating one command per selected object
+- Repeatedly resolving the same object identities inside inner rendering loops when a local snapshot would suffice
+
+Do not introduce speculative caching unless profiling or obvious hot paths justify it.
+
+## Out of Scope
+
+- Group resize
+- Alignment/distribution
+- Duplicate/copy/paste
+- Full context-menu redesign
+- Shift modifiers in viewports
+- Relative Inspector expressions
+- Group-node selection
+
+## Tests
+
+Add or update tests for:
+
+- Atomic bulk delete
+- Ordering restoration on undo
+- Redo
+- Mixed deletable/non-deletable handling
+- Primary and anchor reconciliation
+- Selection state after undo/redo
+- Document switching and closing
+- Lost-capture preview restoration
+- Compatibility cleanup
+- Panel2D/Face behaviour parity
+
+Run the full OasisEditor test suite.
+
+## Manual Regression Checklist
+
+- Multi-select and move in Panel2D, then undo/redo.
+- Multi-select and move in Face, then undo/redo.
+- Multi-edit from Inspector, then undo/redo.
+- Delete a multi-selection from Hierarchy and undo/redo.
+- Delete a multi-selection while the primary item is not first in hierarchy order.
+- Switch documents with different selections.
+- Close and reopen documents.
+- Test locked backgrounds and unlocked normal components.
+- Test hidden components where supported.
+- Confirm Face Source Shapes, mask layers, asset inspection, resize, pan, zoom, and existing add commands still work.
+- Confirm no old lock behaviour makes an item unselectable.
+
+## Completion Report
+
+Report:
+
+- Files changed
+- Bulk delete command design
+- Compatibility members removed or retained
+- Full test results
+- Manual regression results requested
+- Remaining known limitations
+- Deferred follow-up recommendations
+
+Stop after Task 06 for final user testing and review.


### PR DESCRIPTION
## Summary

Adds a focused planning set for the Oasis Editor selection-system refactor.

The plan covers:

- document-local ordered multi-selection state with primary and hierarchy anchor
- removal of the old unselectable `IsLocked` behaviour
- explicit transform-lock semantics, including background defaults
- Panel2D Ctrl-click, rectangle selection, group movement, and atomic undo
- Face viewport parity using shared selection/move infrastructure
- hierarchy Ctrl and Shift-range selection
- Unity-style Inspector common and mixed-value multi-editing
- atomic bulk deletion and final integration hardening

## Deliberately deferred

- group resizing
- viewport Shift selection
- context-menu redesign
- alignment/distribution
- copy/paste and duplicate
- selection of hierarchy group nodes as component groups

## Files

- `Docs/Selection/MULTI_SELECTION_CONTEXT.md`
- `Docs/Selection/TASK_01_SELECTION_FOUNDATION_AND_TRANSFORM_LOCK.md`
- `Docs/Selection/TASK_02_PANEL2D_MULTI_SELECTION_AND_GROUP_MOVE.md`
- `Docs/Selection/TASK_03_FACE_MULTI_SELECTION_PARITY.md`
- `Docs/Selection/TASK_04_HIERARCHY_MULTI_SELECTION.md`
- `Docs/Selection/TASK_05_INSPECTOR_MULTI_EDIT.md`
- `Docs/Selection/TASK_06_BULK_DELETE_AND_INTEGRATION_HARDENING.md`
- `Docs/Selection/CODEX_START_PROMPT.md`

No production code is changed by this PR.