### PR TITLE
Panel2D: multi-selection and atomic group-move (Task 02)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DSelectionServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DSelectionServiceTests.cs
@@ -66,3 +66,86 @@ public sealed class Panel2DSelectionServiceTests
         Assert.Null(selection);
     }
 }
+
+public sealed class Panel2DSelectionInteractionServiceTests
+{
+    private static readonly EditorSelectionItem A = new(EditorSelectionDomain.PanelElement, "a");
+    private static readonly EditorSelectionItem B = new(EditorSelectionDomain.PanelElement, "b");
+
+    [Fact]
+    public void DocumentSelection_ClickReplacePreserveCtrlAndEmptySpaceBehaviors()
+    {
+        var state = new DocumentSelectionState();
+        state.Replace(A);
+        state.Add(B);
+
+        // Click an already-selected item: preserve group, make clicked item primary.
+        state.SetPrimary(A);
+        Assert.Equal(new[] { A, B }, state.Items);
+        Assert.Equal(A, state.PrimaryItem);
+
+        // Click an unselected item: replace.
+        var c = new EditorSelectionItem(EditorSelectionDomain.PanelElement, "c");
+        state.Replace(c);
+        Assert.Equal(new[] { c }, state.Items);
+
+        // Ctrl-click add/remove.
+        state.Add(A);
+        Assert.Equal(new[] { c, A }, state.Items);
+        Assert.Equal(A, state.PrimaryItem);
+        state.Toggle(A);
+        Assert.Equal(new[] { c }, state.Items);
+
+        // Empty-space clear and Ctrl-empty preserve.
+        state.Clear();
+        Assert.Empty(state.Items);
+        state.Replace(c);
+        Assert.Equal(new[] { c }, state.Items);
+    }
+
+    [Fact]
+    public void SelectItemsFromRect_UsesFullEnclosureAndReturnsAllEligiblePanelElements()
+    {
+        var elements = new[]
+        {
+            new PanelElementModel { ObjectId = "a", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true },
+            new PanelElementModel { ObjectId = "partial", Kind = PanelElementKind.Lamp, X = 8, Y = 8, Width = 10, Height = 10, IsVisible = true },
+            new PanelElementModel { ObjectId = "hidden", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10, IsVisible = false },
+            new PanelElementModel { ObjectId = "b", Kind = PanelElementKind.Reel, X = 20, Y = 20, Width = 5, Height = 5, IsVisible = true }
+        };
+
+        var selected = Panel2DSelectionInteractionService.SelectItemsFromRect(elements, new Rect(0, 0, 25, 25));
+
+        Assert.Equal(new[] { "a", "b" }, selected.Select(item => item.ObjectId));
+    }
+
+    [Fact]
+    public void RectangleReplaceAndCtrlAdd_UseDocumentSelectionState()
+    {
+        var state = new DocumentSelectionState();
+        state.Replace(A);
+        state.Replace(new[] { B });
+        Assert.Equal(new[] { B }, state.Items);
+
+        state.AddRange(new[] { A });
+        Assert.Equal(new[] { B, A }, state.Items);
+    }
+
+    [Fact]
+    public void LockedElementCannotStartMoveAndSingleUnlockedSelectionCanShowResizeHandles()
+    {
+        var state = new DocumentSelectionState();
+        var unlocked = new PanelElementModel { ObjectId = "unlocked", IsTransformLocked = false };
+        var locked = new PanelElementModel { ObjectId = "locked", IsTransformLocked = true };
+        state.Replace(Panel2DSelectionInteractionService.ToSelectionItem(unlocked));
+        state.Add(Panel2DSelectionInteractionService.ToSelectionItem(locked));
+
+        Assert.True(Panel2DSelectionInteractionService.CanStartGroupMoveFrom(unlocked, state));
+        Assert.False(Panel2DSelectionInteractionService.CanStartGroupMoveFrom(locked, state));
+        Assert.False(Panel2DSelectionInteractionService.CanShowResizeHandles(state.Items, unlocked));
+
+        state.Replace(Panel2DSelectionInteractionService.ToSelectionItem(unlocked));
+        Assert.True(Panel2DSelectionInteractionService.CanShowResizeHandles(state.Items, unlocked));
+        Assert.False(Panel2DSelectionInteractionService.CanShowResizeHandles(state.Items, locked));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementBulkMoveServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementBulkMoveServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PanelElementBulkMoveServiceTests
+{
+    [Fact]
+    public void ComputeMovedElements_UsesOriginalSnapshotsAndSharedDelta()
+    {
+        var document = CreateDocument(
+            new PanelElementModel { ObjectId = "a", Kind = PanelElementKind.Lamp, X = 10, Y = 20, Width = 5, Height = 5, IsVisible = true },
+            new PanelElementModel { ObjectId = "b", Kind = PanelElementKind.Reel, X = 30, Y = 40, Width = 5, Height = 5, IsVisible = true });
+        document.SelectionState.Replace(new EditorSelectionItem(EditorSelectionDomain.PanelElement, "a"));
+        document.SelectionState.Add(new EditorSelectionItem(EditorSelectionDomain.PanelElement, "b"));
+
+        var snapshots = PanelElementBulkMoveService.CaptureMovableSelection(document);
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreview(document, "a", PanelElementModelCloner.Clone(document.GetPanelElements()[0], x: 999, y: 999)));
+
+        var moved = PanelElementBulkMoveService.ComputeMovedElements(snapshots, new Point(0, 0), new Point(7, 9));
+
+        Assert.Equal(17, moved["a"].X);
+        Assert.Equal(29, moved["a"].Y);
+        Assert.Equal(37, moved["b"].X);
+        Assert.Equal(49, moved["b"].Y);
+    }
+
+    [Fact]
+    public void CaptureMovableSelection_ExcludesSelectedTransformLockedMembers()
+    {
+        var document = CreateDocument(
+            new PanelElementModel { ObjectId = "a", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new PanelElementModel { ObjectId = "locked", Kind = PanelElementKind.Background, X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true, IsTransformLocked = true });
+        document.SelectionState.Replace(new EditorSelectionItem(EditorSelectionDomain.PanelElement, "a"));
+        document.SelectionState.Add(new EditorSelectionItem(EditorSelectionDomain.PanelElement, "locked"));
+
+        var snapshots = PanelElementBulkMoveService.CaptureMovableSelection(document);
+
+        Assert.Equal(new[] { "a" }, snapshots.Select(snapshot => snapshot.ObjectId));
+    }
+
+    [Fact]
+    public void BulkPreviewCancellation_RestoresAllPreviewedItemsWithoutUndoHistory()
+    {
+        var document = CreateDocument(
+            new PanelElementModel { ObjectId = "a", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new PanelElementModel { ObjectId = "b", Kind = PanelElementKind.Reel, X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetPanelElements().ToDictionary(element => element.ObjectId, element => PanelElementModelCloner.Clone(element));
+        var preview = originals.ToDictionary(pair => pair.Key, pair => PanelElementModelCloner.Clone(pair.Value, x: pair.Value.X + 5, y: pair.Value.Y + 6));
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreviews(document, preview));
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreviews(document, originals));
+
+        Assert.Equal(0, document.GetPanelElements()[0].X);
+        Assert.Equal(10, document.GetPanelElements()[1].X);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.False(document.IsDirty);
+    }
+
+    [Fact]
+    public void BulkMoveCommand_IsOneAtomicUndoRedoEntryForCompleteMove()
+    {
+        var document = CreateDocument(
+            new PanelElementModel { ObjectId = "a", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new PanelElementModel { ObjectId = "b", Kind = PanelElementKind.Reel, X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetPanelElements().ToDictionary(element => element.ObjectId, element => PanelElementModelCloner.Clone(element));
+        var moved = originals.ToDictionary(pair => pair.Key, pair => PanelElementModelCloner.Clone(pair.Value, x: pair.Value.X + 3, y: pair.Value.Y + 4));
+
+        document.CommandService.Execute(CanvasMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, moved, originals, "Move elements"));
+
+        Assert.Single(document.CommandService.History.Entries);
+        Assert.Equal(3, document.GetPanelElements()[0].X);
+        Assert.Equal(13, document.GetPanelElements()[1].X);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Equal(0, document.GetPanelElements()[0].X);
+        Assert.Equal(10, document.GetPanelElements()[1].X);
+
+        Assert.True(document.CommandService.TryRedo());
+        Assert.Equal(3, document.GetPanelElements()[0].X);
+        Assert.Equal(13, document.GetPanelElements()[1].X);
+    }
+
+    private static DocumentTabViewModel CreateDocument(params PanelElementModel[] elements)
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(elements);
+        return document;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -129,6 +129,119 @@ internal static class CanvasMutationCommands
         return new UpdateElementMutationCommand(documentId, document, objectId, updatedElement, description, originalElement);
     }
 
+    public static Commands.ICommand CreateBulkUpdateElementsCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        IReadOnlyDictionary<string, PanelElementModel> updatedElements,
+        IReadOnlyDictionary<string, PanelElementModel> originalElements,
+        string description)
+    {
+        return new BulkUpdateElementsMutationCommand(documentId, document, updatedElements, originalElements, description);
+    }
+
+
+    private sealed class BulkUpdateElementsMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly Dictionary<string, PanelElementModel> _updatedElements;
+        private readonly Dictionary<string, PanelElementModel> _originalElements;
+        private readonly string _description;
+        private Dictionary<string, PanelElementModel>? _previousElements;
+
+        public BulkUpdateElementsMutationCommand(Guid documentId, DocumentTabViewModel document, IReadOnlyDictionary<string, PanelElementModel> updatedElements, IReadOnlyDictionary<string, PanelElementModel> originalElements, string description)
+        {
+            _documentId = documentId;
+            _document = document;
+            _updatedElements = updatedElements.ToDictionary(pair => pair.Key, pair => PanelElementModelCloner.Clone(pair.Value));
+            _originalElements = originalElements.ToDictionary(pair => pair.Key, pair => PanelElementModelCloner.Clone(pair.Value));
+            _description = string.IsNullOrWhiteSpace(description) ? "Update elements" : description;
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => _description;
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetPanelElements().ToList();
+            var previous = new Dictionary<string, PanelElementModel>();
+            var changedProperties = PanelChangeProperties.None;
+            var changed = false;
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var existing = elements[i];
+                if (string.IsNullOrWhiteSpace(existing.ObjectId) || !_updatedElements.TryGetValue(existing.ObjectId, out var updated))
+                {
+                    continue;
+                }
+
+                if (updated.Kind != existing.Kind || !PanelElementValidation.IsValidForInspectorUpdate(updated))
+                {
+                    continue;
+                }
+
+                if (_originalElements.TryGetValue(existing.ObjectId, out var original) && original.Kind == existing.Kind && PanelElementValidation.IsValidForInspectorUpdate(original))
+                {
+                    previous[existing.ObjectId] = PanelElementModelCloner.Clone(original);
+                }
+                else
+                {
+                    previous[existing.ObjectId] = PanelElementModelCloner.Clone(existing);
+                }
+
+                if (!PanelElementModelComparer.AreEquivalent(existing, updated))
+                {
+                    elements[i] = PanelElementModelCloner.Clone(updated);
+                    changed = true;
+                }
+
+                changedProperties |= UpdateElementMutationCommand.GetChangedProperties(previous[existing.ObjectId], updated);
+            }
+
+            if (previous.Count == 0)
+            {
+                return;
+            }
+
+            _previousElements = previous;
+            if (changed)
+            {
+                _document.SetPanelElements(elements, CreateElementChange(_document, null, changedProperties));
+            }
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_previousElements is null || _previousElements.Count == 0)
+            {
+                return;
+            }
+
+            var elements = _document.GetPanelElements().ToList();
+            var changed = false;
+            foreach (var previous in _previousElements)
+            {
+                var index = elements.FindIndex(element => string.Equals(element.ObjectId, previous.Key, StringComparison.Ordinal));
+                if (index >= 0 && !PanelElementModelComparer.AreEquivalent(elements[index], previous.Value))
+                {
+                    elements[index] = PanelElementModelCloner.Clone(previous.Value);
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                _document.SetPanelElements(elements, CreateElementChange(_document, null, PanelChangeProperties.Geometry));
+                _document.MarkDirty();
+            }
+        }
+    }
+
     private sealed class AddPanelElementMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
     {
         private readonly Guid _documentId;
@@ -862,7 +975,7 @@ internal static class CanvasMutationCommands
             _document.MarkDirty();
         }
 
-        private static PanelChangeProperties GetChangedProperties(PanelElementModel before, PanelElementModel after)
+        internal static PanelChangeProperties GetChangedProperties(PanelElementModel before, PanelElementModel after)
         {
             var changed = PanelChangeProperties.None;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentSelectionState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentSelectionState.cs
@@ -60,25 +60,58 @@ public sealed class DocumentSelectionState
         RaiseChanged();
     }
 
+    public void Replace(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        var distinct = items.Where(item => item.IsValid).Distinct().ToList();
+        var primary = primaryItem is { IsValid: true } validPrimary && distinct.Contains(validPrimary)
+            ? validPrimary
+            : distinct.Count > 0 ? distinct[^1] : (EditorSelectionItem?)null;
+
+        if (_items.SequenceEqual(distinct) && _primaryItem == primary && _hierarchyAnchorItem == primary)
+        {
+            return;
+        }
+
+        _items.Clear();
+        _items.AddRange(distinct);
+        _primaryItem = primary;
+        _hierarchyAnchorItem = primary;
+        RaiseChanged();
+    }
+
     public void Add(EditorSelectionItem item)
     {
-        if (!item.IsValid) return;
+        AddRange([item], item);
+    }
+
+    public void AddRange(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null)
+    {
+        ArgumentNullException.ThrowIfNull(items);
         var changed = false;
-        if (!_items.Contains(item))
+        EditorSelectionItem? lastAdded = null;
+        foreach (var item in items.Where(item => item.IsValid).Distinct())
         {
-            _items.Add(item);
+            if (!_items.Contains(item))
+            {
+                _items.Add(item);
+                changed = true;
+            }
+            lastAdded = item;
+        }
+
+        var requestedPrimary = primaryItem is { IsValid: true } validPrimary && _items.Contains(validPrimary)
+            ? validPrimary
+            : lastAdded is { } added && _items.Contains(added) ? added : (EditorSelectionItem?)null;
+        if (requestedPrimary is { } primary && _primaryItem != primary)
+        {
+            _primaryItem = primary;
             changed = true;
         }
 
-        if (_primaryItem != item)
+        if (_hierarchyAnchorItem is null && _primaryItem is { } currentPrimary)
         {
-            _primaryItem = item;
-            changed = true;
-        }
-
-        if (_hierarchyAnchorItem is null)
-        {
-            _hierarchyAnchorItem = item;
+            _hierarchyAnchorItem = currentPrimary;
             changed = true;
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DSelectionInteractionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DSelectionInteractionService.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+internal static class Panel2DSelectionInteractionService
+{
+    public static EditorSelectionItem ToSelectionItem(PanelElementModel element) => new(EditorSelectionDomain.PanelElement, element.ObjectId);
+
+    public static IReadOnlyList<EditorSelectionItem> SelectItemsFromRect(IReadOnlyList<PanelElementModel> elements, Rect rect)
+    {
+        return elements
+            .Where(element => element.IsVisible
+                              && !string.IsNullOrWhiteSpace(element.ObjectId)
+                              && IsFullyEnclosed(element, rect))
+            .Select(ToSelectionItem)
+            .ToList();
+    }
+
+    public static bool IsFullyEnclosed(PanelElementModel element, Rect rect)
+    {
+        var left = Math.Min(element.X, element.X + element.Width);
+        var right = Math.Max(element.X, element.X + element.Width);
+        var top = Math.Min(element.Y, element.Y + element.Height);
+        var bottom = Math.Max(element.Y, element.Y + element.Height);
+        return left >= rect.Left && right <= rect.Right && top >= rect.Top && bottom <= rect.Bottom;
+    }
+
+    public static bool CanShowResizeHandles(IReadOnlyList<EditorSelectionItem> selectedItems, PanelElementModel? primaryElement)
+    {
+        return selectedItems.Count(item => item.Domain == EditorSelectionDomain.PanelElement) == 1
+               && primaryElement is not null
+               && TransformLockInteractionService.CanMoveOrResize(primaryElement);
+    }
+
+    public static bool CanStartGroupMoveFrom(PanelElementModel element, DocumentSelectionState selectionState)
+    {
+        return TransformLockInteractionService.CanMoveOrResize(element)
+               && selectionState.Items.Contains(ToSelectionItem(element));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementBulkMoveService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementBulkMoveService.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+internal sealed record PanelElementMoveSnapshot(string ObjectId, PanelElementModel OriginalElement);
+
+internal static class PanelElementBulkMoveService
+{
+    public static IReadOnlyList<PanelElementMoveSnapshot> CaptureMovableSelection(DocumentTabViewModel document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var snapshots = new List<PanelElementMoveSnapshot>();
+        foreach (var item in document.SelectionState.Items)
+        {
+            if (item.Domain != EditorSelectionDomain.PanelElement || !document.TryGetPanelElementByObjectId(item.ObjectId, out var element))
+            {
+                continue;
+            }
+
+            if (!TransformLockInteractionService.CanMoveOrResize(element))
+            {
+                continue;
+            }
+
+            snapshots.Add(new PanelElementMoveSnapshot(item.ObjectId, PanelElementModelCloner.Clone(element)));
+        }
+
+        return snapshots;
+    }
+
+    public static IReadOnlyDictionary<string, PanelElementModel> ComputeMovedElements(IEnumerable<PanelElementMoveSnapshot> snapshots, Point start, Point end)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+        return snapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => Panel2DMoveComputationService.ComputeMovedElement(snapshot.OriginalElement, start, end));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
@@ -2,6 +2,20 @@ namespace OasisEditor;
 
 internal static class PanelElementPreviewMutationService
 {
+    public static bool TryApplyPreviews(DocumentTabViewModel document, IReadOnlyDictionary<string, PanelElementModel> updatedElements)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(updatedElements);
+
+        var changed = false;
+        foreach (var update in updatedElements)
+        {
+            changed |= TryApplyPreview(document, update.Key, update.Value);
+        }
+
+        return changed;
+    }
+
     public static bool TryApplyPreview(DocumentTabViewModel document, string objectId, PanelElementModel updatedElement)
     {
         ArgumentNullException.ThrowIfNull(document);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -26,6 +26,7 @@ public partial class SkiaPanel2DEditView : UserControl
     private Point _leftMouseDownStart;
     private Point _dragSelectionCurrent;
     private PanelElementModel? _moveSourceElement;
+    private IReadOnlyList<PanelElementMoveSnapshot> _moveSnapshots = [];
     private PanelElementModel? _resizeSourceElement;
     private PanelFaceSourceShapeModel? _shapeDragSource;
     private int _activeShapeCornerIndex = -1;
@@ -179,31 +180,29 @@ public partial class SkiaPanel2DEditView : UserControl
 
     private static void DrawSelectionOutline(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
     {
-        var selection = document.HierarchySelectedPanelSelection;
-        if (selection is null)
+        foreach (var item in document.SelectionState.Items.Where(item => item.Domain == EditorSelectionDomain.PanelElement))
         {
-            return;
+            if (!document.TryGetPanelElementByObjectId(item.ObjectId, out var selectedElement))
+            {
+                continue;
+            }
+
+            var isPrimary = document.SelectionState.PrimaryItem == item;
+            using var selectionPaint = new SKPaint
+            {
+                Style = SKPaintStyle.Stroke,
+                Color = isPrimary ? new SKColor(0xFF, 0xEA, 0x00) : new SKColor(0x4F, 0xC3, 0xF7),
+                StrokeWidth = (float)((isPrimary ? 3d : 2d) / viewport.NormalizedZoom),
+                IsAntialias = true
+            };
+
+            canvas.DrawRect(
+                (float)selectedElement.X,
+                (float)selectedElement.Y,
+                (float)Math.Max(0d, selectedElement.Width),
+                (float)Math.Max(0d, selectedElement.Height),
+                selectionPaint);
         }
-
-        if (!document.TryGetPanelElement(selection.Value, out var selectedElement))
-        {
-            return;
-        }
-
-        using var selectionPaint = new SKPaint
-        {
-            Style = SKPaintStyle.Stroke,
-            Color = new SKColor(0x4F, 0xC3, 0xF7),
-            StrokeWidth = (float)(2d / viewport.NormalizedZoom),
-            IsAntialias = true
-        };
-
-        canvas.DrawRect(
-            (float)selectedElement.X,
-            (float)selectedElement.Y,
-            (float)Math.Max(0d, selectedElement.Width),
-            (float)Math.Max(0d, selectedElement.Height),
-            selectionPaint);
     }
 
     private static void DrawResizeHandles(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
@@ -219,7 +218,7 @@ public partial class SkiaPanel2DEditView : UserControl
             return;
         }
 
-        if (!TransformLockInteractionService.CanMoveOrResize(selectedElement))
+        if (!Panel2DSelectionInteractionService.CanShowResizeHandles(document.SelectionState.Items, selectedElement))
         {
             return;
         }
@@ -302,15 +301,15 @@ public partial class SkiaPanel2DEditView : UserControl
             }
 
             if (document is not null
-                && TryGetSelectedElement(document, out var selectedElement)
-                && IsPointInsideElement(pointer, selectedElement, new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY))
-                && TransformLockInteractionService.CanMoveOrResize(selectedElement))
+                && TryGetSelectedElementAtPoint(document, pointer, out var selectedElement)
+                && Panel2DSelectionInteractionService.CanStartGroupMoveFrom(selectedElement, document.SelectionState))
             {
                 _isLeftMouseDown = true;
                 _isDragSelecting = false;
                 _isMovingSelection = true;
                 _isResizingSelection = false;
                 _moveSourceElement = selectedElement;
+                _moveSnapshots = PanelElementBulkMoveService.CaptureMovableSelection(document);
                 _leftMouseDownStart = pointer;
                 _dragSelectionCurrent = pointer;
                 EditSkiaSurface.CaptureMouse();
@@ -438,6 +437,7 @@ public partial class SkiaPanel2DEditView : UserControl
             _isMovingSelection = false;
             _isResizingSelection = false;
             _moveSourceElement = null;
+            _moveSnapshots = [];
             _resizeSourceElement = null;
             _shapeDragSource = null;
             _activeShapeCornerIndex = -1;
@@ -480,6 +480,11 @@ public partial class SkiaPanel2DEditView : UserControl
         if (_isPanning)
         {
             EndPan(releaseMouseCapture: false);
+        }
+
+        if (_isLeftMouseDown && _isMovingSelection)
+        {
+            CancelActiveMovePreview();
         }
 
         if (_isLeftMouseDown && _isResizingSelection && _shapeDragSource is null)
@@ -603,14 +608,34 @@ public partial class SkiaPanel2DEditView : UserControl
 
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var documentPoint = viewport.ScreenToDocument(screenPoint);
+        var isCtrl = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control;
         var shapeSelection = document.GetPanelFaceSourceShapes().LastOrDefault(shape => IsInsideShapeBounds(shape, documentPoint));
-        var selection = shapeSelection is not null
-            ? PanelFaceSourceShapeCommands.ToSelection(shapeSelection)
-            : Panel2DSelectionService.SelectFromPoint(
-                document.GetPanelElements(),
-                documentPoint,
-                document.HierarchySelectedPanelSelection);
-        NotifySelection(document, selection);
+        if (shapeSelection is not null)
+        {
+            NotifySelection(document, PanelFaceSourceShapeCommands.ToSelection(shapeSelection));
+            return;
+        }
+
+        var selection = Panel2DSelectionService.SelectFromPoint(document.GetPanelElements(), documentPoint, document.HierarchySelectedPanelSelection);
+        if (selection is not { } selected)
+        {
+            if (!isCtrl) document.SelectionState.Clear();
+            return;
+        }
+
+        var item = new EditorSelectionItem(EditorSelectionDomain.PanelElement, selected.ObjectId);
+        if (isCtrl)
+        {
+            document.SelectionState.Toggle(item);
+        }
+        else if (!document.SelectionState.Items.Contains(item))
+        {
+            document.SelectionState.Replace(item);
+        }
+        else
+        {
+            document.SelectionState.SetPrimary(item);
+        }
     }
 
     private static bool HasDraggedSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
@@ -632,13 +657,15 @@ public partial class SkiaPanel2DEditView : UserControl
         var a = viewport.ScreenToDocument(startScreenPoint);
         var b = viewport.ScreenToDocument(endScreenPoint);
         var rect = Panel2DSelectionBoundsService.CreateNormalizedDocumentRect(a, b);
-        var selection = Panel2DSelectionService.SelectFromRect(
-            document.GetPanelElements(),
-            rect.Left,
-            rect.Top,
-            rect.Right,
-            rect.Bottom);
-        NotifySelection(document, selection);
+        var items = Panel2DSelectionInteractionService.SelectItemsFromRect(document.GetPanelElements(), rect);
+        if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+        {
+            document.SelectionState.AddRange(items);
+        }
+        else
+        {
+            document.SelectionState.Replace(items);
+        }
     }
 
     private void DrawDragSelectionRect(SKCanvas canvas, PanelViewportTransform viewport)
@@ -675,7 +702,7 @@ public partial class SkiaPanel2DEditView : UserControl
 
     private void HandleMoveSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
     {
-        if (_moveSourceElement is null || string.IsNullOrWhiteSpace(_moveSourceElement.ObjectId))
+        if (_moveSnapshots.Count == 0)
         {
             return;
         }
@@ -688,21 +715,16 @@ public partial class SkiaPanel2DEditView : UserControl
             return;
         }
 
-        var updated = Panel2DMoveComputationService.ComputeMovedElement(_moveSourceElement, start, end);
-        var moveCommand = CanvasMutationCommands.CreateUpdateElementCommand(
-            document.DocumentId,
-            document,
-            _moveSourceElement.ObjectId,
-            updated,
-            _moveSourceElement,
-            "Move element");
+        var updated = PanelElementBulkMoveService.ComputeMovedElements(_moveSnapshots, start, end);
+        var originals = _moveSnapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => snapshot.OriginalElement);
+        var moveCommand = CanvasMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, updated, originals, updated.Count == 1 ? "Move element" : "Move elements");
         document.CommandService.Execute(moveCommand);
     }
 
     private void UpdateMoveSelectionPreview(Point currentScreenPoint)
     {
         var document = Document;
-        if (document is null || _moveSourceElement is null || string.IsNullOrWhiteSpace(_moveSourceElement.ObjectId))
+        if (document is null || _moveSnapshots.Count == 0)
         {
             return;
         }
@@ -710,14 +732,14 @@ public partial class SkiaPanel2DEditView : UserControl
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var start = viewport.ScreenToDocument(_leftMouseDownStart);
         var current = viewport.ScreenToDocument(currentScreenPoint);
-        var updated = Panel2DMoveComputationService.ComputeMovedElement(_moveSourceElement, start, current);
-        if (PanelElementPreviewMutationService.TryApplyPreview(document, _moveSourceElement.ObjectId, updated))
+        var updated = PanelElementBulkMoveService.ComputeMovedElements(_moveSnapshots, start, current);
+        if (PanelElementPreviewMutationService.TryApplyPreviews(document, updated))
         {
             RequestRender();
         }
     }
 
-    private static bool TryGetSelectedElement(DocumentTabViewModel document, out PanelElementModel selectedElement)
+    private static bool TryGetPrimarySelectedElement(DocumentTabViewModel document, out PanelElementModel selectedElement)
     {
         selectedElement = new PanelElementModel();
         var selection = document.HierarchySelectedPanelSelection;
@@ -727,6 +749,21 @@ public partial class SkiaPanel2DEditView : UserControl
         }
 
         return document.TryGetPanelElement(selection.Value, out selectedElement);
+    }
+
+    private static bool TryGetSelectedElementAtPoint(DocumentTabViewModel document, Point screenPoint, out PanelElementModel selectedElement)
+    {
+        selectedElement = new PanelElementModel();
+        var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
+        foreach (var item in document.SelectionState.Items.Where(item => item.Domain == EditorSelectionDomain.PanelElement).Reverse())
+        {
+            if (document.TryGetPanelElementByObjectId(item.ObjectId, out var element) && IsPointInsideElement(screenPoint, element, viewport))
+            {
+                selectedElement = element;
+                return true;
+            }
+        }
+        return false;
     }
 
     private static bool IsPointInsideElement(Point screenPoint, PanelElementModel element, PanelViewportTransform viewport)
