### PR TITLE
Import unassigned MFME Lamps as Images during FML mapping

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -491,7 +491,19 @@ public sealed class FmlToOasisMapperTests
     [Fact]
     public void Map_WithInvalidOnlyLampNumbers_ImportsAsImage()
     {
-        var lamp = new Lamp { SublampTable = [new LampSublampTableEntry(1, -1), new LampSublampTableEntry(2, -2)] };
+        var lamp = new Lamp { SublampTable = [new LampSublampTableEntry(1, 0), new LampSublampTableEntry(2, -2)] };
+        lamp.UInt32s["NumberOfDefinedLampNumbers"] = 0;
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        Assert.Equal(PanelElementKind.Image, Assert.Single(result.Elements).Kind);
+        Assert.DoesNotContain(result.Elements, e => e.Kind == PanelElementKind.Lamp);
+    }
+
+    [Fact]
+    public void Map_WithNegativeFallbackNumber_ImportsLampAsImage()
+    {
+        var lamp = new Lamp { Number = -1 };
 
         var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -439,4 +439,64 @@ public sealed class FmlToOasisMapperTests
         Assert.All(result.Elements, element => Assert.True(element.HasBorder));
     }
 
+    [Fact]
+    public void Map_WithAssignedLampNumber_ImportsAsLampUnchanged()
+    {
+        var lamp = new Lamp { X = 10, Y = 20, Width = 30, Height = 40, SublampTable = [new LampSublampTableEntry(1, 7)] };
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Sublamp 1 Main")] = "lamps/assigned-on.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Mask")] = "lamps/assigned-mask.bmp"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), images);
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Lamp, element.Kind);
+        Assert.Equal(7, element.DisplayNumber);
+        Assert.Equal("lamps/assigned-on.bmp", element.AssetPath);
+        Assert.Equal("lamps/assigned-mask.bmp", element.SecondaryAssetPath);
+        Assert.Empty(result.InformationalDiagnostics);
+    }
+
+    [Fact]
+    public void Map_WithUnassignedMfmeLamp_ImportsAsImageWithOnBitmapAndDiagnostic()
+    {
+        var lamp = new Lamp { X = 11, Y = 22, Width = 33, Height = 44 };
+        lamp.Strings["Name"] = "StaticLogo";
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Off Image")] = "lamps/static-off.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Main")] = "lamps/static-on.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Mask")] = "lamps/static-mask.bmp"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), images);
+
+        var image = Assert.Single(result.Elements);
+        Assert.Equal(PanelElementKind.Image, image.Kind);
+        Assert.Equal("Image", image.Name);
+        Assert.Equal(11, image.X);
+        Assert.Equal(22, image.Y);
+        Assert.Equal(33, image.Width);
+        Assert.Equal(44, image.Height);
+        Assert.Equal("lamps/static-on.bmp", image.AssetPath);
+        Assert.Equal("lamps/static-mask.bmp", image.SecondaryAssetPath);
+        Assert.Null(image.DisplayNumber);
+        Assert.Equal(0, image.SourceComponentIndex);
+        Assert.DoesNotContain(result.Elements, e => e.Kind == PanelElementKind.Lamp);
+        Assert.Contains(result.InformationalDiagnostics, diagnostic => diagnostic == "Converted unassigned MFME Lamp 'StaticLogo' to an Image because it has no Lamp number.");
+    }
+
+    [Fact]
+    public void Map_WithInvalidOnlyLampNumbers_ImportsAsImage()
+    {
+        var lamp = new Lamp { SublampTable = [new LampSublampTableEntry(1, -1), new LampSublampTableEntry(2, -2)] };
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), new Dictionary<FmlDecodedImageKey, string>());
+
+        Assert.Equal(PanelElementKind.Image, Assert.Single(result.Elements).Kind);
+        Assert.DoesNotContain(result.Elements, e => e.Kind == PanelElementKind.Lamp);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
@@ -127,6 +127,7 @@ internal sealed class FmlImportDiagnosticsWriter
         AppendList(sb, "Decoder errors", report.DecoderErrors);
         AppendList(sb, "Decoder warnings", report.DecoderWarnings);
         AppendList(sb, "Mapper warnings", report.MapperWarnings.Select(FormatWarning));
+        AppendList(sb, "Mapper informational diagnostics", report.MapperInformationalDiagnostics);
         AppendList(sb, "Asset copy warnings", report.AssetCopyWarnings.Select(FormatWarning));
         sb.AppendLine();
 
@@ -266,6 +267,7 @@ internal sealed class FmlImportDiagnosticsReport
     public IReadOnlyList<string> DecoderErrors { get; init; } = [];
     public IReadOnlyList<string> DecoderWarnings { get; init; } = [];
     public IReadOnlyList<LayoutImportWarning> MapperWarnings { get; init; } = [];
