### PR TITLE
Fix face drag undo and lock generated artwork

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs
@@ -79,4 +79,68 @@ public sealed class FaceGenerationServiceTests
         Assert.True(lamp.SourceBlend);
     }
 
+
+    [Fact]
+    public void GenerateFromPanelFaceSourceShape_LocksGeneratedArtworkTransformByDefault()
+    {
+        var result = new FaceGenerationService().GenerateFromPanelFaceSourceShape(CreatePanelWithFaceSourceShape(), CreateSourceShape(), "Face", "panel-doc-1");
+
+        var artwork = Assert.IsType<FaceArtworkElement>(Assert.Single(result.Document.Elements.OfType<FaceArtworkElement>()));
+        Assert.True(artwork.IsTransformLocked);
+    }
+
+    [Fact]
+    public void Regenerate_LocksReplacementGeneratedArtworkTransformByDefault()
+    {
+        var existingFace = new FaceDocumentModel
+        {
+            Id = "face-1",
+            Title = "Face",
+            SourcePanel2DDocumentId = "panel-doc-1",
+            SourceFaceShapeId = "shape-1",
+            SourceRegion = FaceSourceRegionModel.FromRect(new Rect(0, 0, 100, 100)),
+            Elements =
+            [
+                new FaceArtworkElement
+                {
+                    ObjectId = "existing-artwork",
+                    Name = "Existing Artwork",
+                    X = 0,
+                    Y = 0,
+                    Width = 100,
+                    Height = 100,
+                    IsVisible = true,
+                    SourcePanel2DDocumentId = "panel-doc-1"
+                }
+            ]
+        };
+
+        var result = new FaceRegenerationService().Regenerate(existingFace, CreatePanelWithFaceSourceShape(), documentPath: "Assets/Faces/Face/asset.face");
+
+        var artwork = Assert.IsType<FaceArtworkElement>(Assert.Single(result.Document.Elements.OfType<FaceArtworkElement>()));
+        Assert.Equal("existing-artwork", artwork.ObjectId);
+        Assert.True(artwork.IsTransformLocked);
+    }
+
+    private static Panel2DDocumentModel CreatePanelWithFaceSourceShape()
+    {
+        return new Panel2DDocumentModel
+        {
+            FaceSourceShapes = [CreateSourceShape()]
+        };
+    }
+
+    private static PanelFaceSourceShapeModel CreateSourceShape()
+    {
+        return new PanelFaceSourceShapeModel
+        {
+            Id = "shape-1",
+            Name = "Glass",
+            TopLeft = new FacePointModel { X = 0, Y = 0 },
+            TopRight = new FacePointModel { X = 100, Y = 0 },
+            BottomRight = new FacePointModel { X = 100, Y = 100 },
+            BottomLeft = new FacePointModel { X = 0, Y = 100 }
+        };
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
@@ -116,6 +116,77 @@ public sealed class FaceMultiSelectionInteractionTests
         Assert.Equal(13, document.GetFaceElements()[1].X);
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void PreviewedBulkMoveCommand_RecordsOneUndoEntryWhenLiveGeometryAlreadyEqualsFinal(int selectedCount)
+    {
+        var document = CreateDocument(
+            new FaceLampWindowElement { ObjectId = "a", X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new FaceReelDisplayElement { ObjectId = "b", X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetFaceElements()
+            .Take(selectedCount)
+            .ToDictionary(element => element.ObjectId, element => FaceElementModelCloner.Clone(element));
+        var moved = originals.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value, x: pair.Value.X + 3, y: pair.Value.Y + 4));
+
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, moved));
+        Assert.Empty(document.CommandService.History.Entries);
+
+        document.CommandService.Execute(FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, moved, originals, "Move face elements"));
+
+        Assert.Single(document.CommandService.History.Entries);
+        foreach (var pair in moved)
+        {
+            var element = Assert.Single(document.GetFaceElements(), faceElement => faceElement.ObjectId == pair.Key);
+            Assert.True(FaceElementModelComparer.AreEquivalent(pair.Value, element));
+        }
+
+        Assert.True(document.CommandService.TryUndo());
+        foreach (var pair in originals)
+        {
+            var element = Assert.Single(document.GetFaceElements(), faceElement => faceElement.ObjectId == pair.Key);
+            Assert.True(FaceElementModelComparer.AreEquivalent(pair.Value, element));
+        }
+
+        Assert.True(document.CommandService.TryRedo());
+        foreach (var pair in moved)
+        {
+            var element = Assert.Single(document.GetFaceElements(), faceElement => faceElement.ObjectId == pair.Key);
+            Assert.True(FaceElementModelComparer.AreEquivalent(pair.Value, element));
+        }
+    }
+
+    [Fact]
+    public void BulkMoveCommand_EquivalentOriginalAndFinalSnapshotsDoesNotRecordUndoHistory()
+    {
+        var document = CreateDocument(new FaceLampWindowElement { ObjectId = "a", X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetFaceElements().ToDictionary(element => element.ObjectId, element => FaceElementModelCloner.Clone(element));
+        var equivalentFinal = originals.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value));
+
+        document.CommandService.Execute(FaceMutationCommands.CreateBulkUpdateElementsCommand(document.DocumentId, document, equivalentFinal, originals, "Move face elements"));
+
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.False(document.IsDirty);
+    }
+
+    [Fact]
+    public void BulkPreviewCancellation_RestoresOriginalsWithoutUndoHistory()
+    {
+        var document = CreateDocument(
+            new FaceLampWindowElement { ObjectId = "a", X = 0, Y = 0, Width = 5, Height = 5, IsVisible = true },
+            new FaceReelDisplayElement { ObjectId = "b", X = 10, Y = 10, Width = 5, Height = 5, IsVisible = true });
+        var originals = document.GetFaceElements().ToDictionary(element => element.ObjectId, element => FaceElementModelCloner.Clone(element));
+        var preview = originals.ToDictionary(pair => pair.Key, pair => FaceElementModelCloner.Clone(pair.Value, x: pair.Value.X + 5, y: pair.Value.Y + 6));
+
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, preview));
+        Assert.True(FaceElementPreviewMutationService.TryApplyPreviews(document, originals));
+
+        Assert.Equal(0, document.GetFaceElements()[0].X);
+        Assert.Equal(10, document.GetFaceElements()[1].X);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.False(document.IsDirty);
+    }
+
     private static DocumentTabViewModel CreateDocument(params FaceElementModel[] elements)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs
@@ -137,6 +137,7 @@ internal sealed class FaceGenerationService
             Width = output.Width,
             Height = output.Height,
             IsVisible = true,
+            IsTransformLocked = true,
             AssetPath = assetPath,
             SourcePanel2DDocumentId = NormalizeOptional(sourcePanel2DDocumentId),
             SourceRegion = region,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs
@@ -213,45 +213,74 @@ internal static class FaceMutationCommands
             WasExecuted = false;
             var elements = _document.GetFaceElements().ToList();
             var previous = new Dictionary<string, FaceElementModel>();
-            var changed = false;
+            var logicalChanged = false;
+
             for (var i = 0; i < elements.Count; i++)
             {
                 var existing = elements[i];
-                if (string.IsNullOrWhiteSpace(existing.ObjectId) || !_updatedElements.TryGetValue(existing.ObjectId, out var updated)) continue;
-                if (updated.GetType() != existing.GetType() || !FaceElementValidation.IsValidForInspectorUpdate(updated)) continue;
-                previous[existing.ObjectId] = _originalElements.TryGetValue(existing.ObjectId, out var original) && original.GetType() == existing.GetType()
-                    ? FaceElementModelCloner.Clone(original)
-                    : FaceElementModelCloner.Clone(existing);
+                if (string.IsNullOrWhiteSpace(existing.ObjectId) || !_updatedElements.TryGetValue(existing.ObjectId, out var updated))
+                {
+                    continue;
+                }
+
+                if (updated.GetType() != existing.GetType() || !FaceElementValidation.IsValidForInspectorUpdate(updated))
+                {
+                    continue;
+                }
+
+                var previousElement = _originalElements.TryGetValue(existing.ObjectId, out var original)
+                    && original.GetType() == existing.GetType()
+                    && FaceElementValidation.IsValidForInspectorUpdate(original)
+                        ? FaceElementModelCloner.Clone(original)
+                        : FaceElementModelCloner.Clone(existing);
+                previous[existing.ObjectId] = previousElement;
+
+                if (!FaceElementModelComparer.AreEquivalent(previousElement, updated))
+                {
+                    logicalChanged = true;
+                }
+
                 if (!FaceElementModelComparer.AreEquivalent(existing, updated))
                 {
                     elements[i] = FaceElementModelCloner.Clone(updated);
-                    changed = true;
                 }
             }
 
