### PR TITLE
Hierarchy multi-selection (Task 04): visible-range, modifier gestures, and bidirectional sync

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyMultiSelectionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyMultiSelectionTests.cs
@@ -1,0 +1,164 @@
+using OasisEditor;
+
+namespace OasisEditor.Tests;
+
+public sealed class HierarchyMultiSelectionTests
+{
+    private static readonly EditorSelectionItem A = new(EditorSelectionDomain.PanelElement, "a");
+    private static readonly EditorSelectionItem B = new(EditorSelectionDomain.PanelElement, "b");
+    private static readonly EditorSelectionItem C = new(EditorSelectionDomain.PanelElement, "c");
+    private static readonly EditorSelectionItem D = new(EditorSelectionDomain.PanelElement, "d");
+
+    [Fact]
+    public void FlattenVisible_IncludesExpandedAndExcludesCollapsedDescendants_InDisplayOrder()
+    {
+        var roots = CreateTree();
+        roots[0].IsExpanded = true;
+        roots[2].IsExpanded = false;
+
+        var visible = HierarchyVisibleRowService.FlattenVisible(roots);
+
+        Assert.Equal(["Group 1", "A", "B", "Structural", "Group 2"], visible.Select(row => row.DisplayName).ToArray());
+    }
+
+    [Fact]
+    public void RangeSelection_CrossesStructuralRows_ButReturnsOnlySelectableComponents()
+    {
+        var roots = CreateTree();
+        roots[0].IsExpanded = true;
+        roots[2].IsExpanded = true;
+        var visible = HierarchyVisibleRowService.FlattenVisible(roots);
+        var clicked = visible.Single(row => row.DisplayName == "D");
+
+        var range = HierarchyVisibleRowService.GetSelectableRange(visible, B, clicked);
+
+        Assert.Equal([B, C, D], range);
+    }
+
+    [Fact]
+    public void MouseSelection_Click_ReplacesPrimaryAndAnchor()
+    {
+        var rows = CreateFlatRows();
+        var state = new DocumentSelectionState();
+
+        HierarchyMouseSelectionService.ApplySelection(state, rows, rows[1], HierarchySelectionModifier.None);
+
+        Assert.Equal([B], state.Items);
+        Assert.Equal(B, state.PrimaryItem);
+        Assert.Equal(B, state.HierarchyAnchorItem);
+    }
+
+    [Fact]
+    public void MouseSelection_CtrlClick_AddsAndUpdatesAnchor()
+    {
+        var rows = CreateFlatRows();
+        var state = new DocumentSelectionState();
+        state.Replace(A);
+
+        HierarchyMouseSelectionService.ApplySelection(state, rows, rows[1], HierarchySelectionModifier.Control);
+
+        Assert.Equal([A, B], state.Items);
+        Assert.Equal(B, state.PrimaryItem);
+        Assert.Equal(B, state.HierarchyAnchorItem);
+    }
+
+    [Fact]
+    public void MouseSelection_CtrlClickSelected_RemovesOnlyThatItemAndChoosesSurvivingPrimary()
+    {
+        var rows = CreateFlatRows();
+        var state = new DocumentSelectionState();
+        state.Replace([A, B, C], B);
+
+        HierarchyMouseSelectionService.ApplySelection(state, rows, rows[1], HierarchySelectionModifier.Control);
+
+        Assert.Equal([A, C], state.Items);
+        Assert.Equal(C, state.PrimaryItem);
+    }
+
+    [Fact]
+    public void MouseSelection_ShiftClick_ReplacesWithVisibleRangeAndKeepsAnchor()
+    {
+        var rows = CreateFlatRows();
+        var state = new DocumentSelectionState();
+        state.Replace(B);
+
+        HierarchyMouseSelectionService.ApplySelection(state, rows, rows[3], HierarchySelectionModifier.Shift);
+
+        Assert.Equal([B, C, D], state.Items);
+        Assert.Equal(D, state.PrimaryItem);
+        Assert.Equal(B, state.HierarchyAnchorItem);
+    }
+
+    [Fact]
+    public void MouseSelection_CtrlShiftClick_AddsVisibleRangeAndKeepsAnchor()
+    {
+        var rows = CreateFlatRows();
+        var state = new DocumentSelectionState();
+        state.Replace(A);
+        state.AddRange([D], D, updateHierarchyAnchor: false);
+
+        HierarchyMouseSelectionService.ApplySelection(state, rows, rows[2], HierarchySelectionModifier.ControlShift);
+
+        Assert.Equal([A, D, B, C], state.Items);
+        Assert.Equal(C, state.PrimaryItem);
+        Assert.Equal(A, state.HierarchyAnchorItem);
+    }
+
+    [Fact]
+    public void HierarchyViewModel_SyncSelection_UpdatesAllRowsAndPrimaryWithoutRebuild()
+    {
+        var document = CreatePanelDocument();
+        var hierarchy = new HierarchyViewModel(() => document, [new Panel2DHierarchyProvider()]);
+        hierarchy.Refresh();
+
+        document.SelectionState.Replace([A, C], C);
+        hierarchy.SyncSelection(document.SelectionState);
+
+        var rows = FlattenAll(hierarchy.Items).Where(row => row.SelectionItem is not null).ToArray();
+        Assert.True(rows.Single(row => row.SelectionItem == A).IsSelected);
+        Assert.True(rows.Single(row => row.SelectionItem == C).IsSelected);
+        Assert.True(rows.Single(row => row.SelectionItem == C).IsPrimarySelected);
+    }
+
+    private static IReadOnlyList<HierarchyItemViewModel> CreateFlatRows()
+    {
+        return [Row("A", A), Row("B", B), Row("C", C), Row("D", D)];
+    }
+
+    private static List<HierarchyItemViewModel> CreateTree()
+    {
+        return
+        [
+            new HierarchyItemViewModel("Group 1", "group:1", isGroup: true, children: [Row("A", A), Row("B", B)]),
+            new HierarchyItemViewModel("Structural", "structural"),
+            new HierarchyItemViewModel("Group 2", "group:2", isGroup: true, children: [Row("C", C), Row("D", D)])
+        ];
+    }
+
+    private static HierarchyItemViewModel Row(string name, EditorSelectionItem item)
+    {
+        return new HierarchyItemViewModel(name, $"row:{item.ObjectId}", panelSelection: new PanelSelectionInfo(item.ObjectId, "lamp", 0, 0, 1, 1));
+    }
+
+    private static DocumentTabViewModel CreatePanelDocument()
+    {
+        var json = Panel2DDocumentStorage.Serialize("Panel", null,
+        [
+            new PanelElementFile { ObjectId = "a", Kind = "lamp", Width = 1, Height = 1 },
+            new PanelElementFile { ObjectId = "c", Kind = "lamp", Width = 1, Height = 1 }
+        ], []);
+        return new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"), panelLayoutJson: json);
+    }
+
+    private static IEnumerable<HierarchyItemViewModel> FlattenAll(IEnumerable<HierarchyItemViewModel> rows)
+    {
+        foreach (var row in rows)
+        {
+            yield return row;
+            foreach (var child in FlattenAll(row.Children))
+            {
+                yield return child;
+            }
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyMultiSelectionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/HierarchyMultiSelectionTests.cs
@@ -1,4 +1,5 @@
 using OasisEditor;
+using Xunit;
 
 namespace OasisEditor.Tests;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/DocumentSelectionState.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/DocumentSelectionState.cs
@@ -6,7 +6,8 @@ public enum EditorSelectionDomain
 {
     PanelElement,
     FaceElement,
-    PanelFaceSourceShape
+    PanelFaceSourceShape,
+    FaceMaskLayer
 }
 
 public readonly record struct EditorSelectionItem(EditorSelectionDomain Domain, string ObjectId)
@@ -60,15 +61,20 @@ public sealed class DocumentSelectionState
         RaiseChanged();
     }
 
-    public void Replace(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null)
+    public void Replace(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null, bool updateHierarchyAnchor = true)
     {
         ArgumentNullException.ThrowIfNull(items);
         var distinct = items.Where(item => item.IsValid).Distinct().ToList();
         var primary = primaryItem is { IsValid: true } validPrimary && distinct.Contains(validPrimary)
             ? validPrimary
             : distinct.Count > 0 ? distinct[^1] : (EditorSelectionItem?)null;
+        var anchor = updateHierarchyAnchor ? primary : _hierarchyAnchorItem;
+        if (anchor is { } existingAnchor && !distinct.Contains(existingAnchor))
+        {
+            anchor = primary;
+        }
 
-        if (_items.SequenceEqual(distinct) && _primaryItem == primary && _hierarchyAnchorItem == primary)
+        if (_items.SequenceEqual(distinct) && _primaryItem == primary && _hierarchyAnchorItem == anchor)
         {
             return;
         }
@@ -76,7 +82,7 @@ public sealed class DocumentSelectionState
         _items.Clear();
         _items.AddRange(distinct);
         _primaryItem = primary;
-        _hierarchyAnchorItem = primary;
+        _hierarchyAnchorItem = anchor;
         RaiseChanged();
     }
 
@@ -85,7 +91,7 @@ public sealed class DocumentSelectionState
         AddRange([item], item);
     }
 
-    public void AddRange(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null)
+    public void AddRange(IEnumerable<EditorSelectionItem> items, EditorSelectionItem? primaryItem = null, bool updateHierarchyAnchor = false)
     {
         ArgumentNullException.ThrowIfNull(items);
         var changed = false;
@@ -109,10 +115,13 @@ public sealed class DocumentSelectionState
             changed = true;
         }
 
-        if (_hierarchyAnchorItem is null && _primaryItem is { } currentPrimary)
+        if ((updateHierarchyAnchor || _hierarchyAnchorItem is null) && _primaryItem is { } currentPrimary)
         {
-            _hierarchyAnchorItem = currentPrimary;
-            changed = true;
+            if (_hierarchyAnchorItem != currentPrimary)
+            {
+                _hierarchyAnchorItem = currentPrimary;
+                changed = true;
+            }
         }
 
         if (changed) RaiseChanged();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchySelectionServices.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchySelectionServices.cs
@@ -1,0 +1,171 @@
+namespace OasisEditor;
+
+public enum HierarchySelectionModifier
+{
+    None,
+    Control,
+    Shift,
+    ControlShift
+}
+
+public static class HierarchySelectionIdentityService
+{
+    public static EditorSelectionItem? ToSelectionItem(PanelSelectionInfo? selection)
+    {
+        if (selection is not PanelSelectionInfo value || string.IsNullOrWhiteSpace(value.ObjectId))
+        {
+            return null;
+        }
+
+        if (string.Equals(value.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal))
+        {
+            return new EditorSelectionItem(EditorSelectionDomain.PanelFaceSourceShape, value.ObjectId);
+        }
+
+        if (FaceSelectionService.IsFaceSelectionKind(value.Kind))
+        {
+            return new EditorSelectionItem(EditorSelectionDomain.FaceElement, value.ObjectId);
+        }
+
+        if (FaceMaskLayerSelectionService.IsMaskLayerSelection(value))
+        {
+            return new EditorSelectionItem(EditorSelectionDomain.FaceMaskLayer, value.ObjectId);
+        }
+
+        return new EditorSelectionItem(EditorSelectionDomain.PanelElement, value.ObjectId);
+    }
+
+    public static bool IsRangeSelectable(EditorSelectionItem item)
+    {
+        return item.Domain is EditorSelectionDomain.PanelElement or EditorSelectionDomain.FaceElement;
+    }
+}
+
+public static class HierarchyVisibleRowService
+{
+    public static IReadOnlyList<HierarchyItemViewModel> FlattenVisible(IEnumerable<HierarchyItemViewModel> roots)
+    {
+        ArgumentNullException.ThrowIfNull(roots);
+        var rows = new List<HierarchyItemViewModel>();
+        foreach (var root in roots)
+        {
+            AddVisible(root, rows);
+        }
+
+        return rows;
+    }
+
+    public static IReadOnlyList<EditorSelectionItem> GetSelectableRange(
+        IReadOnlyList<HierarchyItemViewModel> visibleRows,
+        EditorSelectionItem anchor,
+        HierarchyItemViewModel clickedRow)
+    {
+        ArgumentNullException.ThrowIfNull(visibleRows);
+        ArgumentNullException.ThrowIfNull(clickedRow);
+
+        var anchorIndex = -1;
+        var clickedIndex = -1;
+        for (var i = 0; i < visibleRows.Count; i++)
+        {
+            var row = visibleRows[i];
+            if (row.SelectionItem == anchor)
+            {
+                anchorIndex = i;
+            }
+
+            if (ReferenceEquals(row, clickedRow))
+            {
+                clickedIndex = i;
+            }
+        }
+
+        if (anchorIndex < 0 || clickedIndex < 0)
+        {
+            return [];
+        }
+
+        var start = Math.Min(anchorIndex, clickedIndex);
+        var end = Math.Max(anchorIndex, clickedIndex);
+        return visibleRows
+            .Skip(start)
+            .Take(end - start + 1)
+            .Select(row => row.SelectionItem)
+            .Where(item => item is { } value && HierarchySelectionIdentityService.IsRangeSelectable(value))
+            .Select(item => item!.Value)
+            .Distinct()
+            .ToArray();
+    }
+
+    private static void AddVisible(HierarchyItemViewModel row, List<HierarchyItemViewModel> rows)
+    {
+        rows.Add(row);
+        if (!row.IsExpanded)
+        {
+            return;
+        }
+
+        foreach (var child in row.Children)
+        {
+            AddVisible(child, rows);
+        }
+    }
+}
+
+public static class HierarchyMouseSelectionService
+{
+    public static void ApplySelection(
+        DocumentSelectionState selectionState,
+        IReadOnlyList<HierarchyItemViewModel> visibleRows,
+        HierarchyItemViewModel row,
+        HierarchySelectionModifier modifier)
+    {
+        ArgumentNullException.ThrowIfNull(selectionState);
+        ArgumentNullException.ThrowIfNull(visibleRows);
+        ArgumentNullException.ThrowIfNull(row);
+
+        var item = row.SelectionItem;
+        if (item is null)
+        {
+            return;
+        }
+
+        var isShift = modifier is HierarchySelectionModifier.Shift or HierarchySelectionModifier.ControlShift;
+        var isControl = modifier is HierarchySelectionModifier.Control or HierarchySelectionModifier.ControlShift;
+
+        if (isShift && selectionState.HierarchyAnchorItem is { } anchor)
+        {
+            var range = HierarchyVisibleRowService.GetSelectableRange(visibleRows, anchor, row);
+            if (range.Count == 0)
+            {
+                return;
+            }
+
+            if (isControl)
+            {
+                selectionState.AddRange(range, range[^1], updateHierarchyAnchor: false);
+            }
+            else
+            {
+                selectionState.Replace(range, range[^1], updateHierarchyAnchor: false);
+            }
+
+            return;
+        }
+
+        if (isControl)
+        {
+            if (selectionState.Items.Contains(item.Value))
+            {
+                selectionState.Remove(item.Value);
+            }
+            else
+            {
+                selectionState.AddRange([item.Value], item.Value, updateHierarchyAnchor: true);
+            }
+
+            return;
+        }
+
+        selectionState.Replace(item.Value);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1064,19 +1064,26 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    public void SelectHierarchyItem(HierarchyItemViewModel? hierarchyItem)
+    public void SelectHierarchyItem(HierarchyItemViewModel? hierarchyItem, HierarchySelectionModifier modifier = HierarchySelectionModifier.None)
     {
         if (SelectedDocument is null || SelectedDocument.Document.DocumentType is not (EditorDocumentType.Panel2D or EditorDocumentType.Face))
         {
             return;
         }
 
-        if (hierarchyItem is null || hierarchyItem.IsGroup || hierarchyItem.PanelSelection is not PanelSelectionInfo selection)
+        if (hierarchyItem is null || hierarchyItem.IsGroup || hierarchyItem.SelectionItem is null)
         {
             return;
         }
 
-        UpdateDocumentPanelSelection(SelectedDocument.DocumentId, selection);
+        HierarchyMouseSelectionService.ApplySelection(
+            SelectedDocument.SelectionState,
+            _hierarchy.GetVisibleRows(),
+            hierarchyItem,
+            modifier);
+        _activeDocumentContext.SetPanelSelection(SelectedDocument.DocumentId, SelectedDocument.HierarchySelectedPanelSelection);
+        _inspector.ActivateDocumentInspection();
+        NotifyInspectorChanged();
         NotifyHierarchyCommands();
     }
 
@@ -1087,14 +1094,19 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        if (hierarchyItem is null || hierarchyItem.IsGroup || hierarchyItem.PanelSelection is not PanelSelectionInfo selection)
+        if (hierarchyItem is null || hierarchyItem.IsGroup || hierarchyItem.SelectionItem is not { } selectionItem)
         {
-            UpdateDocumentPanelSelection(SelectedDocument.DocumentId, null);
             NotifyHierarchyCommands();
             return;
         }
 
-        UpdateDocumentPanelSelection(SelectedDocument.DocumentId, selection);
+        if (!SelectedDocument.SelectionState.Items.Contains(selectionItem))
+        {
+            SelectedDocument.SelectionState.Replace(selectionItem);
+            _activeDocumentContext.SetPanelSelection(SelectedDocument.DocumentId, SelectedDocument.HierarchySelectedPanelSelection);
+            _inspector.ActivateDocumentInspection();
+            NotifyInspectorChanged();
+        }
         NotifyHierarchyCommands();
     }
 
@@ -3633,7 +3645,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _inspector.ActivateDocumentInspection();
         if (selectionChanged)
         {
-            _hierarchy.SyncSelection(selection);
+            _hierarchy.SyncSelection(document?.SelectionState);
         }
         NotifyInspectorChanged();
         OnPropertyChanged(nameof(HierarchyItems));
@@ -4458,7 +4470,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 _activeDocumentContext.SetPanelSelection(SelectedDocument.DocumentId, SelectedDocument.HierarchySelectedPanelSelection);
             }
 
-            _hierarchy.SyncSelection(SelectedDocument?.HierarchySelectedPanelSelection);
+            _hierarchy.SyncSelection(SelectedDocument?.SelectionState);
             OnPropertyChanged(nameof(HierarchyItems));
             NotifyInspectorChanged();
             NotifyHierarchyCommands();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/DocumentTabViewModel.cs
@@ -355,6 +355,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
             EditorSelectionDomain.PanelElement => _panelDocumentModel.Elements.Any(element => string.Equals(element.ObjectId, item.ObjectId, StringComparison.Ordinal)),
             EditorSelectionDomain.FaceElement => _faceDocumentModel.Elements.Any(element => string.Equals(element.ObjectId, item.ObjectId, StringComparison.Ordinal)),
             EditorSelectionDomain.PanelFaceSourceShape => _panelDocumentModel.FaceSourceShapes.Any(shape => string.Equals(shape.Id, item.ObjectId, StringComparison.Ordinal)),
+            EditorSelectionDomain.FaceMaskLayer => _faceDocumentModel.MaskLayer is { } maskLayer && string.Equals(FaceMaskLayerSelectionService.ToSelectionInfo(maskLayer).ObjectId, item.ObjectId, StringComparison.Ordinal),
             _ => false
         });
     }
