### PR TITLE
Inspector: implement multi-selection aggregation and atomic multi-edit

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs
@@ -1,0 +1,120 @@
+using System.Linq;
+using EditorCommands = OasisEditor.Commands;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class InspectorAggregateValueTests
+{
+    [Fact]
+    public void From_CommonAndMixedValues_ReportsExplicitState()
+    {
+        Assert.True(InspectorAggregateValue.From(new[] { 10d, 10d }).IsCommon);
+        Assert.True(InspectorAggregateValue.From(new[] { 10d, 20d }).IsMixed);
+        Assert.True(InspectorAggregateValue.From(new[] { "Lamp", "Lamp" }).IsCommon);
+        Assert.True(InspectorAggregateValue.From(new[] { "Lamp", "Other" }).IsMixed);
+        Assert.True(InspectorAggregateValue.From(new[] { true, false }).IsMixed);
+        Assert.False(InspectorAggregateValue.From(Array.Empty<int>()).IsAvailable);
+    }
+
+    [Fact]
+    public void SameTypePanelSelection_ExposesTypeSpecificRowsAndMixedState()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10, DisplayNumber = 7 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 3, Width = 10, Height = 10, DisplayNumber = 7 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document);
+
+        viewModel.NotifyContextChanged();
+
+        Assert.Equal("2 Lamps", viewModel.InspectorTitle);
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Name");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Display Number");
+        var xRow = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "X"));
+        var yRow = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "Y"));
+        Assert.False(xRow.IsMixed);
+        Assert.True(yRow.IsMixed);
+    }
+
+    [Fact]
+    public void MixedTypePanelSelection_ExposesBaseRowsOnly()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "reel-1", Name = "B", Kind = PanelElementKind.Reel, X = 1, Y = 3, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "reel-1")]);
+        var viewModel = CreateInspectorViewModel(document);
+
+        viewModel.NotifyContextChanged();
+
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "X");
+        Assert.Contains(viewModel.InspectorPropertyRows, row => row.DisplayName == "Visible");
+        Assert.DoesNotContain(viewModel.InspectorPropertyRows, row => row.DisplayName == "Name");
+        Assert.DoesNotContain(viewModel.InspectorPropertyRows, row => row.DisplayName == "Display Number");
+    }
+
+    [Fact]
+    public void PanelMultiEdit_AssignsAbsoluteValueAndSkipsLockedTransforms()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 3, Width = 10, Height = 10, IsTransformLocked = true });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var yRow = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "Y"));
+        yRow.Value = "42";
+        yRow.Commit();
+
+        Assert.Equal(42, document.GetPanelElements().Single(element => element.ObjectId == "lamp-1").Y);
+        Assert.Equal(3, document.GetPanelElements().Single(element => element.ObjectId == "lamp-2").Y);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_NonTransformEditAppliesToLockedMembers()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 3, Width = 10, Height = 10, IsTransformLocked = true });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document, ExecuteImmediately);
+        viewModel.NotifyContextChanged();
+
+        var visibleRow = Assert.IsType<InspectorBoolPropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "Visible"));
+        visibleRow.Value = false;
+
+        Assert.All(document.GetPanelElements(), element => Assert.False(element.IsVisible));
+    }
+
+    private static DocumentTabViewModel CreatePanelDocument(params PanelElementModel[] elements)
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));
+        document.SetPanelElements(elements);
+        return document;
+    }
+
+    private static InspectorViewModel CreateInspectorViewModel(DocumentTabViewModel document, Func<Guid, EditorCommands.ICommand, bool>? executeCanvasCommand = null)
+    {
+        var context = new ActiveDocumentContextService();
+        context.SetActiveDocument(document);
+        return new InspectorViewModel(
+            selectedAssetAccessor: () => null,
+            selectedDocumentAccessor: () => document,
+            loadedProjectAccessor: () => null,
+            activeDocumentContext: context,
+            executeCanvasCommand: executeCanvasCommand ?? ((_, _) => true),
+            applySummary: (selectedDocument, _) => selectedDocument);
+    }
+
+    private static bool ExecuteImmediately(Guid _, EditorCommands.ICommand command)
+    {
+        command.Execute();
+        return command is not EditorCommands.IExecutionTrackedCommand tracked || tracked.WasExecuted;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -236,7 +236,7 @@ internal static class CanvasMutationCommands
 
             if (changed)
             {
-                _document.SetPanelElements(elements, CreateElementChange(_document, null, PanelChangeProperties.Geometry));
+                _document.SetPanelElements(elements, CreateElementChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
                 _document.MarkDirty();
             }
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -213,6 +213,7 @@ internal static class FaceMutationCommands
             WasExecuted = false;
             var elements = _document.GetFaceElements().ToList();
             var previous = new Dictionary<string, FaceElementModel>();
+            var changed = false;
             for (var i = 0; i < elements.Count; i++)
             {
                 var existing = elements[i];
@@ -224,14 +225,18 @@ internal static class FaceMutationCommands
                 if (!FaceElementModelComparer.AreEquivalent(existing, updated))
                 {
                     elements[i] = FaceElementModelCloner.Clone(updated);
+                    changed = true;
                 }
             }
 
             if (previous.Count == 0) return;
             _previousElements = previous;
-            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
-            _document.MarkDirty();
-            WasExecuted = true;
+            if (changed)
+            {
+                _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
+                _document.MarkDirty();
+                WasExecuted = true;
+            }
         }
 
         public void Undo()
@@ -245,7 +250,7 @@ internal static class FaceMutationCommands
                     elements[i] = FaceElementModelCloner.Clone(previous);
                 }
             }
