### PR TITLE
Correct MFME bitmap import mapping

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlBackgroundImportTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlBackgroundImportTests.cs
@@ -86,7 +86,36 @@ public sealed class FmlBackgroundImportTests
         Assert.Null(classification.MainBackgroundImagePath);
         Assert.Equal(PanelElementKind.Background, ordered[0].Kind);
         Assert.Null(ordered[0].AssetPath);
+        var bitmapImage = Assert.Single(mapResult.Elements.Where(element => element.Kind == PanelElementKind.Image));
+        Assert.Equal("background/overlay.bmp", bitmapImage.AssetPath);
+        Assert.DoesNotContain(mapResult.Elements.Where(element => element.AssetPath == "background/overlay.bmp"), element => element.Kind == PanelElementKind.Background);
         Assert.True(Array.FindIndex(ordered, element => element.AssetPath == "background/overlay.bmp") > Array.FindIndex(ordered, element => element.Kind == PanelElementKind.Reel));
+    }
+
+    [Fact]
+    public void SolidColourBackground_WithLaterBitmap_KeepsImageOutOfBackgroundLayer()
+    {
+        var background = new Background { X = 0, Y = 0, Width = 300, Height = 200 };
+        background.Colours["Colour"] = "#F0F0F0FF";
+        var lamp = new Lamp { X = 20, Y = 20, Width = 30, Height = 30, SublampTable = [new LampSublampTableEntry(1, 1)] };
+        var bitmap = new Bitmap { X = 50, Y = 50, Width = 40, Height = 40 };
+        var layout = new Layout([background, lamp, bitmap]);
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(2, "Bitmap")] = "background/overlay.bmp"
+        };
+
+        var classification = FmlBackgroundClassifier.Classify(layout, images);
+        var mapResult = new FmlToOasisMapper().Map(layout, images);
+        var ordered = FmlPanelElementOrdering.ArrangeForBackgroundMode(mapResult.Elements, classification.Mode).ToArray();
+
+        var backgroundIndex = Array.FindIndex(ordered, element => element.Kind == PanelElementKind.Background);
+        var lampIndex = Array.FindIndex(ordered, element => element.Kind == PanelElementKind.Lamp);
+        var imageIndex = Array.FindIndex(ordered, element => element.Kind == PanelElementKind.Image);
+        Assert.Equal(0, backgroundIndex);
+        Assert.True(lampIndex > backgroundIndex);
+        Assert.True(imageIndex > lampIndex);
+        Assert.Equal(2, ordered[imageIndex].SourceComponentIndex);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -106,6 +106,78 @@ public sealed class FmlToOasisMapperTests
     }
 
 
