### PR TITLE
Face: implement multi-selection parity (Task 03)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
@@ -93,11 +93,15 @@ public sealed class FaceMultiSelectionInteractionTests
         var originals = document.GetFaceElements().ToDictionary(element => element.ObjectId, element => FaceElementModelCloner.Clone(element));
         var moved = originals.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value, x: pair.Value.X + 3, y: pair.Value.Y + 4));
 
+        var originalJson = document.FaceDocumentJson;
         Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, moved));
+        Assert.Equal(originalJson, document.FaceDocumentJson);
         Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, originals));
+        Assert.Equal(originalJson, document.FaceDocumentJson);
         Assert.Empty(document.CommandService.History.Entries);
 
         document.CommandService.Execute(FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, moved, originals, "Move face elements"));
+        Assert.NotEqual(originalJson, document.FaceDocumentJson);
 
         Assert.Single(document.CommandService.History.Entries);
         Assert.Equal(3, document.GetFaceElements()[0].X);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
@@ -1,0 +1,121 @@
+using System.Windows;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FaceMultiSelectionInteractionTests
+{
+    private static readonly EditorSelectionItem A = new(EditorSelectionDomain.FaceElement, "a");
+    private static readonly EditorSelectionItem B = new(EditorSelectionDomain.FaceElement, "b");
+
+    [Fact]
+    public void DocumentSelection_ClickReplacePreserveCtrlAndEmptySpaceBehaviors_ForFaceItems()
+    {
+        var state = new DocumentSelectionState();
+        state.Replace(A);
+        state.Add(B);
+
+        state.SetPrimary(A);
+        Assert.Equal(new[] { A, B }, state.Items);
+        Assert.Equal(A, state.PrimaryItem);
+
+        var c = new EditorSelectionItem(EditorSelectionDomain.FaceElement, "c");
+        state.Replace(c);
+        Assert.Equal(new[] { c }, state.Items);
+
+        state.Add(A);
+        Assert.Equal(new[] { c, A }, state.Items);
+        state.Toggle(A);
+        Assert.Equal(new[] { c }, state.Items);
+
+        state.Clear();
+        Assert.Empty(state.Items);
+    }
+
+    [Fact]
+    public void SelectItemsFromRect_UsesFullEnclosureAndKeepsLockedArtworkSelectable()
+    {
+        var elements = new FaceElementModel[]
+        {
+            new FaceArtworkElement { ObjectId = "art", X = 0, Y = 0, Width = 10, Height = 10, IsVisible = true, IsTransformLocked = true },
+            new FaceLampWindowElement { ObjectId = "partial", X = 8, Y = 8, Width = 10, Height = 10, IsVisible = true },
+            new FaceLampWindowElement { ObjectId = "hidden", X = 0, Y = 0, Width = 10, Height = 10, IsVisible = false },
+            new FaceReelDisplayElement { ObjectId = "reel", X = 20, Y = 20, Width = 5, Height = 5, IsVisible = true }
+        };
+
+        var selected = FaceSelectionInteractionService.SelectItemsFromRect(elements, new Rect(0, 0, 25, 25));
+
+        Assert.Equal(new[] { "art", "reel" }, selected.Select(item => item.ObjectId));
+    }
+
+    [Fact]
+    public void CaptureMovableSelection_ExcludesLockedMembersAndRejectsLockedDragStart()
+    {
+        var unlocked = new FaceLampWindowElement { ObjectId = "a", X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true };
+        var locked = new FaceArtworkElement { ObjectId = "locked", X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true, IsTransformLocked = true };
+        var document = CreateDocument(unlocked, locked);
+        document.SelectionState.Replace(FaceSelectionInteractionService.ToSelectionItem(unlocked));
+        document.SelectionState.Add(FaceSelectionInteractionService.ToSelectionItem(locked));
+
+        var snapshots = FaceElementBulkMoveService.CaptureMovableSelection(document);
+
+        Assert.Equal(new[] { "a" }, snapshots.Select(snapshot => snapshot.ObjectId));
+        Assert.True(FaceSelectionInteractionService.CanStartGroupMoveFrom(unlocked, document.SelectionState));
+        Assert.False(FaceSelectionInteractionService.CanStartGroupMoveFrom(locked, document.SelectionState));
+    }
+
+    [Fact]
+    public void ComputeMovedElements_UsesImmutableOriginalsAndCommonDocumentDelta()
+    {
+        var document = CreateDocument(
+            new FaceLampWindowElement { ObjectId = "a", X = 10, Y = 20, Width = 5, Height = 5, IsVisible = true },
+            new FaceReelDisplayElement { ObjectId = "b", X = 30, Y = 40, Width = 5, Height = 5, IsVisible = true });
+        document.SelectionState.Replace(A);
+        document.SelectionState.Add(B);
+
+        var snapshots = FaceElementBulkMoveService.CaptureMovableSelection(document);
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreview(document, "a", FaceElementModelCloner.Clone(document.GetFaceElements()[0], x: 999, y: 999)));
+
+        var moved = FaceElementBulkMoveService.ComputeMovedElements(snapshots, new Point(0, 0), new Point(7, 9));
+
+        Assert.Equal(17, moved["a"].X);
+        Assert.Equal(29, moved["a"].Y);
+        Assert.Equal(37, moved["b"].X);
+        Assert.Equal(49, moved["b"].Y);
+    }
+
+    [Fact]
+    public void BulkPreviewRestoreAndBulkMoveCommand_AreAtomicUndoRedo()
+    {
+        var document = CreateDocument(
+            new FaceLampWindowElement { ObjectId = "a", X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new FaceReelDisplayElement { ObjectId = "b", X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetFaceElements().ToDictionary(element => element.ObjectId, element => FaceElementModelCloner.Clone(element));
+        var moved = originals.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value, x: pair.Value.X + 3, y: pair.Value.Y + 4));
+
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, moved));
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, originals));
+        Assert.Empty(document.CommandService.History.Entries);
+
+        document.CommandService.Execute(FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, moved, originals, "Move face elements"));
+
+        Assert.Single(document.CommandService.History.Entries);
+        Assert.Equal(3, document.GetFaceElements()[0].X);
+        Assert.Equal(13, document.GetFaceElements()[1].X);
+
+        Assert.True(document.CommandService.TryUndo());
+        Assert.Equal(0, document.GetFaceElements()[0].X);
+        Assert.Equal(10, document.GetFaceElements()[1].X);
+
+        Assert.True(document.CommandService.TryRedo());
+        Assert.Equal(3, document.GetFaceElements()[0].X);
+        Assert.Equal(13, document.GetFaceElements()[1].X);
+    }
+
+    private static DocumentTabViewModel CreateDocument(params FaceElementModel[] elements)
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));
+        document.SetFaceElements(elements);
+        return document;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementBulkMoveService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementBulkMoveService.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+internal sealed record FaceElementMoveSnapshot(string ObjectId, FaceElementModel OriginalElement);
+
+internal static class FaceElementBulkMoveService
+{
+    public static IReadOnlyList<FaceElementMoveSnapshot> CaptureMovableSelection(DocumentTabViewModel document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        var snapshots = new List<FaceElementMoveSnapshot>();
+        foreach (var item in document.SelectionState.Items)
+        {
+            if (item.Domain != EditorSelectionDomain.FaceElement || !document.TryGetFaceElementByObjectId(item.ObjectId, out var element)) continue;
+            if (!TransformLockInteractionService.CanMoveOrResize(element)) continue;
+            snapshots.Add(new FaceElementMoveSnapshot(item.ObjectId, FaceElementModelCloner.Clone(element)));
+        }
+        return snapshots;
+    }
+
+    public static IReadOnlyDictionary<string, FaceElementModel> ComputeMovedElements(IEnumerable<FaceElementMoveSnapshot> snapshots, Point start, Point end)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+        var delta = end - start;
+        return snapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => FaceElementModelCloner.Clone(snapshot.OriginalElement, x: snapshot.OriginalElement.X + delta.X, y: snapshot.OriginalElement.Y + delta.Y));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementModelCloner.cs
@@ -1,0 +1,16 @@
+namespace OasisEditor;
+
+internal static class FaceElementModelCloner
+{
+    public static FaceElementModel Clone(FaceElementModel source, double? x = null, double? y = null, double? width = null, double? height = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return FaceElementModelUpdater.Apply(source, new FaceElementModelUpdate
+        {
+            X = x ?? source.X,
+            Y = y ?? source.Y,
+            Width = width ?? source.Width,
+            Height = height ?? source.Height
+        });
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementModelComparer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementModelComparer.cs
@@ -1,0 +1,19 @@
+namespace OasisEditor;
+
+internal static class FaceElementModelComparer
+{
+    public static bool AreEquivalent(FaceElementModel left, FaceElementModel right)
+    {
+        return left.GetType() == right.GetType()
+               && left.ObjectId == right.ObjectId
+               && left.Name == right.Name
+               && left.X == right.X
+               && left.Y == right.Y
+               && left.Width == right.Width
+               && left.Height == right.Height
+               && left.IsVisible == right.IsVisible
+               && left.IsTransformLocked == right.IsTransformLocked
+               && Equals(left.LinkedMachineObjectReference, right.LinkedMachineObjectReference)
+               && left.LinkedPanel2DElementId == right.LinkedPanel2DElementId;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementPreviewMutationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementPreviewMutationService.cs
@@ -1,0 +1,30 @@
+namespace OasisEditor;
+
+internal static class FaceElementPreviewMutationService
+{
+    public static bool TryApplyPreviews(DocumentTabViewModel document, IReadOnlyDictionary<string, FaceElementModel> updatedElements)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(updatedElements);
+        var changed = false;
+        foreach (var update in updatedElements) changed |= TryApplyPreview(document, update.Key, update.Value);
+        return changed;
+    }
+
+    public static bool TryApplyPreview(DocumentTabViewModel document, string objectId, FaceElementModel updatedElement)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (string.IsNullOrWhiteSpace(objectId)) return false;
+        var elements = document.GetFaceElements().ToList();
+        var index = elements.FindIndex(element => string.Equals(element.ObjectId, objectId, StringComparison.Ordinal));
+        if (index < 0) return false;
+        var existing = elements[index];
+        if (!string.Equals(updatedElement.ObjectId, objectId, StringComparison.Ordinal)
+            || updatedElement.GetType() != existing.GetType()
+            || !FaceElementValidation.IsValidForInspectorUpdate(updatedElement)
+            || FaceElementModelComparer.AreEquivalent(existing, updatedElement)) return false;
+        elements[index] = FaceElementModelCloner.Clone(updatedElement);
+        document.SetFaceElements(elements, new PanelChangeEvent(document.DocumentId, objectId, PanelChangeProperties.Geometry, true, false, true, false));
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementPreviewMutationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceElementPreviewMutationService.cs
@@ -24,7 +24,10 @@ internal static class FaceElementPreviewMutationService
             || !FaceElementValidation.IsValidForInspectorUpdate(updatedElement)
             || FaceElementModelComparer.AreEquivalent(existing, updatedElement)) return false;
         elements[index] = FaceElementModelCloner.Clone(updatedElement);
-        document.SetFaceElements(elements, new PanelChangeEvent(document.DocumentId, objectId, PanelChangeProperties.Geometry, true, false, true, false));
+        document.SetFaceElements(
+            elements,
+            new PanelChangeEvent(document.DocumentId, objectId, PanelChangeProperties.Geometry, true, false, true, false),
+            updateSerializedDocument: false);
         return true;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -213,8 +213,6 @@ internal static class FaceMutationCommands
             WasExecuted = false;
             var elements = _document.GetFaceElements().ToList();
             var previous = new Dictionary<string, FaceElementModel>();
-            var changed = false;
-
             for (var i = 0; i < elements.Count; i++)
             {
                 var existing = elements[i];
@@ -226,13 +224,12 @@ internal static class FaceMutationCommands
                 if (!FaceElementModelComparer.AreEquivalent(existing, updated))
                 {
                     elements[i] = FaceElementModelCloner.Clone(updated);
-                    changed = true;
                 }
             }
 
             if (previous.Count == 0) return;
             _previousElements = previous;
-            if (changed) _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
+            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
             _document.MarkDirty();
             WasExecuted = true;
         }
@@ -241,16 +238,14 @@ internal static class FaceMutationCommands
         {
             if (_previousElements is null || _previousElements.Count == 0) return;
             var elements = _document.GetFaceElements().ToList();
-            var changed = false;
             for (var i = 0; i < elements.Count; i++)
             {
                 if (_previousElements.TryGetValue(elements[i].ObjectId, out var previous))
                 {
                     elements[i] = FaceElementModelCloner.Clone(previous);
-                    changed = true;
                 }
             }
-            if (changed) _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
+            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
             _document.MarkDirty();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -17,6 +17,17 @@ internal static class FaceMutationCommands
         return new UpdateFaceElementMutationCommand(documentId, document, objectId, updatedElement, description);
     }
 
+
+    public static Commands.ICommand CreateBulkUpdateElementsCommand(
+        Guid documentId,
+        DocumentTabViewModel document,
+        IReadOnlyDictionary<string, FaceElementModel> updatedElements,
+        IReadOnlyDictionary<string, FaceElementModel> originalElements,
+        string description)
+    {
+        return new BulkUpdateFaceElementsMutationCommand(documentId, document, updatedElements, originalElements, description);
+    }
+
     public static Commands.ICommand CreateAssignCabinetFaceTargetCommand(
         Guid documentId,
         DocumentTabViewModel document,
@@ -171,6 +182,75 @@ internal static class FaceMutationCommands
             elements[index] = _originalElement;
             _document.SetFaceElements(elements, CreateChange(_document, _objectId, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
             _document.HierarchySelectedPanelSelection = FaceSelectionService.ToSelectionInfo(_originalElement);
+            _document.MarkDirty();
+        }
+    }
+
+    private sealed class BulkUpdateFaceElementsMutationCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+    {
+        private readonly Guid _documentId;
+        private readonly DocumentTabViewModel _document;
+        private readonly Dictionary<string, FaceElementModel> _updatedElements;
+        private readonly Dictionary<string, FaceElementModel> _originalElements;
+        private readonly string _description;
+        private Dictionary<string, FaceElementModel>? _previousElements;
+
+        public BulkUpdateFaceElementsMutationCommand(Guid documentId, DocumentTabViewModel document, IReadOnlyDictionary<string, FaceElementModel> updatedElements, IReadOnlyDictionary<string, FaceElementModel> originalElements, string description)
+        {
+            _documentId = documentId;
+            _document = document;
+            _updatedElements = updatedElements.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value));
+            _originalElements = originalElements.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value));
+            _description = string.IsNullOrWhiteSpace(description) ? "Update face elements" : description;
+        }
+
+        public Guid DocumentId => _documentId;
+        public string Description => _description;
+        public bool WasExecuted { get; private set; }
+
+        public void Execute()
+        {
+            WasExecuted = false;
+            var elements = _document.GetFaceElements().ToList();
+            var previous = new Dictionary<string, FaceElementModel>();
+            var changed = false;
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var existing = elements[i];
+                if (string.IsNullOrWhiteSpace(existing.ObjectId) || !_updatedElements.TryGetValue(existing.ObjectId, out var updated)) continue;
+                if (updated.GetType() != existing.GetType() || !FaceElementValidation.IsValidForInspectorUpdate(updated)) continue;
+                previous[existing.ObjectId] = _originalElements.TryGetValue(existing.ObjectId, out var original) && original.GetType() == existing.GetType()
+                    ? FaceElementModelCloner.Clone(original)
+                    : FaceElementModelCloner.Clone(existing);
+                if (!FaceElementModelComparer.AreEquivalent(existing, updated))
+                {
+                    elements[i] = FaceElementModelCloner.Clone(updated);
+                    changed = true;
+                }
+            }
+
+            if (previous.Count == 0) return;
+            _previousElements = previous;
+            if (changed) _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+
+        public void Undo()
+        {
+            if (_previousElements is null || _previousElements.Count == 0) return;
+            var elements = _document.GetFaceElements().ToList();
+            var changed = false;
+            for (var i = 0; i < elements.Count; i++)
+            {
+                if (_previousElements.TryGetValue(elements[i].ObjectId, out var previous))
+                {
+                    elements[i] = FaceElementModelCloner.Clone(previous);
+                    changed = true;
+                }
+            }
+            if (changed) _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
             _document.MarkDirty();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceSelectionInteractionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceSelectionInteractionService.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+
+namespace OasisEditor;
+
+internal static class FaceSelectionInteractionService
+{
+    public static EditorSelectionItem ToSelectionItem(FaceElementModel element) => new(EditorSelectionDomain.FaceElement, element.ObjectId);
+
+    public static IReadOnlyList<EditorSelectionItem> SelectItemsFromRect(IReadOnlyList<FaceElementModel> elements, Rect rect)
+    {
+        return elements
+            .Where(element => element.IsVisible
+                              && !string.IsNullOrWhiteSpace(element.ObjectId)
+                              && IsFullyEnclosed(element, rect))
+            .Select(ToSelectionItem)
+            .ToList();
+    }
+
+    public static bool IsFullyEnclosed(FaceElementModel element, Rect rect)
+    {
+        var left = Math.Min(element.X, element.X + element.Width);
+        var right = Math.Max(element.X, element.X + element.Width);
+        var top = Math.Min(element.Y, element.Y + element.Height);
+        var bottom = Math.Max(element.Y, element.Y + element.Height);
+        return left >= rect.Left && right <= rect.Right && top >= rect.Top && bottom <= rect.Bottom;
+    }
+
+    public static bool CanStartGroupMoveFrom(FaceElementModel element, DocumentSelectionState selectionState)
+    {
+        return TransformLockInteractionService.CanMoveOrResize(element)
+               && selectionState.Items.Contains(ToSelectionItem(element));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -240,14 +240,17 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         return true;
     }
 
-    internal void SetFaceDocument(FaceDocumentModel model, PanelChangeEvent? faceChange = null)
+    internal void SetFaceDocument(FaceDocumentModel model, PanelChangeEvent? faceChange = null, bool updateSerializedDocument = true)
     {
         ArgumentNullException.ThrowIfNull(model);
 
         _faceDocumentModel = model;
-        _faceDocumentJson = GetFaceDocumentJson();
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
-        ReconcileSelection();
+        if (updateSerializedDocument)
+        {
+            _faceDocumentJson = GetFaceDocumentJson();
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FaceDocumentJson)));
+            ReconcileSelection();
+        }
 
         if (faceChange is PanelChangeEvent change)
         {
@@ -255,7 +258,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         }
     }
 