-            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry));
+            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
             _document.MarkDirty();
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InspectorAggregateValue.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InspectorAggregateValue.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace OasisEditor;
+
+public enum InspectorAggregateValueState
+{
+    Unavailable,
+    Common,
+    Mixed
+}
+
+public readonly record struct InspectorAggregateValue<T>(InspectorAggregateValueState State, T? Value)
+{
+    public bool IsAvailable => State != InspectorAggregateValueState.Unavailable;
+    public bool IsCommon => State == InspectorAggregateValueState.Common;
+    public bool IsMixed => State == InspectorAggregateValueState.Mixed;
+
+    public static InspectorAggregateValue<T> Unavailable() => new(InspectorAggregateValueState.Unavailable, default);
+    public static InspectorAggregateValue<T> Common(T? value) => new(InspectorAggregateValueState.Common, value);
+    public static InspectorAggregateValue<T> Mixed() => new(InspectorAggregateValueState.Mixed, default);
+}
+
+public static class InspectorAggregateValue
+{
+    public static InspectorAggregateValue<T> From<T>(IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        using var enumerator = values.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            return InspectorAggregateValue<T>.Unavailable();
+        }
+
+        var first = enumerator.Current;
+        var comparer = EqualityComparer<T>.Default;
+        while (enumerator.MoveNext())
+        {
+            if (!comparer.Equals(first, enumerator.Current))
+            {
+                return InspectorAggregateValue<T>.Mixed();
+            }
+        }
+
+        return InspectorAggregateValue<T>.Common(first);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs
@@ -60,11 +60,17 @@ public abstract class InspectorEditablePropertyRowViewModel : InspectorPropertyR
     public abstract void Commit();
 }
 
-public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRowViewModel
+public interface IInspectorAggregatePropertyRow
+{
+    bool IsMixed { get; }
+}
+
+public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRowViewModel, IInspectorAggregatePropertyRow
 {
     private string _value;
     private string _committedValue;
     private readonly Func<string, string?>? _commit;
+    private bool _isMixed;
 
     public InspectorTextPropertyViewModel(string displayName, string groupName, string value, bool isReadOnly = false, Func<string, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
@@ -78,6 +84,12 @@ public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRo
     {
         get => _value;
         set => SetProperty(ref _value, value);
+    }
+
+    public bool IsMixed
+    {
+        get => _isMixed;
+        private set => SetProperty(ref _isMixed, value);
     }
 
     public override void Commit()
@@ -98,6 +110,7 @@ public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRo
 
         ErrorText = string.Empty;
         _committedValue = _value;
+        IsMixed = false;
     }
 
     public void SetCommittedValue(string? value)
@@ -105,17 +118,28 @@ public sealed class InspectorTextPropertyViewModel : InspectorEditablePropertyRo
         ErrorText = string.Empty;
         _value = value ?? string.Empty;
         _committedValue = _value;
+        IsMixed = false;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetMixedValue(string placeholder = "—")
+    {
+        ErrorText = string.Empty;
+        _value = placeholder;
+        _committedValue = placeholder;
+        IsMixed = true;
         RaisePropertyChanged(nameof(Value));
     }
 
 }
 
-public sealed class InspectorDoublePropertyViewModel : InspectorEditablePropertyRowViewModel
+public sealed class InspectorDoublePropertyViewModel : InspectorEditablePropertyRowViewModel, IInspectorAggregatePropertyRow
 {
     private string _value;
     private string _committedValue;
     private readonly Func<double, string?>? _commit;
     private readonly string _format;
+    private bool _isMixed;
 
     public InspectorDoublePropertyViewModel(string displayName, string groupName, double value, bool isReadOnly = false, Func<double, string?>? commit = null, string format = "0.###")
         : base(displayName, groupName, isReadOnly)
@@ -130,6 +154,12 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
     {
         get => _value;
         set => SetProperty(ref _value, value);
+    }
+
+    public bool IsMixed
+    {
+        get => _isMixed;
+        private set => SetProperty(ref _isMixed, value);
     }
 
     public override void Commit()
@@ -160,6 +190,7 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
         ErrorText = string.Empty;
         _committedValue = parsed.ToString(_format, CultureInfo.InvariantCulture);
         _value = _committedValue;
+        IsMixed = false;
         RaisePropertyChanged(nameof(Value));
     }
 
@@ -168,16 +199,27 @@ public sealed class InspectorDoublePropertyViewModel : InspectorEditableProperty
         ErrorText = string.Empty;
         _committedValue = value.ToString(_format, CultureInfo.InvariantCulture);
         _value = _committedValue;