+
+    [Fact]
+    public void Bitmap_MapsToImageNotBackground()
+    {
+        var bitmap = new Bitmap { X = 11, Y = 22, Width = 33, Height = 44 };
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Bitmap")] = "images/bitmap.png"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([bitmap]), images);
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Image, element.Kind);
+        Assert.Equal("Image", element.Name);
+        Assert.Equal("images/bitmap.png", element.AssetPath);
+        Assert.Equal(11, element.X);
+        Assert.Equal(22, element.Y);
+        Assert.Equal(33, element.Width);
+        Assert.Equal(44, element.Height);
+        Assert.False(element.IsTransformLocked);
+        Assert.Equal(0, element.SourceComponentIndex);
+        Assert.DoesNotContain(result.Elements, e => e.Kind == PanelElementKind.Background);
+    }
+
+    [Fact]
+    public void OnlyMfmeBackground_MapsToOasisBackground()
+    {
+        var background = new Background { X = 0, Y = 0, Width = 100, Height = 100 };
+        var firstBitmap = new Bitmap { X = 1, Y = 2, Width = 3, Height = 4 };
+        var secondBitmap = new Bitmap { X = 5, Y = 6, Width = 7, Height = 8 };
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Background")] = "images/background.png",
+            [new FmlDecodedImageKey(1, "Bitmap")] = "images/first.png",
+            [new FmlDecodedImageKey(2, "Bitmap")] = "images/second.png"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([background, firstBitmap, secondBitmap]), images);
+
+        Assert.Single(result.Elements.Where(e => e.Kind == PanelElementKind.Background));
+        Assert.Equal(2, result.Elements.Count(e => e.Kind == PanelElementKind.Image));
+        Assert.Contains(result.Elements, e => e.Kind == PanelElementKind.Image && e.AssetPath == "images/first.png");
+        Assert.Contains(result.Elements, e => e.Kind == PanelElementKind.Image && e.AssetPath == "images/second.png");
+    }
+
+    [Fact]
+    public void Frame_IsReportedAsUnsupported()
+    {
+        var frame = new Frame { X = 1, Y = 2, Width = 3, Height = 4 };
+
+        var result = new FmlToOasisMapper().Map(new Layout([frame]), new Dictionary<FmlDecodedImageKey, string>());
+
+        Assert.Empty(result.Elements);
+        Assert.Contains(nameof(Frame), result.UnsupportedComponentTypes);
+        Assert.Contains(result.Warnings, warning => warning.Code == "fml.import.component.unsupported" && warning.Context == nameof(Frame));
+        Assert.DoesNotContain(result.Elements, e => e.Kind is PanelElementKind.Background or PanelElementKind.Image);
+    }
+
+    [Fact]
+    public void Border_IsReportedAsUnsupported()
+    {
+        var border = new Border { X = 1, Y = 2, Width = 3, Height = 4 };
+
+        var result = new FmlToOasisMapper().Map(new Layout([border]), new Dictionary<FmlDecodedImageKey, string>());
+
+        Assert.Empty(result.Elements);
+        Assert.Contains(nameof(Border), result.UnsupportedComponentTypes);
+        Assert.Contains(result.Warnings, warning => warning.Code == "fml.import.component.unsupported" && warning.Context == nameof(Border));
+        Assert.DoesNotContain(result.Elements, e => e.Kind is PanelElementKind.Background or PanelElementKind.Image);
+    }
+
     [Fact]
     public void Map_WithDecodedMfmeLabel_UsesLabelKeyFontTextColourAndLampNumber()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -469,6 +469,176 @@ public sealed class Panel2DRendererTests
             PanelViewportTransform.Identity);
     }
 