-    internal void SetFaceElements(IReadOnlyList<FaceElementModel> elements, PanelChangeEvent? faceChange = null)
+    internal void SetFaceElements(IReadOnlyList<FaceElementModel> elements, PanelChangeEvent? faceChange = null, bool updateSerializedDocument = true)
     {
         SetFaceDocument(new FaceDocumentModel
         {
@@ -275,7 +278,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             LampEmitters = _faceDocumentModel.LampEmitters,
             Layers = _faceDocumentModel.Layers,
             Elements = elements.ToArray()
-        }, faceChange);
+        }, faceChange, updateSerializedDocument);
     }
 
     internal Panel2DDocumentModel GetPanelDocument()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -23,6 +23,7 @@ public partial class SkiaFaceEditView : UserControl
     private bool _isLeftMouseDown;
     private bool _isDragSelecting;
     private bool _isMovingSelection;
+    private bool _isCommittingMoveSelection;
     private Point _leftMouseDownStart;
     private Point _dragSelectionCurrent;
     private FaceElementModel? _moveSourceElement;
@@ -513,7 +514,15 @@ public partial class SkiaFaceEditView : UserControl
                 {
                     if (HasDraggedSelection(document, _leftMouseDownStart, _dragSelectionCurrent))
                     {
-                        HandleMoveSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                        _isCommittingMoveSelection = true;
+                        try
+                        {
+                            HandleMoveSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                        }
+                        finally
+                        {
+                            _isCommittingMoveSelection = false;
+                        }
                     }
                     else
                     {
@@ -571,7 +580,7 @@ public partial class SkiaFaceEditView : UserControl
             EndPan(releaseMouseCapture: false);
         }
 
-        if (_isLeftMouseDown && _isMovingSelection)
+        if (_isLeftMouseDown && _isMovingSelection && !_isCommittingMoveSelection)
         {
             CancelActiveMovePreview();
         }
@@ -715,6 +724,7 @@ public partial class SkiaFaceEditView : UserControl
         _isLeftMouseDown = false;
         _isDragSelecting = false;
         _isMovingSelection = false;
+        _isCommittingMoveSelection = false;
         _moveSourceElement = null;
         _moveSnapshots = [];
         FaceSkiaSurface.Cursor = Cursors.Arrow;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaFaceEditView.xaml.cs
@@ -16,9 +16,17 @@ namespace OasisEditor.Views;
 public partial class SkiaFaceEditView : UserControl
 {
     private const double TargetFrameMillis = 16.0;
+    private const double DragSelectionStartThreshold = 4d;
     private static readonly ConcurrentDictionary<string, SKImage?> CachedArtworkImages = new(StringComparer.OrdinalIgnoreCase);
     private DocumentTabViewModel? _subscribedDocument;
     private bool _isPanning;
+    private bool _isLeftMouseDown;
+    private bool _isDragSelecting;
+    private bool _isMovingSelection;
+    private Point _leftMouseDownStart;
+    private Point _dragSelectionCurrent;
+    private FaceElementModel? _moveSourceElement;
+    private IReadOnlyList<FaceElementMoveSnapshot> _moveSnapshots = [];
     private bool _isRenderQueued;
     private bool _isRenderDirty;
     private Point _panStart;
@@ -160,6 +168,8 @@ public partial class SkiaFaceEditView : UserControl
         canvas.Translate((float)viewport.PanX, (float)viewport.PanY);
         canvas.Scale((float)viewport.NormalizedZoom, (float)viewport.NormalizedZoom);
         DrawFaceElements(canvas, document, viewport);
+        DrawSelectionOutline(canvas, document, viewport);
+        DrawDragSelectionRect(canvas, viewport);
         canvas.Restore();
     }
 
@@ -206,22 +216,22 @@ public partial class SkiaFaceEditView : UserControl
             }
         }
 
