### PR TITLE
Fix aggregate Inspector refresh flicker during multi-drag

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs
@@ -92,6 +92,143 @@ public sealed class InspectorAggregateValueTests
         Assert.All(document.GetPanelElements(), element => Assert.False(element.IsVisible));
     }
 
+
+    [Fact]
+    public void PanelMultiEdit_GeometryOnlyPanelChange_RefreshesAggregateRowsInPlace()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+        var originalRows = viewModel.InspectorPropertyRows.ToArray();
+
+        document.SetPanelElements(
+            [
+                new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 5, Y = 7, Width = 10, Height = 10 },
+                new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 5, Y = 7, Width = 10, Height = 10 }
+            ]);
+        viewModel.NotifyPanelChanged(CreatePanelChange(document, PanelChangeProperties.Geometry));
+
+        Assert.Same(originalRows[0], viewModel.InspectorPropertyRows[0]);
+        Assert.True(originalRows.SequenceEqual(viewModel.InspectorPropertyRows));
+        Assert.Equal("5", Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "X")).Value);
+        Assert.Equal("7", Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "Y")).Value);
+        Assert.Contains("2 Panel2D components selected", viewModel.InspectorSummary);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_GeometryOnlyPanelChange_UpdatesMixedStatesInPlace()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 2, Y = 2, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+        var originalRows = viewModel.InspectorPropertyRows.ToArray();
+        var xRow = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "X"));
+        var yRow = Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "Y"));
+        Assert.True(xRow.IsMixed);
+        Assert.False(yRow.IsMixed);
+
+        document.SetPanelElements(
+            [
+                new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 4, Y = 2, Width = 10, Height = 10 },
+                new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 4, Y = 3, Width = 10, Height = 10 }
+            ]);
+        viewModel.NotifyPanelChanged(CreatePanelChange(document, PanelChangeProperties.Geometry));
+
+        Assert.True(originalRows.SequenceEqual(viewModel.InspectorPropertyRows));
+        Assert.False(xRow.IsMixed);
+        Assert.Equal("4", xRow.Value);
+        Assert.True(yRow.IsMixed);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_RepeatedGeometryOnlyPanelChanges_RetainAggregateRowInstances()
+    {
+        var elements = Enumerable.Range(0, 50)
+            .Select(index => new PanelElementModel { ObjectId = $"lamp-{index}", Name = $"Lamp {index}", Kind = PanelElementKind.Lamp, X = 0, Y = 0, Width = 10, Height = 10 })
+            .ToArray();
+        var document = CreatePanelDocument(elements);
+        document.SelectionState.Replace(elements.Select(element => new EditorSelectionItem(EditorSelectionDomain.PanelElement, element.ObjectId)).ToArray());
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+        var originalRows = viewModel.InspectorPropertyRows.ToArray();
+
+        for (var step = 1; step <= 5; step++)
+        {
+            document.SetPanelElements(elements.Select(element => new PanelElementModel { ObjectId = element.ObjectId, Name = element.Name, Kind = element.Kind, X = step, Y = step, Width = 10, Height = 10 }).ToArray());
+            viewModel.NotifyPanelChanged(CreatePanelChange(document, PanelChangeProperties.Geometry));
+        }
+
+        Assert.True(originalRows.SequenceEqual(viewModel.InspectorPropertyRows));
+        Assert.Equal("5", Assert.IsType<InspectorDoublePropertyViewModel>(viewModel.InspectorPropertyRows.Single(row => row.DisplayName == "X")).Value);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_StructuralPanelChange_RebuildsAggregateRows()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+        var firstRow = viewModel.InspectorPropertyRows[0];
+
+        viewModel.NotifyPanelChanged(CreatePanelChange(document, PanelChangeProperties.Structure));
+
+        Assert.NotSame(firstRow, viewModel.InspectorPropertyRows[0]);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_SelectionMembershipChange_RebuildsAggregateRows()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-2", Name = "B", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 },
+            new PanelElementModel { ObjectId = "lamp-3", Name = "C", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2")]);
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+        var firstRow = viewModel.InspectorPropertyRows[0];
+
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-2"), new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-3")]);
+        viewModel.NotifyContextChanged();
+
+        Assert.NotSame(firstRow, viewModel.InspectorPropertyRows[0]);
+        Assert.Contains("3 Panel2D components selected", viewModel.InspectorSummary);
+    }
+
+    [Fact]
+    public void PanelMultiEdit_UnsupportedMixedSelection_RemainsReadOnlyAfterPanelChange()
+    {
+        var document = CreatePanelDocument(
+            new PanelElementModel { ObjectId = "lamp-1", Name = "A", Kind = PanelElementKind.Lamp, X = 1, Y = 2, Width = 10, Height = 10 });
+        document.SelectionState.Replace(
+            [new EditorSelectionItem(EditorSelectionDomain.PanelElement, "lamp-1"), new EditorSelectionItem(EditorSelectionDomain.FaceElement, "face-1")]);
+        var viewModel = CreateInspectorViewModel(document);
+        viewModel.NotifyContextChanged();
+
+        viewModel.NotifyPanelChanged(CreatePanelChange(document, PanelChangeProperties.Geometry));
+
+        Assert.All(viewModel.InspectorPropertyRows, row => Assert.True(row.IsReadOnly));
+        Assert.Contains("cannot be edited together", Assert.IsType<InspectorInfoPropertyViewModel>(viewModel.InspectorPropertyRows[0]).Value);
+    }
+
+    private static PanelChangeEvent CreatePanelChange(DocumentTabViewModel document, PanelChangeProperties properties)
+    {
+        return new PanelChangeEvent(document.DocumentId, null, properties, AffectsCanvas: true, AffectsHierarchy: false, AffectsInspectorRows: true, AffectsPersistence: false);
+    }
+
     private static DocumentTabViewModel CreatePanelDocument(params PanelElementModel[] elements)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreatePanel2DStub("Panel"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -399,7 +399,11 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
             if (!ShouldSuppressPropertyRowRefresh())
             {
-                RebuildPropertyRows();
+                if (ShouldRebuildAggregateRows(panelChange, aggregate)
+                    || !TryRefreshAggregatePropertyRowValues(selectedDocument, aggregate))
+                {
+                    RebuildPropertyRows();
+                }
             }
 
             OnPropertyChanged(nameof(InspectorSummary));
@@ -669,19 +673,7 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
 
     private void RebuildAggregatePropertyRows(DocumentTabViewModel document, AggregateSelection selection)
     {
-        if (selection.Domain == EditorSelectionDomain.PanelElement)
-        {
-            AddPanelAggregateRows(document, selection.PanelElements, includeSameTypeRows: selection.IsSameConcreteType);
-        }
-        else
-        {
-            AddFaceAggregateRows(document, selection.FaceElements, includeSameTypeRows: selection.IsSameConcreteType);
-        }
-
-        if (selection.TransformLockedCount > 0)
-        {
-            _propertyRows.Add(new InspectorInfoPropertyViewModel("Transform Lock Note", "Multi-Edit", "X, Y, Width, and Height edits apply only to unlocked selected objects."));
-        }
+        AddAggregateRows(document, selection, _propertyRows);
 
         _hadInspectorSelection = true;
         _lastInspectorSelectionObjectId = GetDocumentSelectionKey();
@@ -690,82 +682,181 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(InspectorPropertyRows));
     }
 
