### PR TITLE
Implement atomic bulk delete for selected Panel2D/Face elements

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceMultiSelectionInteractionTests.cs
@@ -187,6 +187,41 @@ public sealed class FaceMultiSelectionInteractionTests
         Assert.False(document.IsDirty);
     }
 
+
+    [Fact]
+    public void BulkDeleteSelectionCommand_DeletesFaceSelectionAtomicallyAndRestoresOrder()
+    {
+        var document = CreateDocument(
+            new FaceLampWindowElement { ObjectId = "first", Name = "First", X = 0, Y = 0, Width = 10, Height = 10, SourceComponentIndex = 1, IsVisible = true },
+            new FaceLampWindowElement { ObjectId = "second", Name = "Second", X = 10, Y = 0, Width = 10, Height = 10, SourceComponentIndex = 2, IsVisible = true },
+            new FaceLampWindowElement { ObjectId = "third", Name = "Third", X = 20, Y = 0, Width = 10, Height = 10, SourceComponentIndex = 3, IsVisible = true });
+        document.SelectionState.Replace(new[]
+        {
+            new EditorSelectionItem(EditorSelectionDomain.FaceElement, "third"),
+            new EditorSelectionItem(EditorSelectionDomain.FaceMaskLayer, "mask"),
+            new EditorSelectionItem(EditorSelectionDomain.FaceElement, "first")
+        }, new EditorSelectionItem(EditorSelectionDomain.FaceElement, "first"));
+
+        var command = new BulkDeleteSelectionCommand(document.DocumentId, document, document.SelectionState.Items);
+        var tracked = Assert.IsAssignableFrom<Commands.IExecutionTrackedCommand>(command);
+
+        command.Execute();
+
+        Assert.True(tracked.WasExecuted);
+        Assert.Equal(new[] { "second" }, document.GetFaceElements().Select(element => element.ObjectId));
+        Assert.Empty(document.SelectionState.Items);
+
+        command.Undo();
+
+        Assert.Equal(new[] { "first", "second", "third" }, document.GetFaceElements().Select(element => element.ObjectId));
+        Assert.Equal(3, Assert.IsType<FaceLampWindowElement>(document.GetFaceElements()[2]).SourceComponentIndex);
+        Assert.Empty(document.SelectionState.Items);
+
+        command.Execute();
+
+        Assert.Equal(new[] { "second" }, document.GetFaceElements().Select(element => element.ObjectId));
+    }
+
     private static DocumentTabViewModel CreateDocument(params FaceElementModel[] elements)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFaceStub("Face"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRoundTripTests.cs
@@ -775,6 +775,58 @@ public sealed class Panel2DRoundTripTests
         Assert.Contains(roundTripped.Elements, element => element.Kind == "alpha");
     }
 