-        if (document.HierarchySelectedPanelSelection is PanelSelectionInfo selection
-            && document.TryGetFaceElement(selection, out var selectedElement))
+    }
+
+    private static void DrawSelectionOutline(SKCanvas canvas, DocumentTabViewModel document, PanelViewportTransform viewport)
+    {
+        foreach (var item in document.SelectionState.Items.Where(item => item.Domain == EditorSelectionDomain.FaceElement))
         {
+            if (!document.TryGetFaceElementByObjectId(item.ObjectId, out var selectedElement)) continue;
+            var isPrimary = document.SelectionState.PrimaryItem == item;
             using var selectionPaint = new SKPaint
             {
                 Style = SKPaintStyle.Stroke,
-                Color = new SKColor(0x4F, 0xC3, 0xF7),
-                StrokeWidth = (float)(2d / viewport.NormalizedZoom),
+                Color = isPrimary ? new SKColor(0xFF, 0xEA, 0x00) : new SKColor(0x4F, 0xC3, 0xF7),
+                StrokeWidth = (float)((isPrimary ? 3d : 2d) / viewport.NormalizedZoom),
                 IsAntialias = true
             };
-            canvas.DrawRect(
-                (float)selectedElement.X,
-                (float)selectedElement.Y,
-                (float)Math.Max(0d, selectedElement.Width),
-                (float)Math.Max(0d, selectedElement.Height),
-                selectionPaint);
+            canvas.DrawRect((float)selectedElement.X, (float)selectedElement.Y, (float)Math.Max(0d, selectedElement.Width), (float)Math.Max(0d, selectedElement.Height), selectionPaint);
         }
     }
 
