### PR TITLE
Add Phase 1 machine build export and Player cabinet loading

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b0abefcfe9b46568ca19d9a1bfe819d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs
@@ -2,22 +2,41 @@ using System.Threading.Tasks;
 using GLTFast;
 using UnityEngine;
 
-namespace OasisPlayer.Loading;
-
-public interface ICabinetModelLoader { Task<GameObject> LoadAsync(string glbPath, Transform parent); void Unload(GameObject root); }
-
-public sealed class GltfFastCabinetModelLoader : ICabinetModelLoader
+namespace OasisPlayer.Loading
 {
-    public async Task<GameObject> LoadAsync(string glbPath, Transform parent)
+    public interface ICabinetModelLoader
     {
-        var sessionRoot = new GameObject("CabinetRuntimeModel");
-        sessionRoot.transform.SetParent(parent, false);
-        var gltf = new GltfImport();
-        var loaded = await gltf.Load(glbPath);
-        if (!loaded) { Object.Destroy(sessionRoot); throw new System.InvalidOperationException($"glTFast failed to load GLB: {glbPath}"); }
-        var instantiated = await gltf.InstantiateMainSceneAsync(sessionRoot.transform);
-        if (!instantiated) { Object.Destroy(sessionRoot); throw new System.InvalidOperationException($"glTFast failed to instantiate GLB: {glbPath}"); }
-        return sessionRoot;
+        Task<GameObject> LoadAsync(string glbPath, Transform parent);
+        void Unload(GameObject root);
     }
-    public void Unload(GameObject root) { if (root != null) Object.Destroy(root); }
+
+    public sealed class GltfFastCabinetModelLoader : ICabinetModelLoader
+    {
+        public async Task<GameObject> LoadAsync(string glbPath, Transform parent)
+        {
+            var sessionRoot = new GameObject("CabinetRuntimeModel");
+            sessionRoot.transform.SetParent(parent, false);
+            var gltf = new GltfImport();
+            var loaded = await gltf.Load(glbPath);
+            if (!loaded)
+            {
+                Object.Destroy(sessionRoot);
+                throw new System.InvalidOperationException($"glTFast failed to load GLB: {glbPath}");
+            }
+
+            var instantiated = await gltf.InstantiateMainSceneAsync(sessionRoot.transform);
+            if (!instantiated)
+            {
+                Object.Destroy(sessionRoot);
+                throw new System.InvalidOperationException($"glTFast failed to instantiate GLB: {glbPath}");
+            }
+
+            return sessionRoot;
+        }
+
+        public void Unload(GameObject root)
+        {
+            if (root != null) Object.Destroy(root);
+        }
+    }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using GLTFast;
+using UnityEngine;
+
+namespace OasisPlayer.Loading;
+
+public interface ICabinetModelLoader { Task<GameObject> LoadAsync(string glbPath, Transform parent); void Unload(GameObject root); }
+
+public sealed class GltfFastCabinetModelLoader : ICabinetModelLoader
+{
+    public async Task<GameObject> LoadAsync(string glbPath, Transform parent)
+    {
+        var sessionRoot = new GameObject("CabinetRuntimeModel");
+        sessionRoot.transform.SetParent(parent, false);
+        var gltf = new GltfImport();
+        var loaded = await gltf.Load(glbPath);
+        if (!loaded) { Object.Destroy(sessionRoot); throw new System.InvalidOperationException($"glTFast failed to load GLB: {glbPath}"); }
+        var instantiated = await gltf.InstantiateMainSceneAsync(sessionRoot.transform);
+        if (!instantiated) { Object.Destroy(sessionRoot); throw new System.InvalidOperationException($"glTFast failed to instantiate GLB: {glbPath}"); }
+        return sessionRoot;
+    }
+    public void Unload(GameObject root) { if (root != null) Object.Destroy(root); }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/CabinetModelLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28cfef7249e84f28b822f691f5297e38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace OasisPlayer.Loading;
+
+public sealed class FatalErrorOverlay : MonoBehaviour
+{
+    private string _message;
+    public void Show(string message) { _message = message; Debug.LogError(message); enabled = true; }
+    private void OnGUI() { if (string.IsNullOrEmpty(_message)) return; GUI.color = Color.white; GUI.Box(new Rect(20,20,Screen.width-40,120), "Oasis Player startup error\n\n" + _message); }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs
@@ -1,10 +1,23 @@
 using UnityEngine;
 
-namespace OasisPlayer.Loading;
-
-public sealed class FatalErrorOverlay : MonoBehaviour
+namespace OasisPlayer.Loading
 {
-    private string _message;
-    public void Show(string message) { _message = message; Debug.LogError(message); enabled = true; }
-    private void OnGUI() { if (string.IsNullOrEmpty(_message)) return; GUI.color = Color.white; GUI.Box(new Rect(20,20,Screen.width-40,120), "Oasis Player startup error\n\n" + _message); }
+    public sealed class FatalErrorOverlay : MonoBehaviour
+    {
+        private string _message;
+
+        public void Show(string message)
+        {
+            _message = message;
+            Debug.LogError(message);
+            enabled = true;
+        }
+
+        private void OnGUI()
+        {
+            if (string.IsNullOrEmpty(_message)) return;
+            GUI.color = Color.white;
+            GUI.Box(new Rect(20, 20, Screen.width - 40, 120), "Oasis Player startup error\n\n" + _message);
+        }
+    }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/FatalErrorOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7b83ff5f4534efbbc167dadbcef502d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
@@ -4,24 +4,46 @@ using System.Threading.Tasks;
 using OasisPlayer.RuntimeBuild;
 using UnityEngine;
 
-namespace OasisPlayer.Loading;
-
-public sealed class MachinePreviewLoader
+namespace OasisPlayer.Loading
 {
-    private readonly ICabinetModelLoader _modelLoader;
-    private GameObject _current;
-    public MachinePreviewLoader(ICabinetModelLoader modelLoader) { _modelLoader = modelLoader; }
-    public async Task LoadAsync(ResolvedRuntimeBuild build)
+    public sealed class MachinePreviewLoader
     {
-        Unload();
-        var spawns = UnityEngine.Object.FindObjectsByType<Transform>(FindObjectsSortMode.None).Where(t => t.parent == null && t.name == "MachineSpawn").ToArray();
-        if (spawns.Length != 1) throw new InvalidOperationException(spawns.Length == 0 ? "MachinePreview scene is missing root transform 'MachineSpawn'." : "MachinePreview scene contains duplicate root transforms named 'MachineSpawn'.");
-        var correctionRoot = new GameObject("OasisCabinetCorrectionRoot");
-        correctionRoot.transform.SetParent(spawns[0], false);
-        correctionRoot.transform.localScale = Vector3.one * Mathf.Max(0.0001f, build.Cabinet.scale);
-        correctionRoot.transform.localRotation = build.Cabinet.upAxis == "Z" ? Quaternion.Euler(-90f, 0f, 0f) : Quaternion.identity;
-        _current = correctionRoot;
-        await _modelLoader.LoadAsync(build.GlbPath, correctionRoot.transform);
+        private readonly ICabinetModelLoader _modelLoader;
+        private GameObject _current;
+
+        public MachinePreviewLoader(ICabinetModelLoader modelLoader)
+        {
+            _modelLoader = modelLoader;
+        }
+
+        public async Task LoadAsync(ResolvedRuntimeBuild build)
+        {
+            Unload();
+            var spawns = UnityEngine.Object.FindObjectsByType<Transform>(FindObjectsSortMode.None)
+                .Where(t => t.parent == null && t.name == "MachineSpawn")
+                .ToArray();
+            if (spawns.Length != 1)
+            {
+                throw new InvalidOperationException(spawns.Length == 0
+                    ? "MachinePreview scene is missing root transform 'MachineSpawn'."
+                    : "MachinePreview scene contains duplicate root transforms named 'MachineSpawn'.");
+            }
+
+            var correctionRoot = new GameObject("OasisCabinetCorrectionRoot");
+            correctionRoot.transform.SetParent(spawns[0], false);
+            correctionRoot.transform.localScale = Vector3.one * Mathf.Max(0.0001f, build.Cabinet.scale);
+            correctionRoot.transform.localRotation = build.Cabinet.upAxis == "Z" ? Quaternion.Euler(-90f, 0f, 0f) : Quaternion.identity;
+            _current = correctionRoot;
+            await _modelLoader.LoadAsync(build.GlbPath, correctionRoot.transform);
+        }
+
+        public void Unload()
+        {
+            if (_current != null)
+            {
+                _modelLoader.Unload(_current);
+                _current = null;
+            }
+        }
     }
-    public void Unload() { if (_current != null) { _modelLoader.Unload(_current); _current = null; } }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+
+namespace OasisPlayer.Loading;
+
+public sealed class MachinePreviewLoader
+{
+    private readonly ICabinetModelLoader _modelLoader;
+    private GameObject _current;
+    public MachinePreviewLoader(ICabinetModelLoader modelLoader) { _modelLoader = modelLoader; }
+    public async Task LoadAsync(ResolvedRuntimeBuild build)
+    {
+        Unload();
+        var spawns = UnityEngine.Object.FindObjectsByType<Transform>(FindObjectsSortMode.None).Where(t => t.parent == null && t.name == "MachineSpawn").ToArray();
+        if (spawns.Length != 1) throw new InvalidOperationException(spawns.Length == 0 ? "MachinePreview scene is missing root transform 'MachineSpawn'." : "MachinePreview scene contains duplicate root transforms named 'MachineSpawn'.");
+        var correctionRoot = new GameObject("OasisCabinetCorrectionRoot");
+        correctionRoot.transform.SetParent(spawns[0], false);
+        correctionRoot.transform.localScale = Vector3.one * Mathf.Max(0.0001f, build.Cabinet.scale);
+        correctionRoot.transform.localRotation = build.Cabinet.upAxis == "Z" ? Quaternion.Euler(-90f, 0f, 0f) : Quaternion.identity;
+        _current = correctionRoot;
+        await _modelLoader.LoadAsync(build.GlbPath, correctionRoot.transform);
+    }
+    public void Unload() { if (_current != null) { _modelLoader.Unload(_current); _current = null; } }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc449b65c72b4ff5b4017628c243cf5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d36623dca53a4787999cba004ae1bdf1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild;
+
+[Serializable] public sealed class MachineRuntimeManifest { public string schema = string.Empty; public int schemaVersion; public string machineId = string.Empty; public string displayName = string.Empty; public string cabinetManifest = string.Empty; }
+[Serializable] public sealed class CabinetRuntimeManifest { public string schema = string.Empty; public int schemaVersion; public string cabinetId = string.Empty; public string glb = string.Empty; public float scale = 1f; public string upAxis = "Y"; }
+public sealed class ResolvedRuntimeBuild { public ResolvedRuntimeBuild(string buildRoot, MachineRuntimeManifest machine, string cabinetManifestPath, CabinetRuntimeManifest cabinet, string glbPath) { BuildRoot=buildRoot; Machine=machine; CabinetManifestPath=cabinetManifestPath; Cabinet=cabinet; GlbPath=glbPath; } public string BuildRoot{get;} public MachineRuntimeManifest Machine{get;} public string CabinetManifestPath{get;} public CabinetRuntimeManifest Cabinet{get;} public string GlbPath{get;} }
+
+public static class RuntimeBuildLoader
+{
+    public const string MachineSchema = "oasis.machine.runtime"; public const string CabinetSchema = "oasis.cabinet.runtime";
+    public static bool TryLoad(string buildDirectory, out ResolvedRuntimeBuild build, out string error)
+    {
+        build = null; error = string.Empty;
+        if (string.IsNullOrWhiteSpace(buildDirectory)) { error = "Build directory is required."; return false; }
+        var root = Path.GetFullPath(buildDirectory);
+        if (!Directory.Exists(root)) { error = $"Build directory does not exist: {root}"; return false; }
+        var machinePath = Path.Combine(root, "machine.runtime.json");
+        if (!File.Exists(machinePath)) { error = $"Machine runtime manifest is missing: {machinePath}"; return false; }
+        MachineRuntimeManifest machine;
+        try { machine = JsonUtility.FromJson<MachineRuntimeManifest>(File.ReadAllText(machinePath)); } catch (Exception ex) { error = $"Machine manifest is invalid JSON: {machinePath}. {ex.Message}"; return false; }
+        if (machine == null || machine.schema != MachineSchema || machine.schemaVersion != 1) { error = $"Unsupported machine manifest schema/version in {machinePath}."; return false; }
+        if (!TryResolveContained(root, root, machine.cabinetManifest, out var cabinetPath, out error)) { error = $"Invalid cabinet manifest path in {machinePath}: {error}"; return false; }
+        if (!File.Exists(cabinetPath)) { error = $"Cabinet runtime manifest is missing: {cabinetPath}"; return false; }
+        CabinetRuntimeManifest cabinet;
+        try { cabinet = JsonUtility.FromJson<CabinetRuntimeManifest>(File.ReadAllText(cabinetPath)); } catch (Exception ex) { error = $"Cabinet manifest is invalid JSON: {cabinetPath}. {ex.Message}"; return false; }
+        if (cabinet == null || cabinet.schema != CabinetSchema || cabinet.schemaVersion != 1) { error = $"Unsupported cabinet manifest schema/version in {cabinetPath}."; return false; }
+        if (!TryResolveContained(root, Path.GetDirectoryName(cabinetPath), cabinet.glb, out var glbPath, out error)) { error = $"Invalid cabinet GLB path in {cabinetPath}: {error}"; return false; }
+        if (!File.Exists(glbPath)) { error = $"Cabinet GLB is missing: {glbPath}"; return false; }
+        build = new ResolvedRuntimeBuild(root, machine, cabinetPath, cabinet, glbPath); return true;
+    }
+    private static bool TryResolveContained(string root, string baseDir, string relative, out string resolved, out string error)
+    { resolved = string.Empty; error = string.Empty; if (string.IsNullOrWhiteSpace(relative)) { error = "path is empty."; return false; } if (Path.IsPathRooted(relative)) { error = "rooted paths are not allowed."; return false; } resolved = Path.GetFullPath(Path.Combine(baseDir, relative.Replace('/', Path.DirectorySeparatorChar))); var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar; if (!resolved.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase)) { error = "path traversal outside the build root is not allowed."; return false; } return true; }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
@@ -2,35 +2,163 @@ using System;
 using System.IO;
 using UnityEngine;
 
-namespace OasisPlayer.RuntimeBuild;
-
-[Serializable] public sealed class MachineRuntimeManifest { public string schema = string.Empty; public int schemaVersion; public string machineId = string.Empty; public string displayName = string.Empty; public string cabinetManifest = string.Empty; }
-[Serializable] public sealed class CabinetRuntimeManifest { public string schema = string.Empty; public int schemaVersion; public string cabinetId = string.Empty; public string glb = string.Empty; public float scale = 1f; public string upAxis = "Y"; }
-public sealed class ResolvedRuntimeBuild { public ResolvedRuntimeBuild(string buildRoot, MachineRuntimeManifest machine, string cabinetManifestPath, CabinetRuntimeManifest cabinet, string glbPath) { BuildRoot=buildRoot; Machine=machine; CabinetManifestPath=cabinetManifestPath; Cabinet=cabinet; GlbPath=glbPath; } public string BuildRoot{get;} public MachineRuntimeManifest Machine{get;} public string CabinetManifestPath{get;} public CabinetRuntimeManifest Cabinet{get;} public string GlbPath{get;} }
-
-public static class RuntimeBuildLoader
+namespace OasisPlayer.RuntimeBuild
 {
-    public const string MachineSchema = "oasis.machine.runtime"; public const string CabinetSchema = "oasis.cabinet.runtime";
-    public static bool TryLoad(string buildDirectory, out ResolvedRuntimeBuild build, out string error)
+    [Serializable]
+    public sealed class MachineRuntimeManifest
     {
-        build = null; error = string.Empty;
-        if (string.IsNullOrWhiteSpace(buildDirectory)) { error = "Build directory is required."; return false; }
-        var root = Path.GetFullPath(buildDirectory);
-        if (!Directory.Exists(root)) { error = $"Build directory does not exist: {root}"; return false; }
-        var machinePath = Path.Combine(root, "machine.runtime.json");
-        if (!File.Exists(machinePath)) { error = $"Machine runtime manifest is missing: {machinePath}"; return false; }
-        MachineRuntimeManifest machine;
-        try { machine = JsonUtility.FromJson<MachineRuntimeManifest>(File.ReadAllText(machinePath)); } catch (Exception ex) { error = $"Machine manifest is invalid JSON: {machinePath}. {ex.Message}"; return false; }
-        if (machine == null || machine.schema != MachineSchema || machine.schemaVersion != 1) { error = $"Unsupported machine manifest schema/version in {machinePath}."; return false; }
-        if (!TryResolveContained(root, root, machine.cabinetManifest, out var cabinetPath, out error)) { error = $"Invalid cabinet manifest path in {machinePath}: {error}"; return false; }
-        if (!File.Exists(cabinetPath)) { error = $"Cabinet runtime manifest is missing: {cabinetPath}"; return false; }
-        CabinetRuntimeManifest cabinet;
-        try { cabinet = JsonUtility.FromJson<CabinetRuntimeManifest>(File.ReadAllText(cabinetPath)); } catch (Exception ex) { error = $"Cabinet manifest is invalid JSON: {cabinetPath}. {ex.Message}"; return false; }
-        if (cabinet == null || cabinet.schema != CabinetSchema || cabinet.schemaVersion != 1) { error = $"Unsupported cabinet manifest schema/version in {cabinetPath}."; return false; }
-        if (!TryResolveContained(root, Path.GetDirectoryName(cabinetPath), cabinet.glb, out var glbPath, out error)) { error = $"Invalid cabinet GLB path in {cabinetPath}: {error}"; return false; }
-        if (!File.Exists(glbPath)) { error = $"Cabinet GLB is missing: {glbPath}"; return false; }
-        build = new ResolvedRuntimeBuild(root, machine, cabinetPath, cabinet, glbPath); return true;
+        public string schema = string.Empty;
+        public int schemaVersion;
+        public string machineId = string.Empty;
+        public string displayName = string.Empty;
+        public string cabinetManifest = string.Empty;
     }
-    private static bool TryResolveContained(string root, string baseDir, string relative, out string resolved, out string error)
-    { resolved = string.Empty; error = string.Empty; if (string.IsNullOrWhiteSpace(relative)) { error = "path is empty."; return false; } if (Path.IsPathRooted(relative)) { error = "rooted paths are not allowed."; return false; } resolved = Path.GetFullPath(Path.Combine(baseDir, relative.Replace('/', Path.DirectorySeparatorChar))); var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar; if (!resolved.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase)) { error = "path traversal outside the build root is not allowed."; return false; } return true; }
+
+    [Serializable]
+    public sealed class CabinetRuntimeManifest
+    {
+        public string schema = string.Empty;
+        public int schemaVersion;
+        public string cabinetId = string.Empty;
+        public string glb = string.Empty;
+        public float scale = 1f;
+        public string upAxis = "Y";
+    }
+
+    public sealed class ResolvedRuntimeBuild
+    {
+        public ResolvedRuntimeBuild(string buildRoot, MachineRuntimeManifest machine, string cabinetManifestPath, CabinetRuntimeManifest cabinet, string glbPath)
+        {
+            BuildRoot = buildRoot;
+            Machine = machine;
+            CabinetManifestPath = cabinetManifestPath;
+            Cabinet = cabinet;
+            GlbPath = glbPath;
+        }
+
+        public string BuildRoot { get; }
+        public MachineRuntimeManifest Machine { get; }
+        public string CabinetManifestPath { get; }
+        public CabinetRuntimeManifest Cabinet { get; }
+        public string GlbPath { get; }
+    }
+
+    public static class RuntimeBuildLoader
+    {
+        public const string MachineSchema = "oasis.machine.runtime";
+        public const string CabinetSchema = "oasis.cabinet.runtime";
+
+        public static bool TryLoad(string buildDirectory, out ResolvedRuntimeBuild build, out string error)
+        {
+            build = null;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(buildDirectory))
+            {
+                error = "Build directory is required.";
+                return false;
+            }
+
+            var root = Path.GetFullPath(buildDirectory);
+            if (!Directory.Exists(root))
+            {
+                error = $"Build directory does not exist: {root}";
+                return false;
+            }
+
+            var machinePath = Path.Combine(root, "machine.runtime.json");
+            if (!File.Exists(machinePath))
+            {
+                error = $"Machine runtime manifest is missing: {machinePath}";
+                return false;
+            }
+
+            MachineRuntimeManifest machine;
+            try
+            {
+                machine = JsonUtility.FromJson<MachineRuntimeManifest>(File.ReadAllText(machinePath));
+            }
+            catch (Exception ex)
+            {
+                error = $"Machine manifest is invalid JSON: {machinePath}. {ex.Message}";
+                return false;
+            }
+
+            if (machine == null || machine.schema != MachineSchema || machine.schemaVersion != 1)
+            {
+                error = $"Unsupported machine manifest schema/version in {machinePath}.";
+                return false;
+            }
+
+            if (!TryResolveContained(root, root, machine.cabinetManifest, out var cabinetPath, out error))
+            {
+                error = $"Invalid cabinet manifest path in {machinePath}: {error}";
+                return false;
+            }
+
+            if (!File.Exists(cabinetPath))
+            {
+                error = $"Cabinet runtime manifest is missing: {cabinetPath}";
+                return false;
+            }
+
+            CabinetRuntimeManifest cabinet;
+            try
+            {
+                cabinet = JsonUtility.FromJson<CabinetRuntimeManifest>(File.ReadAllText(cabinetPath));
+            }
+            catch (Exception ex)
+            {
+                error = $"Cabinet manifest is invalid JSON: {cabinetPath}. {ex.Message}";
+                return false;
+            }
+
+            if (cabinet == null || cabinet.schema != CabinetSchema || cabinet.schemaVersion != 1)
+            {
+                error = $"Unsupported cabinet manifest schema/version in {cabinetPath}.";
+                return false;
+            }
+
+            if (!TryResolveContained(root, Path.GetDirectoryName(cabinetPath), cabinet.glb, out var glbPath, out error))
+            {
+                error = $"Invalid cabinet GLB path in {cabinetPath}: {error}";
+                return false;
+            }
+
+            if (!File.Exists(glbPath))
+            {
+                error = $"Cabinet GLB is missing: {glbPath}";
+                return false;
+            }
+
+            build = new ResolvedRuntimeBuild(root, machine, cabinetPath, cabinet, glbPath);
+            return true;
+        }
+
+        private static bool TryResolveContained(string root, string baseDir, string relative, out string resolved, out string error)
+        {
+            resolved = string.Empty;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(relative))
+            {
+                error = "path is empty.";
+                return false;
+            }
+
+            if (Path.IsPathRooted(relative))
+            {
+                error = "rooted paths are not allowed.";
+                return false;
+            }
+
+            resolved = Path.GetFullPath(Path.Combine(baseDir, relative.Replace('/', Path.DirectorySeparatorChar)));
+            var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            if (!resolved.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                error = "path traversal outside the build root is not allowed.";
+                return false;
+            }
+
+            return true;
+        }
+    }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ce1a1b34f424001a51b7631547c9d01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47b492ba924a4bbfb49a3cfd091c8e7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OasisPlayer.Startup;
+
+public enum StartupMode { MachinePreview, Arcade }
+
+public sealed class StartupOptions
+{
+    public StartupOptions(StartupMode mode, string buildDirectory, bool fullscreen, int width, int height)
+    {
+        Mode = mode; BuildDirectory = buildDirectory ?? string.Empty; Fullscreen = fullscreen; Width = width; Height = height;
+    }
+    public StartupMode Mode { get; }
+    public string BuildDirectory { get; }
+    public bool Fullscreen { get; }
+    public int Width { get; }
+    public int Height { get; }
+    public string SceneName => Mode switch { StartupMode.MachinePreview => "MachinePreview", StartupMode.Arcade => throw new NotSupportedException("Arcade mode is not implemented in Phase 1."), _ => throw new NotSupportedException($"Unsupported startup mode: {Mode}") };
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs
@@ -1,19 +1,35 @@
 using System;
 
-namespace OasisPlayer.Startup;
-
-public enum StartupMode { MachinePreview, Arcade }
-
-public sealed class StartupOptions
+namespace OasisPlayer.Startup
 {
-    public StartupOptions(StartupMode mode, string buildDirectory, bool fullscreen, int width, int height)
+    public enum StartupMode
     {
-        Mode = mode; BuildDirectory = buildDirectory ?? string.Empty; Fullscreen = fullscreen; Width = width; Height = height;
+        MachinePreview,
+        Arcade
     }
-    public StartupMode Mode { get; }
-    public string BuildDirectory { get; }
-    public bool Fullscreen { get; }
-    public int Width { get; }
-    public int Height { get; }
-    public string SceneName => Mode switch { StartupMode.MachinePreview => "MachinePreview", StartupMode.Arcade => throw new NotSupportedException("Arcade mode is not implemented in Phase 1."), _ => throw new NotSupportedException($"Unsupported startup mode: {Mode}") };
+
+    public sealed class StartupOptions
+    {
+        public StartupOptions(StartupMode mode, string buildDirectory, bool fullscreen, int width, int height)
+        {
+            Mode = mode;
+            BuildDirectory = buildDirectory ?? string.Empty;
+            Fullscreen = fullscreen;
+            Width = width;
+            Height = height;
+        }
+
+        public StartupMode Mode { get; }
+        public string BuildDirectory { get; }
+        public bool Fullscreen { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public string SceneName => Mode switch
+        {
+            StartupMode.MachinePreview => "MachinePreview",
+            StartupMode.Arcade => throw new NotSupportedException("Arcade mode is not implemented in Phase 1."),
+            _ => throw new NotSupportedException($"Unsupported startup mode: {Mode}")
+        };
+    }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15bd1e098bc14c3795e0aaac0ee0cd76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs
@@ -1,39 +1,106 @@
 using System;
 using System.Collections.Generic;
 
-namespace OasisPlayer.Startup;
-
-public static class StartupOptionsParser
+namespace OasisPlayer.Startup
 {
-    public static bool TryParse(IReadOnlyList<string> args, out StartupOptions options, out string error)
+    public static class StartupOptionsParser
     {
-        options = new StartupOptions(StartupMode.MachinePreview, string.Empty, false, 1280, 800);
-        error = string.Empty;
-        var mode = StartupMode.MachinePreview; var modeSet = false; string build = string.Empty; bool? fullscreen = null; int width = 1280; int height = 800;
-        for (var i = 0; i < args.Count; i++)
+        public static bool TryParse(IReadOnlyList<string> args, out StartupOptions options, out string error)
         {
-            var arg = args[i];
-            switch (arg)
+            options = new StartupOptions(StartupMode.MachinePreview, string.Empty, false, 1280, 800);
+            error = string.Empty;
+            var mode = StartupMode.MachinePreview;
+            var modeSet = false;
+            var build = string.Empty;
+            bool? fullscreen = null;
+            var width = 1280;
+            var height = 800;
+
+            for (var i = 0; i < args.Count; i++)
             {
-                case "--mode":
-                    if (!ReadValue(args, ref i, arg, out var rawMode, out error)) return false;
-                    if (rawMode == "machine-preview") { mode = StartupMode.MachinePreview; modeSet = true; }
-                    else if (rawMode == "arcade") { error = "Arcade mode is recognised but is not implemented in Phase 1."; return false; }
-                    else { error = $"Unknown startup mode '{rawMode}'. Supported mode: machine-preview."; return false; }
-                    break;
-                case "--build":
-                    if (!ReadValue(args, ref i, arg, out build, out error)) return false; break;
-                case "--windowed": fullscreen = false; break;
-                case "--fullscreen": fullscreen = true; break;
-                case "--width": if (!ReadPositiveInt(args, ref i, arg, out width, out error)) return false; break;
-                case "--height": if (!ReadPositiveInt(args, ref i, arg, out height, out error)) return false; break;
-                default: error = $"Unknown startup argument '{arg}'."; return false;
+                var arg = args[i];
+                switch (arg)
+                {
+                    case "--mode":
+                        if (!ReadValue(args, ref i, arg, out var rawMode, out error)) return false;
+                        if (rawMode == "machine-preview")
+                        {
+                            mode = StartupMode.MachinePreview;
+                            modeSet = true;
+                        }
+                        else if (rawMode == "arcade")
+                        {
+                            error = "Arcade mode is recognised but is not implemented in Phase 1.";
+                            return false;
+                        }
+                        else
+                        {
+                            error = $"Unknown startup mode '{rawMode}'. Supported mode: machine-preview.";
+                            return false;
+                        }
+                        break;
+                    case "--build":
+                        if (!ReadValue(args, ref i, arg, out build, out error)) return false;
+                        break;
+                    case "--windowed":
+                        fullscreen = false;
+                        break;
+                    case "--fullscreen":
+                        fullscreen = true;
+                        break;
+                    case "--width":
+                        if (!ReadPositiveInt(args, ref i, arg, out width, out error)) return false;
+                        break;
+                    case "--height":
+                        if (!ReadPositiveInt(args, ref i, arg, out height, out error)) return false;
+                        break;
+                    default:
+                        error = $"Unknown startup argument '{arg}'.";
+                        return false;
+                }
             }
+
+            if (!modeSet)
+            {
+                error = "Missing required --mode machine-preview argument.";
+                return false;
+            }
+
+            if (mode == StartupMode.MachinePreview && string.IsNullOrWhiteSpace(build))
+            {
+                error = "Machine preview mode requires --build <directory>.";
+                return false;
+            }
+
+            options = new StartupOptions(mode, build, fullscreen ?? false, width, height);
+            return true;
         }
-        if (!modeSet) { error = "Missing required --mode machine-preview argument."; return false; }
-        if (mode == StartupMode.MachinePreview && string.IsNullOrWhiteSpace(build)) { error = "Machine preview mode requires --build <directory>."; return false; }
-        options = new StartupOptions(mode, build, fullscreen ?? false, width, height); return true;
+
+        private static bool ReadValue(IReadOnlyList<string> args, ref int index, string option, out string value, out string error)
+        {
+            value = string.Empty;
+            error = string.Empty;
+            if (index + 1 >= args.Count || args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"{option} requires a value.";
+                return false;
+            }
+
+            value = args[++index];
+            return true;
+        }
+
+        private static bool ReadPositiveInt(IReadOnlyList<string> args, ref int index, string option, out int value, out string error)
+        {
+            value = 0;
+            if (!ReadValue(args, ref index, option, out var raw, out error)) return false;
+            if (!int.TryParse(raw, out value) || value <= 0)
+            {
+                error = $"{option} requires a positive integer value.";
+                return false;
+            }
+
+            return true;
+        }
     }
-    private static bool ReadValue(IReadOnlyList<string> args, ref int index, string option, out string value, out string error) { value = string.Empty; error = string.Empty; if (index + 1 >= args.Count || args[index + 1].StartsWith("--", StringComparison.Ordinal)) { error = $"{option} requires a value."; return false; } value = args[++index]; return true; }
-    private static bool ReadPositiveInt(IReadOnlyList<string> args, ref int index, string option, out int value, out string error) { value = 0; if (!ReadValue(args, ref index, option, out var raw, out error)) return false; if (!int.TryParse(raw, out value) || value <= 0) { error = $"{option} requires a positive integer value."; return false; } return true; }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace OasisPlayer.Startup;
+
+public static class StartupOptionsParser
+{
+    public static bool TryParse(IReadOnlyList<string> args, out StartupOptions options, out string error)
+    {
+        options = new StartupOptions(StartupMode.MachinePreview, string.Empty, false, 1280, 800);
+        error = string.Empty;
+        var mode = StartupMode.MachinePreview; var modeSet = false; string build = string.Empty; bool? fullscreen = null; int width = 1280; int height = 800;
+        for (var i = 0; i < args.Count; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--mode":
+                    if (!ReadValue(args, ref i, arg, out var rawMode, out error)) return false;
+                    if (rawMode == "machine-preview") { mode = StartupMode.MachinePreview; modeSet = true; }
+                    else if (rawMode == "arcade") { error = "Arcade mode is recognised but is not implemented in Phase 1."; return false; }
+                    else { error = $"Unknown startup mode '{rawMode}'. Supported mode: machine-preview."; return false; }
+                    break;
+                case "--build":
+                    if (!ReadValue(args, ref i, arg, out build, out error)) return false; break;
+                case "--windowed": fullscreen = false; break;
+                case "--fullscreen": fullscreen = true; break;
+                case "--width": if (!ReadPositiveInt(args, ref i, arg, out width, out error)) return false; break;
+                case "--height": if (!ReadPositiveInt(args, ref i, arg, out height, out error)) return false; break;
+                default: error = $"Unknown startup argument '{arg}'."; return false;
+            }
+        }
+        if (!modeSet) { error = "Missing required --mode machine-preview argument."; return false; }
+        if (mode == StartupMode.MachinePreview && string.IsNullOrWhiteSpace(build)) { error = "Machine preview mode requires --build <directory>."; return false; }
+        options = new StartupOptions(mode, build, fullscreen ?? false, width, height); return true;
+    }
+    private static bool ReadValue(IReadOnlyList<string> args, ref int index, string option, out string value, out string error) { value = string.Empty; error = string.Empty; if (index + 1 >= args.Count || args[index + 1].StartsWith("--", StringComparison.Ordinal)) { error = $"{option} requires a value."; return false; } value = args[++index]; return true; }
+    private static bool ReadPositiveInt(IReadOnlyList<string> args, ref int index, string option, out int value, out string error) { value = 0; if (!ReadValue(args, ref index, option, out var raw, out error)) return false; if (!int.TryParse(raw, out value) || value <= 0) { error = $"{option} requires a positive integer value."; return false; } return true; }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Startup/StartupOptionsParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d42a1225aae4e7e8ac6c8c7a60682b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/StartupController.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/StartupController.cs
@@ -1,6 +1,43 @@
+using System;
+using System.Linq;
+using OasisPlayer.Loading;
+using OasisPlayer.RuntimeBuild;
+using OasisPlayer.Startup;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class StartupController : MonoBehaviour
 {
+    [SerializeField] private string[] editorDevelopmentArguments = { "--mode", "machine-preview", "--build", "" };
+    private FatalErrorOverlay _errors;
+    private static StartupController _instance;
 
+    private void Awake()
+    {
+        if (_instance != null && _instance != this) { Destroy(gameObject); return; }
+        _instance = this; DontDestroyOnLoad(gameObject); _errors = gameObject.GetComponent<FatalErrorOverlay>() ?? gameObject.AddComponent<FatalErrorOverlay>();
+    }
+
+    private async void Start()
+    {
+        try
+        {
+            var args = GetStartupArguments();
+            if (!StartupOptionsParser.TryParse(args, out var options, out var error)) { _errors.Show(error); return; }
+            Screen.SetResolution(options.Width, options.Height, options.Fullscreen);
+            if (!RuntimeBuildLoader.TryLoad(options.BuildDirectory, out var build, out error)) { _errors.Show(error); return; }
+            await SceneManager.LoadSceneAsync(options.SceneName, LoadSceneMode.Single);
+            await new MachinePreviewLoader(new GltfFastCabinetModelLoader()).LoadAsync(build);
+        }
+        catch (Exception ex) { _errors.Show(ex.Message); }
+    }
+
+    private string[] GetStartupArguments()
+    {
+#if UNITY_EDITOR
+        return editorDevelopmentArguments.Where(a => !string.IsNullOrWhiteSpace(a)).ToArray();
+#else
+        return Environment.GetCommandLineArgs().Skip(1).ToArray();
+#endif
+    }
 }

--- a/UnityProjects/OasisPlayer/Packages/manifest.json
+++ b/UnityProjects/OasisPlayer/Packages/manifest.json
@@ -42,6 +42,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.cloud.gltfast": "6.14.1"
   }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor.Tests;
+
+public sealed class MachineRuntimeBuildServiceTests
+{
+    [Fact]
+    public void BuildFromCabinetDocument_WritesDeterministicVersionedBuildAndCopiesGlb()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var cabinetDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Cabinet3D", "Test Cabinet")).FullName;
+        var sourceGlb = Path.Combine(cabinetDir, "source.glb");
+        File.WriteAllBytes(sourceGlb, [1, 2, 3]);
+        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(new CabinetDocument(1, new CabinetModelReference("source.glb", 2.5, "Z"), [], CabinetPreviewSettings.Default)));
+        var stale = Path.Combine(project.GeneratedDirectory, "Builds", "Test Cabinet", "stale.txt");
+        Directory.CreateDirectory(Path.GetDirectoryName(stale)!);
+        File.WriteAllText(stale, "stale");
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName));
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(Path.Combine(project.GeneratedDirectory, "Builds", "Test Cabinet"), result.BuildRoot);
+        Assert.False(File.Exists(stale));
+        Assert.Equal([1, 2, 3], File.ReadAllBytes(Path.Combine(result.BuildRoot!, "cabinet", "cabinet.glb")));
+        using var machine = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot, "machine.runtime.json")));
+        Assert.Equal("oasis.machine.runtime", machine.RootElement.GetProperty("schema").GetString());
+        Assert.Equal(1, machine.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("TestProject", machine.RootElement.GetProperty("machineId").GetString());
+        Assert.Equal("cabinet/cabinet.runtime.json", machine.RootElement.GetProperty("cabinetManifest").GetString());
+        using var cabinet = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot, "cabinet", "cabinet.runtime.json")));
+        Assert.Equal("oasis.cabinet.runtime", cabinet.RootElement.GetProperty("schema").GetString());
+        Assert.Equal(1, cabinet.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("Test Cabinet", cabinet.RootElement.GetProperty("cabinetId").GetString());
+        Assert.Equal("cabinet.glb", cabinet.RootElement.GetProperty("glb").GetString());
+        Assert.Equal(2.5, cabinet.RootElement.GetProperty("scale").GetDouble());
+        Assert.Equal("Z", cabinet.RootElement.GetProperty("upAxis").GetString());
+    }
+
+    [Fact]
+    public void BuildFromCabinetDocument_MissingGlb_ReturnsClearFailure()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var cabinetDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Cabinet3D", "Broken Cabinet")).FullName;
+        var manifest = Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName);
+        File.WriteAllText(manifest, CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("missing.glb")));
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, manifest);
+
+        Assert.False(result.Success);
+        Assert.Contains("GLB model was not found", result.ErrorMessage);
+    }
+
+    private static EditorProject CreateProject(string root)
+    {
+        var projectDir = Path.Combine(root, "TestProject");
+        var assets = Directory.CreateDirectory(Path.Combine(projectDir, "Assets")).FullName;
+        var machines = Directory.CreateDirectory(Path.Combine(projectDir, "Machines")).FullName;
+        var generated = Directory.CreateDirectory(Path.Combine(projectDir, "Generated")).FullName;
+        return new EditorProject { Name = "TestProject", ProjectFilePath = Path.Combine(projectDir, "TestProject.oasisproj"), ProjectDirectory = projectDir, AssetsDirectory = assets, MachinesDirectory = machines, GeneratedDirectory = generated };
+    }
+
+    private static string CreateTempRoot() => Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"))).FullName;
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using System.Text.Json;
 using OasisEditor.Features.CabinetEditor.Models;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OasisEditor.Features.CabinetEditor.Models;