-    private void AddPanelAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, bool includeSameTypeRows)
+    private void AddAggregateRows(DocumentTabViewModel document, AggregateSelection selection, ICollection<InspectorPropertyRowViewModel> rows)
     {
-        if (includeSameTypeRows)
+        if (selection.Domain == EditorSelectionDomain.PanelElement)
         {
-            AddAggregateText("Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyPanelAggregateUpdate(document, elements, "Update names", new PanelElementModelUpdate { Name = value }, includeLockedTransforms: true));
+            AddPanelAggregateRows(document, selection.PanelElements, includeSameTypeRows: selection.IsSameConcreteType, rows);
+        }
+        else
+        {
+            AddFaceAggregateRows(document, selection.FaceElements, includeSameTypeRows: selection.IsSameConcreteType, rows);
         }
 
-        AddAggregateDouble("X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyPanelAggregateUpdate(document, elements, "Update X", new PanelElementModelUpdate { X = value }, includeLockedTransforms: false));
-        AddAggregateDouble("Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyPanelAggregateUpdate(document, elements, "Update Y", new PanelElementModelUpdate { Y = value }, includeLockedTransforms: false));
-        AddAggregateDouble("Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update width", new PanelElementModelUpdate { Width = value }, includeLockedTransforms: false) : "Width must be greater than zero.");
-        AddAggregateDouble("Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update height", new PanelElementModelUpdate { Height = value }, includeLockedTransforms: false) : "Height must be greater than zero.");
-        AddAggregateBool("Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyPanelAggregateUpdate(document, elements, "Update transform lock state", new PanelElementModelUpdate { IsTransformLocked = value }, includeLockedTransforms: true));
-        AddAggregateBool("Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyPanelAggregateUpdate(document, elements, "Update visibility", new PanelElementModelUpdate { IsVisible = value }, includeLockedTransforms: true));
-
-        if (includeSameTypeRows)
+        if (selection.TransformLockedCount > 0)
         {
-            AddPanelTypeSpecificAggregateRows(document, elements);
+            rows.Add(new InspectorInfoPropertyViewModel("Transform Lock Note", "Multi-Edit", "X, Y, Width, and Height edits apply only to unlocked selected objects."));
         }
     }
 
-    private void AddPanelTypeSpecificAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements)
+    private static bool ShouldRebuildAggregateRows(PanelChangeEvent panelChange, AggregateSelection selection)
+    {
+        if (!selection.IsSupported)
+        {
+            return true;
+        }
+
+        var structuralProperties = PanelChangeProperties.Structure | PanelChangeProperties.Ordering;
+        return panelChange.ChangedProperties.HasFlag(PanelChangeProperties.Structure)
+            || (panelChange.ChangedProperties & structuralProperties) != PanelChangeProperties.None;
+    }
+
+    private bool TryRefreshAggregatePropertyRowValues(DocumentTabViewModel document, AggregateSelection selection)
+    {
+        if (!selection.IsSupported)
+        {
+            return false;
+        }
+
+        var expectedRows = new List<InspectorPropertyRowViewModel>();
+        AddAggregateRows(document, selection, expectedRows);
+
+        if (_propertyRows.Count != expectedRows.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < expectedRows.Count; i++)
+        {
+            if (!HasSameAggregateRowSchema(_propertyRows[i], expectedRows[i]))
+            {
+                return false;
+            }
+        }
+
+        for (var i = 0; i < expectedRows.Count; i++)
+        {
+            RefreshAggregateRowValue(_propertyRows[i], expectedRows[i]);
+        }
+
+        _hadInspectorSelection = true;
+        _lastInspectorSelectionObjectId = GetDocumentSelectionKey();
+        _lastInspectorSelectionKind = selection.Domain == EditorSelectionDomain.PanelElement && selection.IsSameConcreteType ? selection.PanelElements[0].Kind : null;
+        _lastInspectorFaceSelectionKind = selection.Domain == EditorSelectionDomain.FaceElement && selection.IsSameConcreteType ? FaceSelectionService.GetKindToken(selection.FaceElements[0]) : "multi";
+        return true;
+    }
+
+    private static bool HasSameAggregateRowSchema(InspectorPropertyRowViewModel current, InspectorPropertyRowViewModel expected)
+    {
+        return current.GetType() == expected.GetType()
+            && string.Equals(current.DisplayName, expected.DisplayName, StringComparison.Ordinal)
+            && string.Equals(current.GroupName, expected.GroupName, StringComparison.Ordinal)
+            && current.IsReadOnly == expected.IsReadOnly;
+    }
+
+    private static void RefreshAggregateRowValue(InspectorPropertyRowViewModel current, InspectorPropertyRowViewModel expected)
+    {
+        switch (current, expected)
+        {
+            case (InspectorTextPropertyViewModel textRow, InspectorTextPropertyViewModel expectedText):
+                if (expectedText.IsMixed) textRow.SetMixedValue(); else textRow.SetCommittedValue(expectedText.Value);
+                break;
+            case (InspectorDoublePropertyViewModel doubleRow, InspectorDoublePropertyViewModel expectedDouble):
+                if (expectedDouble.IsMixed) doubleRow.SetMixedValue(); else if (double.TryParse(expectedDouble.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var value)) doubleRow.SetCommittedValue(value);
+                break;
+            case (InspectorIntPropertyViewModel intRow, InspectorIntPropertyViewModel expectedInt):
+                if (expectedInt.IsMixed) intRow.SetMixedValue(); else if (int.TryParse(expectedInt.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)) intRow.SetCommittedValue(value); else intRow.SetCommittedValue(null);
+                break;
+            case (InspectorColorPropertyViewModel colorRow, InspectorColorPropertyViewModel expectedColor):
+                if (expectedColor.IsMixed) colorRow.SetMixedValue(); else colorRow.SetCommittedValue(expectedColor.HexValue);
+                break;
+            case (InspectorBoolPropertyViewModel boolRow, InspectorBoolPropertyViewModel expectedBool):
+                if (expectedBool.IsMixed) boolRow.SetMixedValue(); else boolRow.SetCommittedValue(expectedBool.Value == true);
+                break;
+            case (InspectorInfoPropertyViewModel infoRow, InspectorInfoPropertyViewModel expectedInfo):
+                infoRow.SetCommittedValue(expectedInfo.Value);
+                break;
+        }
+    }
+
+    private void AddPanelAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, bool includeSameTypeRows, ICollection<InspectorPropertyRowViewModel>? rows = null)
+    {
+        rows ??= _propertyRows;
+        if (includeSameTypeRows)
+        {
+            AddAggregateText(rows, "Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyPanelAggregateUpdate(document, elements, "Update names", new PanelElementModelUpdate { Name = value }, includeLockedTransforms: true));
+        }
+
+        AddAggregateDouble(rows, "X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyPanelAggregateUpdate(document, elements, "Update X", new PanelElementModelUpdate { X = value }, includeLockedTransforms: false));
+        AddAggregateDouble(rows, "Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyPanelAggregateUpdate(document, elements, "Update Y", new PanelElementModelUpdate { Y = value }, includeLockedTransforms: false));
+        AddAggregateDouble(rows, "Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update width", new PanelElementModelUpdate { Width = value }, includeLockedTransforms: false) : "Width must be greater than zero.");
+        AddAggregateDouble(rows, "Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyPanelAggregateUpdate(document, elements, "Update height", new PanelElementModelUpdate { Height = value }, includeLockedTransforms: false) : "Height must be greater than zero.");
+        AddAggregateBool(rows, "Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyPanelAggregateUpdate(document, elements, "Update transform lock state", new PanelElementModelUpdate { IsTransformLocked = value }, includeLockedTransforms: true));
+        AddAggregateBool(rows, "Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyPanelAggregateUpdate(document, elements, "Update visibility", new PanelElementModelUpdate { IsVisible = value }, includeLockedTransforms: true));
+
+        if (includeSameTypeRows)
+        {
+            AddPanelTypeSpecificAggregateRows(document, elements, rows);
+        }
+    }
+
+    private void AddPanelTypeSpecificAggregateRows(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, ICollection<InspectorPropertyRowViewModel> rows)
     {
         var kind = elements[0].Kind;
         if (kind is PanelElementKind.Lamp or PanelElementKind.Reel or PanelElementKind.SevenSegment)
-            AddAggregateInt("Display Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayNumber)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display number", new PanelElementModelUpdate { DisplayNumber = value }, true));
+            AddAggregateInt(rows, "Display Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayNumber)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display number", new PanelElementModelUpdate { DisplayNumber = value }, true));
         if (kind is PanelElementKind.Image or PanelElementKind.Background or PanelElementKind.Lamp or PanelElementKind.Reel)
-            AddAggregateText("Asset Path", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.AssetPath ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update asset path", new PanelElementModelUpdate { AssetPath = NormalizeOptionalText(value) }, true));
+            AddAggregateText(rows, "Asset Path", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.AssetPath ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update asset path", new PanelElementModelUpdate { AssetPath = NormalizeOptionalText(value) }, true));
         if (kind is PanelElementKind.Lamp)
         {
-            AddAggregateColor("On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
-            AddAggregateColor("Off Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OffColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update off color", new PanelElementModelUpdate { OffColorHex = NormalizeOptionalText(value) }, true));
-            AddAggregateBool("Border", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.HasBorder)), value => TryApplyPanelAggregateUpdate(document, elements, "Update lamp border", new PanelElementModelUpdate { HasBorder = value }, true));
+            AddAggregateColor(rows, "On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateColor(rows, "Off Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OffColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update off color", new PanelElementModelUpdate { OffColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateBool(rows, "Border", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.HasBorder)), value => TryApplyPanelAggregateUpdate(document, elements, "Update lamp border", new PanelElementModelUpdate { HasBorder = value }, true));
         }
         if (kind is PanelElementKind.Alpha)
         {
-            AddAggregateColor("On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
-            AddAggregateBool("Decimal Point", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowDecimalPoint)), value => TryApplyPanelAggregateUpdate(document, elements, "Update decimal point visibility", new PanelElementModelUpdate { ShowDecimalPoint = value }, true));
-            AddAggregateBool("Comma", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowCommaTail)), value => TryApplyPanelAggregateUpdate(document, elements, "Update comma visibility", new PanelElementModelUpdate { ShowCommaTail = value }, true));
-            AddAggregateBool("Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
+            AddAggregateColor(rows, "On Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.OnColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update on color", new PanelElementModelUpdate { OnColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateBool(rows, "Decimal Point", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowDecimalPoint)), value => TryApplyPanelAggregateUpdate(document, elements, "Update decimal point visibility", new PanelElementModelUpdate { ShowDecimalPoint = value }, true));
+            AddAggregateBool(rows, "Comma", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.ShowCommaTail)), value => TryApplyPanelAggregateUpdate(document, elements, "Update comma visibility", new PanelElementModelUpdate { ShowCommaTail = value }, true));
+            AddAggregateBool(rows, "Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
         }
         if (kind is PanelElementKind.Label)
         {
-            AddAggregateText("Display Text", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayText ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display text", new PanelElementModelUpdate { DisplayText = NormalizeOptionalText(value) }, true));
-            AddAggregateColor("Text Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.TextColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update text color", new PanelElementModelUpdate { TextColorHex = NormalizeOptionalText(value) }, true));
-            AddAggregateInt("Lamp Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.LampNumber)), value => value < 0 ? "Lamp Number must be zero or greater." : TryApplyPanelAggregateUpdate(document, elements, "Update lamp number", new PanelElementModelUpdate { LampNumber = value }, true));
+            AddAggregateText(rows, "Display Text", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.DisplayText ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update display text", new PanelElementModelUpdate { DisplayText = NormalizeOptionalText(value) }, true));
+            AddAggregateColor(rows, "Text Color", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.TextColorHex ?? string.Empty)), value => TryApplyPanelAggregateUpdate(document, elements, "Update text color", new PanelElementModelUpdate { TextColorHex = NormalizeOptionalText(value) }, true));
+            AddAggregateInt(rows, "Lamp Number", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.LampNumber)), value => value < 0 ? "Lamp Number must be zero or greater." : TryApplyPanelAggregateUpdate(document, elements, "Update lamp number", new PanelElementModelUpdate { LampNumber = value }, true));
         }
         if (kind is PanelElementKind.Reel)
         {
-            AddAggregateInt("Stops", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.Stops)), value => TryApplyPanelAggregateUpdate(document, elements, "Update stops", new PanelElementModelUpdate { Stops = value }, true));
-            AddAggregateDouble("Band Offset", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.BandOffset ?? 0d)), value => PanelElementValidation.IsValidBandOffset(value) ? TryApplyPanelAggregateUpdate(document, elements, "Update band offset", new PanelElementModelUpdate { BandOffset = value }, true) : "Enter a value from -1 to 1.", "G17");
-            AddAggregateBool("Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
+            AddAggregateInt(rows, "Stops", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.Stops)), value => TryApplyPanelAggregateUpdate(document, elements, "Update stops", new PanelElementModelUpdate { Stops = value }, true));
+            AddAggregateDouble(rows, "Band Offset", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.BandOffset ?? 0d)), value => PanelElementValidation.IsValidBandOffset(value) ? TryApplyPanelAggregateUpdate(document, elements, "Update band offset", new PanelElementModelUpdate { BandOffset = value }, true) : "Enter a value from -1 to 1.", "G17");
+            AddAggregateBool(rows, "Reversed", "Type-specific", InspectorAggregateValue.From(elements.Select(e => e.IsReversed ?? false)), value => TryApplyPanelAggregateUpdate(document, elements, "Update reversed", new PanelElementModelUpdate { IsReversed = value }, true));
         }
     }
 