@@ -533,7 +534,7 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
         {
             if (value is PanelSelectionInfo selection)
             {
-                SelectionState.Replace(ToSelectionItem(selection));
+                SelectionState.Replace(HierarchySelectionIdentityService.ToSelectionItem(selection));
             }
             else
             {
@@ -572,20 +573,18 @@ public sealed class DocumentTabViewModel : INotifyPropertyChanged
                 selection = PanelFaceSourceShapeCommands.ToSelection(shape);
                 return true;
             }
+
+            if (item.Domain == EditorSelectionDomain.FaceMaskLayer
+                && _faceDocumentModel.MaskLayer is { } maskLayer
+                && string.Equals(FaceMaskLayerSelectionService.ToSelectionInfo(maskLayer).ObjectId, item.ObjectId, StringComparison.Ordinal))
+            {
+                selection = FaceMaskLayerSelectionService.ToSelectionInfo(maskLayer);
+                return true;
+            }
         }
 
         selection = default;
         return false;
-    }
-
-    private static EditorSelectionItem ToSelectionItem(PanelSelectionInfo selection)
-    {
-        var domain = string.Equals(selection.Kind, PanelFaceSourceShapeCommands.SelectionKind, StringComparison.Ordinal)
-            ? EditorSelectionDomain.PanelFaceSourceShape
-            : FaceSelectionService.IsFaceSelectionKind(selection.Kind)
-                ? EditorSelectionDomain.FaceElement
-                : EditorSelectionDomain.PanelElement;
-        return new EditorSelectionItem(domain, selection.ObjectId);
     }
 
     public double PanelZoom

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyItemViewModel.cs
@@ -7,6 +7,7 @@ public sealed class HierarchyItemViewModel : INotifyPropertyChanged
 {
     private bool _isExpanded;
     private bool _isSelected;
+    private bool _isPrimarySelected;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -29,6 +30,7 @@ public sealed class HierarchyItemViewModel : INotifyPropertyChanged
     public bool IsGroup { get; }
     public ObservableCollection<HierarchyItemViewModel> Children { get; }
     public PanelSelectionInfo? PanelSelection { get; }
+    public EditorSelectionItem? SelectionItem => HierarchySelectionIdentityService.ToSelectionItem(PanelSelection);
 
     public bool IsExpanded
     {
@@ -57,6 +59,21 @@ public sealed class HierarchyItemViewModel : INotifyPropertyChanged
 
             _isSelected = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+        }
+    }
+
+    public bool IsPrimarySelected
+    {
+        get => _isPrimarySelected;
+        set
+        {
+            if (_isPrimarySelected == value)
+            {
+                return;
+            }
+
+            _isPrimarySelected = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsPrimarySelected)));
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/HierarchyViewModel.cs
@@ -68,14 +68,19 @@ public sealed class HierarchyViewModel : INotifyPropertyChanged
             Items.Add(item);
         }
 