@@ -801,6 +838,27 @@ public partial class SkiaPanel2DEditView : UserControl
         EditSkiaSurface.Cursor = Cursors.Arrow;
     }
 
+    private void CancelActiveMovePreview()
+    {
+        var document = Document;
+        if (document is not null && _moveSnapshots.Count > 0)
+        {
+            var originals = _moveSnapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => snapshot.OriginalElement);
+            if (PanelElementPreviewMutationService.TryApplyPreviews(document, originals))
+            {
+                RequestRender();
+            }
+        }
+
+        _isLeftMouseDown = false;
+        _isDragSelecting = false;
+        _isMovingSelection = false;
+        _isResizingSelection = false;
+        _moveSourceElement = null;
+        _moveSnapshots = [];
+        EditSkiaSurface.Cursor = Cursors.Arrow;
+    }
+
     private void UpdateHoverCursor(Point screenPoint)
     {
         if (_isPanning || (_isLeftMouseDown && _isResizingSelection && _shapeDragSource is null))
@@ -834,14 +892,14 @@ public partial class SkiaPanel2DEditView : UserControl
     {
         handleKind = ResizeHandleKind.None;
         selectedElement = new PanelElementModel();
-        if (!TryGetSelectedElement(document, out selectedElement))
+        if (!TryGetPrimarySelectedElement(document, out selectedElement))
         {
             return false;
         }
 
         var viewport = new PanelViewportTransform(document.PanelZoom, document.PanelPanX, document.PanelPanY);
         var docPoint = viewport.ScreenToDocument(screenPoint);
-        if (!TransformLockInteractionService.CanMoveOrResize(selectedElement))
+        if (!Panel2DSelectionInteractionService.CanShowResizeHandles(document.SelectionState.Items, selectedElement))
         {
             return false;
         }


### PR DESCRIPTION
### Motivation
- Implement Task 02: add Panel2D viewport multi-selection, rectangle selection, and atomic group-move using the existing `DocumentSelectionState` as the single authoritative selection model. 
- Ensure group movement previews are computed from immutable drag-start snapshots and that transform-locked members remain selected but stationary. 
- Introduce small reusable infrastructure for bulk moves suitable for later Face viewport reuse while preserving existing single-item resize/Face Source Shape behaviour.

### Description
- Extended `DocumentSelectionState` with bulk operations: `Replace(IEnumerable<EditorSelectionItem>)`, `AddRange(...)` and adjusted single-item `Add` to reuse the bulk API so rectangle and Ctrl-add flows can update ordered selection sets. 
- Updated `SkiaPanel2DEditView.xaml.cs` to drive click, Ctrl-click toggle, empty-space clear/Ctrl-preserve, rectangle replace/Ctrl-add, multi-outline rendering (all selected items) with a stronger primary outline, single-item resize-handle eligibility, and group-move gesture handling and previews from `DocumentSelectionState`. 
- Added `Panel2DSelectionInteractionService` for rectangle full-enclosure selection logic and resize/move eligibility helpers. 
- Added `PanelElementBulkMoveService` that captures immutable per-item snapshots at drag start and computes moved elements from the shared document-space delta. 
- Extended `PanelElementPreviewMutationService` with `TryApplyPreviews(...)` to apply/restore bulk previews, and introduced `CanvasMutationCommands.CreateBulkUpdateElementsCommand(...)` plus the `BulkUpdateElementsMutationCommand` implementation so group moves commit as a single atomic undoable command. 
- Tests added to cover click/ctrl behaviour, rectangle full-enclosure rules, locked-member exclusion from movement, preview cancellation, delta computation, resize-handle eligibility, and that bulk move produces a single undo/redo entry (`Panel2DSelectionInteractionServiceTests` and `PanelElementBulkMoveServiceTests`). 
- No migration, old `IsLocked` compatibility, or schema fallback code was introduced.

### Testing
- Added focused unit tests: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DSelectionServiceTests.cs` (new interaction tests appended) and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementBulkMoveServiceTests.cs`; these tests were added but not executed in this environment. 
- No automated tests were run inside this agent environment because `WindowsNetProjects/OasisEditor/AGENTS.md` prohibits building/running the Windows/.NET/WPF toolchain here. 
- To run tests locally, execute: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` from the repository root (this environment must have the Windows/.NET/WPF toolchain available). 
- The user should verify locally: Ctrl-click multi-select and remove, click-to-replace, rectangle replace and Ctrl-add, dragging any selected unlocked element moves unlocked selected members together, preview cancellation and lost-capture restore originals, and that one Undo/Redo applies to the whole bulk move.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5392f808e8832792d5a54dc375df89)