+    public IReadOnlyList<string> MapperInformationalDiagnostics { get; init; } = [];
     public IReadOnlyList<LayoutImportWarning> AssetCopyWarnings { get; init; } = [];
     public IReadOnlyList<string> UnsupportedComponentTypes { get; init; } = [];
     public int ImportedAssetCount { get; init; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -127,6 +127,7 @@ internal sealed class FmlImportService : IFmlImportService
 
         diagnostics.Add($"Generated image count: {imagePaths.Count}; image root: {stagingDirectory}; image paths: {FormatImagePaths(imagePaths.Values)}");
         diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(layout))}");
+        diagnostics.AddRange(mapResult.InformationalDiagnostics);
 
         var assetCopyStopwatch = Stopwatch.StartNew();
         var assetResult = _assetCopier.CopyAssetsFromStaging(
@@ -151,6 +152,7 @@ internal sealed class FmlImportService : IFmlImportService
             ImagePaths = imagePaths,
             DecoderWarnings = decodeResult.Warnings,
             MapperWarnings = [.. mapResult.Warnings, .. backgroundClassification.Warnings],
+            MapperInformationalDiagnostics = mapResult.InformationalDiagnostics,
             AssetCopyWarnings = assetResult.Warnings,
             UnsupportedComponentTypes = mapResult.UnsupportedComponentTypes,
             ImportedAssetCount = assetResult.CopiedAssetRelativePaths.Count,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -89,12 +89,17 @@ internal sealed class FmlToOasisMapper
 
     private static bool HasAssignedLampNumber(BaseComponent c)
     {
+        if (c is Lamp && UInt(c, "NumberOfDefinedLampNumbers") is uint definedCount)
+        {
+            return definedCount > 0 && GetSublamps(c).Any(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0);
+        }
+
         if (GetSublamps(c).Any(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0))
         {
             return true;
         }
 
-        return Number(c).HasValue;
+        return Number(c) is int number && number >= 0;
     }
 
     private static string ComponentIdentifier(BaseComponent c, int index)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -23,6 +23,7 @@ internal sealed class FmlToOasisMapper
         var warnings = new List<LayoutImportWarning>();
         var inputs = new List<InputDefinitionModel>();
         var unsupported = new List<string>();
+        var diagnostics = new List<string>();
 
         for (var index = 0; index < layout.Components.Count; index++)
         {
@@ -39,7 +40,7 @@ internal sealed class FmlToOasisMapper
                     AddUnsupportedComponent(component, unsupported, warnings);
                     break;
                 case Lamp or PrismLamp or Button or Checkbox:
-                    MapLampLike(component, index, exportedImages, elements, inputs);
+                    MapLampLike(component, index, exportedImages, elements, inputs, diagnostics);
                     break;
                 case Reel or BandReel or DiscReel or FlipReel:
                     elements.Add(MapReel(component, index, exportedImages, warnings));
@@ -59,7 +60,7 @@ internal sealed class FmlToOasisMapper
             }
         }
 
-        return new FmlToOasisMapResult { Elements = elements, Warnings = warnings, InputDefinitions = inputs, UnsupportedComponentTypes = unsupported };
+        return new FmlToOasisMapResult { Elements = elements, Warnings = warnings, InputDefinitions = inputs, UnsupportedComponentTypes = unsupported, InformationalDiagnostics = diagnostics };
     }
 
     private static PanelElementModel MapBackground(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images) => new()
@@ -76,6 +77,29 @@ internal sealed class FmlToOasisMapper
         AssetPath = FirstImage(images, index), IsTransformLocked = false, SourceComponentIndex = index, ImportSource = Source(c, index)
     };
 
+
+    private static PanelElementModel MapUnassignedLampAsImage(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images) => new()
+    {
+        ObjectId = Guid.NewGuid().ToString("N"), Name = "Image", Kind = PanelElementKind.Image,
+        X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height),
+        AssetPath = FirstLampOnImage(images, index) ?? FirstLampImage(images, index, isMask: false) ?? FirstLampImage(images, index, isMask: null),
+        SecondaryAssetPath = FirstLampImage(images, index, isMask: true),
+        IsTransformLocked = false, SourceComponentIndex = index, ImportSource = Source(c, index)
+    };
+
+    private static bool HasAssignedLampNumber(BaseComponent c)
+    {
+        if (GetSublamps(c).Any(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0))
+        {
+            return true;
+        }
+
+        return Number(c).HasValue;
+    }
+
+    private static string ComponentIdentifier(BaseComponent c, int index)
+        => Text(c) ?? Str(c, "Name") ?? Str(c, "Identifier") ?? $"{c.GetType().Name}:{index.ToString(CultureInfo.InvariantCulture)}";
+
     private static void AddUnsupportedComponent(BaseComponent component, ICollection<string> unsupported, ICollection<LayoutImportWarning> warnings)
     {
         var componentType = component.GetType().Name;
@@ -83,8 +107,15 @@ internal sealed class FmlToOasisMapper
         warnings.Add(new LayoutImportWarning("fml.import.component.unsupported", $"Unsupported FML component '{componentType}' was skipped.", componentType));
     }
 
