### PR TITLE
Sync embedded FML decoder with upstream fixes

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Application/Application.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Application/Application.cs
@@ -24,6 +24,7 @@ namespace MfmeFmlDecoder.Application
                     out bool writeLayoutJson,
                     out bool exportLayout,
                     out string exportOutputPath,
+                    out bool printMfmeVersion,
                     out string parseError))
             {
                 if (!string.IsNullOrEmpty(parseError))
@@ -32,13 +33,20 @@ namespace MfmeFmlDecoder.Application
                 return 1;
             }
 
-            RunLog.Quiet = writeLayoutJson || exportLayout;
+            RunLog.Quiet = writeLayoutJson || exportLayout || printMfmeVersion;
             try
             {
                 string inputPath = Path.GetFullPath(fileName);
                 if (!File.Exists(inputPath))
                 {
                     throw new FileNotFoundException(inputPath);
+                }
+
+                if (printMfmeVersion)
+                {
+                    string version = ReadMfmeVersion(inputPath, offset);
+                    Console.Out.WriteLine(version);
+                    return 0;
                 }
 
                 var componentParser = new ComponentParser();
@@ -94,6 +102,17 @@ namespace MfmeFmlDecoder.Application
             }
         }
 
+        private static string ReadMfmeVersion(string inputPath, uint offset)
+        {
+            if (string.Equals(Path.GetExtension(inputPath), ".fml", StringComparison.OrdinalIgnoreCase))
+            {
+                byte[] decrypted = FmlDecryptor.Decrypt(ReadFileBytes(inputPath));
+                return MfmeVersionReader.Read(decrypted, offset);
+            }
+
+            return MfmeVersionReader.Read(inputPath, offset);
+        }
+
         private static bool TryParseArgs(
             string[] args,
             out string fileName,
@@ -101,6 +120,7 @@ namespace MfmeFmlDecoder.Application
             out bool writeLayoutJson,
             out bool exportLayout,
             out string exportOutputPath,
+            out bool printMfmeVersion,
             out string error)
         {
             fileName = null;
@@ -108,6 +128,7 @@ namespace MfmeFmlDecoder.Application
             writeLayoutJson = false;
             exportLayout = false;
             exportOutputPath = null;
+            printMfmeVersion = false;
             error = null;
 
             var positionals = new List<string>();
@@ -147,6 +168,10 @@ namespace MfmeFmlDecoder.Application
                     exportLayout = true;
                     exportOutputPath = value;
                 }