+
+namespace OasisEditor;
+
+public sealed class MachineRuntimeBuildService
+{
+    public const string MachineManifestFileName = "machine.runtime.json";
+    public const string CabinetDirectoryName = "cabinet";
+    public const string CabinetManifestFileName = "cabinet.runtime.json";
+    public const string CabinetGlbFileName = "cabinet.glb";
+    public const string MachineSchema = "oasis.machine.runtime";
+    public const string CabinetSchema = "oasis.cabinet.runtime";
+    public const int MachineSchemaVersion = 1;
+    public const int CabinetSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly ProjectAssetPathService _pathService;
+
+    public MachineRuntimeBuildService(ProjectAssetPathService? pathService = null)
+    {
+        _pathService = pathService ?? new ProjectAssetPathService();
+    }
+
+    public MachineRuntimeBuildResult BuildFromCabinetDocument(EditorProject project, string cabinetManifestPath)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        if (string.IsNullOrWhiteSpace(cabinetManifestPath)) return MachineRuntimeBuildResult.Fail("A saved Cabinet3D asset must be selected before building for Oasis Player.");
+        if (!File.Exists(cabinetManifestPath)) return MachineRuntimeBuildResult.Fail($"Cabinet3D manifest was not found: {cabinetManifestPath}");
+        if (!CabinetDocumentStorage.TryRead(File.ReadAllText(cabinetManifestPath), out var cabinetDocument)) return MachineRuntimeBuildResult.Fail($"Cabinet3D manifest is invalid or missing model.path: {cabinetManifestPath}");
+        var cabinetAssetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(cabinetManifestPath, EditorAssetType.Cabinet3D);
+        if (string.IsNullOrWhiteSpace(cabinetAssetName)) return MachineRuntimeBuildResult.Fail("Cabinet3D manifests must be stored as Assets/Cabinet3D/<AssetName>/asset.cabinet3d before building for Oasis Player.");
+        var sourceGlb = ResolveCabinetModelPath(cabinetManifestPath, cabinetDocument.Model.Path);
+        if (!File.Exists(sourceGlb)) return MachineRuntimeBuildResult.Fail($"Cabinet3D GLB model was not found: {sourceGlb}");
+        var buildRoot = GetBuildRoot(project, cabinetAssetName);
+        var stagingRoot = buildRoot + ".staging";
+        try
+        {
+            ReplaceEmptyDirectory(stagingRoot);
+            var cabinetRoot = Path.Combine(stagingRoot, CabinetDirectoryName);
+            Directory.CreateDirectory(cabinetRoot);
+            File.Copy(sourceGlb, Path.Combine(cabinetRoot, CabinetGlbFileName), overwrite: true);
+            var cabinetManifest = new CabinetRuntimeManifest(CabinetSchema, CabinetSchemaVersion, cabinetAssetName, CabinetGlbFileName, cabinetDocument.Model.Scale, cabinetDocument.Model.UpAxis);
+            File.WriteAllText(Path.Combine(cabinetRoot, CabinetManifestFileName), JsonSerializer.Serialize(cabinetManifest, JsonOptions));
+            var machineManifest = new MachineRuntimeManifest(MachineSchema, MachineSchemaVersion, project.Name, project.Name, ProjectAssetPathService.NormalizeProjectRelativePath(Path.Combine(CabinetDirectoryName, CabinetManifestFileName)));
+            File.WriteAllText(Path.Combine(stagingRoot, MachineManifestFileName), JsonSerializer.Serialize(machineManifest, JsonOptions));
+            ReplaceFinalDirectory(stagingRoot, buildRoot);
+            return MachineRuntimeBuildResult.Ok(buildRoot);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return MachineRuntimeBuildResult.Fail($"Failed to build Oasis Player runtime output: {ex.Message}");
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot)) Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
+    public string GetBuildRoot(EditorProject project, string machineName) => Path.Combine(project.GeneratedDirectory, "Builds", _pathService.SanitizePathSegment(machineName));
+    private static string ResolveCabinetModelPath(string manifestPath, string modelPath) => Path.IsPathFullyQualified(modelPath) ? Path.GetFullPath(modelPath) : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(manifestPath) ?? string.Empty, modelPath));
+    private static void ReplaceEmptyDirectory(string path) { if (Directory.Exists(path)) Directory.Delete(path, true); Directory.CreateDirectory(path); }
+    private static void ReplaceFinalDirectory(string stagingRoot, string buildRoot) { if (Directory.Exists(buildRoot)) Directory.Delete(buildRoot, true); Directory.CreateDirectory(Path.GetDirectoryName(buildRoot)!); Directory.Move(stagingRoot, buildRoot); }
+}
+
+public sealed record MachineRuntimeBuildResult(bool Success, string? BuildRoot, string? ErrorMessage)
+{
+    public static MachineRuntimeBuildResult Ok(string buildRoot) => new(true, buildRoot, null);
+    public static MachineRuntimeBuildResult Fail(string errorMessage) => new(false, null, errorMessage);
+}
+
+public sealed record MachineRuntimeManifest(string Schema, int SchemaVersion, string MachineId, string DisplayName, string CabinetManifest);
+public sealed record CabinetRuntimeManifest(string Schema, int SchemaVersion, string CabinetId, string Glb, double Scale, string UpAxis);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -66,6 +66,9 @@
                     <MenuItem Header="_GLB Model..."
                               Command="{Binding ImportGlbModelCommand}" />
                 </MenuItem>