-    private void AddFaceAggregateRows(DocumentTabViewModel document, IReadOnlyList<FaceElementModel> elements, bool includeSameTypeRows)
+    private void AddFaceAggregateRows(DocumentTabViewModel document, IReadOnlyList<FaceElementModel> elements, bool includeSameTypeRows, ICollection<InspectorPropertyRowViewModel>? rows = null)
     {
+        rows ??= _propertyRows;
         if (includeSameTypeRows)
-            AddAggregateText("Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyFaceAggregateUpdate(document, elements, "Update names", new FaceElementModelUpdate { Name = value }, true));
-        AddAggregateDouble("X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyFaceAggregateUpdate(document, elements, "Update X", new FaceElementModelUpdate { X = value }, false));
-        AddAggregateDouble("Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyFaceAggregateUpdate(document, elements, "Update Y", new FaceElementModelUpdate { Y = value }, false));
-        AddAggregateDouble("Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update width", new FaceElementModelUpdate { Width = value }, false) : "Width must be greater than zero.");
-        AddAggregateDouble("Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update height", new FaceElementModelUpdate { Height = value }, false) : "Height must be greater than zero.");
-        AddAggregateBool("Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyFaceAggregateUpdate(document, elements, "Update transform lock state", new FaceElementModelUpdate { IsTransformLocked = value }, true));
-        AddAggregateBool("Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyFaceAggregateUpdate(document, elements, "Update visibility", new FaceElementModelUpdate { IsVisible = value }, true));
+            AddAggregateText(rows, "Name", "Common", InspectorAggregateValue.From(elements.Select(e => e.Name)), value => TryApplyFaceAggregateUpdate(document, elements, "Update names", new FaceElementModelUpdate { Name = value }, true));
+        AddAggregateDouble(rows, "X", "Transform", InspectorAggregateValue.From(elements.Select(e => e.X)), value => TryApplyFaceAggregateUpdate(document, elements, "Update X", new FaceElementModelUpdate { X = value }, false));
+        AddAggregateDouble(rows, "Y", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Y)), value => TryApplyFaceAggregateUpdate(document, elements, "Update Y", new FaceElementModelUpdate { Y = value }, false));
+        AddAggregateDouble(rows, "Width", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Width)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update width", new FaceElementModelUpdate { Width = value }, false) : "Width must be greater than zero.");
+        AddAggregateDouble(rows, "Height", "Transform", InspectorAggregateValue.From(elements.Select(e => e.Height)), value => value > 0 ? TryApplyFaceAggregateUpdate(document, elements, "Update height", new FaceElementModelUpdate { Height = value }, false) : "Height must be greater than zero.");
+        AddAggregateBool(rows, "Lock Transform", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsTransformLocked)), value => TryApplyFaceAggregateUpdate(document, elements, "Update transform lock state", new FaceElementModelUpdate { IsTransformLocked = value }, true));
+        AddAggregateBool(rows, "Visible", "Common", InspectorAggregateValue.From(elements.Select(e => e.IsVisible)), value => TryApplyFaceAggregateUpdate(document, elements, "Update visibility", new FaceElementModelUpdate { IsVisible = value }, true));
         if (includeSameTypeRows)
         {
-            AddAggregateText("Machine Reference", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedMachineObjectReference?.ToString() ?? string.Empty)), value => TryApplyFaceAggregateMachineReferenceUpdate(document, elements, value));
-            AddAggregateText("Linked Panel2D Element", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedPanel2DElementId ?? string.Empty)), value => TryApplyFaceAggregateUpdate(document, elements, "Update linked Panel2D element", new FaceElementModelUpdate { HasLinkedPanel2DElementId = true, LinkedPanel2DElementId = NormalizeOptionalText(value) }, true));
+            AddAggregateText(rows, "Machine Reference", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedMachineObjectReference?.ToString() ?? string.Empty)), value => TryApplyFaceAggregateMachineReferenceUpdate(document, elements, value));
+            AddAggregateText(rows, "Linked Panel2D Element", "References", InspectorAggregateValue.From(elements.Select(e => e.LinkedPanel2DElementId ?? string.Empty)), value => TryApplyFaceAggregateUpdate(document, elements, "Update linked Panel2D element", new FaceElementModelUpdate { HasLinkedPanel2DElementId = true, LinkedPanel2DElementId = NormalizeOptionalText(value) }, true));
         }
     }
 
