### PR TITLE
Add Oasis Player preview launch workflow

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -14,6 +14,41 @@ public sealed class EditorPreferencesSerializationTests
     }
 
     [Fact]
+    public void PlayerPreferences_Defaults_ToWindowed1280By800()
+    {
+        var preferences = new EditorPreferences();
+
+        Assert.Equal(string.Empty, preferences.Player.ExecutablePath);
+        Assert.False(preferences.Player.Fullscreen);
+        Assert.Equal(1280, preferences.Player.PreviewWidth);
+        Assert.Equal(800, preferences.Player.PreviewHeight);
+    }
+
+    [Fact]
+    public void PlayerPreferences_RoundTrip_PreservesSettings()
+    {
+        var preferences = new EditorPreferences
+        {
+            Player = new OasisPlayerPreferences
+            {
+                ExecutablePath = "C:\\Oasis Player\\OasisPlayer.exe",
+                Fullscreen = true,
+                PreviewWidth = 1920,
+                PreviewHeight = 1080
+            }
+        };
+
+        var json = JsonSerializer.Serialize(preferences);
+        var roundTripped = JsonSerializer.Deserialize<EditorPreferences>(json);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal("C:\\Oasis Player\\OasisPlayer.exe", roundTripped!.Player.ExecutablePath);
+        Assert.True(roundTripped.Player.Fullscreen);
+        Assert.Equal(1920, roundTripped.Player.PreviewWidth);
+        Assert.Equal(1080, roundTripped.Player.PreviewHeight);
+    }
+
+    [Fact]
     public void DeserializingLegacyPreferences_UsesAutoUpdateDefaultTrue()
     {
         var json = """

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisPlayerLaunchServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisPlayerLaunchServiceTests.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class OasisPlayerLaunchServiceTests
+{
+    [Fact]
+    public void Launch_MissingExecutable_ReturnsPreferencesGuidance()
+    {
+        var result = new OasisPlayerLaunchService(new CapturingStarter()).Launch(new OasisPlayerLaunchRequest("", "C:\\Build", false, 1280, 800));
+
+        Assert.False(result.Success);
+        Assert.Contains("Preferences > Player", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Launch_DirectoryExecutable_ReturnsClearFailure()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+
+        var result = new OasisPlayerLaunchService(new CapturingStarter()).Launch(new OasisPlayerLaunchRequest(directory, "C:\\Build", false, 1280, 800));
+
+        Assert.False(result.Success);
+        Assert.Contains("points to a directory", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Launch_MissingExecutable_ReturnsClearFailure()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"), "OasisPlayer.exe");
+
+        var result = new OasisPlayerLaunchService(new CapturingStarter()).Launch(new OasisPlayerLaunchRequest(missing, "C:\\Build", false, 1280, 800));
+
+        Assert.False(result.Success);
+        Assert.Contains("does not exist", result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(0, 800, "width")]
+    [InlineData(1280, 0, "height")]
+    public void Launch_InvalidSize_ReturnsClearFailure(int width, int height, string expectedTerm)
+    {
+        var result = new OasisPlayerLaunchService(new CapturingStarter()).Launch(new OasisPlayerLaunchRequest("C:\\OasisPlayer.exe", "C:\\Build", false, width, height));
+
+        Assert.False(result.Success);
+        Assert.Contains(expectedTerm, result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Launch_WindowedArguments_PassSeparateArgumentsAndPreserveSpaces()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var exe = Path.Combine(root, "Oasis Player.exe");
+        var build = Path.Combine(root, "Build With Spaces");
+        File.WriteAllText(exe, string.Empty);
+        Directory.CreateDirectory(build);
+        var starter = new CapturingStarter();
+
+        var result = new OasisPlayerLaunchService(starter).Launch(new OasisPlayerLaunchRequest(exe, build, false, 1440, 900));
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.NotNull(starter.StartInfo);
+        Assert.Equal(Path.GetFullPath(exe), starter.StartInfo!.FileName);
+        Assert.Equal(new[] { "--mode", "machine-preview", "--build", Path.GetFullPath(build), "--windowed", "--width", "1440", "--height", "900" }, starter.StartInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void Launch_FullscreenArguments_UseFullscreenInsteadOfWindowed()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var exe = Path.Combine(root, "OasisPlayer.exe");
+        File.WriteAllText(exe, string.Empty);
+        var starter = new CapturingStarter();
+
+        var result = new OasisPlayerLaunchService(starter).Launch(new OasisPlayerLaunchRequest(exe, root, true, 1280, 800));
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Contains("--fullscreen", starter.StartInfo!.ArgumentList);
+        Assert.DoesNotContain("--windowed", starter.StartInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void Launch_ProcessException_ReturnsClearFailure()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var exe = Path.Combine(root, "OasisPlayer.exe");
+        File.WriteAllText(exe, string.Empty);
+
+        var result = new OasisPlayerLaunchService(new ThrowingStarter()).Launch(new OasisPlayerLaunchRequest(exe, root, false, 1280, 800));
+
+        Assert.False(result.Success);
+        Assert.Contains("Failed to launch Oasis Player", result.ErrorMessage);
+        Assert.Contains("blocked", result.ErrorMessage);
+    }
+
+    private sealed class CapturingStarter : IOasisPlayerProcessStarter
+    {
+        public ProcessStartInfo? StartInfo { get; private set; }
+        public void Start(ProcessStartInfo startInfo) => StartInfo = startInfo;
+    }
+
+    private sealed class ThrowingStarter : IOasisPlayerProcessStarter
+    {
+        public void Start(ProcessStartInfo startInfo) => throw new Win32Exception("blocked");
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisPlayerPreviewServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisPlayerPreviewServiceTests.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class OasisPlayerPreviewServiceTests
+{
+    [Fact]
+    public void Preview_BuildFailure_PreventsLaunch()
+    {
+        var project = CreateProject();
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var exe = Path.Combine(root, "OasisPlayer.exe");
+        File.WriteAllText(exe, string.Empty);
+        var starter = new CapturingStarter();
+        var service = new OasisPlayerPreviewService(new StubBuildService(MachineRuntimeBuildResult.Fail("machine build failed")), new OasisPlayerLaunchService(starter));
+
+        var result = service.Preview(project, "asset.cabinet3d", new OasisPlayerPreferences { ExecutablePath = exe });
+
+        Assert.False(result.Success);
+        Assert.Equal("machine build failed", result.ErrorMessage);
+        Assert.Null(starter.StartInfo);
+    }
+
+    [Fact]
+    public void Preview_SuccessfulBuild_PassesExactReturnedBuildRoot()
+    {
+        var project = CreateProject();
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var exe = Path.Combine(root, "OasisPlayer.exe");
+        var exactBuildRoot = Path.Combine(root, "Exact Build Root With Spaces");
+        File.WriteAllText(exe, string.Empty);
+        Directory.CreateDirectory(exactBuildRoot);
+        var starter = new CapturingStarter();
+        var service = new OasisPlayerPreviewService(new StubBuildService(MachineRuntimeBuildResult.Ok(exactBuildRoot)), new OasisPlayerLaunchService(starter));
+
+        var result = service.Preview(project, "asset.cabinet3d", new OasisPlayerPreferences { ExecutablePath = exe, PreviewWidth = 1600, PreviewHeight = 900 });
+
+        Assert.True(result.Success, result.ErrorMessage);
+        Assert.Equal(exactBuildRoot, result.BuildRoot);
+        Assert.Equal(Path.GetFullPath(exactBuildRoot), starter.StartInfo!.ArgumentList[3]);
+    }
+
+    private static EditorProject CreateProject()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "Oasis Player Tests", Guid.NewGuid().ToString("N"))).FullName;
+        return new EditorProject
+        {
+            Name = "TestProject",
+            ProjectFilePath = Path.Combine(root, "TestProject.oasisproj"),
+            ProjectDirectory = root,
+            AssetsDirectory = Path.Combine(root, "Assets"),
+            MachinesDirectory = Path.Combine(root, "Machines"),
+            GeneratedDirectory = Path.Combine(root, "Generated")
+        };
+    }
+
+    private sealed class StubBuildService : IMachineRuntimeBuildService
+    {
+        private readonly MachineRuntimeBuildResult _result;
+        public StubBuildService(MachineRuntimeBuildResult result) => _result = result;
+        public MachineRuntimeBuildResult BuildFromCabinetDocument(EditorProject project, string cabinetManifestPath) => _result;
+    }
+
+    private sealed class CapturingStarter : IOasisPlayerProcessStarter
+    {
+        public ProcessStartInfo? StartInfo { get; private set; }
+        public void Start(ProcessStartInfo startInfo) => StartInfo = startInfo;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -8,6 +8,7 @@ public sealed class EditorPreferences
     public NativeEmulationPreferences NativeEmulation { get; init; } = new();
     public OutputLogPreferences OutputLog { get; init; } = new();
     public FaceGenerationPreferences FaceGeneration { get; init; } = new();
+    public OasisPlayerPreferences Player { get; init; } = new();
     public string LastMfmeFmlImportDirectory { get; init; } = string.Empty;
 
     public Dictionary<string, ProjectWindowState> ProjectWindowStates { get; init; } = new();
@@ -29,6 +30,14 @@ public sealed class MamePreferences
     public string LocalRomArchiveExtension { get; init; } = ".zip";
 }
 
+
+public sealed class OasisPlayerPreferences
+{
+    public string ExecutablePath { get; init; } = string.Empty;
+    public bool Fullscreen { get; init; }
+    public int PreviewWidth { get; init; } = OasisPlayerLaunchService.DefaultPreviewWidth;
+    public int PreviewHeight { get; init; } = OasisPlayerLaunchService.DefaultPreviewHeight;
+}
 
 public sealed class NativeEmulationPreferences
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
@@ -5,7 +5,12 @@ using OasisEditor.Features.CabinetEditor.Models;
 
 namespace OasisEditor;
 
-public sealed class MachineRuntimeBuildService
+public interface IMachineRuntimeBuildService
+{
+    MachineRuntimeBuildResult BuildFromCabinetDocument(EditorProject project, string cabinetManifestPath);
+}
+
+public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
 {
     public const string MachineManifestFileName = "machine.runtime.json";
     public const string CabinetDirectoryName = "cabinet";

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -69,6 +69,8 @@
                 <Separator />
                 <MenuItem Header="Build Oasis _Player Machine"
                           Command="{Binding BuildOasisPlayerMachineCommand}" />
+                <MenuItem Header="Preview in Oasis _Player"
+                          Command="{Binding PreviewInOasisPlayerCommand}" />
                 <MenuItem Header="_Save Asset"
                           Command="{Binding SaveSelectedDocumentCommand}" />
                 <MenuItem Header="_Close Project"

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml.cs
@@ -193,6 +193,7 @@ public partial class MainWindow : Window
             NativeEmulation = preferences.NativeEmulation,
             OutputLog = preferences.OutputLog,
             FaceGeneration = preferences.FaceGeneration,
+            Player = preferences.Player,
             LastMfmeFmlImportDirectory = preferences.LastMfmeFmlImportDirectory,
             ProjectWindowStates = states
         });

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -289,6 +289,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameRomDownloadService.ArchiveExtension = _mameRomArchiveExtension;
             _mameRomDownloadService.LocalRomSourceDirectory = _mameLocalRomSourceDirectory;
             _mameRomDownloadService.LocalRomArchiveExtension = _mameLocalRomArchiveExtension;
+            _oasisPlayerExecutablePath = preferences.Player.ExecutablePath;
+            _oasisPlayerFullscreen = preferences.Player.Fullscreen;
+            _oasisPlayerPreviewWidth = preferences.Player.PreviewWidth;
+            _oasisPlayerPreviewHeight = preferences.Player.PreviewHeight;
             _keepMameUpToDateAutomatically = preferences.Mame.KeepMameUpToDateAutomatically;
             _debugOutputLamps = preferences.Mame.DebugOutputLamps;
             _debugOutputStdIn = preferences.Mame.DebugOutputStdIn;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -55,6 +55,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private FaceGenerationSettingsModel _defaultFaceGenerationSettings = FaceGenerationSettingsModel.Default;
     private bool _showFaceGenerationSettingsBeforeRegenerate = true;
     private string _mameValidationSummary = "Not validated.";
+    private string _oasisPlayerExecutablePath = string.Empty;
+    private bool _oasisPlayerFullscreen;
+    private int _oasisPlayerPreviewWidth = OasisPlayerLaunchService.DefaultPreviewWidth;
+    private int _oasisPlayerPreviewHeight = OasisPlayerLaunchService.DefaultPreviewHeight;
     private string _selectedPreferencesCategory = "Appearance";
     private string _selectedProjectSettingsCategory = "General";
     private string _selectedNativeProjectSettingsTab = "ROMS";
@@ -114,6 +118,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private bool _isMameUnthrottled;
     private MameEmulationState _mameEmulationState = MameEmulationState.Stopped;
     private readonly IInputMapDiagnosticsService _inputMapDiagnosticsService = new InputMapDiagnosticsService(new MameInputPortResolver());
+    private readonly OasisPlayerPreviewService _oasisPlayerPreviewService = new();
     private IReadOnlyList<InputMapDiagnostic> _inputMapDiagnostics = [];
     private PlayViewInputRouter? _playViewInputRouter;
     private PlayViewInputDispatcher? _playViewInputDispatcher;
@@ -168,6 +173,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ImportMfmeFmlCommand = new RelayCommand(ImportMfmeFml, CanImportMfmeFml);
         ImportGlbModelCommand = new RelayCommand(ImportGlbModel, CanImportGlbModel);
         BuildOasisPlayerMachineCommand = new RelayCommand(BuildOasisPlayerMachine, CanBuildOasisPlayerMachine);
+        PreviewInOasisPlayerCommand = new RelayCommand(PreviewInOasisPlayer, CanBuildOasisPlayerMachine);
         SaveSelectedDocumentCommand = new RelayCommand(SaveSelectedDocument, CanSaveSelectedDocument);
         CloseSelectedDocumentCommand = new RelayCommand(CloseSelectedDocument, CanCloseSelectedDocument);
         OpenPreferencesCommand = new RelayCommand(OpenPreferences);
@@ -182,6 +188,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OpenDebuggerWatchpointsCommand = new RelayCommand(OpenDebuggerWatchpoints);
         ClosePreferencesCommand = new RelayCommand(ClosePreferences);
         BrowseMameExecutableCommand = new RelayCommand(BrowseMameExecutable);
+        BrowseOasisPlayerExecutableCommand = new RelayCommand(BrowseOasisPlayerExecutable);
         ValidateMamePreferencesCommand = new RelayCommand(ValidateMamePreferences);
         RefreshMameVersionsCommand = new RelayCommand(RefreshMameVersions);
         DownloadMameVersionCommand = new RelayCommand(DownloadMameVersion);
@@ -492,6 +499,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand ImportMfmeFmlCommand { get; }
     public ICommand ImportGlbModelCommand { get; }
     public ICommand BuildOasisPlayerMachineCommand { get; }
+    public ICommand PreviewInOasisPlayerCommand { get; }
     public ICommand SaveSelectedDocumentCommand { get; }
     public ICommand CloseSelectedDocumentCommand { get; }
     public ICommand RefreshAssetBrowserCommand { get; }
@@ -526,6 +534,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand OpenDebuggerWatchpointsCommand { get; }
     public ICommand ClosePreferencesCommand { get; }
     public ICommand BrowseMameExecutableCommand { get; }
+    public ICommand BrowseOasisPlayerExecutableCommand { get; }
     public ICommand ValidateMamePreferencesCommand { get; }
     public ICommand RefreshMameVersionsCommand { get; }
     public ICommand DownloadMameVersionCommand { get; }
@@ -579,7 +588,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
 
     public IReadOnlyList<ThemePreference> ThemePreferences { get; } = Enum.GetValues<ThemePreference>();
-    public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "MAME", "Native Emulation"];
+    public IReadOnlyList<string> PreferencesCategories { get; } = ["Appearance", "Player", "MAME", "Native Emulation"];
     public IReadOnlyList<string> ProjectSettingsCategories { get; } = ["General", "MAME", "Native"];
     public IReadOnlyList<string> NativeProjectSettingsTabs { get; } = ["ROMS", "Stake/Prize", "Reels", "Coins"];
     public IReadOnlyList<FruitMachinePlatformType> FruitMachinePlatformTypes { get; } = Enum.GetValues<FruitMachinePlatformType>();
@@ -640,6 +649,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     }
 
     public string MameVersion { get => _mameVersion; set { if (SetProperty(ref _mameVersion, value)) SavePreferences(); } }
+    public string OasisPlayerExecutablePath { get => _oasisPlayerExecutablePath; set { if (SetProperty(ref _oasisPlayerExecutablePath, value)) SavePreferences(); } }
+    public bool OasisPlayerFullscreen { get => _oasisPlayerFullscreen; set { if (SetProperty(ref _oasisPlayerFullscreen, value)) SavePreferences(); } }
+    public int OasisPlayerPreviewWidth { get => _oasisPlayerPreviewWidth; set { if (SetProperty(ref _oasisPlayerPreviewWidth, value)) SavePreferences(); } }
+    public int OasisPlayerPreviewHeight { get => _oasisPlayerPreviewHeight; set { if (SetProperty(ref _oasisPlayerPreviewHeight, value)) SavePreferences(); } }
     public string MameExecutablePath { get => _mameExecutablePath; set { if (SetProperty(ref _mameExecutablePath, value)) SavePreferences(); } }
     public string MameInstallRootDirectory => _mameInstallRootDirectory;
     public string MameReleaseSource { get => _mameReleaseSource; set { if (SetProperty(ref _mameReleaseSource, value)) SavePreferences(); } }
@@ -1500,6 +1513,42 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         AddOutputEntry($"Oasis Player machine build written: {result.BuildRoot}", OutputLogStatus.Info);
     }
 
+
+    private void PreviewInOasisPlayer()
+    {
+        if (LoadedProject is null)
+        {
+            ReportEditorOperationError("Open a project before previewing in Oasis Player.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var selectedDocument = SelectedDocument;
+        if (selectedDocument?.Document.DocumentType != EditorDocumentType.Cabinet3D || selectedDocument.Document.IsUntitled)
+        {
+            ReportEditorOperationError("Select a saved Cabinet3D asset before previewing in Oasis Player.", OutputLogStatus.Warning);
+            return;
+        }
+
+        var result = _oasisPlayerPreviewService.Preview(LoadedProject, selectedDocument.Document.FilePath, new OasisPlayerPreferences
+        {
+            ExecutablePath = OasisPlayerExecutablePath,
+            Fullscreen = OasisPlayerFullscreen,
+            PreviewWidth = OasisPlayerPreviewWidth,
+            PreviewHeight = OasisPlayerPreviewHeight
+        });
+
+        if (!result.Success)
+        {
+            ReportEditorOperationError(result.ErrorMessage ?? "Failed to preview in Oasis Player.", OutputLogStatus.Error);
+            return;
+        }
+
+        var arguments = string.Join(" ", result.Arguments);
+        StatusMessage = $"Oasis Player preview launched: {result.BuildRoot}";
+        AddOutputEntry($"Oasis Player machine build written: {result.BuildRoot}", OutputLogStatus.Info);
+        AddOutputEntry($"Oasis Player preview launched: {result.ExecutablePath} {arguments}", OutputLogStatus.Info);
+    }
+
     private bool CanBuildOasisPlayerMachine()
     {
         return LoadedProject is not null
@@ -2126,6 +2175,28 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+
+    private void BrowseOasisPlayerExecutable()
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Select Oasis Player executable",
+            Filter = "Oasis Player executable|*.exe|All files|*.*",
+            CheckFileExists = true
+        };
+
+        if (!string.IsNullOrWhiteSpace(OasisPlayerExecutablePath))
+        {
+            dialog.InitialDirectory = Path.GetDirectoryName(OasisPlayerExecutablePath);
+        }
+
+        if (dialog.ShowDialog(_ownerWindow) == true)
+        {
+            OasisPlayerExecutablePath = dialog.FileName;
+            AddOutputEntry($"Oasis Player executable path set to: {OasisPlayerExecutablePath}", OutputLogStatus.Info);
+        }
+    }
+
     private async void ValidateMamePreferences()
     {
         await ValidateMamePreferencesAsync();
@@ -2467,6 +2538,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             {
                 System6LibraryPath = System6NativeLibraryPath,
                 AudioBufferLengthMilliseconds = System6AudioBufferLengthMilliseconds
+            },
+            Player = new OasisPlayerPreferences
+            {
+                ExecutablePath = OasisPlayerExecutablePath,
+                Fullscreen = OasisPlayerFullscreen,
+                PreviewWidth = OasisPlayerPreviewWidth,
+                PreviewHeight = OasisPlayerPreviewHeight
             },
             FaceGeneration = FaceGenerationPreferences.FromSettings(
                 _defaultFaceGenerationSettings,
@@ -4398,6 +4476,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         if (BuildOasisPlayerMachineCommand is RelayCommand buildOasisPlayerRelayCommand)
         {
             buildOasisPlayerRelayCommand.RaiseCanExecuteChanged();
+        }
+
+        if (PreviewInOasisPlayerCommand is RelayCommand previewInOasisPlayerRelayCommand)
+        {
+            previewInOasisPlayerRelayCommand.RaiseCanExecuteChanged();
         }
 
         if (SaveSelectedDocumentCommand is RelayCommand saveRelayCommand)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisPlayerLaunchService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisPlayerLaunchService.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+
+namespace OasisEditor;
+
+public interface IOasisPlayerProcessStarter
+{
+    void Start(ProcessStartInfo startInfo);
+}
+
+public sealed class OasisPlayerProcessStarter : IOasisPlayerProcessStarter
+{
+    public void Start(ProcessStartInfo startInfo)
+    {
+        Process.Start(startInfo);
+    }
+}
+
+public sealed class OasisPlayerLaunchService
+{
+    public const int DefaultPreviewWidth = 1280;
+    public const int DefaultPreviewHeight = 800;
+
+    private readonly IOasisPlayerProcessStarter _processStarter;
+
+    public OasisPlayerLaunchService(IOasisPlayerProcessStarter? processStarter = null)
+    {
+        _processStarter = processStarter ?? new OasisPlayerProcessStarter();
+    }
+
+    public OasisPlayerLaunchResult Launch(OasisPlayerLaunchRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var validationError = Validate(request);
+        if (validationError is not null)
+        {
+            return OasisPlayerLaunchResult.Fail(validationError);
+        }
+
+        try
+        {
+            var startInfo = CreateStartInfo(request);
+            _processStarter.Start(startInfo);
+            return OasisPlayerLaunchResult.Ok(startInfo.FileName, Path.GetFullPath(request.BuildRoot), startInfo.ArgumentList.ToArray());
+        }
+        catch (Exception ex) when (ex is Win32Exception or IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return OasisPlayerLaunchResult.Fail($"Failed to launch Oasis Player: {ex.Message}");
+        }
+    }
+
+    public static ProcessStartInfo CreateStartInfo(OasisPlayerLaunchRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Path.GetFullPath(request.ExecutablePath),
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("--mode");
+        startInfo.ArgumentList.Add("machine-preview");
+        startInfo.ArgumentList.Add("--build");
+        startInfo.ArgumentList.Add(Path.GetFullPath(request.BuildRoot));
+        startInfo.ArgumentList.Add(request.Fullscreen ? "--fullscreen" : "--windowed");
+        startInfo.ArgumentList.Add("--width");
+        startInfo.ArgumentList.Add(request.Width.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        startInfo.ArgumentList.Add("--height");
+        startInfo.ArgumentList.Add(request.Height.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        return startInfo;
+    }
+
+    public static string? Validate(OasisPlayerLaunchRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ExecutablePath))
+        {
+            return "The Oasis Player executable has not been configured. Set it under Preferences > Player.";
+        }
+
+        if (request.Width <= 0)
+        {
+            return "Oasis Player preview width must be greater than zero.";
+        }
+
+        if (request.Height <= 0)
+        {
+            return "Oasis Player preview height must be greater than zero.";
+        }
+
+        if (Directory.Exists(request.ExecutablePath))
+        {
+            return $"The configured Oasis Player path points to a directory, not an executable: {request.ExecutablePath}";
+        }
+
+        if (!File.Exists(request.ExecutablePath))
+        {
+            return $"The configured Oasis Player executable does not exist: {request.ExecutablePath}";
+        }
+
+        if (OperatingSystem.IsWindows() && !string.Equals(Path.GetExtension(request.ExecutablePath), ".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"The configured Oasis Player path must be a Windows .exe file: {request.ExecutablePath}";
+        }
+
+        if (string.IsNullOrWhiteSpace(request.BuildRoot))
+        {
+            return "The Oasis Player build directory was not provided.";
+        }
+
+        return null;
+    }
+}
+
+public sealed record OasisPlayerLaunchRequest(string ExecutablePath, string BuildRoot, bool Fullscreen, int Width, int Height);
+
+public sealed record OasisPlayerLaunchResult(bool Success, string? ExecutablePath, string? BuildRoot, IReadOnlyList<string> Arguments, string? ErrorMessage)
+{
+    public static OasisPlayerLaunchResult Ok(string executablePath, string buildRoot, IReadOnlyList<string> arguments) => new(true, executablePath, buildRoot, arguments, null);
+    public static OasisPlayerLaunchResult Fail(string errorMessage) => new(false, null, null, Array.Empty<string>(), errorMessage);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/OasisPlayerPreviewService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/OasisPlayerPreviewService.cs
@@ -1,0 +1,46 @@
+namespace OasisEditor;
+
+public sealed class OasisPlayerPreviewService
+{
+    private readonly IMachineRuntimeBuildService _buildService;
+    private readonly OasisPlayerLaunchService _launchService;
+
+    public OasisPlayerPreviewService(IMachineRuntimeBuildService? buildService = null, OasisPlayerLaunchService? launchService = null)
+    {
+        _buildService = buildService ?? new MachineRuntimeBuildService();
+        _launchService = launchService ?? new OasisPlayerLaunchService();
+    }
+
+    public OasisPlayerPreviewResult Preview(EditorProject project, string cabinetManifestPath, OasisPlayerPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        var validationRequest = new OasisPlayerLaunchRequest(preferences.ExecutablePath, project.GeneratedDirectory, preferences.Fullscreen, preferences.PreviewWidth, preferences.PreviewHeight);
+        var validationError = OasisPlayerLaunchService.Validate(validationRequest);
+        if (validationError is not null)
+        {
+            return OasisPlayerPreviewResult.Fail(validationError);
+        }
+
+        var buildResult = _buildService.BuildFromCabinetDocument(project, cabinetManifestPath);
+        if (!buildResult.Success || string.IsNullOrWhiteSpace(buildResult.BuildRoot))
+        {
+            return OasisPlayerPreviewResult.Fail(buildResult.ErrorMessage ?? "Failed to build Oasis Player runtime output.");
+        }
+
+        var launchResult = _launchService.Launch(new OasisPlayerLaunchRequest(preferences.ExecutablePath, buildResult.BuildRoot, preferences.Fullscreen, preferences.PreviewWidth, preferences.PreviewHeight));
+        if (!launchResult.Success)
+        {
+            return OasisPlayerPreviewResult.Fail(launchResult.ErrorMessage ?? "Failed to launch Oasis Player.", buildResult.BuildRoot);
+        }
+
+        return OasisPlayerPreviewResult.Ok(buildResult.BuildRoot, launchResult.ExecutablePath!, launchResult.Arguments);
+    }
+}
+
+public sealed record OasisPlayerPreviewResult(bool Success, string? BuildRoot, string? ExecutablePath, IReadOnlyList<string> Arguments, string? ErrorMessage)
+{
+    public static OasisPlayerPreviewResult Ok(string buildRoot, string executablePath, IReadOnlyList<string> arguments) => new(true, buildRoot, executablePath, arguments, null);
+    public static OasisPlayerPreviewResult Fail(string errorMessage, string? buildRoot = null) => new(false, buildRoot, null, Array.Empty<string>(), errorMessage);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -38,6 +38,46 @@
                           SelectedItem="{Binding SelectedThemePreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
 
+
+
+            <StackPanel>
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedPreferencesCategory}" Value="Player">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock FontSize="18" FontWeight="SemiBold" Text="Player" />
+                <TextBlock Margin="0,16,0,4" Text="Oasis Player executable path" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="8" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox Grid.Column="0" Text="{Binding OasisPlayerExecutablePath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                    <Button Grid.Column="2" Padding="10,4" Content="Browse" Command="{Binding BrowseOasisPlayerExecutableCommand}" />
+                </Grid>
+                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondaryBrush}" Text="Build OasisPlayer.exe manually from Unity, then configure that executable here. This user preference is not stored in the Oasis project." />
+                <TextBlock Margin="0,18,0,6" Text="Preview Display" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <CheckBox Foreground="{DynamicResource TextPrimaryBrush}" Content="Fullscreen" IsChecked="{Binding OasisPlayerFullscreen, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                    <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="Width" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <TextBox Width="100" Text="{Binding OasisPlayerPreviewWidth, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                    </StackPanel>
+                    <StackPanel Margin="12,0,0,0">
+                        <TextBlock Margin="0,0,0,4" Text="Height" Foreground="{DynamicResource TextSecondaryBrush}" />
+                        <TextBox Width="100" Text="{Binding OasisPlayerPreviewHeight, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock Margin="0,6,0,0" TextWrapping="Wrap" Foreground="{DynamicResource TextSecondaryBrush}" Text="Windowed preview defaults to 1280 x 800. Fullscreen passes --fullscreen instead of --windowed." />
+            </StackPanel>
+
             <StackPanel>
                 <StackPanel.Style>
                     <Style TargetType="StackPanel">


### PR DESCRIPTION
### Motivation

- Connect the Editor build output to the Unity Player so users can configure and launch a built `OasisPlayer.exe` from the Editor for Phase 1 machine-preview testing. 
- Persist a machine/user-level player executable path and preview display settings using the existing preferences system instead of project/asset data. 
- Provide a testable, UI-independent launch boundary so automated tests can validate argument construction and error handling without starting a real process.

### Description

- Add `OasisPlayerLaunchService` with `IOasisPlayerProcessStarter` test seam that validates settings, builds a `ProcessStartInfo` using `ArgumentList`, and starts the process in a fire-and-forget fashion. 
- Add `OasisPlayerPreviewService` to orchestrate validation -> `MachineRuntimeBuildService.BuildFromCabinetDocument` -> launch and return exact `BuildRoot`/arguments; keep build logic delegated to the existing build service. 
- Extend `EditorPreferences` with `OasisPlayerPreferences`, wire `Preferences > Player` UI (executable path + Browse, fullscreen toggle, width/height), add `File > Preview in Oasis Player` command and a Browse dialog command, and persist settings through the existing `EditorPreferencesStore`. 
- Add focused unit tests that capture `ProcessStartInfo` instead of launching a real Player: `OasisPlayerLaunchServiceTests`, `OasisPlayerPreviewServiceTests`, and updated preference serialization tests; preserve existing `File > Build Oasis Player Machine` command.

### Testing

- No automated test suite was executed in this environment per `AGENTS.md`; unit tests were added (`OasisPlayerLaunchServiceTests`, `OasisPlayerPreviewServiceTests`, and preference round-trip tests) but not run here. 
- Performed a repository consistency check with `git diff --check` and created a commit containing the changes. 
- Local test recommendation: run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` on a Windows/.NET/WPF-capable machine to verify the new tests pass and to validate the UI persistence and browse behaviors manually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5b894f94508327a3b48fe18e7307f3)