+                <Separator />
+                <MenuItem Header="Build Oasis _Player Machine"
+                          Command="{Binding BuildOasisPlayerMachineCommand}" />
                 <MenuItem Header="_Save Asset"
                           Command="{Binding SaveSelectedDocumentCommand}" />
                 <MenuItem Header="_Close Project"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -167,6 +167,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenMachineStubCommand = new RelayCommand(OpenMachineStubDocument, CanOpenUntitledDocument);
         ImportMfmeFmlCommand = new RelayCommand(ImportMfmeFml, CanImportMfmeFml);
         ImportGlbModelCommand = new RelayCommand(ImportGlbModel, CanImportGlbModel);
+        BuildOasisPlayerMachineCommand = new RelayCommand(BuildOasisPlayerMachine, CanBuildOasisPlayerMachine);
         SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         OpenPreferencesCommand = new RelayCommand(OpenPreferences);
@@ -490,6 +491,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenMachineStubCommand { get; }
     public ICommand ImportMfmeFmlCommand { get; }
     public ICommand ImportGlbModelCommand { get; }
+    public ICommand BuildOasisPlayerMachineCommand { get; }
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
@@ -1471,6 +1473,39 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                && SelectedDocument?.Document.DocumentType == EditorDocumentType.Panel2D;
     }
 