@@ -416,7 +426,28 @@ public partial class SkiaFaceEditView : UserControl
 
         if (eventArgs.ChangedButton == MouseButton.Left)
         {
-            HandleSelectionClick(eventArgs.GetPosition(FaceSkiaSurface));
+            var pointer = eventArgs.GetPosition(FaceSkiaSurface);
+            if (TryGetSelectedElementAtPoint(document, pointer, out var selectedElement)
+                && FaceSelectionInteractionService.CanStartGroupMoveFrom(selectedElement, document.SelectionState))
+            {
+                _isLeftMouseDown = true;
+                _isDragSelecting = false;
+                _isMovingSelection = true;
+                _moveSourceElement = selectedElement;
+                _moveSnapshots = FaceElementBulkMoveService.CaptureMovableSelection(document);
+                _leftMouseDownStart = pointer;
+                _dragSelectionCurrent = pointer;
+                FaceSkiaSurface.CaptureMouse();
+                eventArgs.Handled = true;
+                return;
+            }
+
+            _isLeftMouseDown = true;
+            _isDragSelecting = false;
+            _isMovingSelection = false;
+            _leftMouseDownStart = pointer;
+            _dragSelectionCurrent = pointer;
+            FaceSkiaSurface.CaptureMouse();
             eventArgs.Handled = true;
             return;
         }