-        ApplySelection(selectedDocument?.HierarchySelectedPanelSelection);
+        ApplySelection(selectedDocument?.SelectionState);
         EmptyStateMessage = Items.Count > 0 ? string.Empty : "This document has no hierarchy items yet.";
         NotifyCollectionStateChanged();
     }
 
-    public void SyncSelection(PanelSelectionInfo? selection)
+    public void SyncSelection(DocumentSelectionState? selectionState)
     {
-        ApplySelection(selection);
+        ApplySelection(selectionState);
+    }
+
+    public IReadOnlyList<HierarchyItemViewModel> GetVisibleRows()
+    {
+        return HierarchyVisibleRowService.FlattenVisible(Items);
     }
 
     public HierarchyItemViewModel? GetSelectedEntity()
@@ -109,29 +114,28 @@ public sealed class HierarchyViewModel : INotifyPropertyChanged
         }
     }
 
-    private void ApplySelection(PanelSelectionInfo? selection)
+    private void ApplySelection(DocumentSelectionState? selectionState)
     {
+        var selected = selectionState?.Items.ToHashSet() ?? new HashSet<EditorSelectionItem>();
+        var primary = selectionState?.PrimaryItem;
+
         foreach (var item in Flatten(Items))
         {
-            item.IsSelected = false;
+            var selectionItem = item.SelectionItem;
+            item.IsSelected = selectionItem is { } value && selected.Contains(value);
+            item.IsPrimarySelected = selectionItem is { } primaryValue && primary == primaryValue;
         }
 
-        if (selection is not PanelSelectionInfo targetSelection)
+        if (primary is not { } targetPrimary)
         {
             return;
         }
 
-        var selectedItem = Flatten(Items)
-            .FirstOrDefault(item => item.PanelSelection is PanelSelectionInfo itemSelection
-                && IsSelectionMatch(itemSelection, targetSelection));
-
-        if (selectedItem is null)
+        var primaryItem = Flatten(Items).FirstOrDefault(item => item.SelectionItem == targetPrimary);
+        if (primaryItem is not null)
         {
-            return;
+            ExpandParents(Items, primaryItem.NodeKey);
         }
-
-        selectedItem.IsSelected = true;
-        ExpandParents(Items, selectedItem.NodeKey);
     }
 
     private static bool ExpandParents(IEnumerable<HierarchyItemViewModel> roots, string targetNodeKey)