+
+    private void BuildOasisPlayerMachine()
+    {
+        if (LoadedProject is null)
+        {
+            ReportEditorOperationError("Open a project before building for Oasis Player.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument?.Document.DocumentType != EditorDocumentType.Cabinet3D || selectedDocument.Document.IsUntitled)
+        {
+            ReportEditorOperationError("Select a saved Cabinet3D asset before building for Oasis Player.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(LoadedProject, selectedDocument.Document.FilePath);
+        if (!result.Success)
+        {
+            ReportEditorOperationError(result.ErrorMessage ?? "Failed to build Oasis Player runtime output.", OutputLogStatus.Error);
+            return;
+        }
+
+        StatusMessage = $"Oasis Player machine build written: {result.BuildRoot}";
+        AddOutputEntry($"Oasis Player machine build written: {result.BuildRoot}", OutputLogStatus.Info);
+    }
+
+    private bool CanBuildOasisPlayerMachine()
+    {
+        return LoadedProject is not null
+               && SelectedDocument?.Document.DocumentType == EditorDocumentType.Cabinet3D
+               && SelectedDocument.Document.IsUntitled == false;
+    }
 
     private bool CanImportGlbModel()
     {
@@ -4358,6 +4393,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (ImportGlbModelCommand is RelayCommand importGlbRelayCommand)
         {
             importGlbRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (BuildOasisPlayerMachineCommand is RelayCommand buildOasisPlayerRelayCommand)
+        {
+            buildOasisPlayerRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (SaveSelectedDocumentCommand is RelayCommand saveRelayCommand)


### PR DESCRIPTION
### Motivation
- Establish a deterministic, versioned Editor->Player runtime build contract (machine + cabinet manifests + copied GLB) so the Unity Player can load an external build in machine-preview mode. 
- Provide a minimal, robust Player startup flow that parses typed CLI options, validates the Editor-produced contract, and instantiates the cabinet beneath the existing `MachineSpawn` root without modifying committed scene assets.

### Description
- Editor: add `MachineRuntimeBuildService` to produce a staged, atomic export at `<Project>/Generated/Builds/<CabinetAssetName>/` containing `machine.runtime.json` and `cabinet/cabinet.runtime.json` plus `cabinet/cabinet.glb`, with schema names `oasis.machine.runtime` and `oasis.cabinet.runtime` at version `1`, portable relative paths, error validation, and stale-output replacement. 
- Editor UI: add a File → Build Oasis Player Machine menu command wired to `MainWindowViewModel` that invokes the build service and reports status/output entries. 
- Editor tests: add `MachineRuntimeBuildServiceTests` covering deterministic paths, GLB copying, manifest fields, stale-output replacement, and missing-GLB validation. 
- Player: add typed startup model and parser (`StartupOptions`, `StartupOptionsParser`) supporting `--mode machine-preview`, `--build <directory>`, `--windowed/--fullscreen`, `--width`, and `--height`, plus `StartupController` orchestration that applies display settings and loads the specified scene. 
- Player runtime: add `RuntimeBuild` DTOs and `RuntimeBuildLoader` to validate and resolve manifests and GLB paths (reject rooted paths and traversal outside build root), `MachinePreviewLoader` to find the single `MachineSpawn` root and apply scale/up-axis corrections, a glTF loader abstraction implemented with `glTFast` (`GltfFastCabinetModelLoader`) to preserve hierarchy/material slots, and a simple `FatalErrorOverlay` for visible errors. 
- Project manifest: add `com.unity.cloud.gltfast` dependency for runtime GLB loading so no custom GLB parser is required. 

### Testing
- Automated tests added: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs` (unit tests for deterministic build output, manifest serialization, GLB copy, missing-GLB failure); these tests were not executed in this environment. 
- Attempted to run `dotnet test` but the environment lacks `dotnet` so no automated tests were run here (command: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore`). 
- Unity package import and Play Mode verification were not run in this environment and must be performed locally (Package Manager will need to resolve `com.unity.cloud.gltfast`). 

Local verification steps (exact commands/steps to run locally):
- Run Editor unit tests: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj --no-restore`.
- In Oasis Editor: open a project containing a saved Cabinet3D asset, select that Cabinet3D document, then choose File → Build Oasis Player Machine and confirm the status/output message with the build root. 
- Inspect generated build at `<Project>/Generated/Builds/<CabinetAssetName>/` and confirm it contains `machine.runtime.json` and `cabinet/cabinet.runtime.json` and `cabinet/cabinet.glb` and that `machine.runtime.json` references `cabinet/cabinet.runtime.json` and schemas/versions are as documented. 
- Open `UnityProjects/OasisPlayer` in Unity, allow Package Manager to import `com.unity.cloud.gltfast`, set `StartupController` Editor development arguments in the Inspector to `--mode machine-preview --build <absolute build path> --windowed --width 1280 --height 800`, enter Play Mode from the Bootstrap scene, and confirm the cabinet is instantiated as a child of the existing `MachineSpawn`. 
- Negative tests: run the Player with missing/invalid `--build`, malformed manifests, rooted or traversal paths in manifests, missing GLB, and duplicate/missing `MachineSpawn` to confirm visible fatal overlay errors appear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5b80c0ec348327a8e367a1895a8193)