### PR TITLE
Batch Panel2D preview mutations

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs
@@ -220,6 +220,145 @@ public sealed class PanelElementPreviewMutationServiceTests
         Assert.Empty(document.CommandService.History.Entries);
     }
 
+    [Fact]
+    public void TryApplyPreviews_AppliesMultipleUpdatesWithOneBatchNotification()
+    {
+        var document = CreateDocument(
+            CreateLamp("lamp-1", 10, 20),
+            CreateLamp("lamp-2", 30, 40),
+            CreateLamp("lamp-3", 50, 60));
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var originals = document.GetPanelElements().ToDictionary(element => element.ObjectId);
+        var updates = new Dictionary<string, PanelElementModel>
+        {
+            ["lamp-1"] = PanelElementModelCloner.Clone(originals["lamp-1"], x: 11, y: 21),
+            ["lamp-2"] = PanelElementModelCloner.Clone(originals["lamp-2"], x: 31, y: 41),
+            ["lamp-3"] = PanelElementModelCloner.Clone(originals["lamp-3"], x: 51, y: 61)
+        };
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreviews(document, updates));
+
+        Assert.Equal(11, document.GetPanelElements()[0].X);
+        Assert.Equal(31, document.GetPanelElements()[1].X);
+        Assert.Equal(51, document.GetPanelElements()[2].X);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+
+        var panelChange = Assert.Single(events);
+        Assert.Null(panelChange.ObjectId);
+        Assert.True(panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Geometry));
+        Assert.True(panelChange.AffectsCanvas);
+        Assert.True(panelChange.AffectsInspectorRows);
+        Assert.False(panelChange.AffectsHierarchy);
+        Assert.False(panelChange.AffectsPersistence);
+    }
+
+    [Fact]
+    public void TryApplyPreviews_IgnoresUnchangedInvalidIdsAndInvalidUpdatesWithoutBlockingValidUpdates()
+    {
+        var document = CreateDocument(
+            CreateLamp("lamp-1", 10, 20),
+            CreateLamp("lamp-2", 30, 40),
+            CreateLamp("lamp-3", 50, 60),
+            CreateLamp("lamp-4", 70, 80));
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+
+        var originals = document.GetPanelElements().ToDictionary(element => element.ObjectId);
+        var updates = new Dictionary<string, PanelElementModel>
+        {
+            ["lamp-1"] = PanelElementModelCloner.Clone(originals["lamp-1"], x: 15, y: 25),
+            ["lamp-2"] = PanelElementModelCloner.Clone(originals["lamp-2"]),
+            ["missing"] = PanelElementModelCloner.Clone(originals["lamp-3"], objectId: "missing", x: 55),
+            ["lamp-3"] = new PanelElementModel
+            {
+                ObjectId = "lamp-3",
+                Name = "Wrong kind",
+                Kind = PanelElementKind.Reel,
+                X = 55,
+                Y = 65,
+                Width = 10,
+                Height = 10,
+                IsVisible = true
+            },
+            ["lamp-4"] = PanelElementModelCloner.Clone(originals["lamp-4"], width: 0)
+        };
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreviews(document, updates));
+
+        Assert.Equal(15, document.GetPanelElements()[0].X);
+        Assert.Equal(30, document.GetPanelElements()[1].X);
+        Assert.Equal(50, document.GetPanelElements()[2].X);
+        Assert.Equal(70, document.GetPanelElements()[3].X);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Single(events);
+    }
+
+    [Fact]
+    public void TryApplyPreviews_ReturnsFalseAndDoesNotNotifyWhenNoElementsChange()
+    {
+        var document = CreateDocument(CreateLamp("lamp-1", 10, 20), CreateLamp("lamp-2", 30, 40));
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+        var originals = document.GetPanelElements().ToDictionary(element => element.ObjectId);
+        var updates = new Dictionary<string, PanelElementModel>
+        {
+            ["lamp-1"] = PanelElementModelCloner.Clone(originals["lamp-1"]),
+            ["missing"] = PanelElementModelCloner.Clone(originals["lamp-2"], objectId: "missing", x: 35)
+        };
+
+        Assert.False(PanelElementPreviewMutationService.TryApplyPreviews(document, updates));
+
+        Assert.Empty(events);
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+    }
+
+    [Fact]
+    public void TryApplyPreviews_UpdatesNinetyLampsInOneBatch()
+    {
+        var elements = Enumerable.Range(0, 90)
+            .Select(index => CreateLamp($"lamp-{index}", index, index + 100))
+            .ToArray();
+        var document = CreateDocument(elements);
+        var events = new List<PanelChangeEvent>();
+        document.PanelChanged += panelChange => events.Add(panelChange);
+        var updates = document.GetPanelElements()
+            .ToDictionary(
+                element => element.ObjectId,
+                element => PanelElementModelCloner.Clone(element, x: element.X + 7, y: element.Y + 9));
+
+        Assert.True(PanelElementPreviewMutationService.TryApplyPreviews(document, updates));
+
+        for (var i = 0; i < 90; i++)
+        {
+            Assert.Equal(i + 7, document.GetPanelElements()[i].X);
+            Assert.Equal(i + 109, document.GetPanelElements()[i].Y);
+        }
+
+        Assert.False(document.IsDirty);
+        Assert.Empty(document.CommandService.History.Entries);
+        Assert.Single(events);
+    }
+
+    private static PanelElementModel CreateLamp(string objectId, double x, double y)
+    {
+        return new PanelElementModel
+        {
+            ObjectId = objectId,
+            Name = objectId,
+            Kind = PanelElementKind.Lamp,
+            X = x,
+            Y = y,
+            Width = 10,
+            Height = 10,
+            IsVisible = true
+        };
+    }
+
     private static DocumentTabViewModel CreateDocument(params PanelElementModel[] elements)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs
@@ -7,13 +7,63 @@ internal static class PanelElementPreviewMutationService
         ArgumentNullException.ThrowIfNull(document);
         ArgumentNullException.ThrowIfNull(updatedElements);
 
+        if (updatedElements.Count == 0)
+        {
+            return false;
+        }
+
+        var elements = document.GetPanelElements().ToList();
+        var elementIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < elements.Count; i++)
+        {
+            var element = elements[i];
+            if (!string.IsNullOrWhiteSpace(element.ObjectId))
+            {
+                elementIndexes[element.ObjectId] = i;
+            }
+        }
+
+        var changedProperties = PanelChangeProperties.None;
         var changed = false;
         foreach (var update in updatedElements)
         {
-            changed |= TryApplyPreview(document, update.Key, update.Value);
+            if (string.IsNullOrWhiteSpace(update.Key)
+                || !elementIndexes.TryGetValue(update.Key, out var index))
+            {
+                continue;
+            }
+
+            var updatedElement = update.Value;
+            var existing = elements[index];
+            if (!string.Equals(updatedElement.ObjectId, update.Key, StringComparison.Ordinal)
+                || updatedElement.Kind != existing.Kind
+                || !PanelElementValidation.IsValidForInspectorUpdate(updatedElement)
+                || PanelElementModelComparer.AreEquivalent(existing, updatedElement))
+            {
+                continue;
+            }
+
+            changedProperties |= GetChangedProperties(existing, updatedElement);
+            elements[index] = PanelElementModelCloner.Clone(updatedElement);
+            changed = true;
         }
 
-        return changed;
+        if (!changed)
+        {
+            return false;
+        }
+
+        document.SetPanelElements(
+            elements,
+            new PanelChangeEvent(
+                document.DocumentId,
+                null,
+                changedProperties,
+                AffectsCanvas: true,
+                AffectsHierarchy: false,
+                AffectsInspectorRows: true,
+                AffectsPersistence: false));
+        return true;
     }
 
     public static bool TryApplyPreview(DocumentTabViewModel document, string objectId, PanelElementModel updatedElement)


### PR DESCRIPTION
### Motivation

- Multi-selection drags cause severe stutter because `TryApplyPreviews` previously delegated each element to `TryApplyPreview`, producing one full `SetPanelElements` + `PanelChangeEvent` per element per mouse move.

### Description

- Refactor `PanelElementPreviewMutationService.TryApplyPreviews` to perform a true batched update by copying `document.GetPanelElements()` once, building an `ObjectId -> index` lookup, validating each update, cloning/replacing changed elements, combining `PanelChangeProperties`, and calling `document.SetPanelElements(...)` at most once with a single batch `PanelChangeEvent` (`ObjectId: null`, `AffectsCanvas: true`, `AffectsHierarchy: false`, `AffectsInspectorRows: true`, `AffectsPersistence: false`).
- Preserve the existing single-element `TryApplyPreview` behavior for callers that still use it.
- Add focused unit tests covering multi-update batching, ignoring unchanged/invalid updates, no-op false return, undo/dirty-state preservation, single notification observation, and a 90-lamp regression scenario.
- Files changed: `WindowsNetProjects/OasisEditor/OasisEditor/PanelElementPreviewMutationService.cs` and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementPreviewMutationServiceTests.cs`.

### Testing

- Added automated tests in `PanelElementPreviewMutationServiceTests` covering the required scenarios including `TryApplyPreviews_AppliesMultipleUpdatesWithOneBatchNotification`, `TryApplyPreviews_IgnoresUnchangedInvalidIdsAndInvalidUpdatesWithoutBlockingValidUpdates`, `TryApplyPreviews_ReturnsFalseAndDoesNotNotifyWhenNoElementsChange`, and `TryApplyPreviews_UpdatesNinetyLampsInOneBatch`.
- No tests were executed in this environment because the workspace lacks the Windows/.NET/WPF toolchain per the project `AGENTS.md`; please run the test suite locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and verify the new tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53dcc923108327bf20cf33cbea0ac5)