+        IsMixed = false;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetMixedValue(string placeholder = "—")
+    {
+        ErrorText = string.Empty;
+        _committedValue = placeholder;
+        _value = placeholder;
+        IsMixed = true;
         RaisePropertyChanged(nameof(Value));
     }
 }
 
-public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRowViewModel
+public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRowViewModel, IInspectorAggregatePropertyRow
 {
     private string _value;
     private string _committedValue;
     private readonly bool _allowEmpty;
     private readonly Func<int?, string?>? _commit;
+    private bool _isMixed;
 
     public InspectorIntPropertyViewModel(string displayName, string groupName, int? value, bool isReadOnly = false, bool allowEmpty = true, Func<int?, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
@@ -192,6 +234,12 @@ public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRow
     {
         get => _value;
         set => SetProperty(ref _value, value);
+    }
+
+    public bool IsMixed
+    {
+        get => _isMixed;
+        private set => SetProperty(ref _isMixed, value);
     }
 
     public override void Commit()
@@ -238,6 +286,7 @@ public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRow
         ErrorText = string.Empty;
         _committedValue = parsedValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         _value = _committedValue;
+        IsMixed = false;
         RaisePropertyChanged(nameof(Value));
     }
 
@@ -246,18 +295,29 @@ public sealed class InspectorIntPropertyViewModel : InspectorEditablePropertyRow
         ErrorText = string.Empty;
         _committedValue = value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
         _value = _committedValue;
+        IsMixed = false;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetMixedValue(string placeholder = "—")
+    {
+        ErrorText = string.Empty;
+        _committedValue = placeholder;
+        _value = placeholder;
+        IsMixed = true;
         RaisePropertyChanged(nameof(Value));
     }
 }
 
 
-public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyRowViewModel
+public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyRowViewModel, IInspectorAggregatePropertyRow
 {
     private Color _selectedColor;
     private Color _committedColor;
     private string _hexValue;
     private readonly Func<string?, string?>? _commit;
     private readonly bool _allowEmpty;
+    private bool _isMixed;
 
     public InspectorColorPropertyViewModel(string displayName, string groupName, string? value, bool isReadOnly = false, bool allowEmpty = true, Func<string?, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
@@ -301,6 +361,12 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
     {
         get => _hexValue;
         set => SetProperty(ref _hexValue, value);
+    }
+
+    public bool IsMixed
+    {
+        get => _isMixed;
+        private set => SetProperty(ref _isMixed, value);
     }
 
     public override void Commit()
@@ -350,6 +416,7 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
         }
 
         _committedHexValue = normalizedHex;
+        IsMixed = false;
     }
 
     private string? _committedHexValue;
@@ -397,14 +464,25 @@ public sealed class InspectorColorPropertyViewModel : InspectorEditablePropertyR
 
         RaisePropertyChanged(nameof(HexValue));
         RaisePropertyChanged(nameof(SelectedColor));
+        IsMixed = false;
+    }
+
+    public void SetMixedValue(string placeholder = "—")
+    {
+        ErrorText = string.Empty;
+        _hexValue = placeholder;
+        _committedHexValue = placeholder;
+        IsMixed = true;
+        RaisePropertyChanged(nameof(HexValue));
     }
 }
 
-public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewModel
+public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewModel, IInspectorAggregatePropertyRow
 {
-    private bool _value;
+    private bool? _value;
     private readonly Func<bool, string?>? _commit;
     private bool _isApplyingChange;
+    private bool _isMixed;
 
     public InspectorBoolPropertyViewModel(string displayName, string groupName, bool value, bool isReadOnly = false, Func<bool, string?>? commit = null)
         : base(displayName, groupName, isReadOnly)
@@ -413,7 +491,7 @@ public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewMod
         _commit = commit;
     }
 
-    public bool Value
+    public bool? Value
     {
         get => _value;
         set
@@ -422,25 +500,46 @@ public sealed class InspectorBoolPropertyViewModel : InspectorPropertyRowViewMod
             {
                 return;
             }
+            if (!value.HasValue)
+            {
+                IsMixed = true;
+                return;
+            }
 
-            var error = _commit?.Invoke(value);
+            var error = _commit?.Invoke(value.Value);
             if (string.IsNullOrWhiteSpace(error))
             {
                 ErrorText = string.Empty;
+                IsMixed = false;
                 return;
             }
 
             ErrorText = error;
             _isApplyingChange = true;
-            Value = !value;
+            Value = !value.Value;
             _isApplyingChange = false;
         }