@@ -151,11 +155,6 @@ public sealed class HierarchyViewModel : INotifyPropertyChanged
         }
 
         return false;
-    }
-
-    private static bool IsSelectionMatch(PanelSelectionInfo left, PanelSelectionInfo right)
-    {
-        return PanelSelectionContract.IsSameSelection(left, right);
     }
 
     private static IEnumerable<HierarchyItemViewModel> Flatten(IEnumerable<HierarchyItemViewModel> items)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml
@@ -84,7 +84,6 @@
                     <Setter Property="BorderThickness" Value="1" />
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
-                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type TreeViewItem}">
@@ -157,18 +156,13 @@
                                         <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource ControlHoverBrush}" />
                                         <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
                                     </Trigger>
-                                    <Trigger Property="IsSelected" Value="True">
+                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
                                         <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource SelectionBrush}" />
                                         <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
-                                    </Trigger>
-                                    <MultiTrigger>
-                                        <MultiTrigger.Conditions>
-                                            <Condition Property="IsSelected" Value="True" />
-                                            <Condition Property="Selector.IsSelectionActive" Value="False" />
-                                        </MultiTrigger.Conditions>
-                                        <Setter TargetName="RowHighlight" Property="Background" Value="{DynamicResource InactiveSelectionBrush}" />
-                                        <Setter TargetName="RowHighlight" Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
-                                    </MultiTrigger>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsPrimarySelected}" Value="True">
+                                        <Setter TargetName="RowHighlight" Property="BorderThickness" Value="2" />
+                                    </DataTrigger>
                                 </ControlTemplate.Triggers>
                             </ControlTemplate>
                         </Setter.Value>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/HierarchyView.xaml.cs