-            if (previous.Count == 0) return;
-            _previousElements = previous;
-            if (changed)
+            if (previous.Count == 0 || !logicalChanged)
             {
-                _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
-                _document.MarkDirty();
-                WasExecuted = true;
+                return;
             }
+
+            _previousElements = previous;
+            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
+            _document.MarkDirty();
+            WasExecuted = true;
         }
 
         public void Undo()
         {
-            if (_previousElements is null || _previousElements.Count == 0) return;
-            var elements = _document.GetFaceElements().ToList();
-            for (var i = 0; i < elements.Count; i++)
+            if (_previousElements is null || _previousElements.Count == 0)
             {
-                if (_previousElements.TryGetValue(elements[i].ObjectId, out var previous))
+                return;
+            }
+
+            var elements = _document.GetFaceElements().ToList();
+            var changed = false;
+            foreach (var previous in _previousElements)
+            {
+                var index = elements.FindIndex(element => string.Equals(element.ObjectId, previous.Key, StringComparison.Ordinal));
+                if (index >= 0 && !FaceElementModelComparer.AreEquivalent(elements[index], previous.Value))
                 {
-                    elements[i] = FaceElementModelCloner.Clone(previous);
+                    elements[index] = FaceElementModelCloner.Clone(previous.Value);
+                    changed = true;
                 }
             }
-            _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
-            _document.MarkDirty();
+
+            if (changed)
+            {
+                _document.SetFaceElements(elements, CreateChange(_document, null, PanelChangeProperties.Geometry | PanelChangeProperties.Name | PanelChangeProperties.Visibility | PanelChangeProperties.TransformLockState | PanelChangeProperties.Metadata));
+                _document.MarkDirty();
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Dragging selected Face elements did not create an undo entry when preview mutation had already applied the final geometry because execution was inferred from the live models rather than the supplied original snapshots.
- Generated perspective-corrected Face artwork was created unlocked, requiring manual locking after generation.

### Description
- Make `BulkUpdateFaceElementsMutationCommand` determine logical change by comparing the supplied original snapshots to the requested updated snapshots and record the command when those differ, while still applying the final live state; update `Undo()` to restore only elements that differ from the captured originals to keep repeated Undo/Redo correct (`WindowsNetProjects/OasisEditor/OasisEditor/FaceMutationCommands.cs`).
- Default generated `FaceArtworkElement` to `IsTransformLocked = true` when creating artwork from a Panel Face Source Shape (`WindowsNetProjects/OasisEditor/OasisEditor/FaceGenerationService.cs`).
- Add focused regression tests that cover previewed bulk moves where live geometry already equals final geometry, no-op final snapshots, preview cancellation, and generation/regeneration artwork lock state (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs` and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceGenerationServiceTests.cs`).
- Keep scope narrow and do not start Task 06 or add migration/compatibility layers.

### Testing
- Added automated unit tests: `PreviewedBulkMoveCommand_RecordsOneUndoEntryWhenLiveGeometryAlreadyEqualsFinal`, `BulkMoveCommand_EquivalentOriginalAndFinalSnapshotsDoesNotRecordUndoHistory`, `BulkPreviewCancellation_RestoresOriginalsWithoutUndoHistory` (in `FaceMultiSelectionInteractionTests.cs`) and `GenerateFromPanelFaceSourceShape_LocksGeneratedArtworkTransformByDefault` and `Regenerate_LocksReplacementGeneratedArtworkTransformByDefault` (in `FaceGenerationServiceTests.cs`).
- Per repository `AGENTS.md` the .NET/WPF toolchain is not available here so `dotnet test` was not executed in this environment; please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` locally to verify all tests pass.
- Ran `git diff --check` which reported no whitespace or diff-check issues prior to committing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53b7ba9780832796c4a9f1e7b9f62e)