+    }
+
+    public bool IsMixed
+    {
+        get => _isMixed;
+        private set => SetProperty(ref _isMixed, value);
     }
 
     public void SetCommittedValue(bool value)
     {
         ErrorText = string.Empty;
         _value = value;
+        IsMixed = false;
+        RaisePropertyChanged(nameof(Value));
+    }
+
+    public void SetMixedValue()
+    {
+        ErrorText = string.Empty;
+        _value = null;
+        IsMixed = true;
         RaisePropertyChanged(nameof(Value));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -126,6 +126,15 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
 
             var selectedDocument = _selectedDocumentAccessor();
+            if (selectedDocument is not null)
+            {
+                var aggregate = TryCreateAggregateSelection(selectedDocument);
+                if (aggregate.Count > 1)
+                {
+                    return aggregate.IsSupported ? BuildAggregateTitle(aggregate) : $"{aggregate.Count} Selected Items";
+                }
+            }
+
             if (selectedDocument is not null
                 && _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection)
             {
@@ -226,6 +235,19 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             var selectedDocument = _selectedDocumentAccessor();
             if (selectedDocument is not null)
             {
+                var aggregate = TryCreateAggregateSelection(selectedDocument);
+                if (aggregate.Count > 1)
+                {
+                    if (!aggregate.IsSupported)
+                    {
+                        return "This mixed selection is read-only in the Inspector. Select only Panel2D components or only Face components to multi-edit.";
+                    }
+
+                    var locked = aggregate.TransformLockedCount;
+                    return $"{aggregate.Count} {aggregate.DomainLabel} selected for multi-edit."
+                        + (locked > 0 ? $" Transform edits will skip {locked} locked selected object(s)." : string.Empty);
+                }
+
                 if (_activeDocumentContext.ActivePanelSelection is PanelSelectionInfo panelSelection)
                 {
                     if (selectedDocument.Document.DocumentType == EditorDocumentType.Face)
@@ -366,6 +388,24 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return;
         }
 
+        var aggregate = TryCreateAggregateSelection(selectedDocument);
+        if (aggregate.Count > 1)
+        {
+            if (!string.IsNullOrWhiteSpace(panelChange.ObjectId)
+                && !selectedDocument.SelectionState.Items.Any(item => string.Equals(item.ObjectId, panelChange.ObjectId, StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            if (!ShouldSuppressPropertyRowRefresh())
+            {
+                RebuildPropertyRows();
+            }
+
+            OnPropertyChanged(nameof(InspectorSummary));
+            return;
+        }
+
         if (!string.IsNullOrWhiteSpace(panelChange.ObjectId)
             && !string.Equals(panelChange.ObjectId, panelSelection.ObjectId, StringComparison.Ordinal))
         {
@@ -417,6 +457,27 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         var selectedDocument = _selectedDocumentAccessor();
         var selection = _activeDocumentContext.ActivePanelSelection;
+        var aggregateSelection = selectedDocument is not null ? TryCreateAggregateSelection(selectedDocument) : default;
+        if (selectedDocument is not null && aggregateSelection.Count > 1)
+        {
+            if (aggregateSelection.IsSupported)
+            {
+                RebuildAggregatePropertyRows(selectedDocument, aggregateSelection);
+            }
+            else
+            {
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Selection", "Multi-Edit", $"{aggregateSelection.Count} selected items cannot be edited together."));
+                _propertyRows.Add(new InspectorInfoPropertyViewModel("Supported Multi-Edit", "Multi-Edit", "Select only Panel2D components or only Face components."));
+                _hadInspectorSelection = true;
+                _lastInspectorSelectionObjectId = GetDocumentSelectionKey();
+                _lastInspectorSelectionKind = null;
+                _lastInspectorFaceSelectionKind = "unsupported-multi";
+                OnPropertyChanged(nameof(InspectorPropertyRows));
+            }
+
+            return;
+        }
+
         if (selectedDocument is not null
             && selectedDocument.Document.DocumentType == EditorDocumentType.Face
             && selection is PanelSelectionInfo maskSelection
@@ -527,6 +588,226 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorPropertyRows));
     }
 
+    private readonly record struct AggregateSelection(
+        EditorSelectionDomain? Domain,
+        IReadOnlyList<PanelElementModel> PanelElements,
+        IReadOnlyList<FaceElementModel> FaceElements,
+        bool IsUnsupported,
+        int UnsupportedCount = 0)
+    {
+        public int Count => IsUnsupported ? UnsupportedCount : PanelElements.Count + FaceElements.Count;
+        public bool IsSupported => !IsUnsupported && Domain is EditorSelectionDomain.PanelElement or EditorSelectionDomain.FaceElement && Count > 0;
+        public string DomainLabel => Domain == EditorSelectionDomain.FaceElement ? "Face Elements" : "Panel2D Components";
+        public bool IsSameConcreteType => Domain == EditorSelectionDomain.PanelElement
+            ? PanelElements.Select(element => element.Kind).Distinct().Count() == 1
+            : FaceElements.Select(element => element.GetType()).Distinct().Count() == 1;
+        public int TransformLockedCount => Domain == EditorSelectionDomain.PanelElement
+            ? PanelElements.Count(element => element.IsTransformLocked)
+            : FaceElements.Count(element => element.IsTransformLocked);
+    }
+
+    private AggregateSelection TryCreateAggregateSelection(DocumentTabViewModel document)
+    {
+        var items = document.SelectionState.Items;
+        if (items.Count == 0)
+        {
+            return default;
+        }
+
+        var domains = items.Select(item => item.Domain).Distinct().ToArray();
+        if (domains.Length != 1 || domains[0] is not (EditorSelectionDomain.PanelElement or EditorSelectionDomain.FaceElement))
+        {
+            return new AggregateSelection(null, [], [], IsUnsupported: true, UnsupportedCount: items.Count);
+        }
+
+        if (domains[0] == EditorSelectionDomain.PanelElement)
+        {
+            var elements = new List<PanelElementModel>();
+            foreach (var item in items)
+            {
+                if (!document.TryGetPanelElementByObjectId(item.ObjectId, out var element))
+                {
+                    return new AggregateSelection(null, [], [], IsUnsupported: true, UnsupportedCount: items.Count);
+                }
+
+                elements.Add(element);
+            }
+
+            return new AggregateSelection(EditorSelectionDomain.PanelElement, elements, [], IsUnsupported: false);
+        }
+
+        var faceElements = new List<FaceElementModel>();
+        foreach (var item in items)
+        {
+            if (!document.TryGetFaceElementByObjectId(item.ObjectId, out var element))
+            {
+                return new AggregateSelection(null, [], [], IsUnsupported: true, UnsupportedCount: items.Count);
+            }
+
+            faceElements.Add(element);
+        }
+
+        return new AggregateSelection(EditorSelectionDomain.FaceElement, [], faceElements, IsUnsupported: false);
+    }
+
+    private static string BuildAggregateTitle(AggregateSelection selection)
+    {
+        if (selection.Domain == EditorSelectionDomain.PanelElement && selection.IsSameConcreteType)
+        {
+            return $"{selection.Count} {Pluralize(NicifyElementKind(selection.PanelElements[0].Kind))}";
+        }
+
+        if (selection.Domain == EditorSelectionDomain.FaceElement && selection.IsSameConcreteType)
+        {
+            return $"{selection.Count} {Pluralize(NicifyFaceElementKind(selection.FaceElements[0]))}";
+        }
+
+        return $"{selection.Count} Components";
+    }
+
+    private static string Pluralize(string value) => value.EndsWith("s", StringComparison.OrdinalIgnoreCase) ? value : $"{value}s";
+
+    private void RebuildAggregatePropertyRows(DocumentTabViewModel document, AggregateSelection selection)
+    {
+        if (selection.Domain == EditorSelectionDomain.PanelElement)
+        {
+            AddPanelAggregateRows(document, selection.PanelElements, includeSameTypeRows: selection.IsSameConcreteType);
+        }
+        else
+        {
+            AddFaceAggregateRows(document, selection.FaceElements, includeSameTypeRows: selection.IsSameConcreteType);
+        }
+
+        if (selection.TransformLockedCount > 0)
+        {
+            _propertyRows.Add(new InspectorInfoPropertyViewModel("Transform Lock Note", "Multi-Edit", "X, Y, Width, and Height edits apply only to unlocked selected objects."));
+        }
+
+        _hadInspectorSelection = true;
+        _lastInspectorSelectionObjectId = GetDocumentSelectionKey();
+        _lastInspectorSelectionKind = selection.Domain == EditorSelectionDomain.PanelElement && selection.IsSameConcreteType ? selection.PanelElements[0].Kind : null;
+        _lastInspectorFaceSelectionKind = selection.Domain == EditorSelectionDomain.FaceElement && selection.IsSameConcreteType ? FaceSelectionService.GetKindToken(selection.FaceElements[0]) : "multi";
+        OnPropertyChanged(nameof(InspectorPropertyRows));
+    }
+
+    private void AddPanelAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, bool includeSameTypeRows)
+    {
+        if (includeSameTypeRows)
+        {
+            AddAggregateText("Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyPanelAggregateUpdate(document, elements, "Update names", new PanelElementModelUpdate { Name = value }, includeLockedTransforms: true));
+        }
+
+        AddAggregateDouble("X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyPanelAggregateUpdate(document, elements, "Update X", new PanelElementModelUpdate { X = value }, includeLockedTransforms: false));
+        AddAggregateDouble("Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyPanelAggregateUpdate(document, elements, "Update Y", new PanelElementModelUpdate { Y = value }, includeLockedTransforms: false));
+        AddAggregateDouble("Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update width", new PanelElementModelUpdate { Width = value }, includeLockedTransforms: false) : "Width must be greater than zero.");
+        AddAggregateDouble("Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update height", new PanelElementModelUpdate { Height = value }, includeLockedTransforms: false) : "Height must be greater than zero.");
+        AddAggregateBool("Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyPanelAggregateUpdate(document, elements, "Update transform lock state", new PanelElementModelUpdate { IsTransformLocked = value }, includeLockedTransforms: true));
+        AddAggregateBool("Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyPanelAggregateUpdate(document, elements, "Update visibility", new PanelElementModelUpdate { IsVisible = value }, includeLockedTransforms: true));
+
+        if (includeSameTypeRows)
+        {
+            AddPanelTypeSpecificAggregateRows(document, elements);
+        }
+    }
+
+    private void AddPanelTypeSpecificAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements)
+    {
+        var kind = elements[0].Kind;
+        if (kind is PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment)
+            AddAggregateInt("Display Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayNumber)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display number", new PanelElementModelUpdate { DisplayNumber = value }, true));
+        if (kind is PanelElementKind.Image or PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel)
+            AddAggregateText("Asset Path", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.AssetPath ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update asset path", new PanelElementModelUpdate { AssetPath = NormalizeOptionalText(value) }, true));
+        if (kind is PanelElementKind.Lamp)
+        {
+            AddAggregateColor("On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateColor("Off Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OffColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update off color", new PanelElementModelUpdate { OffColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateBool("Border", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.HasBorder)), value => TryApplyPanelAggregateUpdate(document, elements, "Update lamp border", new PanelElementModelUpdate { HasBorder = value }, true));
+        }
+        if (kind is PanelElementKind.Alpha)
+        {
+            AddAggregateColor("On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateBool("Decimal Point", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowDecimalPoint)), value => TryApplyPanelAggregateUpdate(document, elements, "Update decimal point visibility", new PanelElementModelUpdate { ShowDecimalPoint = value }, true));
+            AddAggregateBool("Comma", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowCommaTail)), value => TryApplyPanelAggregateUpdate(document, elements, "Update comma visibility", new PanelElementModelUpdate { ShowCommaTail = value }, true));
+            AddAggregateBool("Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
+        }
+        if (kind is PanelElementKind.Label)
+        {
+            AddAggregateText("Display Text", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayText ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display text", new PanelElementModelUpdate { DisplayText = NormalizeOptionalText(value) }, true));
+            AddAggregateColor("Text Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.TextColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update text color", new PanelElementModelUpdate { TextColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateInt("Lamp Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.LampNumber)), value => value < 0 ? "Lamp Number must be zero or greater." : TryApplyPanelAggregateUpdate(document, elements, "Update lamp number", new PanelElementModelUpdate { LampNumber = value }, true));
+        }
+        if (kind is PanelElementKind.Reel)
+        {
+            AddAggregateInt("Stops", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.Stops)), value => TryApplyPanelAggregateUpdate(document, elements, "Update stops", new PanelElementModelUpdate { Stops = value }, true));
+            AddAggregateDouble("Band Offset", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.BandOffset ?? 0d)), value => PanelElementValidation.IsValidBandOffset(value) ? TryApplyPanelAggregateUpdate(document, elements, "Update band offset", new PanelElementModelUpdate { BandOffset = value }, true) : "Enter a value from -1 to 1.", "G17");
+            AddAggregateBool("Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
+        }
+    }
+
+    private void AddFaceAggregateRows(DocumentTabViewModel document, IReadOnlyList<FaceElementModel> elements, bool includeSameTypeRows)
+    {
+        if (includeSameTypeRows)
+            AddAggregateText("Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyFaceAggregateUpdate(document, elements, "Update names", new FaceElementModelUpdate { Name = value }, true));
+        AddAggregateDouble("X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyFaceAggregateUpdate(document, elements, "Update X", new FaceElementModelUpdate { X = value }, false));
+        AddAggregateDouble("Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyFaceAggregateUpdate(document, elements, "Update Y", new FaceElementModelUpdate { Y = value }, false));
+        AddAggregateDouble("Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update width", new FaceElementModelUpdate { Width = value }, false) : "Width must be greater than zero.");
+        AddAggregateDouble("Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update height", new FaceElementModelUpdate { Height = value }, false) : "Height must be greater than zero.");
+        AddAggregateBool("Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyFaceAggregateUpdate(document, elements, "Update transform lock state", new FaceElementModelUpdate { IsTransformLocked = value }, true));
+        AddAggregateBool("Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyFaceAggregateUpdate(document, elements, "Update visibility", new FaceElementModelUpdate { IsVisible = value }, true));
+        if (includeSameTypeRows)
+        {
+            AddAggregateText("Machine Reference", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedMachineObjectReference?.ToString() ?? string.Empty)), value => TryApplyFaceAggregateMachineReferenceUpdate(document, elements, value));
+            AddAggregateText("Linked Panel2D Element", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedPanel2DElementId ?? string.Empty)), value => TryApplyFaceAggregateUpdate(document, elements, "Update linked Panel2D element", new FaceElementModelUpdate { HasLinkedPanel2DElementId = true, LinkedPanel2DElementId = NormalizeOptionalText(value) }, true));
+        }
+    }
+
+    private void AddAggregateText(string name, string group, InspectorAggregateValue<string> value, Func<string, string?> commit) { var row = new InspectorTextPropertyViewModel(name, group, value.IsCommon ? value.Value ?? string.Empty : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+    private void AddAggregateDouble(string name, string group, InspectorAggregateValue<double> value, Func<double, string?> commit, string format = "0.###") { var row = new InspectorDoublePropertyViewModel(name, group, value.IsCommon ? value.Value : 0d, commit: commit, format: format); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+    private void AddAggregateInt(string name, string group, InspectorAggregateValue<int?> value, Func<int?, string?> commit) { var row = new InspectorIntPropertyViewModel(name, group, value.IsCommon ? value.Value : null, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+    private void AddAggregateColor(string name, string group, InspectorAggregateValue<string> value, Func<string?, string?> commit) { var row = new InspectorColorPropertyViewModel(name, group, value.IsCommon ? value.Value : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+    private void AddAggregateBool(string name, string group, InspectorAggregateValue<bool> value, Func<bool, string?> commit) { var row = new InspectorBoolPropertyViewModel(name, group, value.IsCommon && value.Value == true, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+
+    private string? TryApplyPanelAggregateUpdate(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, string description, PanelElementModelUpdate update, bool includeLockedTransforms)
+    {
+        var originals = new Dictionary<string, PanelElementModel>();
+        var updated = new Dictionary<string, PanelElementModel>();
+        foreach (var element in elements.Where(e => includeLockedTransforms || !e.IsTransformLocked))
+        {
+            var next = PanelElementModelUpdater.Apply(element, update);
+            if (!PanelElementValidation.IsValidForInspectorUpdate(next)) return "Invalid element dimensions.";
+            if (PanelElementModelComparer.AreEquivalent(element, next)) continue;
+            originals[element.ObjectId] = element;
+            updated[element.ObjectId] = next;
+        }
+        if (updated.Count == 0) return null;
+        return _executeCanvasCommand(document.DocumentId, CanvasMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, updated, originals, description)) ? null : "Unable to apply update.";
+    }
+
+    private string? TryApplyFaceAggregateMachineReferenceUpdate(DocumentTabViewModel document, IReadOnlyList<FaceElementModel> elements, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return TryApplyFaceAggregateUpdate(document, elements, "Update machine reference", new FaceElementModelUpdate { HasLinkedMachineObjectReference = true, LinkedMachineObjectReference = null }, true);
+        return MachineObjectReference.TryParse(value, out var reference)
+            ? TryApplyFaceAggregateUpdate(document, elements, "Update machine reference", new FaceElementModelUpdate { HasLinkedMachineObjectReference = true, LinkedMachineObjectReference = reference }, true)
+            : "Use a machine reference such as lamp:17, reel:2, alpha:0, sevenSegment:12, or input:start.";
+    }
+
+    private string? TryApplyFaceAggregateUpdate(DocumentTabViewModel document, IReadOnlyList<FaceElementModel> elements, string description, FaceElementModelUpdate update, bool includeLockedTransforms)
+    {
+        var originals = new Dictionary<string, FaceElementModel>();
+        var updated = new Dictionary<string, FaceElementModel>();
+        foreach (var element in elements.Where(e => includeLockedTransforms || !e.IsTransformLocked))
+        {
+            var next = FaceElementModelUpdater.Apply(element, update);
+            if (!FaceElementValidation.IsValidForInspectorUpdate(next)) return "Invalid face element dimensions.";
+            if (FaceElementModelComparer.AreEquivalent(element, next)) continue;
+            originals[element.ObjectId] = element;
+            updated[element.ObjectId] = next;
+        }
+        if (updated.Count == 0) return null;
+        return _executeCanvasCommand(document.DocumentId, FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, updated, originals, description)) ? null : "Unable to apply update.";
+    }
+
 
     private void RebuildFaceSourceShapePropertyRows(DocumentTabViewModel selectedDocument, PanelFaceSourceShapeModel sourceShape)
     {
@@ -630,7 +911,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
             return null;
         }
 
-        return _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo selection
+        return selectedDocument.SelectionState.Items.Count > 0
+            ? $"{selectedDocument.DocumentId:N}:{string.Join("|", selectedDocument.SelectionState.Items.Select(item => $"{item.Domain}:{item.ObjectId}"))}:p={selectedDocument.SelectionState.PrimaryItem?.Domain}:{selectedDocument.SelectionState.PrimaryItem?.ObjectId}"
+            : _activeDocumentContext.ActivePanelSelection is PanelSelectionInfo selection
             ? $"{selectedDocument.DocumentId:N}:{selection.Kind}:{selection.ObjectId}"
             : $"{selectedDocument.DocumentId:N}:document";
     }
@@ -644,6 +927,14 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
         var selectedDocument = _selectedDocumentAccessor();
         var selection = _activeDocumentContext.ActivePanelSelection;
+        if (selectedDocument is not null && TryCreateAggregateSelection(selectedDocument) is { Count: > 1 } aggregateSelection)
+        {
+            return !_hadInspectorSelection
+                || !string.Equals(_lastInspectorSelectionObjectId, GetDocumentSelectionKey(), StringComparison.Ordinal)
+                || (aggregateSelection.IsSupported && aggregateSelection.Domain == EditorSelectionDomain.PanelElement && aggregateSelection.IsSameConcreteType && _lastInspectorSelectionKind != aggregateSelection.PanelElements[0].Kind)
+                || (aggregateSelection.IsSupported && aggregateSelection.Domain == EditorSelectionDomain.FaceElement && aggregateSelection.IsSameConcreteType && !string.Equals(_lastInspectorFaceSelectionKind, FaceSelectionService.GetKindToken(aggregateSelection.FaceElements[0]), StringComparison.Ordinal));
+        }
+
         if (selectedDocument is not null
             && selectedDocument.Document.DocumentType == EditorDocumentType.Face
             && selection is PanelSelectionInfo maskSelection

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -595,15 +595,15 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         bool IsUnsupported,
         int UnsupportedCount = 0)
     {
-        public int Count => IsUnsupported ? UnsupportedCount : PanelElements.Count + FaceElements.Count;
+        public int Count => IsUnsupported ? UnsupportedCount : (PanelElements?.Count ?? 0) + (FaceElements?.Count ?? 0);
         public bool IsSupported => !IsUnsupported && Domain is EditorSelectionDomain.PanelElement or EditorSelectionDomain.FaceElement && Count > 0;
         public string DomainLabel => Domain == EditorSelectionDomain.FaceElement ? "Face Elements" : "Panel2D Components";
         public bool IsSameConcreteType => Domain == EditorSelectionDomain.PanelElement
-            ? PanelElements.Select(element => element.Kind).Distinct().Count() == 1
-            : FaceElements.Select(element => element.GetType()).Distinct().Count() == 1;
+            ? (PanelElements?.Select(element => element.Kind).Distinct().Count() ?? 0) == 1
+            : (FaceElements?.Select(element => element.GetType()).Distinct().Count() ?? 0) == 1;
         public int TransformLockedCount => Domain == EditorSelectionDomain.PanelElement
-            ? PanelElements.Count(element => element.IsTransformLocked)
-            : FaceElements.Count(element => element.IsTransformLocked);
+            ? PanelElements?.Count(element => element.IsTransformLocked) ?? 0
+            : FaceElements?.Count(element => element.IsTransformLocked) ?? 0;
     }
 
     private AggregateSelection TryCreateAggregateSelection(DocumentTabViewModel document)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml
@@ -90,7 +90,8 @@
                 <TextBlock VerticalAlignment="Center"
                            Text="{Binding DisplayName}" />
                 <CheckBox Grid.Column="1"
-                          IsChecked="{Binding Value}" />
+                          IsThreeState="True"
+                          IsChecked="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
         </DataTemplate>
 


### PR DESCRIPTION
### Motivation

- Implement Task 05: provide Unity-style Inspector aggregation and atomic multi-object editing for selected Panel2D and Face components driven by `DocumentSelectionState.Items` rather than temporary bridges.
- Represent aggregated property state explicitly (common / mixed / unavailable) so the Inspector can show mixed placeholders and three-state booleans without storing presentation strings as values.

### Description

- Added `InspectorAggregateValue<T>` and `InspectorAggregateValueState` to represent `Unavailable`, `Common`, and `Mixed` aggregation results and an `From<T>` helper to compute aggregation across a selection (`WindowsNetProjects/OasisEditor/OasisEditor/InspectorAggregateValue.cs`).
- Extended Inspector property row view models with aggregate-aware state and API: added `IInspectorAggregatePropertyRow`, `IsMixed` flags, and `SetMixedValue(...)` on text/double/int/color rows, and made boolean rows three-state using `bool?` internally (`WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorPropertyRowViewModels.cs` and `WindowsNetProjects/OasisEditor/OasisEditor/Views/InspectorView.xaml`).
- Implemented aggregate selection resolution and row building in `InspectorViewModel`: added an `AggregateSelection` record and `TryCreateAggregateSelection(...)`, aggregate title/summary logic, and `RebuildAggregatePropertyRows(...)` with separate builders for Panel2D and Face aggregates that show base fields for mixed types and type-specific fields for same-concrete-type selections (`WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs`).
- Implemented atomic multi-object commit helpers that validate all proposed updates, skip unchanged items, and call existing bulk commands: `CanvasMutationCommands.CreateBulkUpdateElementsCommand(...)` for Panel2D and `FaceMutationCommands.CreateBulkUpdateElementsCommand(...)` for Face; transform edits exclude `IsTransformLocked` members while non-transform edits include locked members (`InspectorViewModel.cs`).
- Updated bulk mutation commands to surface broader `PanelChangeProperties` flags for multi-object Undo/Redo so Inspector, hierarchy, and viewport refresh correctly after multi-object edits (`CanvasMutationCommands.cs`, `FaceMutationCommands.cs`).
- Added targeted unit tests that exercise aggregation and multi-edit semantics (new test file `WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs`) covering aggregate state, same-type vs mixed-type rows, absolute transform assignment, locked-transform exclusion, and non-transform edits applying to locked items.

### Testing

- Added automated tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs` but tests were not executed in this environment because the available agent environment lacks the Windows/.NET/WPF toolchain per repository `AGENTS.md` (do not run builds/tests here). The new tests include checks for aggregation state, row exposure for same-type and mixed-type Panel selections, absolute multi-edit behavior, and transform-lock rules.
- Per the local-agent constraints we ran repository static checks: `git diff --check` completed without issues.
- Please run the new test suite locally with the OasisEditor toolchain (for example: run the solution's tests via `dotnet test` on a Windows machine with the required toolchain) and verify the manual checklist described in Task 05 (multi-selection title/summary, mixed placeholders, three-state booleans, transform-lock exclusion, atomic undo/redo, and refresh behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53ada3264c8327a42327d60c148ddd)