@@ -17,12 +17,7 @@ public partial class HierarchyView : UserControl
 
     private void OnTreeViewSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> eventArgs)
     {
-        if (DataContext is not MainWindowViewModel viewModel)
-        {
-            return;
-        }
-
-        viewModel.SelectHierarchyItem(eventArgs.NewValue as HierarchyItemViewModel);
+        // Native TreeView selection is focus/navigation only. DocumentSelectionState is updated by explicit mouse gestures.
     }
 
     private void OnTreeViewPreviewKeyDown(object sender, KeyEventArgs eventArgs)
@@ -75,7 +70,7 @@ public partial class HierarchyView : UserControl
             return;
         }
 
-        treeViewItem.IsSelected = true;
+        treeViewItem.Focus();
         viewModel.SelectHierarchyItemForContextMenu(hierarchyItem);
     }
 
@@ -86,15 +81,37 @@ public partial class HierarchyView : UserControl
             return;
         }
 
-        if (FindAncestor<TreeViewItem>(source) is null)
+        var treeViewItem = FindAncestor<TreeViewItem>(source);
+        if (treeViewItem?.DataContext is not HierarchyItemViewModel hierarchyItem)
         {
             return;
+        }
+
+        treeViewItem.Focus();
+        if (DataContext is MainWindowViewModel viewModel)
+        {
+            viewModel.SelectHierarchyItem(hierarchyItem, GetSelectionModifier());
+            eventArgs.Handled = hierarchyItem.SelectionItem is not null;
         }
 
         _suppressAutoScrollForUserTreeSelection = true;
         Dispatcher.BeginInvoke(
             DispatcherPriority.Input,
             new Action(() => _suppressAutoScrollForUserTreeSelection = false));