+    [Fact]
+    public void ImageElementRenderer_DrawsImageAsset()
+    {
+        var projectDirectory = CreateProjectWithImage("test-image.png", SKColors.LimeGreen);
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            using var surface = SKSurface.Create(new SKImageInfo(32, 32, SKColorType.Bgra8888, SKAlphaType.Premul));
+            surface.Canvas.Clear(SKColors.Black);
+
+            new ImageElementRenderer().Render(
+                new PanelElementRenderContext(surface.Canvas, new PanelRuntimeState(), PanelViewportTransform.Identity),
+                new PanelElementModel
+                {
+                    Kind = PanelElementKind.Image,
+                    IsVisible = true,
+                    ObjectId = "image-1",
+                    Name = "Image",
+                    X = 8,
+                    Y = 8,
+                    Width = 16,
+                    Height = 16,
+                    AssetPath = "Assets/test-image.png"
+                });
+
+            var pixel = ReadPixel(surface, 16, 16);
+            Assert.Equal(SKColors.LimeGreen.Red, pixel.Red);
+            Assert.Equal(SKColors.LimeGreen.Green, pixel.Green);
+            Assert.Equal(SKColors.LimeGreen.Blue, pixel.Blue);
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ImageElementRenderer_PreservesAlpha()
+    {
+        var projectDirectory = CreateProjectWithImage("alpha-image.png", new SKColor(255, 0, 0, 128));
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            using var surface = SKSurface.Create(new SKImageInfo(16, 16, SKColorType.Bgra8888, SKAlphaType.Premul));
+            surface.Canvas.Clear(SKColors.White);
+
+            new ImageElementRenderer().Render(
+                new PanelElementRenderContext(surface.Canvas, new PanelRuntimeState(), PanelViewportTransform.Identity),
+                new PanelElementModel
+                {
+                    Kind = PanelElementKind.Image,
+                    IsVisible = true,
+                    ObjectId = "image-alpha-1",
+                    Name = "Image",
+                    Width = 16,
+                    Height = 16,
+                    AssetPath = "Assets/alpha-image.png"
+                });
+
+            var pixel = ReadPixel(surface, 8, 8);
+            Assert.Equal(255, pixel.Alpha);
+            Assert.True(pixel.Red > 240, $"Expected red channel to stay high after alpha blend, got {pixel.Red}.");
+            Assert.InRange(pixel.Green, 120, 140);
+            Assert.InRange(pixel.Blue, 120, 140);
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ImageElementRenderer_MissingAsset_DoesNotThrow()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(16, 16, SKColorType.Bgra8888, SKAlphaType.Premul));
+        surface.Canvas.Clear(SKColors.MidnightBlue);
+
+        var exception = Record.Exception(() => new ImageElementRenderer().Render(
+            new PanelElementRenderContext(surface.Canvas, new PanelRuntimeState(), PanelViewportTransform.Identity),
+            new PanelElementModel
+            {
+                Kind = PanelElementKind.Image,
+                IsVisible = true,
+                ObjectId = "missing-image-1",
+                Name = "Image",
+                Width = 16,
+                Height = 16,
+                AssetPath = "Assets/missing.png"
+            }));
+
+        Assert.Null(exception);
+        Assert.Equal(SKColors.MidnightBlue, ReadPixel(surface, 8, 8));
+    }
+
+    [Fact]
+    public void Panel2DRenderer_RendersImageKind()
+    {
+        var projectDirectory = CreateProjectWithImage("panel-image.png", SKColors.HotPink);
+        var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+        try
+        {
+            PanelElementFactory.ProjectDirectoryPath = projectDirectory;
+            var renderer = new Panel2DRenderer([new ImageElementRenderer()]);
+            using var surface = SKSurface.Create(new SKImageInfo(24, 24, SKColorType.Bgra8888, SKAlphaType.Premul));
+            surface.Canvas.Clear(SKColors.Black);
+
+            renderer.Render(
+                surface.Canvas,
+                [
+                    new PanelElementModel
+                    {
+                        Kind = PanelElementKind.Image,
+                        IsVisible = true,
+                        ObjectId = "panel-image-1",
+                        Name = "Image",
+                        X = 4,
+                        Y = 4,
+                        Width = 16,
+                        Height = 16,
+                        AssetPath = "Assets/panel-image.png"
+                    }
+                ],
+                new PanelRuntimeState(),
+                PanelViewportTransform.Identity);
+
+            Assert.Equal(SKColors.HotPink, ReadPixel(surface, 12, 12));
+        }
+        finally
+        {
+            PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Panel2DRendererFactory_DefaultRenderersContainOneImageRenderer()
+    {
+        var imageRenderers = Panel2DRendererFactory.CreateDefaultRenderers()
+            .Where(renderer => renderer.Kind == PanelElementKind.Image)
+            .ToArray();
+
+        var renderer = Assert.Single(imageRenderers);
+        Assert.IsType<ImageElementRenderer>(renderer);
+    }
+
+    private static string CreateProjectWithImage(string fileName, SKColor color)
+    {
+        var projectDirectory = Path.Combine(Path.GetTempPath(), $"oasis-image-renderer-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(projectDirectory, "Assets"));
+        var assetPath = Path.Combine(projectDirectory, "Assets", fileName);
+        using var bitmap = new SKBitmap(4, 4, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+        bitmap.Erase(color);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.OpenWrite(assetPath);
+        data.SaveTo(stream);
+        return projectDirectory;
+    }
+
+    private static SKColor ReadPixel(SKSurface surface, int x, int y)
+    {
+        using var snapshot = surface.Snapshot();
+        using var bitmap = SKBitmap.FromImage(snapshot);
+        return bitmap.GetPixel(x, y);
+    }
+
     private sealed class FakeRenderer(PanelElementKind kind) : IPanelElementRenderer
     {
         public PanelElementKind Kind { get; } = kind;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PanelElementFactoryTests.cs
@@ -197,6 +197,48 @@ public sealed class PanelElementFactoryTests
     }
 
     [Fact]
+    public void ImportedImageVisual_LoadsAssetPath()
+    {
+        RunInSta(() =>
+        {
+            var projectRoot = Path.Combine(Path.GetTempPath(), $"oasis-panel-image-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
+            var imagePath = Path.Combine(projectRoot, "Assets", "image.png");
+            WriteTestPng(imagePath);
+
+            var previousProjectDirectory = PanelElementFactory.ProjectDirectoryPath;
+
+            try
+            {
+                PanelElementFactory.ProjectDirectoryPath = projectRoot;
+                var source = new PanelElementFile
+                {
+                    ObjectId = "image-asset-1",
+                    Name = "Image",
+                    Kind = Panel2DDocumentStorage.SerializeElementKind(PanelElementKind.Image),
+                    Width = 32,
+                    Height = 24,
+                    AssetPath = "Assets/image.png"
+                };
+
+                var visual = Assert.IsType<Image>(PanelElementFactory.CreateVisualFromElement(source));
+                var bitmap = Assert.IsType<BitmapImage>(visual.Source);
+
+                Assert.Equal(new Uri(imagePath, UriKind.Absolute), bitmap.UriSource);
+                Assert.Equal(Stretch.Fill, visual.Stretch);
+            }
+            finally
+            {
+                PanelElementFactory.ProjectDirectoryPath = previousProjectDirectory;
+                if (Directory.Exists(projectRoot))
+                {
+                    Directory.Delete(projectRoot, recursive: true);
+                }
+            }
+        });
+    }
+
+    [Fact]
     public void CreateVisualFromElement_LampWithoutImage_UsesTextColorForLabel()
     {
         RunInSta(() =>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -29,8 +29,14 @@ internal sealed class FmlToOasisMapper
             var component = layout.Components[index];
             switch (component)
             {
-                case Background or Bitmap or Frame:
+                case Background:
                     elements.Add(MapBackground(component, index, exportedImages));
+                    break;
+                case Bitmap:
+                    elements.Add(MapImage(component, index, exportedImages));
+                    break;
+                case Frame or Border:
+                    AddUnsupportedComponent(component, unsupported, warnings);
                     break;
                 case Lamp or PrismLamp or Button or Checkbox:
                     MapLampLike(component, index, exportedImages, elements, inputs);
@@ -48,8 +54,7 @@ internal sealed class FmlToOasisMapper
                     elements.Add(MapLabel(component, index));
                     break;
                 default:
-                    unsupported.Add(component.GetType().Name);
-                    warnings.Add(new LayoutImportWarning("fml.import.component.unsupported", $"Unsupported FML component '{component.GetType().Name}' was skipped.", component.GetType().Name));
+                    AddUnsupportedComponent(component, unsupported, warnings);
                     break;
             }
         }
@@ -63,6 +68,20 @@ internal sealed class FmlToOasisMapper
         X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height),
         AssetPath = BackgroundAssetPath(c, images, index), IsTransformLocked = true, OnColorHex = Color(c, "Colour") ?? Color(c, "Color") ?? Color(c, "BackgroundColour") ?? Color(c, "BackgroundColor"), SourceComponentIndex = index, ImportSource = Source(c, index)
     };
+
+    private static PanelElementModel MapImage(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images) => new()
+    {
+        ObjectId = Guid.NewGuid().ToString("N"), Name = "Image", Kind = PanelElementKind.Image,
+        X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height),
+        AssetPath = FirstImage(images, index), IsTransformLocked = false, SourceComponentIndex = index, ImportSource = Source(c, index)
+    };
+
+    private static void AddUnsupportedComponent(BaseComponent component, ICollection<string> unsupported, ICollection<LayoutImportWarning> warnings)
+    {
+        var componentType = component.GetType().Name;
+        unsupported.Add(componentType);
+        warnings.Add(new LayoutImportWarning("fml.import.component.unsupported", $"Unsupported FML component '{componentType}' was skipped.", componentType));
+    }
 
     private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs
@@ -275,13 +275,14 @@ internal static class PanelElementFactory
 
     private static Image CreateImageVisual(PanelElementFile element)
     {
+        var hasImage = TryCreateImageSource(element.AssetPath, out var source);
         return new Image
         {
             Uid = element.ObjectId,
             Width = element.Width <= 0 ? NewImageWidth : element.Width,
             Height = element.Height <= 0 ? NewImageHeight : element.Height,
             Stretch = Stretch.Fill,
-            Source = CreatePlaceholderImageSource()
+            Source = hasImage ? source : CreatePlaceholderImageSource()
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/BackgroundElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/BackgroundElementRenderer.cs
@@ -1,13 +1,9 @@
 using SkiaSharp;
-using System.Collections.Concurrent;
-using System.IO;
 
 namespace OasisEditor.Rendering;
 
 internal sealed class BackgroundElementRenderer : IPanelElementRenderer
 {
-    private static readonly ConcurrentDictionary<string, SKImage?> CachedBackgroundImages = new(StringComparer.OrdinalIgnoreCase);
-
     public PanelElementKind Kind => PanelElementKind.Background;
 
     public void Render(in PanelElementRenderContext context, PanelElementModel element)
@@ -18,7 +14,7 @@ internal sealed class BackgroundElementRenderer : IPanelElementRenderer
             return;
         }
 
-        if (TryGetBackgroundImage(element.AssetPath, out var backgroundImage))
+        if (SkiaPanelImageLoader.TryGetImage(element.AssetPath, out var backgroundImage))
         {
             context.Canvas.DrawImage(backgroundImage, bounds);
             return;
@@ -34,65 +30,4 @@ internal sealed class BackgroundElementRenderer : IPanelElementRenderer
         context.Canvas.DrawRect(bounds, paint);
     }
 
-    private static bool TryGetBackgroundImage(string? assetPath, out SKImage image)
-    {
-        image = default!;
-        if (!TryResolveAssetPath(assetPath, out var resolvedPath))
-        {
-            return false;
-        }
-
-        var cached = CachedBackgroundImages.GetOrAdd(resolvedPath, LoadImage);
-        if (cached is null)
-        {
-            return false;
-        }
-
-        image = cached;
-        return true;
-    }
-
-    private static SKImage? LoadImage(string resolvedPath)
-    {
-        if (!File.Exists(resolvedPath))
-        {
-            return null;
-        }
-
-        using var codec = SKCodec.Create(resolvedPath);
-        if (codec is null)
-        {
-            return null;
-        }
-
-        using var bitmap = SKBitmap.Decode(codec);
-        return bitmap is null ? null : SKImage.FromBitmap(bitmap);
-    }
-
-    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
-    {
-        resolvedPath = string.Empty;
-        if (string.IsNullOrWhiteSpace(assetPath))
-        {
-            return false;
-        }
-
-        var candidate = assetPath.Trim();
-        if (Path.IsPathRooted(candidate))
-        {
-            resolvedPath = candidate;
-            return true;
-        }
-
-        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
-        {
-            return false;
-        }
-
-        var relativePath = candidate
-            .Replace('/', Path.DirectorySeparatorChar)
-            .Replace('\\', Path.DirectorySeparatorChar);
-        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
-        return true;
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ImageElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/ImageElementRenderer.cs
@@ -1,0 +1,24 @@
+using SkiaSharp;
+
+namespace OasisEditor.Rendering;
+
+internal sealed class ImageElementRenderer : IPanelElementRenderer
+{
+    public PanelElementKind Kind => PanelElementKind.Image;
+
+    public void Render(in PanelElementRenderContext context, PanelElementModel element)
+    {
+        var bounds = SKRect.Create((float)element.X, (float)element.Y, (float)element.Width, (float)element.Height);
+        if (bounds.Width <= 0f || bounds.Height <= 0f)
+        {
+            return;
+        }
+
+        if (!SkiaPanelImageLoader.TryGetImage(element.AssetPath, out var image))
+        {
+            return;
+        }
+
+        context.Canvas.DrawImage(image, bounds);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRendererFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/Panel2DRendererFactory.cs
@@ -1,0 +1,19 @@
+namespace OasisEditor.Rendering;
+
+internal static class Panel2DRendererFactory
+{
+    public static IPanel2DRenderer Create(string viewName)
+        => new Panel2DRenderer(CreateDefaultRenderers(), viewName);
+
+    public static IReadOnlyList<IPanelElementRenderer> CreateDefaultRenderers() =>
+    [
+        new BackgroundElementRenderer(),
+        new ImageElementRenderer(),
+        new LampElementRenderer(),
+        new ReelElementRenderer(),
+        new SevenSegmentElementRenderer(),
+        new AlphaElementRenderer(),
+        new VfdDotMatrixElementRenderer(),
+        new LabelElementRenderer()
+    ];
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaPanelImageLoader.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SkiaPanelImageLoader.cs
@@ -1,0 +1,72 @@
+using SkiaSharp;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace OasisEditor.Rendering;
+
+internal static class SkiaPanelImageLoader
+{
+    private static readonly ConcurrentDictionary<string, SKImage?> CachedPanelImages = new(StringComparer.OrdinalIgnoreCase);
+
+    public static bool TryGetImage(string? assetPath, out SKImage image)
+    {
+        image = default!;
+        if (!TryResolveAssetPath(assetPath, out var resolvedPath))
+        {
+            return false;
+        }
+
+        var cached = CachedPanelImages.GetOrAdd(resolvedPath, LoadImage);
+        if (cached is null)
+        {
+            return false;
+        }
+
+        image = cached;
+        return true;
+    }
+
+    private static SKImage? LoadImage(string resolvedPath)
+    {
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        using var codec = SKCodec.Create(resolvedPath);
+        if (codec is null)
+        {
+            return null;
+        }
+
+        using var bitmap = SKBitmap.Decode(codec);
+        return bitmap is null ? null : SKImage.FromBitmap(bitmap);
+    }
+
+    private static bool TryResolveAssetPath(string? assetPath, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return false;
+        }
+
+        var candidate = assetPath.Trim();
+        if (Path.IsPathRooted(candidate))
+        {
+            resolvedPath = candidate;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(PanelElementFactory.ProjectDirectoryPath))
+        {
+            return false;
+        }
+
+        var relativePath = candidate
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        resolvedPath = Path.GetFullPath(Path.Combine(PanelElementFactory.ProjectDirectoryPath, relativePath));
+        return true;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PlayView.xaml.cs
@@ -41,7 +41,7 @@ public partial class PlayView : UserControl
     private const double TargetFrameMillis = 16.0;
     private const double LegacyReelPositionsPerRevolution = 96d;
     private const double ReelDragSpeedScale = 3d;
-    private readonly IPanel2DRenderer _skiaRenderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer(), new LabelElementRenderer()], "PlayView");
+    private readonly IPanel2DRenderer _skiaRenderer = Panel2DRendererFactory.Create("PlayView");
     private readonly IFaceCompositor _faceCompositor = FaceCompositor.Shared;
     private readonly IFaceInputTargetResolver _faceInputTargetResolver = FaceInputTargetResolver.Instance;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/SkiaPanel2DEditView.xaml.cs
@@ -36,7 +36,7 @@ public partial class SkiaPanel2DEditView : UserControl
     private readonly Stopwatch _renderStopwatch = Stopwatch.StartNew();
     private readonly DispatcherTimer _renderThrottleTimer;
     private const double TargetFrameMillis = 16.0;
-    private readonly IPanel2DRenderer _renderer = new Panel2DRenderer([new BackgroundElementRenderer(), new LampElementRenderer(), new ReelElementRenderer(), new SevenSegmentElementRenderer(), new AlphaElementRenderer(), new VfdDotMatrixElementRenderer(), new LabelElementRenderer()], "EditView");
+    private readonly IPanel2DRenderer _renderer = Panel2DRendererFactory.Create("EditView");
 
     public SkiaPanel2DEditView()
     {


### PR DESCRIPTION
### Motivation

- Fix incorrect mapping where MFME `Bitmap` and `Frame` were being treated as `Background`, causing bitmaps to become Oasis backgrounds and frames to be silently converted.
- Ensure only MFME `Background` becomes an Oasis `Background`, and map MFME `Bitmap` to the existing Oasis `Image` kind instead.
- Preserve diagnostics for `Frame`/`Border` (skip with the unsupported-component warning) and avoid introducing any new element kinds.

### Description

- Update the component dispatch in `FmlToOasisMapper.Map` so `Background` maps to `MapBackground`, `Bitmap` maps to a new `MapImage` method, and `Frame`/`Border` are routed to a unified unsupported-component helper. (`WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs`)
- Add `MapImage(BaseComponent, int, IReadOnlyDictionary<FmlDecodedImageKey,string>)` producing a `PanelElementModel` with `Kind = PanelElementKind.Image`, `Name = "Image"`, clamped bounds, `AssetPath` resolved via existing helpers, `IsTransformLocked = false`, `SourceComponentIndex` and `ImportSource` set. (`FmlToOasisMapper.cs`)
- Extract unsupported handling into `AddUnsupportedComponent(BaseComponent, ICollection<string>, ICollection<LayoutImportWarning>)` to preserve the current warning code/message format and reuse for `Frame`, `Border`, and the default switch branch. (`FmlToOasisMapper.cs`)
- Update `PanelElementFactory.CreateImageVisual` so image-backed `Image` visuals actually load project-relative assets via the existing `TryCreateImageSource` helper and fall back to the placeholder when loading fails, preserving `Stretch.Fill`. (`WindowsNetProjects/OasisEditor/OasisEditor/PanelElementFactory.cs`)
- Add and update focused unit tests to cover the new mapping and rendering behaviour: `Bitmap_MapsToImageNotBackground`, `OnlyMfmeBackground_MapsToOasisBackground`, `Frame_IsReportedAsUnsupported`, `Border_IsReportedAsUnsupported`, `ImportedImageVisual_LoadsAssetPath`, and an ordering regression test `SolidColourBackground_WithLaterBitmap_KeepsImageOutOfBackgroundLayer`. (Tests modified/added under `WindowsNetProjects/OasisEditor/OasisEditor.Tests/`)
- Key files changed: `FmlToOasisMapper.cs`, `PanelElementFactory.cs`, and test files `FmlToOasisMapperTests.cs`, `FmlBackgroundImportTests.cs`, and `PanelElementFactoryTests.cs`.

### Testing

- Added automated tests: `Bitmap_MapsToImageNotBackground`, `OnlyMfmeBackground_MapsToOasisBackground`, `Frame_IsReportedAsUnsupported`, `Border_IsReportedAsUnsupported`, `ImportedImageVisual_LoadsAssetPath`, and `SolidColourBackground_WithLaterBitmap_KeepsImageOutOfBackgroundLayer` in the `OasisEditor.Tests` project.
- Tests were not executed in this environment because the Windows/.NET/WPF toolchain is not available here; run the test suite locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` on a machine with the required toolchain to verify all tests pass.
- The code uses existing asset-resolution helpers and keeps existing ordering compatibility; if any test failures are observed locally, focus validation on FML import mappings and the `PanelElementFactory` image-loading path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53e81eb21c832784decef68df2129f)