+
+    [Fact]
+    public void BulkDeleteSelectionCommand_DeletesPanelSelectionAtomicallyAndRestoresOrder()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "first", Name = "First", Kind = PanelElementKind.Rectangle, X = 0, Y = 0, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "second", Name = "Second", Kind = PanelElementKind.Lamp, X = 10, Y = 0, Width = 10, Height = 10, LampNumber = 7 },
+            new PanelElementModel { ObjectId = "third", Name = "Third", Kind = PanelElementKind.Rectangle, X = 20, Y = 0, Width = 10, Height = 10 });
+        document.SelectionState.Replace(new[]
+        {
+            new EditorSelectionItem(EditorSelectionDomain.PanelElement, "third"),
+            new EditorSelectionItem(EditorSelectionDomain.PanelFaceSourceShape, "unsupported-shape"),
+            new EditorSelectionItem(EditorSelectionDomain.PanelElement, "first")
+        }, new EditorSelectionItem(EditorSelectionDomain.PanelElement, "first"));
+
+        var command = new BulkDeleteSelectionCommand(document.DocumentId, document, document.SelectionState.Items);
+        var tracked = Assert.IsAssignableFrom<Commands.IExecutionTrackedCommand>(command);
+
+        command.Execute();
+
+        Assert.True(tracked.WasExecuted);
+        Assert.Equal(new[] { "second" }, document.GetPanelElements().Select(element => element.ObjectId));
+        Assert.Empty(document.SelectionState.Items);
+
+        command.Undo();
+
+        Assert.Equal(new[] { "first", "second", "third" }, document.GetPanelElements().Select(element => element.ObjectId));
+        var restoredLamp = Assert.IsType<PanelElementModel>(document.GetPanelElements()[1]);
+        Assert.Equal(7, restoredLamp.LampNumber);
+        Assert.Empty(document.SelectionState.Items);
+
+        command.Execute();
+
+        Assert.Equal(new[] { "second" }, document.GetPanelElements().Select(element => element.ObjectId));
+    }
+
+    [Fact]
+    public void BulkDeleteSelectionCommand_NoDeletableSelection_DoesNotExecute()
+    {
+        var document = CreatePanelDocument(new PanelElementModel { ObjectId = "first", Name = "First", Kind = PanelElementKind.Rectangle, X = 0, Y = 0, Width = 10, Height = 10 });
+        var command = new BulkDeleteSelectionCommand(
+            document.DocumentId,
+            document,
+            new[] { new EditorSelectionItem(EditorSelectionDomain.PanelFaceSourceShape, "shape") });
+        var tracked = Assert.IsAssignableFrom<Commands.IExecutionTrackedCommand>(command);
+
+        command.Execute();
+
+        Assert.False(tracked.WasExecuted);
+        Assert.Equal(new[] { "first" }, document.GetPanelElements().Select(element => element.ObjectId));
+    }
+
     [Fact]
     public void DeleteElementCommand_TracksExecutionAndSupportsUndoRedo()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/BulkDeleteSelectionCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/BulkDeleteSelectionCommand.cs
@@ -1,6 +1,6 @@
 namespace OasisEditor;
 
-internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+public sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
 {
     private readonly Guid _documentId;
     private readonly DocumentTabViewModel _document;
@@ -34,7 +34,7 @@ internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Co
             var ids = _deletedPanelElements.Select(item => item.Element.ObjectId).ToHashSet(StringComparer.Ordinal);
             var elements = _document.GetPanelElements()
                 .Where(element => !ids.Contains(element.ObjectId))
-                .Select(PanelElementModelCloner.Clone)
+                .Select(element => PanelElementModelCloner.Clone(element))
                 .ToArray();
             _document.SetPanelElements(elements, CreateStructureChange(_document));
             changed = true;
@@ -45,7 +45,7 @@ internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Co
             var ids = _deletedFaceElements.Select(item => item.Element.ObjectId).ToHashSet(StringComparer.Ordinal);
             var elements = _document.GetFaceElements()
                 .Where(element => !ids.Contains(element.ObjectId))
-                .Select(FaceElementModelCloner.Clone)
+                .Select(element => FaceElementModelCloner.Clone(element))
                 .ToArray();
             _document.SetFaceElements(elements, CreateStructureChange(_document));
             changed = true;
@@ -63,7 +63,7 @@ internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Co
         var changed = false;
         if (_deletedPanelElements.Count > 0)
         {
-            var elements = _document.GetPanelElements().Select(PanelElementModelCloner.Clone).ToList();
+            var elements = _document.GetPanelElements().Select(element => PanelElementModelCloner.Clone(element)).ToList();
             foreach (var deleted in _deletedPanelElements.OrderBy(item => item.Index))
             {
                 if (elements.Any(element => string.Equals(element.ObjectId, deleted.Element.ObjectId, StringComparison.Ordinal)))
@@ -83,7 +83,7 @@ internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Co
         var faceChanged = false;
         if (_deletedFaceElements.Count > 0)
         {
-            var elements = _document.GetFaceElements().Select(FaceElementModelCloner.Clone).ToList();
+            var elements = _document.GetFaceElements().Select(element => FaceElementModelCloner.Clone(element)).ToList();
             foreach (var deleted in _deletedFaceElements.OrderBy(item => item.Index))
             {
                 if (elements.Any(element => string.Equals(element.ObjectId, deleted.Element.ObjectId, StringComparison.Ordinal)))

--- a/WindowsNetProjects/OasisEditor/OasisEditor/BulkDeleteSelectionCommand.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/BulkDeleteSelectionCommand.cs
@@ -1,0 +1,163 @@
+namespace OasisEditor;
+
+internal sealed class BulkDeleteSelectionCommand : Commands.IDocumentCommand, Commands.IExecutionTrackedCommand
+{
+    private readonly Guid _documentId;
+    private readonly DocumentTabViewModel _document;
+    private readonly EditorSelectionItem[] _selectionSnapshot;
+    private readonly List<DeletedPanelElement> _deletedPanelElements = [];
+    private readonly List<DeletedFaceElement> _deletedFaceElements = [];
+
+    public BulkDeleteSelectionCommand(Guid documentId, DocumentTabViewModel document, IEnumerable<EditorSelectionItem> selectionSnapshot)
+    {
+        _documentId = documentId;
+        _document = document;
+        _selectionSnapshot = selectionSnapshot.Where(item => item.IsValid).Distinct().ToArray();
+    }
+
+    public Guid DocumentId => _documentId;
+    public string Description => "Delete selected components";
+    public bool WasExecuted { get; private set; }
+
+    public void Execute()
+    {
+        WasExecuted = false;
+        CaptureDeletedSnapshotsIfNeeded();
+        if (_deletedPanelElements.Count == 0 && _deletedFaceElements.Count == 0)
+        {
+            return;
+        }
+
+        var changed = false;
+        if (_deletedPanelElements.Count > 0)
+        {
+            var ids = _deletedPanelElements.Select(item => item.Element.ObjectId).ToHashSet(StringComparer.Ordinal);
+            var elements = _document.GetPanelElements()
+                .Where(element => !ids.Contains(element.ObjectId))
+                .Select(PanelElementModelCloner.Clone)
+                .ToArray();
+            _document.SetPanelElements(elements, CreateStructureChange(_document));
+            changed = true;
+        }
+
+        if (_deletedFaceElements.Count > 0)
+        {
+            var ids = _deletedFaceElements.Select(item => item.Element.ObjectId).ToHashSet(StringComparer.Ordinal);
+            var elements = _document.GetFaceElements()
+                .Where(element => !ids.Contains(element.ObjectId))
+                .Select(FaceElementModelCloner.Clone)
+                .ToArray();
+            _document.SetFaceElements(elements, CreateStructureChange(_document));
+            changed = true;
+        }
+
+        if (changed)
+        {
+            _document.MarkDirty();
+            WasExecuted = true;
+        }
+    }
+
+    public void Undo()
+    {
+        var changed = false;
+        if (_deletedPanelElements.Count > 0)
+        {
+            var elements = _document.GetPanelElements().Select(PanelElementModelCloner.Clone).ToList();
+            foreach (var deleted in _deletedPanelElements.OrderBy(item => item.Index))
+            {
+                if (elements.Any(element => string.Equals(element.ObjectId, deleted.Element.ObjectId, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                elements.Insert(Math.Clamp(deleted.Index, 0, elements.Count), PanelElementModelCloner.Clone(deleted.Element));
+                changed = true;
+            }
+            if (changed)
+            {
+                _document.SetPanelElements(elements, CreateStructureChange(_document));
+            }
+        }
+
+        var faceChanged = false;
+        if (_deletedFaceElements.Count > 0)
+        {
+            var elements = _document.GetFaceElements().Select(FaceElementModelCloner.Clone).ToList();
+            foreach (var deleted in _deletedFaceElements.OrderBy(item => item.Index))
+            {
+                if (elements.Any(element => string.Equals(element.ObjectId, deleted.Element.ObjectId, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                elements.Insert(Math.Clamp(deleted.Index, 0, elements.Count), FaceElementModelCloner.Clone(deleted.Element));
+                faceChanged = true;
+            }
+            if (faceChanged)
+            {
+                _document.SetFaceElements(elements, CreateStructureChange(_document));
+            }
+        }
+
+        if (changed || faceChanged)
+        {
+            _document.MarkDirty();
+        }
+    }
+
+    private void CaptureDeletedSnapshotsIfNeeded()
+    {
+        if (_deletedPanelElements.Count > 0 || _deletedFaceElements.Count > 0)
+        {
+            return;
+        }
+
+        var selectedPanelIds = _selectionSnapshot
+            .Where(item => item.Domain == EditorSelectionDomain.PanelElement)
+            .Select(item => item.ObjectId)
+            .ToHashSet(StringComparer.Ordinal);
+        if (selectedPanelIds.Count > 0)
+        {
+            var panelElements = _document.GetPanelElements();
+            for (var i = 0; i < panelElements.Count; i++)
+            {
+                if (selectedPanelIds.Contains(panelElements[i].ObjectId))
+                {
+                    _deletedPanelElements.Add(new DeletedPanelElement(i, PanelElementModelCloner.Clone(panelElements[i])));
+                }
+            }
+        }
+
+        var selectedFaceIds = _selectionSnapshot
+            .Where(item => item.Domain == EditorSelectionDomain.FaceElement)
+            .Select(item => item.ObjectId)
+            .ToHashSet(StringComparer.Ordinal);
+        if (selectedFaceIds.Count > 0)
+        {
+            var faceElements = _document.GetFaceElements();
+            for (var i = 0; i < faceElements.Count; i++)
+            {
+                if (selectedFaceIds.Contains(faceElements[i].ObjectId))
+                {
+                    _deletedFaceElements.Add(new DeletedFaceElement(i, FaceElementModelCloner.Clone(faceElements[i])));
+                }
+            }
+        }
+    }
+
+    private static PanelChangeEvent CreateStructureChange(DocumentTabViewModel document)
+    {
+        return new PanelChangeEvent(
+            document.DocumentId,
+            null,
+            PanelChangeProperties.Structure,
+            AffectsCanvas: true,
+            AffectsHierarchy: true,
+            AffectsInspectorRows: true,
+            AffectsPersistence: true);
+    }
+
+    private sealed record DeletedPanelElement(int Index, PanelElementModel Element);
+    private sealed record DeletedFaceElement(int Index, FaceElementModel Element);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -30,7 +30,7 @@ internal static class CanvasMutationCommands
 
     public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
     {
-        return new DeleteElementMutationCommand(documentId, document, selection);
+        return new BulkDeleteSelectionCommand(documentId, document, [HierarchySelectionIdentityService.ToSelectionItem(selection)]);
     }
 
     public static Commands.ICommand CreateRenameElementCommand(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/CanvasMutationCommands.cs
@@ -30,7 +30,11 @@ internal static class CanvasMutationCommands
 
     public static Commands.ICommand CreateDeleteElementCommand(Guid documentId, DocumentTabViewModel document, PanelSelectionInfo selection)
     {
-        return new BulkDeleteSelectionCommand(documentId, document, [HierarchySelectionIdentityService.ToSelectionItem(selection)]);
+        var selectionItem = HierarchySelectionIdentityService.ToSelectionItem(selection);
+        return new BulkDeleteSelectionCommand(
+            documentId,
+            document,
+            selectionItem is { } item ? [item] : Array.Empty<EditorSelectionItem>());
     }
 
     public static Commands.ICommand CreateRenameElementCommand(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/HierarchyPanelCommandService.cs
@@ -22,7 +22,9 @@ internal sealed class HierarchyPanelCommandService
 
     public bool CanDeleteSelected()
     {
-        return TryGetSelectionDocument(out var document, out var selection) && document.HasPanelElement(selection);
+        var document = _selectedDocumentAccessor();
+        return document is not null
+            && document.SelectionState.Items.Any(IsBulkDeletableSelectionItem);
     }
 
     public bool CanDeleteItem(HierarchyItemViewModel hierarchyItem)
@@ -57,19 +59,25 @@ internal sealed class HierarchyPanelCommandService
 
     public bool DeleteSelected()
     {
-        if (!TryGetSelectionDocument(out var document, out var selection) || !document.HasPanelElement(selection))
+        var document = _selectedDocumentAccessor();
+        if (document is null)
         {
             return false;
         }
 
-        var command = CanvasMutationCommands.CreateDeleteElementCommand(document.DocumentId, document, selection);
-        var wasDeleted = _executeCanvasCommand(document.DocumentId, command);
-        if (wasDeleted)
+        var selectionSnapshot = document.SelectionState.Items.ToArray();
+        if (!selectionSnapshot.Any(IsBulkDeletableSelectionItem))
         {
-            _updateDocumentSelection(document.DocumentId, null);
+            return false;
         }
 
-        return wasDeleted;
+        var command = new BulkDeleteSelectionCommand(document.DocumentId, document, selectionSnapshot);
+        return _executeCanvasCommand(document.DocumentId, command);
+    }
+
+    private static bool IsBulkDeletableSelectionItem(EditorSelectionItem item)
+    {
+        return item.Domain is EditorSelectionDomain.PanelElement or EditorSelectionDomain.FaceElement;
     }
 
     public bool TryGetSelectedName(out string currentName)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1165,9 +1165,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private HierarchyItemViewModel? GetSelectedHierarchyEntity() => _hierarchy.GetSelectedEntity();
 
-    private bool CanDeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.CanDeleteItem(hierarchyItem);
+    private bool CanDeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.CanDeleteSelected() || _hierarchyPanelCommands.CanDeleteItem(hierarchyItem);
 
-    private void DeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.DeleteItem(hierarchyItem);
+    private void DeleteHierarchyItem(HierarchyItemViewModel hierarchyItem) => _hierarchyPanelCommands.DeleteSelected();
 
     private bool CanOpenUntitledDocument()
     {


### PR DESCRIPTION
### Motivation

- Implement the Task 06 requirement to provide one atomic, user-facing Delete action that removes all supported selected components in a single undoable operation and preserves deterministic ordering and model data.
- Harden integration points so existing hierarchy/viewport delete paths route through the same bulk-delete behavior and unsupported selection domains are explicitly excluded from deletion.
- Begin integration work without performing the full compatibility cleanup (temporary bridge and old-lock removal remain and are deferred for a follow-up), to limit this change to the atomic delete and immediate routing/hardening.

### Description

- Added `BulkDeleteSelectionCommand` which snapshots the selected `PanelElement` and `FaceElement` identities, captures cloned model snapshots with original indices, performs deletions in one operation, and restores elements deterministically on `Undo` by reinserting clones at the original indices.
- Restricts deletable domains to `EditorSelectionDomain.PanelElement` and `EditorSelectionDomain.FaceElement`, treats other domains as non-deletable inputs, and makes the command a no-op (no history entry) when no supported items are selected.
- Integrated the bulk-delete path across the editor by updating `HierarchyPanelCommandService` to invoke the bulk-delete for the full selection snapshot and by changing `CanvasMutationCommands.CreateDeleteElementCommand` to dispatch to the bulk-delete path for ordinary deletion requests; `MainWindowViewModel` hierarchy-delete binding now prefers the selected-set delete path.
- Added focused unit tests that cover Panel2D and Face multi-selection delete scenarios including multi-delete, `Undo` order restoration, `Redo`, unsupported/no-op selection behavior, selection reconciliation after delete, and preservation of type-specific data in restored models.

### Testing

- Added tests: `BulkDeleteSelectionCommand_DeletesPanelSelectionAtomicallyAndRestoresOrder`, `BulkDeleteSelectionCommand_NoDeletableSelection_DoesNotExecute` (Panel2D), and `BulkDeleteSelectionCommand_DeletesFaceSelectionAtomicallyAndRestoresOrder` (Face); these tests were added to the existing test projects but were not executed in this environment.
- Per repository `AGENTS.md` constraints, I ran repository static checks (`git diff --check`) and basic repository searches, which completed without edit conflicts, but I did not build or run the full Windows/.NET/WPF test suite in this environment.
- Local verification instructions: run the OasisEditor test suite on a supported Windows/.NET environment (execute unit tests and perform the manual regression checklist in `TASK_06_BULK_DELETE_AND_INTEGRATION_HARDENING.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53bb63a8a88327b29e87a0e0f372c1)