+    }
+
+    private static HierarchySelectionModifier GetSelectionModifier()
+    {
+        var modifiers = Keyboard.Modifiers;
+        var ctrl = (modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+        var shift = (modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
+        return (ctrl, shift) switch
+        {
+            (true, true) => HierarchySelectionModifier.ControlShift,
+            (true, false) => HierarchySelectionModifier.Control,
+            (false, true) => HierarchySelectionModifier.Shift,
+            _ => HierarchySelectionModifier.None
+        };
     }
 
     private void OnTreeViewItemSelected(object sender, RoutedEventArgs eventArgs)


### PR DESCRIPTION
### Motivation
- Implement Unity-style component multi-selection in the Hierarchy per Task 04 and synchronize it bidirectionally with Panel2D and Face viewports while keeping `DocumentSelectionState` as the single source of truth.

### Description
- Added a focused selection service file `HierarchySelectionServices.cs` providing identity mapping (`HierarchySelectionIdentityService`), visible-row flattening (`HierarchyVisibleRowService`), visible-range calculation, and mouse-gesture application (`HierarchyMouseSelectionService`).
- Extended `DocumentSelectionState` to support optional hierarchy-anchor updates for range/add operations and added `FaceMaskLayer` as a selection domain to preserve specialized row identities.
- Exposed explicit row visual state in the hierarchy via `HierarchyItemViewModel.SelectionItem`, `IsSelected`, and `IsPrimarySelected`, and updated `HierarchyViewModel` to sync visuals directly from `DocumentSelectionState` and to expose `GetVisibleRows()` for range computation.
- Reworked the WPF hierarchy view so native `TreeViewItem.IsSelected` is no longer authoritative: `HierarchyView.xaml`/code-behind routes left/right clicks (including Ctrl/Shift modifiers) to the new selection service, retains focus/navigation and F2/Delete behavior, and drives highlight/primary styling from view-model properties.
- Wired MainWindowViewModel and DocumentTabViewModel to use the new services and selection identity mapping, preserved the temporary `HierarchySelectedPanelSelection` bridge as a mirror of the primary item, and excluded group/structural rows from component selection ranges while preserving specialized single-selection rows (Panel Face Source Shape, Face Mask Layer).
- Added unit tests `HierarchyMultiSelectionTests.cs` exercising visible flattening, collapsed-descendant exclusion, range results, click/Ctrl/Shift/Ctrl+Shift behaviors, deterministic primary/anchor updates, and hierarchy-to-view-model sync.
- Files added/modified (high level):
  - Added: `OasisEditor/HierarchySelectionServices.cs`, `OasisEditor.Tests/HierarchyMultiSelectionTests.cs`.
  - Modified: `OasisEditor/DocumentSelectionState.cs`, `OasisEditor/ViewModels/HierarchyItemViewModel.cs`, `OasisEditor/ViewModels/HierarchyViewModel.cs`, `OasisEditor/Views/HierarchyView.xaml`, `OasisEditor/Views/HierarchyView.xaml.cs`, `OasisEditor/MainWindowViewModel.cs`, `OasisEditor/ViewModels/DocumentTabViewModel.cs`.

### Testing
- Added focused unit tests in `OasisEditor.Tests/HierarchyMultiSelectionTests.cs` covering visible flattening, range selection, modifier-click behaviors, and view-model synchronization, but automated tests were not executed here because this environment does not contain the required Windows/.NET/WPF toolchain per project guidance.
- Performed repository static checks in this environment; no static diff/check failures were reported.

If you can run the solution locally, run the OasisEditor test project (e.g. `dotnet test <OasisEditor.Tests csproj>` locally on a Windows/.NET environment) and exercise the manual verification checklist in Task 04 to validate runtime behavior in both Panel2D and Face documents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53a45239348327bd93cd81a61c88ad)