-    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs)
+    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs, List<string> diagnostics)
     {
+        if (c is Lamp && !HasAssignedLampNumber(c))
+        {
+            elements.Add(MapUnassignedLampAsImage(c, index, images));
+            diagnostics.Add($"Converted unassigned MFME Lamp '{ComponentIdentifier(c, index)}' to an Image because it has no Lamp number.");
+            return;
+        }
+
         var entries = GetSublamps(c).Where(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0).OrderBy(e => e.SublampIndex).ToArray();
         if (entries.Length == 0)
         {
@@ -198,8 +229,10 @@ internal sealed class FmlToOasisMapper
     private static string? FirstRoleImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, Func<string, bool> role) => images.Where(k => k.Key.ComponentIndex == index && role(k.Key.ImageName)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
     private static string? FindLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, int sub, bool? isMask) => images.Where(k => k.Key.ComponentIndex == index && IsSublamp(k.Key.ImageName, sub) && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
     private static string? FirstLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, bool? isMask) => images.Where(k => k.Key.ComponentIndex == index && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
+    private static string? FirstLampOnImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index) => images.Where(k => k.Key.ComponentIndex == index && !MatchesMask(k.Key.ImageName, true) && IsLampOnImage(k.Key.ImageName)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
     private static bool IsSublamp(string key, int sub) { var n = Norm(key); return n.StartsWith($"sublamp_{sub}_", StringComparison.Ordinal) || key.StartsWith($"Sublamp {sub} ", StringComparison.OrdinalIgnoreCase); }
     private static bool MatchesMask(string key, bool? mask) => mask is null || Norm(key).Contains("mask", StringComparison.Ordinal) == mask.Value;
+    private static bool IsLampOnImage(string key) { var n = Norm(key); return (n.Contains("on") || n.Contains("main") || n.Contains("fixed")) && !n.Contains("off"); }
     private static bool IsReelBand(string k) { var n = Norm(k); return n.Contains("band") || n.Contains("gradient") || n.Contains("strip") || n.Contains("reel_image") || n.EndsWith("reel"); }
     private static bool IsOverlay(string k) { var n = Norm(k); return n.Contains("overlay") || n.Contains("over_lay") || n.Contains("window") || n.Contains("cutout") || n.Contains("cut_out") || n.Contains("mask_overlay"); }
     private static bool IsMainBackgroundImage(string k) { var n = Norm(k); return n.Contains("background") && !n.Contains("mask") && !IsOverlay(k); }
@@ -214,4 +247,5 @@ internal sealed class FmlToOasisMapResult
     public required IReadOnlyList<LayoutImportWarning> Warnings { get; init; }
     public required IReadOnlyList<InputDefinitionModel> InputDefinitions { get; init; }
     public required IReadOnlyList<string> UnsupportedComponentTypes { get; init; }
+    public required IReadOnlyList<string> InformationalDiagnostics { get; init; }
 }


### PR DESCRIPTION
### Motivation

- Some MFME layouts use Lamp components with no assigned lamp number as static artwork (permanently-on images), but the existing importer created Oasis Lamps which are runtime/state-driven and therefore invisible when unassigned.
- The importer should perform a compatibility conversion so unassigned MFME Lamps survive import as static Oasis Images without changing Lamp runtime semantics.

### Description

- Added detection and conversion in `FmlToOasisMapper.Map` so an MFME `Lamp` with no assigned lamp number is converted to a `PanelElementKind.Image`, while lamps with valid assigned numbers continue to import as `PanelElementKind.Lamp`.
- Detection treats any sublamp entry with `SublampNumber >= 0` or a parsed `Number` as an assigned lamp number, otherwise the component is considered unassigned; this logic is implemented in `HasAssignedLampNumber` and invoked from `MapLampLike` in `FmlToOasisMapper`.
- The converted Image preserves position, size, source component index, and chooses the lamp fixed/on bitmap (preferring names containing `on`, `main`, or `fixed` and avoiding `off`) as the Image `AssetPath`, and preserves a mask as `SecondaryAssetPath` when available via the existing `FirstLampImage` helpers.
- Added an informational import diagnostic when a conversion occurs using the existing import diagnostics flow, with the message format: `Converted unassigned MFME Lamp '<name>' to an Image because it has no Lamp number.`, and surfaced these diagnostics through `FmlImportService` and `FmlImportDiagnosticsWriter`.

### Testing

- Added unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs` covering: assigned lamp -> Lamp, unassigned lamp -> Image with on-bitmap and mask, and invalid-only lamp numbers -> Image.
- Did not run the test suite in this environment because the required Windows/.NET/WPF toolchain (`dotnet`) is not available here, per `AGENTS.md` guidance, so automated tests were not executed.
- Performed repository checks and committed the changes (`git diff --check` completed and changes were committed successfully).

Files changed: `WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs`, and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53f72ec0bc8327a87e17c711017fcb)