### PR TITLE
Phase 2: Export Face runtime assets into machine build (machine manifest v2)

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
@@ -9,14 +9,22 @@ namespace OasisPlayer.Loading
     public sealed class MachinePreviewLoader
     {
         private readonly ICabinetModelLoader _modelLoader;
+        private readonly RuntimeFaceLoader _faceLoader;
         private GameObject _current;
+        private RuntimeMachine _runtimeMachine;
 
         public MachinePreviewLoader(ICabinetModelLoader modelLoader)
+            : this(modelLoader, new RuntimeFaceLoader(new PngRuntimeTextureAssetLoader()))
         {
-            _modelLoader = modelLoader;
         }
 
-        public async Task LoadAsync(ResolvedRuntimeBuild build)
+        public MachinePreviewLoader(ICabinetModelLoader modelLoader, RuntimeFaceLoader faceLoader)
+        {
+            _modelLoader = modelLoader;
+            _faceLoader = faceLoader;
+        }
+
+        public async Task<RuntimeMachine> LoadAsync(ResolvedRuntimeBuild build)
         {
             Unload();
             var spawns = UnityEngine.Object.FindObjectsByType<Transform>(FindObjectsSortMode.None)
@@ -34,11 +42,22 @@ namespace OasisPlayer.Loading
             correctionRoot.transform.localScale = Vector3.one * Mathf.Max(0.0001f, build.Cabinet.scale);
             correctionRoot.transform.localRotation = build.Cabinet.upAxis == "Z" ? Quaternion.Euler(-90f, 0f, 0f) : Quaternion.identity;
             _current = correctionRoot;
-            await _modelLoader.LoadAsync(build.GlbPath, correctionRoot.transform);
+            var cabinet = await _modelLoader.LoadAsync(build.GlbPath, correctionRoot.transform);
+            var machine = new RuntimeMachine(build, cabinet);
+            _runtimeMachine = machine;
+            _faceLoader.LoadFaces(machine);
+            foreach (var warning in machine.Warnings) Debug.LogWarning(warning);
+            return machine;
         }
 
         public void Unload()
         {
+            if (_runtimeMachine != null)
+            {
+                _runtimeMachine.UnloadAssets();
+                _runtimeMachine = null;
+            }
+
             if (_current != null)
             {
                 _modelLoader.Unload(_current);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/RuntimeFaceLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/RuntimeFaceLoader.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+
+namespace OasisPlayer.Loading
+{
+    public interface IRuntimeTextureAssetLoader
+    {
+        bool TryLoad(string path, out RuntimeTextureAsset asset, out string error);
+    }
+
+    public sealed class PngRuntimeTextureAssetLoader : IRuntimeTextureAssetLoader
+    {
+        public bool TryLoad(string path, out RuntimeTextureAsset asset, out string error)
+        {
+            asset = null;
+            error = string.Empty;
+            if (!File.Exists(path))
+            {
+                error = $"Texture file is missing: {path}";
+                return false;
+            }
+
+            try
+            {
+                var bytes = File.ReadAllBytes(path);
+                var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                if (!texture.LoadImage(bytes, false))
+                {
+                    UnityEngine.Object.Destroy(texture);
+                    error = $"Texture file could not be decoded as an image: {path}";
+                    return false;
+                }
+
+                texture.name = System.IO.Path.GetFileName(path);
+                asset = new RuntimeTextureAsset(path, texture);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = $"Texture file could not be read: {path}. {ex.Message}";
+                return false;
+            }
+        }
+    }
+
+    public sealed class RuntimeFaceLoader
+    {
+        private const int FaceSchemaVersion = 1;
+        private const string TargetPrefix = "OasisFace_";
+
+        private readonly IRuntimeTextureAssetLoader _assetLoader;
+
+        public RuntimeFaceLoader(IRuntimeTextureAssetLoader assetLoader)
+        {
+            _assetLoader = assetLoader ?? throw new ArgumentNullException(nameof(assetLoader));
+        }
+
+        public void LoadFaces(RuntimeMachine machine)
+        {
+            if (machine == null) throw new ArgumentNullException(nameof(machine));
+
+            var seenFaceIds = new HashSet<string>(StringComparer.Ordinal);
+            var seenTargetIds = new HashSet<string>(StringComparer.Ordinal);
+            var targets = FindFaceTargets(machine.Cabinet);
+
+            foreach (var reference in machine.Build.Faces)
+            {
+                if (reference == null)
+                {
+                    machine.AddWarning("Machine manifest contains an empty Face reference.");
+                    continue;
+                }
+
+                var referenceFaceId = Normalize(reference.faceId);
+                if (string.IsNullOrEmpty(referenceFaceId))
+                {
+                    machine.AddWarning("Machine manifest contains a Face reference with an empty faceId.");
+                    continue;
+                }
+
+                if (!seenFaceIds.Add(referenceFaceId))
+                {
+                    machine.AddWarning($"Duplicate Face identifier '{referenceFaceId}' was skipped.");
+                    continue;
+                }
+
+                var targetId = Normalize(reference.cabinetFaceTargetId);
+                if (string.IsNullOrEmpty(targetId))
+                {
+                    machine.AddWarning($"Face '{referenceFaceId}' does not specify a cabinetFaceTargetId.");
+                    continue;
+                }
+
+                if (!seenTargetIds.Add(targetId))
+                {
+                    machine.AddWarning($"Duplicate Face assignment for cabinet target '{targetId}' was skipped.");
+                    continue;
+                }
+
+                if (!TryLoadFaceManifest(machine.Build.BuildRoot, reference.ResolvedManifestPath, referenceFaceId, out var manifest, out var manifestDirectory, out var error))
+                {
+                    machine.AddWarning(error);
+                    continue;
+                }
+
+                if (manifest.schemaVersion != FaceSchemaVersion)
+                {
+                    machine.AddWarning($"Unsupported Face manifest schema version for Face '{referenceFaceId}' in {reference.ResolvedManifestPath}.");
+                    continue;
+                }
+
+                if (!TryResolveContained(machine.Build.BuildRoot, manifestDirectory, manifest.artwork, out var artworkPath, out error))
+                {
+                    machine.AddWarning($"Invalid artwork path for Face '{referenceFaceId}': {error}");
+                    continue;
+                }
+
+                if (!TryResolveContained(machine.Build.BuildRoot, manifestDirectory, manifest.mask, out var maskPath, out error))
+                {
+                    machine.AddWarning($"Invalid mask path for Face '{referenceFaceId}': {error}");
+                    continue;
+                }
+
+                if (!targets.TryGetValue(targetId, out var target))
+                {
+                    machine.AddWarning($"Cabinet target mesh '{targetId}' was not found for Face '{referenceFaceId}'.");
+                    continue;
+                }
+
+                if (!_assetLoader.TryLoad(artworkPath, out var artwork, out error))
+                {
+                    machine.AddWarning($"Artwork for Face '{referenceFaceId}' could not be loaded. {error}");
+                    continue;
+                }
+
+                if (!_assetLoader.TryLoad(maskPath, out var mask, out error))
+                {
+                    artwork.Unload();
+                    machine.AddWarning($"Mask for Face '{referenceFaceId}' could not be loaded. {error}");
+                    continue;
+                }
+
+                machine.RegisterFace(new RuntimeFace(reference, manifest, target, artwork, mask));
+            }
+        }
+
+        private static bool TryLoadFaceManifest(string buildRoot, string manifestPath, string faceId, out FaceRuntimeManifest manifest, out string manifestDirectory, out string error)
+        {
+            manifest = null;
+            manifestDirectory = string.Empty;
+            error = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(manifestPath))
+            {
+                error = $"Face '{faceId}' does not specify a runtime manifest path.";
+                return false;
+            }
+
+            if (!TryResolveContained(buildRoot, buildRoot, manifestPath, out var resolvedManifestPath, out error))
+            {
+                error = $"Invalid Face manifest path for Face '{faceId}': {error}";
+                return false;
+            }
+
+            if (!File.Exists(resolvedManifestPath))
+            {
+                error = $"Face runtime manifest is missing for Face '{faceId}': {resolvedManifestPath}";
+                return false;
+            }
+
+            try
+            {
+                manifest = JsonUtility.FromJson<FaceRuntimeManifest>(File.ReadAllText(resolvedManifestPath));
+            }
+            catch (Exception ex)
+            {
+                error = $"Face manifest is invalid JSON for Face '{faceId}': {resolvedManifestPath}. {ex.Message}";
+                return false;
+            }
+
+            if (manifest == null)
+            {
+                error = $"Face manifest could not be parsed for Face '{faceId}': {resolvedManifestPath}";
+                return false;
+            }
+
+            manifestDirectory = Path.GetDirectoryName(resolvedManifestPath);
+            return true;
+        }
+
+        private static Dictionary<string, Transform> FindFaceTargets(GameObject cabinet)
+        {
+            var targets = new Dictionary<string, Transform>(StringComparer.Ordinal);
+            if (cabinet == null) return targets;
+
+            foreach (var transform in cabinet.GetComponentsInChildren<Transform>(true))
+            {
+                var sourceName = IsTargetName(transform.name) ? transform.name : null;
+                if (sourceName == null)
+                {
+                    var meshFilter = transform.GetComponent<MeshFilter>();
+                    if (meshFilter != null && meshFilter.sharedMesh != null && IsTargetName(meshFilter.sharedMesh.name)) sourceName = meshFilter.sharedMesh.name;
+                }
+
+                if (sourceName == null) continue;
+                var targetId = CreateStableId(sourceName);
+                if (!targets.ContainsKey(targetId)) targets.Add(targetId, transform);
+            }
+
+            return targets;
+        }
+
+        private static bool IsTargetName(string name)
+        {
+            return !string.IsNullOrEmpty(name) && name.StartsWith(TargetPrefix, StringComparison.Ordinal);
+        }
+
+        private static string CreateStableId(string sourceName)
+        {
+            var suffix = sourceName.StartsWith(TargetPrefix, StringComparison.Ordinal) ? sourceName.Substring(TargetPrefix.Length) : sourceName;
+            var chars = suffix.Where(char.IsLetterOrDigit).ToArray();
+            if (chars.Length == 0) return "target";
+            var text = new string(chars);
+            return char.ToLowerInvariant(text[0]) + text.Substring(1);
+        }
+
+        private static string Normalize(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+        }
+
+        private static bool TryResolveContained(string root, string baseDir, string relative, out string resolved, out string error)
+        {
+            resolved = string.Empty;
+            error = string.Empty;
+            if (string.IsNullOrWhiteSpace(relative))
+            {
+                error = "path is empty.";
+                return false;
+            }
+
+            if (Path.IsPathRooted(relative))
+            {
+                error = "rooted paths are not allowed.";
+                return false;
+            }
+
+            resolved = Path.GetFullPath(Path.Combine(baseDir, relative.Replace('/', Path.DirectorySeparatorChar)));
+            var fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            if (!resolved.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                error = "path traversal outside the build root is not allowed.";
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/RuntimeFaceLoader.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/RuntimeFaceLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94b8300cc4e840cfa096730f5ee34876
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
@@ -12,6 +13,21 @@ namespace OasisPlayer.RuntimeBuild
         public string machineId = string.Empty;
         public string displayName = string.Empty;
         public string cabinetManifest = string.Empty;
+        public MachineRuntimeFaceReference[] faces = Array.Empty<MachineRuntimeFaceReference>();
+    }
+
+    [Serializable]
+    public sealed class MachineRuntimeFaceReference
+    {
+        public string faceId = string.Empty;
+        public string assetName = string.Empty;
+        public string cabinetFaceTargetId = string.Empty;
+        public string manifest = string.Empty;
+
+        public string ResolvedManifestPath
+        {
+            get { return string.IsNullOrWhiteSpace(manifest) ? string.Empty : manifest.Trim(); }
+        }
     }
 
     [Serializable]
@@ -25,15 +41,66 @@ namespace OasisPlayer.RuntimeBuild
         public string upAxis = "Y";
     }
 
+    [Serializable]
+    public sealed class FaceRuntimeManifest
+    {
+        public int schemaVersion;
+        public string faceId = string.Empty;
+        public int width;
+        public int height;
+        public string artwork = string.Empty;
+        public string mask = string.Empty;
+        public string trayId = string.Empty;
+        public string lampIds0 = string.Empty;
+        public string lampWeights0 = string.Empty;
+        public string lampIds1 = string.Empty;
+        public string lampWeights1 = string.Empty;
+        public string trayIdDebug = string.Empty;
+        public string lampWeightsDebug = string.Empty;
+        public FaceRuntimeLampManifestEntry[] lamps = Array.Empty<FaceRuntimeLampManifestEntry>();
+        public FaceRuntimeElementManifestEntry[] trays = Array.Empty<FaceRuntimeElementManifestEntry>();
+        public FaceRuntimeElementManifestEntry[] reels = Array.Empty<FaceRuntimeElementManifestEntry>();
+        public FaceRuntimeElementManifestEntry[] sevenSegmentDisplays = Array.Empty<FaceRuntimeElementManifestEntry>();
+        public FaceRuntimeElementManifestEntry[] alphaDisplays = Array.Empty<FaceRuntimeElementManifestEntry>();
+        public FaceRuntimeButtonManifestEntry[] buttons = Array.Empty<FaceRuntimeButtonManifestEntry>();
+    }
+
+    [Serializable]
+    public class FaceRuntimeElementManifestEntry
+    {
+        public string objectId = string.Empty;
+        public string machineReference = string.Empty;
+        public string name = string.Empty;
+        public float x;
+        public float y;
+        public float width;
+        public float height;
+    }
+
+    [Serializable]
+    public sealed class FaceRuntimeLampManifestEntry : FaceRuntimeElementManifestEntry
+    {
+        public string sourceLampWindowObjectId = string.Empty;
+        public int lampId;
+        public int trayId;
+    }
+
+    [Serializable]
+    public sealed class FaceRuntimeButtonManifestEntry : FaceRuntimeElementManifestEntry
+    {
+        public string inputReference = string.Empty;
+    }
+
     public sealed class ResolvedRuntimeBuild
     {
-        public ResolvedRuntimeBuild(string buildRoot, MachineRuntimeManifest machine, string cabinetManifestPath, CabinetRuntimeManifest cabinet, string glbPath)
+        public ResolvedRuntimeBuild(string buildRoot, MachineRuntimeManifest machine, string cabinetManifestPath, CabinetRuntimeManifest cabinet, string glbPath, MachineRuntimeFaceReference[] faces)
         {
             BuildRoot = buildRoot;
             Machine = machine;
             CabinetManifestPath = cabinetManifestPath;
             Cabinet = cabinet;
             GlbPath = glbPath;
+            Faces = faces ?? Array.Empty<MachineRuntimeFaceReference>();
         }
 
         public string BuildRoot { get; }
@@ -41,6 +108,7 @@ namespace OasisPlayer.RuntimeBuild
         public string CabinetManifestPath { get; }
         public CabinetRuntimeManifest Cabinet { get; }
         public string GlbPath { get; }
+        public IReadOnlyList<MachineRuntimeFaceReference> Faces { get; }
     }
 
     public static class RuntimeBuildLoader
@@ -83,7 +151,7 @@ namespace OasisPlayer.RuntimeBuild
                 return false;
             }
 
-            if (machine == null || machine.schema != MachineSchema || machine.schemaVersion != 1)
+            if (machine == null || machine.schema != MachineSchema || (machine.schemaVersion != 1 && machine.schemaVersion != 2))
             {
                 error = $"Unsupported machine manifest schema/version in {machinePath}.";
                 return false;
@@ -130,7 +198,7 @@ namespace OasisPlayer.RuntimeBuild
                 return false;
             }
 
-            build = new ResolvedRuntimeBuild(root, machine, cabinetPath, cabinet, glbPath);
+            build = new ResolvedRuntimeBuild(root, machine, cabinetPath, cabinet, glbPath, machine.schemaVersion >= 2 ? machine.faces : Array.Empty<MachineRuntimeFaceReference>());
             return true;
         }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public sealed class RuntimeMachine
+    {
+        private readonly List<RuntimeFace> _faces = new List<RuntimeFace>();
+        private readonly List<string> _warnings = new List<string>();
+
+        public RuntimeMachine(ResolvedRuntimeBuild build, GameObject cabinet)
+        {
+            Build = build;
+            Cabinet = cabinet;
+        }
+
+        public ResolvedRuntimeBuild Build { get; private set; }
+        public GameObject Cabinet { get; private set; }
+        public IReadOnlyList<RuntimeFace> Faces { get { return _faces; } }
+        public IReadOnlyList<string> Warnings { get { return _warnings; } }
+
+        public void RegisterFace(RuntimeFace face)
+        {
+            if (face != null) _faces.Add(face);
+        }
+
+        public void AddWarning(string warning)
+        {
+            if (!string.IsNullOrWhiteSpace(warning)) _warnings.Add(warning);
+        }
+
+        public void UnloadAssets()
+        {
+            foreach (var face in _faces)
+            {
+                face.UnloadAssets();
+            }
+
+            _faces.Clear();
+            _warnings.Clear();
+        }
+    }
+
+    public sealed class RuntimeFace
+    {
+        public RuntimeFace(MachineRuntimeFaceReference reference, FaceRuntimeManifest manifest, Transform cabinetTarget, RuntimeTextureAsset artwork, RuntimeTextureAsset mask)
+        {
+            Reference = reference;
+            Manifest = manifest;
+            CabinetTarget = cabinetTarget;
+            Artwork = artwork;
+            Mask = mask;
+        }
+
+        public MachineRuntimeFaceReference Reference { get; private set; }
+        public FaceRuntimeManifest Manifest { get; private set; }
+        public Transform CabinetTarget { get; private set; }
+        public RuntimeTextureAsset Artwork { get; private set; }
+        public RuntimeTextureAsset Mask { get; private set; }
+
+        public void UnloadAssets()
+        {
+            if (Artwork != null) Artwork.Unload();
+            if (Mask != null) Mask.Unload();
+        }
+    }
+
+    public sealed class RuntimeTextureAsset
+    {
+        public RuntimeTextureAsset(string path, Texture2D texture)
+        {
+            Path = path;
+            Texture = texture;
+        }
+
+        public string Path { get; private set; }
+        public Texture2D Texture { get; private set; }
+
+        public void Unload()
+        {
+            if (Texture != null)
+            {
+                UnityEngine.Object.Destroy(Texture);
+                Texture = null;
+            }
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87ec75f04b074b7da5e5b6d8d17f0a51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
+++ b/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
@@ -17,10 +17,16 @@ Open additional Phase 2 task documents only as directed by `Docs/OasisPlayerPhas
 Priority workstream:
 
 - Oasis Player Phase 2: Face Runtime Integration
-- deterministic Editor-generated Face runtime build contract
-- Face runtime manifests and texture/image export in generated machine builds
+- Player-side loading and validation of exported Face runtime assets
+- in-memory RuntimeFace model registration after cabinet instantiation
 
 Primary implementation project:
+
+```text
+UnityProjects/OasisPlayer
+```
+
+Related contract producer:
 
 ```text
 WindowsNetProjects/OasisEditor
@@ -28,21 +34,22 @@ WindowsNetProjects/OasisEditor
 
 ## Immediate Direction
 
-Implement only Phase 2 Task 01:
+Implement only Phase 2 Task 02:
 
 ```text
-Docs/OasisPlayerPhase2/TASK_01_RUNTIME_FACE_EXPORT.md
+Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
 ```
 
-The Phase 1 cabinet runtime build and Player launch flow are complete and merged.
+Phase 2 Task 01 is complete. Do not modify the runtime Face export contract unless a genuine defect is discovered.
 
 ## Explicit Non-Goals
 
 Do not implement in this priority:
 
-- Player-side Face loading
 - runtime Face rendering
 - Unity material changes
+- RenderTextures
+- mesh replacement or mesh modification
 - lamp rendering
 - display rendering
 - reels
@@ -55,10 +62,14 @@ Do not implement in this priority:
 
 Prefer focused tests around:
 
-- machine manifests listing exported Face runtime manifests
-- deterministic Face output paths under generated machine builds
-- copied artwork and mask images
-- copied existing Face runtime metadata/textures required for later reconstruction
-- clear failures for invalid or missing Face runtime source data
+- valid machine manifests with multiple Faces
+- missing `face.runtime.json`
+- unsupported Face manifest schema version
+- missing artwork or mask image files
+- duplicate Face identifiers
+- duplicate cabinet target assignments
+- missing cabinet target mesh warnings
+- successful RuntimeFace registration
+- continued loading after invalid Face entries
 
-Do not attempt to build the WPF application in Codex. Do not claim WPF, Unity Player, or visual verification unless it was actually performed locally.
+Do not claim WPF, Unity Player, or visual verification unless it was actually performed locally.

--- a/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
+++ b/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
@@ -6,23 +6,19 @@ Read only:
 
 1. `AGENTS.md`
 2. `00_CURRENT_PRIORITY.md`
-3. `Docs/OasisPlayerPhase1/CODEX_START_PROMPT.md`
+3. `Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md`
 
 Do not scan all Markdown files in this directory.
 
-Open additional Phase 1 task documents only as directed by `Docs/OasisPlayerPhase1/CODEX_START_PROMPT.md` or when directly relevant to the requested work.
+Open additional Phase 2 task documents only as directed by `Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md` or when directly relevant to the requested work.
 
 ## Current Focus
 
 Priority workstream:
 
-- Oasis Editor Player preferences
-- persisted Oasis Player executable path
-- preview window/fullscreen settings
-- build-then-launch workflow
-- `File > Preview in Oasis Player`
-- safe command-line argument construction
-- clear launch validation and errors
+- Oasis Player Phase 2: Face Runtime Integration
+- deterministic Editor-generated Face runtime build contract
+- Face runtime manifests and texture/image export in generated machine builds
 
 Primary implementation project:
 
@@ -30,83 +26,39 @@ Primary implementation project:
 WindowsNetProjects/OasisEditor
 ```
 
-Existing Player command-line implementation to inspect for compatibility:
-
-```text
-UnityProjects/OasisPlayer
-```
-
 ## Immediate Direction
 
-Complete the Phase 1 launch-integration task described in:
+Implement only Phase 2 Task 01:
 
 ```text
-Docs/OasisPlayerPhase1/CODEX_START_PROMPT.md
-Docs/OasisPlayerPhase1/TASK_03_EDITOR_PLAYER_LAUNCH_INTEGRATION.md
+Docs/OasisPlayerPhase2/TASK_01_RUNTIME_FACE_EXPORT.md
 ```
 
-The earlier machine-build and Player cabinet-loading checkpoints are already merged.
-
-Core target flow:
-
-```text
-Preferences > Player
-    -> configure OasisPlayer.exe
-
-File > Preview in Oasis Player
-    -> build selected saved Cabinet3D asset
-    -> launch OasisPlayer.exe
-       --mode machine-preview
-       --build <absolute generated build path>
-       --windowed or --fullscreen
-       --width <pixels>
-       --height <pixels>
-```
-
-Keep the existing command:
-
-```text
-File > Build Oasis Player Machine
-```
-
-## Architectural Boundaries
-
-- Store the Player executable path as a user/machine preference, not project or asset data.
-- Extend the existing Preferences and settings architecture rather than adding a second settings system.
-- Reuse `MachineRuntimeBuildService`; do not duplicate build logic.
-- Keep process-launch logic out of WPF code-behind.
-- Prefer a focused testable launch service and injectable process-start boundary.
-- Pass process arguments separately; do not manually quote a single argument string.
-- Do not assume the Player executable lives at a repository-relative path.
-- Keep the launch fire-and-forget for this MVP.
+The Phase 1 cabinet runtime build and Player launch flow are complete and merged.
 
 ## Explicit Non-Goals
 
 Do not implement in this priority:
 
-- automatic Unity Player builds
-- Unity installation discovery
-- launching the Unity Editor
-- live Editor-to-Player IPC or hot reload
-- reuse, shutdown, or monitoring of an already-running Player
-- arcade mode or multiple machines
-- Face shaders or material replacement
-- lamps, reels, displays, buttons, or emulation
-- remote downloads or archive packaging
+- Player-side Face loading
+- runtime Face rendering
+- Unity material changes
+- lamp rendering
+- display rendering
+- reels
+- buttons
+- shaders
+- emulation integration
+- Player hot reload or IPC
 
 ## Testing Direction
 
 Prefer focused tests around:
 
-- Player preference defaults and persistence
-- missing/invalid executable validation
-- paths containing spaces
-- windowed and fullscreen arguments
-- width and height propagation
-- build failure preventing launch
-- successful build passing the exact returned build root
-- process-start failure reporting
+- machine manifests listing exported Face runtime manifests
+- deterministic Face output paths under generated machine builds
+- copied artwork and mask images
+- copied existing Face runtime metadata/textures required for later reconstruction
+- clear failures for invalid or missing Face runtime source data
 
-Do not launch the real Player from automated tests.
-
-Do not attempt to build the WPF application in Codex. Do not claim process-launch or visual verification unless it was actually performed. John will run builds, tests, Unity Player builds, and end-to-end checks locally.
+Do not attempt to build the WPF application in Codex. Do not claim WPF, Unity Player, or visual verification unless it was actually performed locally.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
@@ -3,16 +3,19 @@
 Read only these Phase 2 documents before implementation unless a task requires source inspection:
 
 1. `PHASE_02_CONTEXT.md`
-2. `TASK_01_RUNTIME_FACE_EXPORT.md`
-3. The task document for the requested Phase 2 task
+2. The task document for the requested Phase 2 task
 
-For the current checkpoint, implement only Task 01: Runtime Face Export.
+For the current checkpoint, implement only Task 02: Player Face Loading.
 
 Respect these boundaries:
 
-- Keep the versioned runtime manifest approach.
-- Export referenced Face assets into the generated machine build.
-- Include Face runtime manifests, artwork image, mask image, and existing reconstruction metadata.
-- Do not implement Player-side loading/rendering yet.
+- Keep the versioned runtime manifest approach established by Task 01.
+- Do not modify the Task 01 runtime Face export contract unless a genuine defect is discovered.
+- Load and validate exported Face runtime manifests after cabinet instantiation.
+- Resolve artwork and mask assets through a reusable loading abstraction.
+- Resolve Face target meshes using the existing `OasisFace_` naming convention.
+- Create/register in-memory runtime Face objects for later rendering tasks.
+- Do not implement runtime Face rendering yet.
 - Do not modify Unity materials.
+- Do not create RenderTextures.
 - Do not introduce lamp rendering, display rendering, reels, buttons, shaders, or emulation.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
@@ -1,0 +1,18 @@
+# Codex Start Prompt: Oasis Player Phase 2
+
+Read only these Phase 2 documents before implementation unless a task requires source inspection:
+
+1. `PHASE_02_CONTEXT.md`
+2. `TASK_01_RUNTIME_FACE_EXPORT.md`
+3. The task document for the requested Phase 2 task
+
+For the current checkpoint, implement only Task 01: Runtime Face Export.
+
+Respect these boundaries:
+
+- Keep the versioned runtime manifest approach.
+- Export referenced Face assets into the generated machine build.
+- Include Face runtime manifests, artwork image, mask image, and existing reconstruction metadata.
+- Do not implement Player-side loading/rendering yet.
+- Do not modify Unity materials.
+- Do not introduce lamp rendering, display rendering, reels, buttons, shaders, or emulation.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/PHASE_02_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/PHASE_02_CONTEXT.md
@@ -1,0 +1,35 @@
+# Oasis Player Phase 2 Context: Face Runtime Integration
+
+Phase 1 established the runtime machine build contract: the Editor produces a versioned machine manifest, exports the Cabinet3D GLB, and the Player loads the cabinet with its authored PBR materials.
+
+Phase 2 extends that contract to Face assets referenced by the machine. The goal is to make Face data available to the Player in deterministic runtime-build output before any dynamic rendering, lamp animation, display emulation, reels, buttons, shaders, or material replacement is introduced.
+
+## End-to-end target flow
+
+```text
+Cabinet3D Asset
+    ↓
+Assigned Face assets
+    ↓
+Editor runtime build
+    ↓
+Generated machine build includes cabinet + faces
+    ↓
+Launch Oasis Player
+    ↓
+Player loads runtime manifest
+    ↓
+Player loads Cabinet GLB
+    ↓
+Player loads Face runtime manifests and static textures
+    ↓
+Later tasks instantiate static Face surfaces
+```
+
+## Phase boundaries
+
+- Keep the existing versioned runtime manifest approach.
+- Treat the Editor-generated build folder as the contract consumed by the Player.
+- Export only data needed to reconstruct the Face at runtime.
+- Do not alter Unity materials during Task 01.
+- Do not implement lamp rendering, display rendering, reels, buttons, shaders, emulation, or dynamic updates in Task 01.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_01_RUNTIME_FACE_EXPORT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_01_RUNTIME_FACE_EXPORT.md
@@ -1,0 +1,46 @@
+# Task 01: Runtime Face Export
+
+## Objective
+
+Extend the Editor runtime build so every Face asset referenced by the machine is exported into the generated Oasis Player build.
+
+## Required output
+
+Each referenced Face must be copied into the machine build under a deterministic folder:
+
+```text
+Generated/Builds/<MachineName>/
+    machine.runtime.json
+    cabinet/
+        cabinet.runtime.json
+        cabinet.glb
+    faces/
+        <FaceAssetName>/
+            face.runtime.json
+            artwork.png
+            mask.png
+            trayId.png
+            lampIds0.png
+            lampWeights0.png
+            trayId_debug.png
+            lampWeights_debug.png
+```
+
+## Manifest contract
+
+`machine.runtime.json` remains schema/versioned and must list exported faces with:
+
+- `faceId`
+- `assetName`
+- `cabinetFaceTargetId`
+- project-build-relative `manifest` path
+
+Each `face.runtime.json` remains independently versioned and includes dimensions, artwork and mask image filenames, runtime texture filenames, and existing metadata needed for later reconstruction.
+
+## Non-goals
+
+- No Player loading implementation.
+- No runtime rendering implementation.
+- No Unity material changes.
+- No lamp/display/reel/button behavior.
+- No emulation integration.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
@@ -1,0 +1,5 @@
+# Task 02: Player Face Loading
+
+Load the Phase 2 Task 01 Face entries from `machine.runtime.json` and deserialize each referenced `face.runtime.json` in Oasis Player.
+
+Do not render Faces in this task beyond validating that data is loadable and errors are reported clearly.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
@@ -1,5 +1,43 @@
 # Task 02: Player Face Loading
 
+## Objective
+
 Load the Phase 2 Task 01 Face entries from `machine.runtime.json` and deserialize each referenced `face.runtime.json` in Oasis Player.
 
-Do not render Faces in this task beyond validating that data is loadable and errors are reported clearly.
+This task reconstructs an in-memory runtime Face model only. It must not render Faces.
+
+## Required behaviour
+
+After cabinet instantiation, the Player should:
+
+1. read Face references from `machine.runtime.json`;
+2. load each `face.runtime.json`;
+3. validate supported Face manifest schema versions;
+4. resolve referenced artwork and mask files inside the runtime build;
+5. locate the cabinet target mesh using the existing `OasisFace_` naming convention;
+6. create a `RuntimeFace` object; and
+7. register the Face with the loaded `RuntimeMachine`.
+
+## Validation behaviour
+
+Non-fatal Face issues should produce warnings and continue loading remaining Faces:
+
+- missing `face.runtime.json`
+- unsupported Face schema version
+- malformed Face manifest
+- missing artwork
+- missing mask
+- duplicate Face identifiers
+- duplicate cabinet target assignments
+- missing target mesh
+
+Fatal cabinet/machine build failures remain handled by the existing machine and cabinet loading path.
+
+## Non-goals
+
+- No RenderTextures.
+- No material replacement.
+- No shader work.
+- No lamp/reel/display/button rendering.
+- No emulation integration.
+- No Unity scene changes.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_03_STATIC_FACE_RENDERING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_03_STATIC_FACE_RENDERING.md
@@ -1,0 +1,5 @@
+# Task 03: Static Face Rendering
+
+Instantiate static Face surfaces on detected cabinet face targets using exported artwork and mask images.
+
+This task should not implement lamp animation, display rendering, reels, buttons, emulation, or shader-driven behavior.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_04_FACE_RENDERER_INFRASTRUCTURE.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_04_FACE_RENDERER_INFRASTRUCTURE.md
@@ -1,0 +1,5 @@
+# Task 04: Face Renderer Infrastructure
+
+Introduce Player-side infrastructure needed for future dynamic Face rendering while keeping behavior static until later phases.
+
+Future systems may include texture binding, renderer lifetimes, and update hooks, but this task must preserve the runtime build contract established by Task 01.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using System.Text.Json;
 using OasisEditor.Features.CabinetEditor.Models;
+using SkiaSharp;
 
 namespace OasisEditor.Tests;
 
@@ -27,7 +28,8 @@ public sealed class MachineRuntimeBuildServiceTests
         Assert.Equal([1, 2, 3], File.ReadAllBytes(Path.Combine(result.BuildRoot!, "cabinet", "cabinet.glb")));
         using var machine = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot, "machine.runtime.json")));
         Assert.Equal("oasis.machine.runtime", machine.RootElement.GetProperty("schema").GetString());
-        Assert.Equal(1, machine.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(2, machine.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Empty(machine.RootElement.GetProperty("faces").EnumerateArray());
         Assert.Equal("TestProject", machine.RootElement.GetProperty("machineId").GetString());
         Assert.Equal("cabinet/cabinet.runtime.json", machine.RootElement.GetProperty("cabinetManifest").GetString());
         using var cabinet = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot, "cabinet", "cabinet.runtime.json")));
@@ -37,6 +39,43 @@ public sealed class MachineRuntimeBuildServiceTests
         Assert.Equal("cabinet.glb", cabinet.RootElement.GetProperty("glb").GetString());
         Assert.Equal(2.5, cabinet.RootElement.GetProperty("scale").GetDouble());
         Assert.Equal("Z", cabinet.RootElement.GetProperty("upAxis").GetString());
+    }
+
+    [Fact]
+    public void BuildFromCabinetDocument_ExportsAssignedFacesIntoRuntimeBuild()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var cabinetDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Cabinet3D", "Test Cabinet")).FullName;
+        var sourceGlb = Path.Combine(cabinetDir, "source.glb");
+        File.WriteAllBytes(sourceGlb, [1, 2, 3]);
+        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("source.glb")));
+        var faceDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Faces", "Front Face")).FullName;
+        WriteSolidPng(Path.Combine(faceDir, "artwork.png"), 4, 4, SKColors.Red);
+        WriteSolidPng(Path.Combine(faceDir, "mask.png"), 4, 4, SKColors.White);
+        var faceDocument = CreateFaceDocument("target-front", "Assets/Faces/Front Face/artwork.png", "Assets/Faces/Front Face/mask.png");
+        File.WriteAllText(Path.Combine(faceDir, ProjectAssetPathService.FaceManifestFileName), FaceDocumentStorage.Serialize(faceDocument));
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName));
+
+        Assert.True(result.Success, result.ErrorMessage);
+        var faceBuildDirectory = Path.Combine(result.BuildRoot!, "faces", "Front Face");
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "face.runtime.json")));
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "artwork.png")));
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "mask.png")));
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "trayId.png")));
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "lampIds0.png")));
+        Assert.True(File.Exists(Path.Combine(faceBuildDirectory, "lampWeights0.png")));
+        using var machine = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot, "machine.runtime.json")));
+        var face = Assert.Single(machine.RootElement.GetProperty("faces").EnumerateArray());
+        Assert.Equal("face-runtime", face.GetProperty("faceId").GetString());
+        Assert.Equal("Front Face", face.GetProperty("assetName").GetString());
+        Assert.Equal("target-front", face.GetProperty("cabinetFaceTargetId").GetString());
+        Assert.Equal("faces/Front Face/face.runtime.json", face.GetProperty("manifest").GetString());
+        using var faceManifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(faceBuildDirectory, "face.runtime.json")));
+        Assert.Equal(1, faceManifest.RootElement.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("artwork.png", faceManifest.RootElement.GetProperty("artwork").GetString());
+        Assert.Equal("mask.png", faceManifest.RootElement.GetProperty("mask").GetString());
     }
 
     [Fact]
@@ -52,6 +91,43 @@ public sealed class MachineRuntimeBuildServiceTests
 
         Assert.False(result.Success);
         Assert.Contains("GLB model was not found", result.ErrorMessage);
+    }
+
+    private static FaceDocumentModel CreateFaceDocument(string targetId, string artworkPath, string maskPath)
+    {
+        return new FaceDocumentModel
+        {
+            Id = "face-runtime",
+            Title = "Front Face",
+            AssignedCabinetFaceTargetId = targetId,
+            SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
+            MaskLayer = new FaceMaskLayerModel { AssetPath = maskPath, Width = 4, Height = 4 },
+            Elements =
+            [
+                new FaceArtworkElement
+                {
+                    ObjectId = "artwork",
+                    Name = "Artwork",
+                    X = 0,
+                    Y = 0,
+                    Width = 4,
+                    Height = 4,
+                    IsVisible = true,
+                    AssetPath = artworkPath
+                }
+            ]
+        };
+    }
+
+    private static void WriteSolidPng(string path, int width, int height, SKColor color)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        bitmap.Erase(color);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
     }
 
     private static EditorProject CreateProject(string root)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
@@ -18,7 +18,7 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
     public const string CabinetGlbFileName = "cabinet.glb";
     public const string MachineSchema = "oasis.machine.runtime";
     public const string CabinetSchema = "oasis.cabinet.runtime";
-    public const int MachineSchemaVersion = 1;
+    public const int MachineSchemaVersion = 2;
     public const int CabinetSchemaVersion = 1;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -29,10 +29,12 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
     };
 
     private readonly ProjectAssetPathService _pathService;
+    private readonly FaceRuntimeExportService _faceRuntimeExportService;
 
-    public MachineRuntimeBuildService(ProjectAssetPathService? pathService = null)
+    public MachineRuntimeBuildService(ProjectAssetPathService? pathService = null, FaceRuntimeExportService? faceRuntimeExportService = null)
     {
         _pathService = pathService ?? new ProjectAssetPathService();
+        _faceRuntimeExportService = faceRuntimeExportService ?? new FaceRuntimeExportService();
     }
 
     public MachineRuntimeBuildResult BuildFromCabinetDocument(EditorProject project, string cabinetManifestPath)
@@ -53,14 +55,15 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
             var cabinetRoot = Path.Combine(stagingRoot, CabinetDirectoryName);
             Directory.CreateDirectory(cabinetRoot);
             File.Copy(sourceGlb, Path.Combine(cabinetRoot, CabinetGlbFileName), overwrite: true);
+            var faceReferences = ExportReferencedFaces(project, stagingRoot);
             var cabinetManifest = new CabinetRuntimeManifest(CabinetSchema, CabinetSchemaVersion, cabinetAssetName, CabinetGlbFileName, cabinetDocument.Model.Scale, cabinetDocument.Model.UpAxis);
             File.WriteAllText(Path.Combine(cabinetRoot, CabinetManifestFileName), JsonSerializer.Serialize(cabinetManifest, JsonOptions));
-            var machineManifest = new MachineRuntimeManifest(MachineSchema, MachineSchemaVersion, project.Name, project.Name, ProjectAssetPathService.NormalizeProjectRelativePath(Path.Combine(CabinetDirectoryName, CabinetManifestFileName)));
+            var machineManifest = new MachineRuntimeManifest(MachineSchema, MachineSchemaVersion, project.Name, project.Name, ProjectAssetPathService.NormalizeProjectRelativePath(Path.Combine(CabinetDirectoryName, CabinetManifestFileName)), faceReferences);
             File.WriteAllText(Path.Combine(stagingRoot, MachineManifestFileName), JsonSerializer.Serialize(machineManifest, JsonOptions));
             ReplaceFinalDirectory(stagingRoot, buildRoot);
             return MachineRuntimeBuildResult.Ok(buildRoot);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
         {
             return MachineRuntimeBuildResult.Fail($"Failed to build Oasis Player runtime output: {ex.Message}");
         }
@@ -69,6 +72,54 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
             if (Directory.Exists(stagingRoot)) Directory.Delete(stagingRoot, recursive: true);
         }
     }
+
+    private IReadOnlyList<MachineRuntimeFaceReference> ExportReferencedFaces(EditorProject project, string stagingRoot)
+    {
+        var faceRoot = _pathService.GetAssetTypeDirectory(project, EditorAssetType.Face);
+        if (!Directory.Exists(faceRoot)) return Array.Empty<MachineRuntimeFaceReference>();
+
+        var references = new List<MachineRuntimeFaceReference>();
+        foreach (var manifestPath in Directory.EnumerateFiles(faceRoot, ProjectAssetPathService.FaceManifestFileName, SearchOption.AllDirectories).OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+        {
+            if (!FaceDocumentStorage.TryReadValidated(File.ReadAllText(manifestPath), out var faceFile, out _))
+            {
+                throw new InvalidOperationException($"Face manifest is invalid: {manifestPath}");
+            }
+
+            var faceDocument = FaceDocumentStorage.ToModel(faceFile);
+            var targetId = NormalizeOptional(faceDocument.AssignedCabinetFaceTargetId);
+            if (targetId is null) continue;
+
+            var faceAssetName = ProjectAssetPathService.GetPackageAssetNameFromManifestPath(manifestPath, EditorAssetType.Face);
+            if (string.IsNullOrWhiteSpace(faceAssetName))
+            {
+                throw new InvalidOperationException($"Face manifests must be stored as Assets/Faces/<AssetName>/{ProjectAssetPathService.FaceManifestFileName}: {manifestPath}");
+            }
+
+            var exportResult = _faceRuntimeExportService.Export(faceDocument, project, manifestPath);
+            var buildFaceDirectory = Path.Combine(stagingRoot, "faces", _pathService.SanitizePathSegment(faceAssetName));
+            CopyDirectory(exportResult.OutputDirectory, buildFaceDirectory);
+            references.Add(new MachineRuntimeFaceReference(
+                faceDocument.Id,
+                faceAssetName,
+                targetId,
+                ProjectAssetPathService.NormalizeProjectRelativePath(Path.Combine("faces", _pathService.SanitizePathSegment(faceAssetName), FaceRuntimeExportService.ManifestFileName))));
+        }
+
+        return references;
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+    {
+        if (Directory.Exists(destinationDirectory)) Directory.Delete(destinationDirectory, recursive: true);
+        Directory.CreateDirectory(destinationDirectory);
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory).OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+        {
+            File.Copy(file, Path.Combine(destinationDirectory, Path.GetFileName(file)), overwrite: true);
+        }
+    }
+
+    private static string? NormalizeOptional(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     public string GetBuildRoot(EditorProject project, string machineName) => Path.Combine(project.GeneratedDirectory, "Builds", _pathService.SanitizePathSegment(machineName));
     private static string ResolveCabinetModelPath(string manifestPath, string modelPath) => Path.IsPathFullyQualified(modelPath) ? Path.GetFullPath(modelPath) : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(manifestPath) ?? string.Empty, modelPath));
@@ -82,5 +133,6 @@ public sealed record MachineRuntimeBuildResult(bool Success, string? BuildRoot, 
     public static MachineRuntimeBuildResult Fail(string errorMessage) => new(false, null, errorMessage);
 }
 
-public sealed record MachineRuntimeManifest(string Schema, int SchemaVersion, string MachineId, string DisplayName, string CabinetManifest);
+public sealed record MachineRuntimeManifest(string Schema, int SchemaVersion, string MachineId, string DisplayName, string CabinetManifest, IReadOnlyList<MachineRuntimeFaceReference> Faces);
+public sealed record MachineRuntimeFaceReference(string FaceId, string AssetName, string CabinetFaceTargetId, string Manifest);
 public sealed record CabinetRuntimeManifest(string Schema, int SchemaVersion, string CabinetId, string Glb, double Scale, string UpAxis);


### PR DESCRIPTION
### Motivation

- Establish Phase 2 runtime contract so Face assets assigned to a Cabinet are deterministically included in Editor-generated machine builds for later Player consumption. 
- Keep Phase 1 cabinet export behavior unchanged while adding a minimal, deterministic Face export step that does not implement any Player-side loading or rendering. 

### Description

- Added Phase 2 planning docs under `WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/` and updated `00_CURRENT_PRIORITY.md` to focus work on Task 01 runtime Face export. 
- Extended `MachineRuntimeBuildService` to bump the machine manifest `schemaVersion` to `2`, integrate `FaceRuntimeExportService`, export assigned Face packages into `faces/<FaceAssetName>/` inside the staging build, and include a `faces` array in `machine.runtime.json` containing `faceId`, `assetName`, `cabinetFaceTargetId`, and build-relative `manifest` path. 
- Added deterministic copy helpers (`ExportReferencedFaces`, `CopyDirectory`) and a small `MachineRuntimeFaceReference` record to represent the new machine manifest face entries. 
- Added test coverage in `OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs` for the new manifest schema v2 (empty faces) and for the face-export behavior that verifies exported `face.runtime.json`, artwork, mask, and runtime texture files are present under the build `faces/<FaceAssetName>/` folder. 

Runtime layout produced by the change:

`Generated/Builds/<MachineName>/` contains `machine.runtime.json`, `cabinet/` (with `cabinet.runtime.json` and `cabinet.glb`), and `faces/<FaceAssetName>/` folders containing `face.runtime.json`, `artwork.png`, `mask.png`, and the runtime texture files produced by the existing `FaceRuntimeExportService`. 

Assumptions:

- Only Face packages with a non-empty `AssignedCabinetFaceTargetId` are exported for Task 01. 
- `FaceRuntimeExportService` remains authoritative for creating each Face runtime package; the build step copies that package into the machine build. 

Files changed:

- `WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md` (updated)
- `WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/*` (new planning and task docs)
- `WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs` (modified)
- `WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs` (tests added/updated)

### Testing

- Added unit tests in `OasisEditor.Tests/MachineRuntimeBuildServiceTests` that assert `machine.runtime.json` schema v2 behavior and that assigned Face assets are exported into the build; these tests were added to the repository but were not executed in this environment due to the repo guidance that the Codex environment lacks the Windows/.NET/WPF toolchain. 
- Ran `git diff --check` to validate the working tree and found no whitespace or diff-check issues. 
- Local verification steps for maintainers: run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` and exercise `File > Build Oasis Player Machine` in the WPF editor to validate generated `Generated/Builds/<MachineName>/faces/<FaceAssetName>/` contents and `machine.runtime.json` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5caf5df99c83279c247537008304f0)