+                else if (a == "--mfme-version")
+                {
+                    printMfmeVersion = true;
+                }
                 else if (!a.StartsWith("-", StringComparison.Ordinal))
                 {
                     positionals.Add(a);
@@ -178,6 +203,12 @@ namespace MfmeFmlDecoder.Application
             if (positionals.Count > 2)
             {
                 error = "Too many positional arguments (expected <file> [offset]).";
+                return false;
+            }
+
+            if (printMfmeVersion && (writeLayoutJson || exportLayout))
+            {
+                error = "--mfme-version cannot be combined with --json or --export.";
                 return false;
             }
 
@@ -249,12 +280,13 @@ namespace MfmeFmlDecoder.Application
         private static void PrintUsage()
         {
             Console.WriteLine("Usage:");
-            Console.WriteLine("  MfmeFmlDecoder <filename.(dat|fml)> [offset] [--json]");
+            Console.WriteLine("  MfmeFmlDecoder <filename.(dat|fml)> [offset] [--json] [--export]");
             Console.WriteLine();
             Console.WriteLine("Options:");
             Console.WriteLine("  --json, -j          Emit decoded layout as JSON on standard output only; errors go to stderr.");
             Console.WriteLine("  --export[=path]     Write layout.json and component images to a zip file.");
             Console.WriteLine("                      Default output: <input-file>.zip in the same directory as the input file.");
+            Console.WriteLine("  --mfme-version      Print the MFME version from the layout file (TLV tag 0x2F) on standard output.");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine("  MfmeFmlDecoder file.dat --json");
@@ -262,6 +294,7 @@ namespace MfmeFmlDecoder.Application
             Console.WriteLine("  MfmeFmlDecoder file.dat 0x1000 --json");
             Console.WriteLine("  MfmeFmlDecoder file.dat --export");
             Console.WriteLine("  MfmeFmlDecoder file.dat --export=C:\\out\\layout.zip");
+            Console.WriteLine("  MfmeFmlDecoder file.fml --mfme-version");
         }
 
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
@@ -15,19 +15,26 @@ namespace MfmeFmlDecoder.src.Decoder.Component
 
         private ComponentTagMap componentTagMap = new ComponentTagMap
         {
-            { 0x01, new TagInfo(0x04, "Colour", new byte[] { 0xF0, 0xF0, 0xF0, 0xFF }, ValueRole.ARGB_COLOR) },
-            { 0x03, new TagInfo(0x00, "Background Image", Array.Empty<byte>(), ValueRole.BITMAP) },
-            { 0x07, new TagInfo(0x04, "BorderColour", new byte[] { 0x00, 0x00, 0x00, 0xFF }, ValueRole.ARGB_COLOR) },
-            { 0x09, new TagInfo(0x04, "TransparentColour", new byte[] { 0x00, 0x00, 0x00, 0xFF }, ValueRole.ARGB_COLOR) },
+            { 0x09, new TagInfo(0x01, "Unknown 0x09", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x0A, new TagInfo(0x01, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x0B, new TagInfo(0x01, "Unknown 0x0B", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x3B, new TagInfo(0x04, "Unknown3B", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
             { 0x36, new TagInfo(0x00, "Overlay image", Array.Empty<byte>(), ValueRole.BITMAP) },
-            { 0x0C, new TagInfo(0x00, "Tile Image", Array.Empty<byte>(), ValueRole.BITMAP) },
-            { 0x08, new TagInfo(0x01, "Transparency_UseColour", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
-            { 0x0F, new TagInfo(0x01, "Transparency_UseAlphaChannel", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x4B, new TagInfo(0x01, "NoOverlayInFullscreenMode", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+        }.WithNestedTagBlock(new ComponentTagMap
+        {
+            { 0x01, new TagInfo(0x04, "Colour", new byte[] { 0xF0, 0xF0, 0xF0, 0xFF }, ValueRole.ARGB_COLOR) },
+            { 0x07, new TagInfo(0x04, "BorderColour", new byte[] { 0x00, 0x00, 0x00, 0xFF }, ValueRole.ARGB_COLOR) },
+            { 0x09, new TagInfo(0x04, "TransparentColour", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+            { 0x0C, new TagInfo(0x00, "Tile Image", Array.Empty<byte>(), ValueRole.BITMAP) },
+            { 0x03, new TagInfo(0x00, "Background Image", Array.Empty<byte>(), ValueRole.BITMAP) },
             { 0x0D, new TagInfo(0x01, "Tiled", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x0E, new TagInfo(0x01, "RandomTile", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
-        };
+            { 0x0F, new TagInfo(0x01, "Transparency_UseAlphaChannel", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x08, new TagInfo(0x01, "Transparency_UseColour", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
+            { 0x0A, new TagInfo(0x04, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+            { 0x0B, new TagInfo(0x04, "Unknown 0x0B", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+        });
 
         public Background Parse(long componentOffset, uint componentId, byte[] data)
         {
@@ -36,11 +43,11 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                     componentId,
                     data, 
                     normalizationRule: new GeometryAngleNormalization.Rule(
-                    RewriteTriggerOffsetDelta: 4,
+                    RewriteTriggerOffsetDelta: 0,
                     ValidAngleOffsetDelta: 0));
 
             var parseOptions = ExtendedTagParser.Options
-                .WithBitmapTags(0x03, 0x36)
+                .WithBitmapTags(0x03, 0x36, 0x0C)
                 .WithFlagDropdown(
                 TransparencyTypeDropdownName,
                 defaultOption: "None",

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BorderParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BorderParser.cs
@@ -8,47 +8,134 @@ namespace MfmeFmlDecoder.src.Decoder.Component
 {
     internal sealed class BorderParser : ComponentParserBase<Border>
     {
-        private ComponentTagMap componentTagMap = new ComponentTagMap
+        private const uint BoundingBoxTagId = 0x06;
+        private const int BoundingBoxLength = 0x10;
+        private const uint PaneSplitTagId = 0x07;
+        private const int PaneSplitLength = 0x10;
+
+        private readonly ComponentTagMap componentTagMap = new ComponentTagMap
         {
-            // TODO: TOTAL HACK -- we need to do a proper job here
             { 0x0A, new TagInfo(0x01, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x0B, new TagInfo(0x01, "Unknown 0x0B", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
-            { 0x37, new TagInfo(0x04, "Unknown 0x37", new byte[] { 0x00 }, ValueRole.UINT32) },
+            { 0x37, new TagInfo(0x04, "Unknown 0x37", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
             { 0x36, new TagInfo(0x00, "Overlay Image", Array.Empty<byte>(), ValueRole.BITMAP) },
-            
-            { 0x3B, new TagInfo(0x04, "Unknown 0x3B", new byte[] { 0x00 }, ValueRole.UINT32) },
-            { 0x06, new TagInfo(0x08, "Unknown 0x06", new byte[] { 0x00 }, ValueRole.RAW) },
-
-
-
+            { 0x3B, new TagInfo(0x04, "Unknown 0x3B", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
         }.WithNestedTagBlock(new ComponentTagMap
         {
+            { 0x01, new TagInfo(0x04, "OuterColour", new byte[] { 0x00, 0x00, 0xFF, 0xFF }, ValueRole.ARGB_COLOR) },
+            { 0x02, new TagInfo(0x04, "BorderWidth", new byte[] { 0x08, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
             { 0x03, new TagInfo(0x00, "Border Image", Array.Empty<byte>(), ValueRole.BITMAP) },
-            { 0x01, new TagInfo(0x04, "Unknown 0x01", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
-            { 0x05, new TagInfo(0x04, "Unknown 0x05", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
-            { 0x06, new TagInfo(0x08, "Unknown 0x06", new byte[] { 0x00 }, ValueRole.RAW) },
-            { 0xCA, new TagInfo(0x04, "Unknown 0xCA", new byte[] { 0x00 }, ValueRole.UINT32) },
-            { 0x4D, new TagInfo(0x04, "Unknown 0x4D", new byte[] { 0x00 }, ValueRole.UINT32) },
-            { 0x22, new TagInfo(0x04, "Unknown 0x4D", new byte[] { 0x00 }, ValueRole.UINT32) },
-            { 0x27, new TagInfo(0x04, "Unknown 0x27", Array.Empty<byte>(), ValueRole.UINT32) },
-
+            { 0x04, new TagInfo(0x04, "Unknown 0x04", new byte[] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
+            { 0x05, new TagInfo(0x04, "InnerColour", new byte[] { 0x00, 0xFF, 0x00, 0xFF }, ValueRole.ARGB_COLOR) },
+            // Four LE uint32s: BoxX, BoxY (always 0), BoxWidth, BoxHeight.
+            { BoundingBoxTagId, new TagInfo(BoundingBoxLength, "BoundingBox", Array.Empty<byte>(), ValueRole.RAW) },
+            // Four LE uint32s: LeftWidth, TopHeight, RightWidth, BottomHeight (2×2 pane split).
+            { PaneSplitTagId, new TagInfo(PaneSplitLength, "PaneSplit", Array.Empty<byte>(), ValueRole.RAW) },
+            { 0x08, new TagInfo(0x04, "Spacing", new byte[] { 0x09, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
         });
+
+        private static readonly Options ExtendedTagOptions =
+            Options.WithBitmapTags(0x03, 0x36);
 
         public Border Parse(long componentOffset, uint componentId, byte[] data)
         {
-            var (component, offset, parseData) = ParseBase(componentOffset, componentId, data);
+            var (component, offset, parseData) = ParseBase(
+                componentOffset,
+                componentId,
+                data,
+                normalizationRule: new GeometryAngleNormalization.Rule(
+                    RewriteTriggerOffsetDelta: 0,
+                    ValidAngleOffsetDelta: 0));
 
-            var parseOptions = WithComponentTagLogging(Options.Default);
+            var parseOptions = WithComponentTagLogging(ExtendedTagOptions);
             var parseResult = ParseExtendedTags(component, componentTagMap, parseData, offset, parseOptions);
-            
+
             ApplyExtendedTags(component, parseResult);
             return component;
         }
 
         private void ApplyExtendedTags(Border component, ParseResult parseResult)
         {
-
             ApplyExtendedTagsByReflection(component, parseResult, componentTagMap);
+
+            ParseResult nested = parseResult.NestedTagBlockResult ?? parseResult;
+            ApplyBoundingBox(component, nested);
+            ApplyPaneSplit(component, nested);
+        }
+
+        private static void ApplyBoundingBox(Border component, ParseResult parseResult)
+        {
+            if (!TryGetFixedRaw(parseResult, 0x06, 0x10, out byte[] raw))
+            {
+                return;
+            }
+
+            uint boxX = BitConverter.ToUInt32(raw, 0);
+            uint boxY = BitConverter.ToUInt32(raw, 4);
+            uint boxWidth = BitConverter.ToUInt32(raw, 8);
+            uint boxHeight = BitConverter.ToUInt32(raw, 12);
+
+            // Wire values stay local (BoxX/BoxY observed as always 0).
+            component.BoxX = boxX;
+            component.BoxY = boxY;
+            component.BoxWidth = boxWidth;
+            component.BoxHeight = boxHeight;
+
+            // Presentation: absolute origin = geometry + local box offset.
+            component.UInt32s["BoxX"] = checked(component.X + boxX);
+            component.UInt32s["BoxY"] = checked(component.Y + boxY);
+            component.UInt32s["BoxWidth"] = boxWidth;
+            component.UInt32s["BoxHeight"] = boxHeight;
+        }
+
+        private static void ApplyPaneSplit(Border component, ParseResult parseResult)
+        {
+            if (!TryGetFixedRaw(parseResult, 0x07, 0x10, out byte[] raw))
+            {
+                return;
+            }
+
+            uint leftWidth = BitConverter.ToUInt32(raw, 0);
+            uint topHeight = BitConverter.ToUInt32(raw, 4);
+            uint rightWidth = BitConverter.ToUInt32(raw, 8);
+            uint bottomHeight = BitConverter.ToUInt32(raw, 12);
+
+            component.LeftWidth = leftWidth;
+            component.TopHeight = topHeight;
+            component.RightWidth = rightWidth;
+            component.BottomHeight = bottomHeight;
+
+            component.UInt32s["LeftWidth"] = leftWidth;
+            component.UInt32s["TopHeight"] = topHeight;
+            component.UInt32s["RightWidth"] = rightWidth;
+            component.UInt32s["BottomHeight"] = bottomHeight;
+        }
+
+        private static bool TryGetFixedRaw(
+            ParseResult parseResult,
+            uint tagId,
+            int expectedLength,
+            out byte[] raw)
+        {
+            raw = null;
+            if (parseResult?.ValuesByTag is null)
+            {
+                return false;
+            }
+
+            if (!parseResult.ValuesByTag.TryGetValue(tagId, out object value) || value is not byte[] bytes)
+            {
+                return false;
+            }
+
+            if (bytes.Length != expectedLength)
+            {
+                throw new InvalidOperationException(
+                    $"Border tag 0x{tagId:X2} expected {expectedLength} bytes, got {bytes.Length}.");
+            }
+
+            raw = bytes;
+            return true;
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ComponentParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ComponentParser.cs
@@ -1,4 +1,5 @@
 using MfmeFmlDecoder.Model;
+using MfmeFmlDecoder.src.Decoder.Component.Helper;
 using MfmeFmlDecoder.src.Model;
 using MfmeFmlDecoder.src.Model.Component;
 using System;
@@ -31,6 +32,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
         private readonly EpochDotAlphaParser epochDotAlphaParser = new();
         private readonly AlphaNewParser alphaNewParser = new();
         private readonly MatrixAlphaParser matrixAlphaParser = new();
+        private readonly BorderParser borderParser = new();
         private readonly SevenSegBlockParser sevenSegBlockParser = new();
         private readonly BFMVideoParser bfmVideoParser = new();
         private readonly IGTVfdParser igtVfdParser = new();
@@ -141,6 +143,9 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                 case (uint)MFMEComponentType.MatrixAlpha:
                     components.Add(matrixAlphaParser.Parse(componentOffset, componentId, data));
                     break;
+                case (uint)MFMEComponentType.Border:
+                    components.Add(borderParser.Parse(componentOffset, componentId, data));
+                    break;
                 case (uint)MFMEComponentType.SevenSegBlock:
                     components.Add(sevenSegBlockParser.Parse(componentOffset, componentId, data));
                     break;
@@ -191,6 +196,10 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
             }
         }
 
-        public Layout ToLayout() => new Layout(components);
+        public Layout ToLayout()
+        {
+            BorderOwnershipAssigner.Annotate(components);
+            return new Layout(components);
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ExtendedTagParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ExtendedTagParser.cs
@@ -158,7 +158,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
 
                     offset++;
                     IReadOnlyDictionary<string, string> flagDropdownSelectionsByName =
-                        ResolveFlagDropdownSelections(options, encounteredTags, valuesByTag);
+                        ResolveFlagDropdownSelections(options, encounteredTags, valuesByTag, nestedTagBlockResult);
                     ApplyDefaultsFromMap(
                         componentTagMap,
                         valuesByTag,
@@ -413,7 +413,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
             if (offset == data.Length)
             {
                 IReadOnlyDictionary<string, string> flagDropdownSelectionsByName =
-                    ResolveFlagDropdownSelections(options, encounteredTags, valuesByTag);
+                    ResolveFlagDropdownSelections(options, encounteredTags, valuesByTag, nestedTagBlockResult);
                 ApplyDefaultsFromMap(
                     componentTagMap,
                     valuesByTag,
@@ -1073,7 +1073,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "FLOAT tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1103,7 +1103,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "UINT32 tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1133,7 +1133,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "INT32 tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1163,7 +1163,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "UINT16 tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1193,7 +1193,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "BOOLEAN tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1223,7 +1223,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "BYTE tag has no attribute name.");
             }
 
-            if (attributeName.StartsWith("Unknown", StringComparison.Ordinal))
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -1278,6 +1278,11 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                         : "ARGB_COLOR tag has no attribute name.");
             }
 
+            if (attributeName.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
             if (coloursByAttributeName.TryGetValue(attributeName, out string existing))
             {
                 string tagSuffix = tag.HasValue ? $" from tag 0x{tag.Value:X2}" : string.Empty;
@@ -1291,11 +1296,33 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
         private static IReadOnlyDictionary<string, string> ResolveFlagDropdownSelections(
             Options options,
             IReadOnlySet<uint> encounteredTags,
-            IReadOnlyDictionary<uint, object> valuesByTag)
+            IReadOnlyDictionary<uint, object> valuesByTag,
+            ParseResult nestedTagBlockResult = null)
         {
             if (options?.FlagDropdownsByName is null || options.FlagDropdownsByName.Count == 0)
             {
                 return new Dictionary<string, string>(StringComparer.Ordinal);
+            }
+
+            IReadOnlySet<uint> effectiveEncounteredTags = encounteredTags;
+            IReadOnlyDictionary<uint, object> effectiveValuesByTag = valuesByTag;
+            if (nestedTagBlockResult?.ValuesByTag is not null && nestedTagBlockResult.ValuesByTag.Count > 0)
+            {
+                HashSet<uint> mergedTags = encounteredTags is null
+                    ? new HashSet<uint>()
+                    : new HashSet<uint>(encounteredTags);
+                Dictionary<uint, object> mergedValues = valuesByTag is null
+                    ? new Dictionary<uint, object>()
+                    : new Dictionary<uint, object>(valuesByTag);
+                foreach (var nestedKvp in nestedTagBlockResult.ValuesByTag)
+                {
+                    mergedTags.Add(nestedKvp.Key);
+                    // Nested values win on tag-id collision so dropdown sources inside 4C ?? 00 are visible.
+                    mergedValues[nestedKvp.Key] = nestedKvp.Value;
+                }
+
+                effectiveEncounteredTags = mergedTags;
+                effectiveValuesByTag = mergedValues;
             }
 
             Dictionary<string, string> selectedByDropdownName = new(StringComparer.Ordinal);
@@ -1309,12 +1336,12 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                 bool hasMatch = false;
                 foreach (var optionByTag in definition.OptionByTag)
                 {
-                    if (!encounteredTags.Contains(optionByTag.Key))
+                    if (!effectiveEncounteredTags.Contains(optionByTag.Key))
                     {
                         continue;
                     }
 
-                    if (valuesByTag.TryGetValue(optionByTag.Key, out object parsedValue))
+                    if (effectiveValuesByTag.TryGetValue(optionByTag.Key, out object parsedValue))
                     {
                         // Support "flag based" dropdowns where source tags are boolean-like fields.
                         if (parsedValue is bool boolValue && !boolValue)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Helper/BorderOwnershipAssigner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Helper/BorderOwnershipAssigner.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MfmeFmlDecoder.src.Model.Component;
+
+namespace MfmeFmlDecoder.src.Decoder.Component.Helper
+{
+    /// <summary>
+    /// Assigns candidate components to border containers by containment,
+    /// sibling local-offset templates, and ordinal order when copies compete.
+    /// See docs/border-lamp-assignment-report.html.
+    /// </summary>
+    internal static class BorderOwnershipAssigner
+    {
+        internal readonly record struct Offset(int Dx, int Dy);
+
+        /// <summary>
+        /// Known sibling template for the 39×75 border examples in the assignment report.
+        /// Used when <paramref name="template"/> is omitted and discovery finds nothing.
+        /// </summary>
+        private static readonly Offset[] DefaultTemplate =
+        {
+            new Offset(1, 1),
+            new Offset(21, 57),
+        };
+
+        internal sealed class Result
+        {
+            public IReadOnlyDictionary<Border, IReadOnlyList<BaseComponent>> Assignment { get; init; }
+            public IReadOnlyList<BaseComponent> Orphans { get; init; }
+            public IReadOnlyList<BaseComponent> Unresolved { get; init; }
+        }
+
+        /// <summary>
+        /// Assigns layout ordinals, then annotates each <see cref="Border"/> with the
+        /// ordinals of components it owns. No-op when the layout has no borders.
+        /// </summary>
+        public static void Annotate(IList<BaseComponent> components)
+        {
+            if (components is null)
+            {
+                throw new ArgumentNullException(nameof(components));
+            }
+
+            for (int i = 0; i < components.Count; i++)
+            {
+                components[i].OrdinalComponentIdentifier = i;
+            }
+
+            List<Border> borders = components.OfType<Border>().ToList();
+            if (borders.Count == 0)
+            {
+                return;
+            }
+
+            // Borders are containers only; nested-border ownership can be added later.
+            List<BaseComponent> candidates = components.Where(c => c is not Border).ToList();
+            Result result = Assign(borders, candidates);
+
+            foreach (Border border in borders)
+            {
+                border.OwnedOrdinalComponentIdentifiers = result.Assignment[border]
+                    .Select(c => c.OrdinalComponentIdentifier!.Value)
+                    .OrderBy(id => id)
+                    .ToArray();
+            }
+        }
+
+        public static Result Assign(
+            IReadOnlyList<Border> borders,
+            IReadOnlyList<BaseComponent> candidates,
+            IReadOnlyList<Offset> template = null)
+        {
+            if (borders is null)
+            {
+                throw new ArgumentNullException(nameof(borders));
+            }
+
+            if (candidates is null)
+            {
+                throw new ArgumentNullException(nameof(candidates));
+            }
+
+            var assignment = borders.ToDictionary(b => b, _ => new List<BaseComponent>());
+            var unmatched = new HashSet<BaseComponent>(candidates);
+            var orphans = new List<BaseComponent>();
+
+            // 1. Orphans — contained by no border
+            foreach (BaseComponent component in candidates.OrderBy(c => c.OrdinalComponentIdentifier))
+            {
+                if (!borders.Any(b => Contains(b, component)))
+                {
+                    orphans.Add(component);
+                    unmatched.Remove(component);
+                }
+            }
+
+            // 2. Unique containment
+            foreach (BaseComponent component in unmatched.OrderBy(c => c.OrdinalComponentIdentifier).ToList())
+            {
+                List<Border> owners = borders.Where(b => Contains(b, component)).ToList();
+                if (owners.Count == 1)
+                {
+                    assignment[owners[0]].Add(component);
+                    unmatched.Remove(component);
+                }
+            }
+
+            // 3. Competing copies — fill template slots by rising border ordinal.
+            //    Do NOT require component.ordinal < border.ordinal.
+            foreach (IGrouping<(uint Width, uint Height), Border> sizeGroup in borders.GroupBy(b => (b.Width, b.Height)))
+            {
+                List<Border> groupBorders = sizeGroup.ToList();
+                Offset[] slots = ResolveTemplate(template, groupBorders, assignment, unmatched);
+
+                foreach (Border border in groupBorders.OrderBy(b => b.OrdinalComponentIdentifier))
+                {
+                    foreach (Offset slot in slots)
+                    {
+                        BaseComponent match = unmatched
+                            .Where(c => Contains(border, c) && LocalOffset(border, c).Equals(slot))
+                            .OrderBy(c => c.OrdinalComponentIdentifier)
+                            .FirstOrDefault();
+
+                        if (match is null)
+                        {
+                            continue;
+                        }
+
+                        assignment[border].Add(match);
+                        unmatched.Remove(match);
+                    }
+                }
+            }
+
+            return new Result
+            {
+                Assignment = assignment.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => (IReadOnlyList<BaseComponent>)kvp.Value),
+                Orphans = orphans,
+                Unresolved = unmatched.OrderBy(c => c.OrdinalComponentIdentifier).ToList(),
+            };
+        }
+
+        public static Offset LocalOffset(BaseComponent border, BaseComponent child) =>
+            new Offset(checked((int)child.X - (int)border.X), checked((int)child.Y - (int)border.Y));
+
+        public static bool Contains(BaseComponent border, BaseComponent other)
+        {
+            long bx = border.X;
+            long by = border.Y;
+            long bw = border.Width;
+            long bh = border.Height;
+            long ox = other.X;
+            long oy = other.Y;
+            long ow = other.Width;
+            long oh = other.Height;
+
+            return ox >= bx
+                && oy >= by
+                && ox + ow <= bx + bw
+                && oy + oh <= by + bh;
+        }
+
+        private static Offset[] ResolveTemplate(
+            IReadOnlyList<Offset> explicitTemplate,
+            IReadOnlyList<Border> sizeGroup,
+            IReadOnlyDictionary<Border, List<BaseComponent>> assignment,
+            HashSet<BaseComponent> unmatched)
+        {
+            if (explicitTemplate is not null)
+            {
+                return explicitTemplate.ToArray();
+            }
+
+            var fromUnique = new HashSet<Offset>();
+            foreach (Border border in sizeGroup)
+            {
+                foreach (BaseComponent child in assignment[border])
+                {
+                    fromUnique.Add(LocalOffset(border, child));
+                }
+            }
+
+            if (fromUnique.Count > 0)
+            {
+                return fromUnique.OrderBy(o => o.Dx).ThenBy(o => o.Dy).ToArray();
+            }
+
+            Border reference = sizeGroup.OrderBy(b => b.OrdinalComponentIdentifier).First();
+            Offset[] discovered = unmatched
+                .Where(c => Contains(reference, c))
+                .Select(c => LocalOffset(reference, c))
+                .Distinct()
+                .OrderBy(o => o.Dx)
+                .ThenBy(o => o.Dy)
+                .ToArray();
+
+            return discovered.Length > 0 ? discovered : DefaultTemplate;
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/LampParser.cs
@@ -97,6 +97,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                 { 0x25, new TagInfo(0x04, "OutlineColour", new byte[ ] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.ARGB_COLOR) },
                 { 0x0B, new TagInfo(0x04, "ShapeParamter", new byte[ ] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) }, // TODO: Add a half number mode for this type.
                 { 0x0D, new TagInfo(0x04, "ShapeAngle", new byte[ ] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
+                { 0x0E, new TagInfo(0x04, "Unknown 0x0E", new byte[ ] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
                 { 0x6A, new TagInfo(0x04, "PieSize", new byte[ ] { 0x78, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
                 { 0x6B, new TagInfo(0x04, "PieStart", new byte[ ] { 0x00, 0x00, 0x00, 0x00 }, ValueRole.UINT32) },
                 { 0x68, new TagInfo(0x00, "Unknown 0x68 (TLV Block)", new byte[ ] { }, ValueRole.TLVBLOCK) },

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/FileWalker.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/FileWalker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using MfmeFmlDecoder.Model;
 using MfmeFmlDecoder.Utilities;
 
 namespace MfmeFmlDecoder.Decoder
@@ -7,6 +8,7 @@ namespace MfmeFmlDecoder.Decoder
     internal sealed class FileWalker
     {
         private const uint TlvTerminationTag = 0xFFFFFFFF;
+        private const string SupportedMfmeVersion = "20.1";
 
         private ComponentWalker _componentWalker;
         public FileWalker(ComponentWalker componentWalker)
@@ -62,6 +64,11 @@ namespace MfmeFmlDecoder.Decoder
 
                 OnRecordRead(recordStartOffset, tag, length, values);
 
+                if (tag == MfmeVersionReader.MfmeVersionTag)
+                {
+                    ValidateMfmeVersion(recordStartOffset, values);
+                }
+
                 if (LengthPrefixedStringTableScanner.IsFileLevelTag(tag))
                 {
                     LengthPrefixedStringTableScanner.SkipContinuation(
@@ -88,6 +95,17 @@ namespace MfmeFmlDecoder.Decoder
         {
             RunLog.WriteLine($"Offset: 0x{offset:X8}, Tag: 0x{tag:X2}, Length: 0x{length:X2}");
             HexDumpUtility.PrintHexDump((uint)(offset + 8), values, maxBytes: 0xFF);
+        }
+
+        private static void ValidateMfmeVersion(long recordStartOffset, byte[] values)
+        {
+            string version = MfmeVersionReader.FormatVersion(values);
+            if (string.Equals(version, SupportedMfmeVersion, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            throw new UnsupportedMfmeVersionException(recordStartOffset, values);
         }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/MfmeVersionReader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/MfmeVersionReader.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace MfmeFmlDecoder.Decoder
+{
+    internal static class MfmeVersionReader
+    {
+        internal const uint MfmeVersionTag = 0x2F;
+
+        public static string Read(string fileName, uint offset)
+        {
+            using FileStream fileStream = new FileStream(
+                fileName,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: 1024 * 1024,
+                options: FileOptions.SequentialScan);
+            return Read(fileStream, offset);
+        }
+
+        public static string Read(byte[] data, uint offset)
+        {
+            using MemoryStream fileStream = new MemoryStream(data, writable: false);
+            return Read(fileStream, offset);
+        }
+
+        public static string Read(Stream stream, uint offset)
+        {
+            using BinaryReader reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+            if (offset > stream.Length)
+            {
+                throw new InvalidOperationException(
+                    $"Offset 0x{offset:X} is beyond file length 0x{stream.Length:X}.");
+            }
+
+            if (offset > 0)
+            {
+                stream.Seek(offset, SeekOrigin.Begin);
+            }
+
+            while (stream.Position < stream.Length)
+            {
+                long recordStartOffset = stream.Position;
+
+                uint tag = reader.ReadUInt32();
+                uint length = reader.ReadUInt32();
+                byte[] values = reader.ReadBytes(checked((int)length));
+                if (values.Length != length)
+                {
+                    throw new EndOfStreamException(
+                        $"Unexpected EOF reading tag 0x{tag:X2} at offset 0x{recordStartOffset:X8}. " +
+                        $"Expected {length} bytes but only {values.Length} bytes were read.");
+                }
+
+                if (tag == MfmeVersionTag)
+                {
+                    return FormatVersion(values);
+                }
+
+                if (LengthPrefixedStringTableScanner.IsFileLevelTag(tag))
+                {
+                    LengthPrefixedStringTableScanner.SkipContinuation(
+                        reader,
+                        hostTagKeyByte: (byte)tag,
+                        scanEndExclusive: stream.Length);
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"MFME version tag 0x{MfmeVersionTag:X2} was not found before end of file.");
+        }
+
+        internal static string FormatVersion(byte[] versionBytes)
+        {
+            if (versionBytes is null || versionBytes.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.ASCII.GetString(versionBytes);
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/BaseComponent.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/BaseComponent.cs
@@ -32,7 +32,7 @@ namespace MfmeFmlDecoder.src.Model.Component
         /// Set by <see cref="Layout"/> when emitting the component list; not part of parsed FML data.
         /// </summary>
         [JsonIgnore]
-        internal int? SerializationZOrder { get; set; }
+        internal int? OrdinalComponentIdentifier { get; set; }
 
         public Dictionary<string, FontTagEntry> Fonts { get; } = new Dictionary<string, FontTagEntry>();
         [JsonIgnore]
@@ -124,9 +124,9 @@ namespace MfmeFmlDecoder.src.Model.Component
             {
                 ["Type"] = GetType().Name,
             };
-            if (SerializationZOrder.HasValue)
+            if (OrdinalComponentIdentifier.HasValue)
             {
-                ordered["ZOrder"] = SerializationZOrder.Value;
+                ordered["OrdinalComponentIdentifier"] = OrdinalComponentIdentifier.Value;
             }
 
             ordered["Geometry"] = BuildGeometryNode();
@@ -228,6 +228,11 @@ namespace MfmeFmlDecoder.src.Model.Component
         {
             foreach (var kvp in source.OrderBy(entry => entry.Key, StringComparer.Ordinal))
             {
+                if (kvp.Key.StartsWith("Unknown", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 if (target.ContainsKey(kvp.Key))
                 {
                     throw new InvalidOperationException($"Duplicate Values key '{kvp.Key}'.");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/Border.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/Border.cs
@@ -1,14 +1,70 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace MfmeFmlDecoder.src.Model.Component
 {
     internal class Border : BaseComponent
     {
-        // TODO: Add attributes
+        public string OuterColour { get; set; }
+        public string InnerColour { get; set; }
+        public uint BorderWidth { get; set; }
+        public uint Spacing { get; set; }
+
+        /// <summary>Wire BoxX from tag 0x06; observed as always zero. JSON Values uses Geometry.X + BoxX.</summary>
+        public uint BoxX { get; set; }
+
+        /// <summary>Wire BoxY from tag 0x06; observed as always zero. JSON Values uses Geometry.Y + BoxY.</summary>
+        public uint BoxY { get; set; }
+
+        public uint BoxWidth { get; set; }
+        public uint BoxHeight { get; set; }
+
+        /// <summary>Tag 0x07: left column width of the 2×2 pane split (LeftWidth + RightWidth == BoxWidth).</summary>
+        public uint LeftWidth { get; set; }
+
+        /// <summary>Tag 0x07: top row height of the 2×2 pane split (TopHeight + BottomHeight == BoxHeight).</summary>
+        public uint TopHeight { get; set; }
+
+        /// <summary>Tag 0x07: right column width of the 2×2 pane split.</summary>
+        public uint RightWidth { get; set; }
+
+        /// <summary>Tag 0x07: bottom row height of the 2×2 pane split.</summary>
+        public uint BottomHeight { get; set; }
+
+        /// <summary>
+        /// Ordinals of layout components owned by this border (post-parse assignment).
+        /// Null until annotation runs; empty when the border owns no components.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyList<int> OwnedOrdinalComponentIdentifiers { get; set; }
+
+        public override JsonObject ToJsonObject()
+        {
+            JsonObject json = base.ToJsonObject();
+            if (OwnedOrdinalComponentIdentifiers is null)
+            {
+                return json;
+            }
+
+            JsonObject ordered = new JsonObject();
+            foreach (var kvp in json)
+            {
+                ordered[kvp.Key] = kvp.Value is null ? null : JsonNode.Parse(kvp.Value.ToJsonString());
+                if (kvp.Key == "Geometry")
+                {
+                    JsonArray owned = new JsonArray();
+                    foreach (int id in OwnedOrdinalComponentIdentifiers)
+                    {
+                        owned.Add(id);
+                    }
+
+                    ordered["OwnedOrdinalComponentIdentifiers"] = owned;
+                }
+            }
+
+            return ordered;
+        }
     }
 }
-

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Layout.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Layout.cs
@@ -30,7 +30,7 @@ namespace MfmeFmlDecoder.src.Model
             for (int i = 0; i < Components.Count; i++)
             {
                 BaseComponent component = Components[i];
-                component.SerializationZOrder = i;
+                component.OrdinalComponentIdentifier = i;
                 component.WriteTo(writer, options, propertyIndentSpaces: indented ? 6 : 0);
             }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/MFMEComponentType.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/MFMEComponentType.cs
@@ -26,6 +26,7 @@
         EpochDotAlpha = 0x16,
         AlphaNew = 0x19,
         MatrixAlpha = 0x1A,
+        Border = 0x1B,
         SevenSegBlock = 0x1C,
         BFMVideo = 0x1F,
         IGTVfd = 0x20,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/UnsupportedMfmeVersionException.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/UnsupportedMfmeVersionException.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Globalization;
+using System.Text;
+using MfmeFmlDecoder.Decoder;
+
+namespace MfmeFmlDecoder.Model
+{
+    internal sealed class UnsupportedMfmeVersionException : InvalidOperationException
+    {
+        public long RecordOffset { get; }
+        public string FoundVersion { get; }
+
+        public UnsupportedMfmeVersionException(long recordOffset, byte[] versionBytes)
+            : base(BuildMessage(recordOffset, versionBytes))
+        {
+            RecordOffset = recordOffset;
+            FoundVersion = MfmeVersionReader.FormatVersion(versionBytes);
+        }
+
+        private static string BuildMessage(long recordOffset, byte[] versionBytes)
+        {
+            var message = new StringBuilder();
+            message.Append("Unsupported MFME version at file offset 0x");
+            message.Append(recordOffset.ToString("X8", CultureInfo.InvariantCulture));
+            message.Append(": '");
+            message.Append(MfmeVersionReader.FormatVersion(versionBytes));
+            message.Append("'. Only MFME v20.1 is supported.");
+            return message.ToString();
+        }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Utilities/LayoutExporter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Utilities/LayoutExporter.cs
@@ -42,15 +42,15 @@ namespace MfmeFmlDecoder.Utilities
 
         private static void WriteComponentImages(Layout layout, string tempDir)
         {
-            for (int zOrder = 0; zOrder < layout.Components.Count; zOrder++)
+            for (int ordinalComponentIdentifier = 0; ordinalComponentIdentifier < layout.Components.Count; ordinalComponentIdentifier++)
             {
-                BaseComponent component = layout.Components[zOrder];
+                BaseComponent component = layout.Components[ordinalComponentIdentifier];
                 if (component.Images.Count == 0)
                 {
                     continue;
                 }
 
-                string imageDir = Path.Combine(tempDir, "images", zOrder.ToString());
+                string imageDir = Path.Combine(tempDir, "images", ordinalComponentIdentifier.ToString());
                 Directory.CreateDirectory(imageDir);
 
                 foreach (var kvp in component.Images)


### PR DESCRIPTION
### Motivation
- Bring the Editor's embedded FML decoder into sync with the updated upstream decoder while preserving editor-specific integration and wiring. 
- Port functional and behavioural fixes from upstream (parsing, version handling, border support) without introducing unrelated refactors.

### Description
- Merged upstream MFME version support and validation: added `--mfme-version` handling in `Application`, added `MfmeVersionReader`, and introduced `UnsupportedMfmeVersionException` with file-level validation in `FileWalker`.
- Added upstream Border component support and ownership annotation: new `Border` model properties, `BorderParser`, `MFMEComponentType.Border` enum entry, and the `BorderOwnershipAssigner` helper; also annotate ordinals before producing a `Layout`.
- Ported extended-tag parsing and tag-map fixes: `ExtendedTagParser` now merges nested TLV block values for flag-dropdown resolution and treats `Unknown*` attribute names case-insensitively; updated `BackgroundParser` and `LampParser` tag maps and bitmap/flag handling.
- Preserved Editor-specific integration: kept the embedded decoder file locations under `OasisEditor/FmlDecoder`, retained project layout, and adjusted layout JSON/export naming from `ZOrder` to `OrdinalComponentIdentifier` and image export folder naming to match upstream behavior.
- Omitted upstream test projects and test files from the application source tree intentionally, because tests belong in separate test projects and would introduce unrelated test-framework dependencies.

### Testing
- Attempted `dotnet build WindowsNetProjects/OasisEditor/OasisEditor.sln`, which failed because the execution environment lacks the .NET SDK (`dotnet: command not found`).
- Ran automated file-parity verification (compare/copy script) to ensure each changed embedded decoder source matches the corresponding upstream non-test source, and the verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53d13842e483278aaebf02ae7b5a69)