-    private void AddAggregateText(string name, string group, InspectorAggregateValue<string> value, Func<string, string?> commit) { var row = new InspectorTextPropertyViewModel(name, group, value.IsCommon ? value.Value ?? string.Empty : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
-    private void AddAggregateDouble(string name, string group, InspectorAggregateValue<double> value, Func<double, string?> commit, string format = "0.###") { var row = new InspectorDoublePropertyViewModel(name, group, value.IsCommon ? value.Value : 0d, commit: commit, format: format); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
-    private void AddAggregateInt(string name, string group, InspectorAggregateValue<int?> value, Func<int?, string?> commit) { var row = new InspectorIntPropertyViewModel(name, group, value.IsCommon ? value.Value : null, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
-    private void AddAggregateColor(string name, string group, InspectorAggregateValue<string> value, Func<string?, string?> commit) { var row = new InspectorColorPropertyViewModel(name, group, value.IsCommon ? value.Value : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
-    private void AddAggregateBool(string name, string group, InspectorAggregateValue<bool> value, Func<bool, string?> commit) { var row = new InspectorBoolPropertyViewModel(name, group, value.IsCommon && value.Value == true, commit: commit); if (value.IsMixed) row.SetMixedValue(); _propertyRows.Add(row); }
+    private void AddAggregateText(ICollection<InspectorPropertyRowViewModel> rows, string name, string group, InspectorAggregateValue<string> value, Func<string, string?> commit) { var row = new InspectorTextPropertyViewModel(name, group, value.IsCommon ? value.Value ?? string.Empty : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); rows.Add(row); }
+    private void AddAggregateDouble(ICollection<InspectorPropertyRowViewModel> rows, string name, string group, InspectorAggregateValue<double> value, Func<double, string?> commit, string format = "0.###") { var row = new InspectorDoublePropertyViewModel(name, group, value.IsCommon ? value.Value : 0d, commit: commit, format: format); if (value.IsMixed) row.SetMixedValue(); rows.Add(row); }
+    private void AddAggregateInt(ICollection<InspectorPropertyRowViewModel> rows, string name, string group, InspectorAggregateValue<int?> value, Func<int?, string?> commit) { var row = new InspectorIntPropertyViewModel(name, group, value.IsCommon ? value.Value : null, commit: commit); if (value.IsMixed) row.SetMixedValue(); rows.Add(row); }
+    private void AddAggregateColor(ICollection<InspectorPropertyRowViewModel> rows, string name, string group, InspectorAggregateValue<string> value, Func<string?, string?> commit) { var row = new InspectorColorPropertyViewModel(name, group, value.IsCommon ? value.Value : string.Empty, commit: commit); if (value.IsMixed) row.SetMixedValue(); rows.Add(row); }
+    private void AddAggregateBool(ICollection<InspectorPropertyRowViewModel> rows, string name, string group, InspectorAggregateValue<bool> value, Func<bool, string?> commit) { var row = new InspectorBoolPropertyViewModel(name, group, value.IsCommon && value.Value == true, commit: commit); if (value.IsMixed) row.SetMixedValue(); rows.Add(row); }
 
     private string? TryApplyPanelAggregateUpdate(DocumentTabViewModel document, IReadOnlyList<PanelElementModel> elements, string description, PanelElementModelUpdate update, bool includeLockedTransforms)
     {


### PR DESCRIPTION
### Motivation

- Dragging many selected Panel2D components caused visible Inspector text flicker because multi-selection panel preview updates repeatedly cleared and rebuilt the `_propertyRows` collection instead of updating existing row view models in place.
- The change aims to preserve existing `InspectorPropertyRowViewModel` instances and update their values/mixed states during ordinary geometry-only preview events while still rebuilding when the row schema genuinely changes.

### Description

- In `NotifyPanelChanged` the multi-selection path now attempts an in-place refresh via `TryRefreshAggregatePropertyRowValues(...)` and falls back to `RebuildPropertyRows()` when `ShouldRebuildAggregateRows(...)` indicates structural/ordering/unsupported changes or the schema does not match. (changed: `InspectorViewModel.cs`)
- Added reusable aggregate helpers (`AddAggregateRows`, `ShouldRebuildAggregateRows`, `TryRefreshAggregatePropertyRowValues`, `HasSameAggregateRowSchema`, `RefreshAggregateRowValue`) and adapted existing aggregate row builders to accept a target `rows` collection so the same aggregate definitions are used for both rebuild and refresh. (changed: `InspectorViewModel.cs`)
- The refresh updates only the values and mixed-value state on existing `InspectorPropertyRowViewModel` instances (text/double/int/color/bool/info types) and updates `InspectorSummary` as before; rebuilds remain in the same fallback scenarios. (changed: `InspectorViewModel.cs`)
- Added unit tests exercising geometry-only multi-selection refreshes, mixed-state transitions, repeated preview-like updates retaining row instances, and fallback rebuild cases. (changed: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/InspectorAggregateValueTests.cs`) 

### Testing

- No automated test suite was executed in this environment because the repository's `AGENTS.md` notes the Codex environment lacks the Windows/.NET/WPF toolchain; therefore `dotnet test` was not run here. 
- Added unit tests (examples): `PanelMultiEdit_GeometryOnlyPanelChange_RefreshesAggregateRowsInPlace`, `PanelMultiEdit_GeometryOnlyPanelChange_UpdatesMixedStatesInPlace`, `PanelMultiEdit_RepeatedGeometryOnlyPanelChanges_RetainAggregateRowInstances`, `PanelMultiEdit_StructuralPanelChange_RebuildsAggregateRows`, `PanelMultiEdit_SelectionMembershipChange_RebuildsAggregateRows`, and `PanelMultiEdit_UnsupportedMixedSelection_RemainsReadOnlyAfterPanelChange`, which should be run locally. 
- Local verification: run the test project with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and exercise dragging large multi-selections in the running application to confirm Inspector text no longer flickers during geometry-only preview updates and that structural/selection changes still rebuild rows as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53e232b2b48327907031f5dcddb61b)