@@ -436,6 +467,24 @@ public partial class SkiaFaceEditView : UserControl
 
     private void OnFaceSkiaSurfaceMouseMove(object sender, MouseEventArgs eventArgs)
     {
+        if (_isLeftMouseDown)
+        {
+            _dragSelectionCurrent = eventArgs.GetPosition(FaceSkiaSurface);
+            if (_isMovingSelection)
+            {
+                UpdateMoveSelectionPreview(_dragSelectionCurrent);
+                return;
+            }
+
+            if (!_isDragSelecting && Panel2DViewportInteractionService.ShouldStartDragSelection(_leftMouseDownStart, _dragSelectionCurrent, DragSelectionStartThreshold))
+            {
+                _isDragSelecting = true;
+            }
+
+            if (_isDragSelecting) RequestRender();
+            return;
+        }
+
         var document = Document;
         if (!_isPanning || document is null)
         {
@@ -451,6 +500,43 @@ public partial class SkiaFaceEditView : UserControl
 
     private void OnFaceSkiaSurfaceMouseUp(object sender, MouseButtonEventArgs eventArgs)
     {
+        if (eventArgs.ChangedButton == MouseButton.Left)
+        {
+            var document = Document;
+            if (document is not null)
+            {
+                if (_isDragSelecting)
+                {
+                    HandleDragSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                }
+                else if (_isMovingSelection)
+                {
+                    if (HasDraggedSelection(document, _leftMouseDownStart, _dragSelectionCurrent))
+                    {
+                        HandleMoveSelection(document, _leftMouseDownStart, _dragSelectionCurrent);
+                    }
+                    else
+                    {
+                        HandleSelectionClick(_leftMouseDownStart);
+                    }
+                }
+                else
+                {
+                    HandleSelectionClick(_leftMouseDownStart);
+                }
+            }
+
+            _isLeftMouseDown = false;
+            _isDragSelecting = false;
+            _isMovingSelection = false;
+            _moveSourceElement = null;
+            _moveSnapshots = [];
+            if (FaceSkiaSurface.IsMouseCaptured) FaceSkiaSurface.ReleaseMouseCapture();
+            RequestRender();
+            eventArgs.Handled = true;
+            return;
+        }
+
         if (eventArgs.ChangedButton != MouseButton.Middle)
         {
             return;
@@ -483,6 +569,11 @@ public partial class SkiaFaceEditView : UserControl
         if (_isPanning)
         {
             EndPan(releaseMouseCapture: false);
+        }
+
+        if (_isLeftMouseDown && _isMovingSelection)
+        {
+            CancelActiveMovePreview();
         }
     }
 
@@ -525,8 +616,108 @@ public partial class SkiaFaceEditView : UserControl
 
         var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
         var selection = FaceSelectionService.SelectFromPoint(document.GetFaceElements(), viewport.ScreenToDocument(screenPoint), document.HierarchySelectedPanelSelection);
-        Panel2DSelectionNotificationService.NotifySelection(this, document, selection);
+        var isCtrl = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+        if (selection is not { } selected)
+        {
+            if (!isCtrl) document.SelectionState.Clear();
+            RequestRender();
+            return;
+        }
+
+        var item = new EditorSelectionItem(EditorSelectionDomain.FaceElement, selected.ObjectId);
+        if (isCtrl)
+        {
+            document.SelectionState.Toggle(item);
+        }
+        else if (!document.SelectionState.Items.Contains(item))
+        {
+            document.SelectionState.Replace(item);
+        }
+        else
+        {
+            document.SelectionState.SetPrimary(item);
+        }
         RequestRender();
+    }
+
+    private static bool HasDraggedSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
+    {
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        return Panel2DViewportInteractionService.HasDocumentDelta(viewport.ScreenToDocument(startScreenPoint), viewport.ScreenToDocument(endScreenPoint));
+    }
+
+    private void HandleDragSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
+    {
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var rect = Panel2DSelectionBoundsService.CreateNormalizedDocumentRect(viewport.ScreenToDocument(startScreenPoint), viewport.ScreenToDocument(endScreenPoint));
+        var items = FaceSelectionInteractionService.SelectItemsFromRect(document.GetFaceElements(), rect);
+        if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control) document.SelectionState.AddRange(items);
+        else document.SelectionState.Replace(items);
+    }
+
+    private void DrawDragSelectionRect(SKCanvas canvas, PanelViewportTransform viewport)
+    {
+        if (!_isLeftMouseDown || !_isDragSelecting) return;
+        var rect = Panel2DSelectionBoundsService.CreateNormalizedDocumentRect(viewport.ScreenToDocument(_leftMouseDownStart), viewport.ScreenToDocument(_dragSelectionCurrent));
+        using var fill = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(0x4F, 0xC3, 0xF7, 0x40) };
+        using var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(0x4F, 0xC3, 0xF7, 0xD0), StrokeWidth = (float)(1.5d / viewport.NormalizedZoom), IsAntialias = true };
+        canvas.DrawRect((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height, fill);
+        canvas.DrawRect((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height, stroke);
+    }
+
+    private void HandleMoveSelection(DocumentTabViewModel document, Point startScreenPoint, Point endScreenPoint)
+    {
+        if (_moveSnapshots.Count == 0) return;
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var start = viewport.ScreenToDocument(startScreenPoint);
+        var end = viewport.ScreenToDocument(endScreenPoint);
+        if (!Panel2DViewportInteractionService.HasDocumentDelta(start, end)) return;
+        var updated = FaceElementBulkMoveService.ComputeMovedElements(_moveSnapshots, start, end);
+        var originals = _moveSnapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => snapshot.OriginalElement);
+        document.CommandService.Execute(FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, updated, originals, updated.Count == 1 ? "Move face element" : "Move face elements"));
+    }
+
+    private void UpdateMoveSelectionPreview(Point currentScreenPoint)
+    {
+        var document = Document;
+        if (document is null || _moveSnapshots.Count == 0) return;
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var updated = FaceElementBulkMoveService.ComputeMovedElements(_moveSnapshots, viewport.ScreenToDocument(_leftMouseDownStart), viewport.ScreenToDocument(currentScreenPoint));
+        if (FaceElementPreviewMutationService.TryApplyPreviews(document, updated)) RequestRender();
+    }
+
+    private static bool TryGetSelectedElementAtPoint(DocumentTabViewModel document, Point screenPoint, out FaceElementModel selectedElement)
+    {
+        selectedElement = new FaceLampWindowElement();
+        var viewport = new PanelViewportTransform(document.FaceZoom, document.FacePanX, document.FacePanY);
+        var documentPoint = viewport.ScreenToDocument(screenPoint);
+        foreach (var item in document.SelectionState.Items.Where(item => item.Domain == EditorSelectionDomain.FaceElement).Reverse())
+        {
+            if (document.TryGetFaceElementByObjectId(item.ObjectId, out var element)
+                && documentPoint.X >= element.X && documentPoint.X <= element.X + element.Width
+                && documentPoint.Y >= element.Y && documentPoint.Y <= element.Y + element.Height)
+            {
+                selectedElement = element;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void CancelActiveMovePreview()
+    {
+        var document = Document;
+        if (document is not null && _moveSnapshots.Count > 0)
+        {
+            var originals = _moveSnapshots.ToDictionary(snapshot => snapshot.ObjectId, snapshot => snapshot.OriginalElement);
+            if (FaceElementPreviewMutationService.TryApplyPreviews(document, originals)) RequestRender();
+        }
+        _isLeftMouseDown = false;
+        _isDragSelecting = false;
+        _isMovingSelection = false;
+        _moveSourceElement = null;
+        _moveSnapshots = [];
+        FaceSkiaSurface.Cursor = Cursors.Arrow;
     }
 
     private void EndPan(bool releaseMouseCapture = true)


### PR DESCRIPTION
### Motivation
- Bring the Face edit viewport onto the shared multi-selection and transform infrastructure introduced for Panel2D (Task 01/02) so Face selection and group-move behavior match Panel2D where the domain allows it.
- Preserve existing Face-specific rendering, mask/layer behavior, right-click add, pan/zoom, and avoid expanding scope (no group-resize, no hierarchy multi-select changes).

### Description
- Implemented Face selection interaction in `SkiaFaceEditView.xaml.cs` including click replacement, Ctrl-click add/remove, empty-space clear/preserve, drag-rectangle replace/add (full-enclosure), multi-outline rendering with distinct primary styling, drag-to-move with preview, and lost-capture/preview cancellation.
- Added Face-domain support services mirroring Panel2D patterns: `FaceSelectionInteractionService`, `FaceElementBulkMoveService`, `FaceElementPreviewMutationService`, `FaceElementModelCloner`, and `FaceElementModelComparer` to handle full-enclosure hit rules, immutable move snapshots, shared-delta movement computation, and preview apply/restore.
- Added an atomic bulk mutation command (`CreateBulkUpdateElementsCommand` / `BulkUpdateFaceElementsMutationCommand`) in `FaceMutationCommands.cs` to commit group moves as a single Undo/Redo entry and reused `DocumentSelectionState`, `Panel2DSelectionBoundsService`, `Panel2DViewportInteractionService`, and `TransformLockInteractionService` where appropriate.
- Added focused tests `FaceMultiSelectionInteractionTests.cs` covering click/ctrl behaviors, rectangle full-enclosure matching, locked-element selection/move exclusion, immutable-move computation, preview restoration, and atomic Undo/Redo for group moves.

### Testing
- Added automated unit tests under `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs` but did not execute the .NET/WPF test suite in this environment due to toolchain restrictions as described in `WindowsNetProjects/OasisEditor/AGENTS.md`.
- Performed repository static checks including `git diff --check` and created/committed the changes; those checks succeeded locally in the agent workspace.
- Request that the OasisEditor tests be run on a developer Windows machine with the .NET/WPF toolchain; the new tests to run are in `OasisEditor.Tests` and should be executed with `dotnet test` against `OasisEditor.Tests.csproj`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5397766ce08327b72cf11d64efd2d9)