### PR TITLE
Phase 2 Task 03 — Static Face Rendering: runtime renderer, material factory, and tests

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
@@ -10,18 +10,25 @@ namespace OasisPlayer.Loading
     {
         private readonly ICabinetModelLoader _modelLoader;
         private readonly RuntimeFaceLoader _faceLoader;
+        private readonly RuntimeFaceRenderer _faceRenderer;
         private GameObject _current;
         private RuntimeMachine _runtimeMachine;
 
         public MachinePreviewLoader(ICabinetModelLoader modelLoader)
-            : this(modelLoader, new RuntimeFaceLoader(new PngRuntimeTextureAssetLoader()))
+            : this(modelLoader, new RuntimeFaceLoader(new PngRuntimeTextureAssetLoader()), new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory()))
         {
         }
 
         public MachinePreviewLoader(ICabinetModelLoader modelLoader, RuntimeFaceLoader faceLoader)
+            : this(modelLoader, faceLoader, new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory()))
+        {
+        }
+
+        public MachinePreviewLoader(ICabinetModelLoader modelLoader, RuntimeFaceLoader faceLoader, RuntimeFaceRenderer faceRenderer)
         {
             _modelLoader = modelLoader;
             _faceLoader = faceLoader;
+            _faceRenderer = faceRenderer;
         }
 
         public async Task<RuntimeMachine> LoadAsync(ResolvedRuntimeBuild build)
@@ -46,6 +53,7 @@ namespace OasisPlayer.Loading
             var machine = new RuntimeMachine(build, cabinet);
             _runtimeMachine = machine;
             _faceLoader.LoadFaces(machine);
+            _faceRenderer.RenderFaces(machine);
             foreach (var warning in machine.Warnings) Debug.LogWarning(warning);
             return machine;
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/OasisPlayer.RuntimeBuild.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/OasisPlayer.RuntimeBuild.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "OasisPlayer.RuntimeBuild",
+    "rootNamespace": "OasisPlayer.RuntimeBuild",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/OasisPlayer.RuntimeBuild.asmdef.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/OasisPlayer.RuntimeBuild.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac3e9730e61947e895283482bd04be2e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
@@ -57,9 +57,21 @@ namespace OasisPlayer.RuntimeBuild
         public Transform CabinetTarget { get; private set; }
         public RuntimeTextureAsset Artwork { get; private set; }
         public RuntimeTextureAsset Mask { get; private set; }
+        public RuntimeFaceRenderBinding RenderBinding { get; private set; }
+
+        public void SetRenderBinding(RuntimeFaceRenderBinding renderBinding)
+        {
+            RenderBinding = renderBinding;
+        }
 
         public void UnloadAssets()
         {
+            if (RenderBinding != null)
+            {
+                RenderBinding.Dispose();
+                RenderBinding = null;
+            }
+
             if (Artwork != null) Artwork.Unload();
             if (Mask != null) Mask.Unload();
         }
@@ -80,7 +92,8 @@ namespace OasisPlayer.RuntimeBuild
         {
             if (Texture != null)
             {
-                UnityEngine.Object.Destroy(Texture);
+                if (Application.isPlaying) UnityEngine.Object.Destroy(Texture);
+                else UnityEngine.Object.DestroyImmediate(Texture);
                 Texture = null;
             }
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -1,0 +1,218 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public sealed class RuntimeFaceRenderer
+    {
+        private readonly RuntimeFaceMaterialFactory _materialFactory;
+
+        public RuntimeFaceRenderer(RuntimeFaceMaterialFactory materialFactory)
+        {
+            _materialFactory = materialFactory ?? throw new ArgumentNullException(nameof(materialFactory));
+        }
+
+        public void RenderFaces(RuntimeMachine machine)
+        {
+            if (machine == null) throw new ArgumentNullException(nameof(machine));
+
+            foreach (var face in machine.Faces)
+            {
+                if (!TryRender(face, out var warning)) machine.AddWarning(warning);
+            }
+        }
+
+        public bool TryRender(RuntimeFace face, out string warning)
+        {
+            warning = string.Empty;
+            if (face == null)
+            {
+                warning = "Runtime Face rendering skipped because the Face was null.";
+                return false;
+            }
+
+            if (face.RenderBinding != null)
+            {
+                warning = $"Runtime Face '{FaceId(face)}' was already rendered; duplicate render request was skipped.";
+                return false;
+            }
+
+            if (face.Artwork == null || face.Artwork.Texture == null)
+            {
+                warning = $"Runtime Face '{FaceId(face)}' has no valid artwork texture.";
+                return false;
+            }
+
+            if (!TryResolveRenderer(face, out var renderer, out warning)) return false;
+            if (!TryResolveMaterialSlot(face, renderer, out var slotIndex, out warning)) return false;
+            if (!_materialFactory.TryCreate(face, out var runtimeMaterial, out warning)) return false;
+
+            var originalMaterials = renderer.sharedMaterials;
+            var replacementMaterials = (Material[])originalMaterials.Clone();
+            replacementMaterials[slotIndex] = runtimeMaterial;
+            renderer.sharedMaterials = replacementMaterials;
+
+            face.SetRenderBinding(new RuntimeFaceRenderBinding(renderer, originalMaterials, slotIndex, runtimeMaterial, null));
+            return true;
+        }
+
+        private static bool TryResolveRenderer(RuntimeFace face, out Renderer renderer, out string warning)
+        {
+            renderer = null;
+            warning = string.Empty;
+            if (face.CabinetTarget == null)
+            {
+                warning = $"Runtime Face '{FaceId(face)}' has no resolved cabinet target.";
+                return false;
+            }
+
+            var renderers = face.CabinetTarget.GetComponentsInChildren<Renderer>(true);
+            var usableCount = 0;
+            for (var i = 0; i < renderers.Length; i++)
+            {
+                if (renderers[i] == null || renderers[i] is SkinnedMeshRenderer) continue;
+                renderer = renderers[i];
+                usableCount++;
+            }
+
+            if (usableCount == 1) return true;
+            renderer = null;
+            warning = usableCount == 0
+                ? $"Cabinet target '{TargetId(face)}' for Runtime Face '{FaceId(face)}' has no usable renderer."
+                : $"Cabinet target '{TargetId(face)}' for Runtime Face '{FaceId(face)}' has {usableCount} usable renderers; static Face rendering skipped to avoid ambiguous material replacement.";
+            return false;
+        }
+
+        private static bool TryResolveMaterialSlot(RuntimeFace face, Renderer renderer, out int slotIndex, out string warning)
+        {
+            slotIndex = -1;
+            warning = string.Empty;
+            var materials = renderer.sharedMaterials;
+            if (materials == null || materials.Length == 0)
+            {
+                warning = $"Cabinet target '{TargetId(face)}' for Runtime Face '{FaceId(face)}' has no material slots.";
+                return false;
+            }
+
+            if (materials.Length == 1)
+            {
+                slotIndex = 0;
+                return true;
+            }
+
+            warning = $"Cabinet target '{TargetId(face)}' for Runtime Face '{FaceId(face)}' has {materials.Length} material slots; static Face rendering skipped because the intended slot cannot be determined safely.";
+            return false;
+        }
+
+        private static string FaceId(RuntimeFace face)
+        {
+            return face.Reference != null && !string.IsNullOrWhiteSpace(face.Reference.faceId) ? face.Reference.faceId.Trim() : "<unknown>";
+        }
+
+        private static string TargetId(RuntimeFace face)
+        {
+            return face.Reference != null && !string.IsNullOrWhiteSpace(face.Reference.cabinetFaceTargetId) ? face.Reference.cabinetFaceTargetId.Trim() : "<unknown>";
+        }
+    }
+
+    public sealed class RuntimeFaceMaterialFactory
+    {
+        public const string BaseMapProperty = "_BaseMap";
+        public const string MainTexProperty = "_MainTex";
+
+        public bool TryCreate(RuntimeFace face, out Material material, out string warning)
+        {
+            material = null;
+            warning = string.Empty;
+            if (face == null || face.Artwork == null || face.Artwork.Texture == null)
+            {
+                warning = "Runtime Face material creation failed because artwork texture is invalid.";
+                return false;
+            }
+
+            var shader = Shader.Find("Universal Render Pipeline/Lit");
+            if (shader == null) shader = Shader.Find("Standard");
+            if (shader == null)
+            {
+                warning = $"Runtime Face '{(face.Reference != null ? face.Reference.faceId : "<unknown>")}' could not render because no compatible Lit shader was available.";
+                return false;
+            }
+
+            material = new Material(shader);
+            material.name = $"RuntimeFace_{(face.Reference != null ? face.Reference.faceId : "Face")}_Static";
+            AssignTexture(material, face.Artwork.Texture);
+            ConfigureColor(material);
+            ConfigureTransparency(material);
+            return true;
+        }
+
+        private static void ConfigureColor(Material material)
+        {
+            if (material.HasProperty("_BaseColor")) material.SetColor("_BaseColor", Color.white);
+            if (material.HasProperty("_Color")) material.SetColor("_Color", Color.white);
+        }
+
+        private static void ConfigureTransparency(Material material)
+        {
+            if (material.HasProperty("_Surface")) material.SetFloat("_Surface", 1f);
+            if (material.HasProperty("_Blend")) material.SetFloat("_Blend", 0f);
+            if (material.HasProperty("_SrcBlend")) material.SetFloat("_SrcBlend", (float)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            if (material.HasProperty("_DstBlend")) material.SetFloat("_DstBlend", (float)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            if (material.HasProperty("_ZWrite")) material.SetFloat("_ZWrite", 0f);
+            material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
+            material.EnableKeyword("_ALPHABLEND_ON");
+            material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+        }
+
+        private static void AssignTexture(Material material, Texture texture)
+        {
+            if (material.HasProperty(BaseMapProperty)) material.SetTexture(BaseMapProperty, texture);
+            if (material.HasProperty(MainTexProperty)) material.SetTexture(MainTexProperty, texture);
+            SetScaleOffset(material, BaseMapProperty);
+            SetScaleOffset(material, MainTexProperty);
+        }
+
+        private static void SetScaleOffset(Material material, string propertyName)
+        {
+            if (!material.HasProperty(propertyName)) return;
+            material.SetTextureScale(propertyName, Vector2.one);
+            material.SetTextureOffset(propertyName, Vector2.zero);
+        }
+    }
+
+    public sealed class RuntimeFaceRenderBinding
+    {
+        public RuntimeFaceRenderBinding(Renderer renderer, Material[] originalMaterials, int materialSlotIndex, Material runtimeMaterial, Texture2D generatedTexture)
+        {
+            Renderer = renderer;
+            OriginalMaterials = originalMaterials != null ? (Material[])originalMaterials.Clone() : Array.Empty<Material>();
+            MaterialSlotIndex = materialSlotIndex;
+            RuntimeMaterial = runtimeMaterial;
+            GeneratedTexture = generatedTexture;
+        }
+
+        public Renderer Renderer { get; private set; }
+        public Material[] OriginalMaterials { get; private set; }
+        public int MaterialSlotIndex { get; private set; }
+        public Material RuntimeMaterial { get; private set; }
+        public Texture2D GeneratedTexture { get; private set; }
+
+        public void Dispose()
+        {
+            if (Renderer != null && OriginalMaterials != null) Renderer.sharedMaterials = (Material[])OriginalMaterials.Clone();
+            DestroyOwned(RuntimeMaterial);
+            DestroyOwned(GeneratedTexture);
+            Renderer = null;
+            OriginalMaterials = Array.Empty<Material>();
+            RuntimeMaterial = null;
+            GeneratedTexture = null;
+        }
+
+        private static void DestroyOwned(UnityEngine.Object obj)
+        {
+            if (obj == null) return;
+            if (Application.isPlaying) UnityEngine.Object.Destroy(obj);
+            else UnityEngine.Object.DestroyImmediate(obj);
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -143,6 +143,7 @@ namespace OasisPlayer.RuntimeBuild
             AssignTexture(material, face.Artwork.Texture);
             ConfigureColor(material);
             ConfigureTransparency(material);
+            ConfigureCulling(material);
             return true;
         }
 
@@ -150,6 +151,12 @@ namespace OasisPlayer.RuntimeBuild
         {
             if (material.HasProperty("_BaseColor")) material.SetColor("_BaseColor", Color.white);
             if (material.HasProperty("_Color")) material.SetColor("_Color", Color.white);
+        }
+
+        private static void ConfigureCulling(Material material)
+        {
+            if (!material.HasProperty("_Cull")) return;
+            material.SetFloat("_Cull", (float)UnityEngine.Rendering.CullMode.Off);
         }
 
         private static void ConfigureTransparency(Material material)

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99f5b8084c6c4aa483e94d6d1cc3c0ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef288e4b914049ef81e5ca7261c688ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bd8570bd29a41c3a77e017b7de9fb28
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
@@ -2,7 +2,7 @@
     "name": "OasisPlayer.EditMode.Tests",
     "rootNamespace": "OasisPlayer.Tests",
     "references": [
-        "Assembly-CSharp"
+        "OasisPlayer.RuntimeBuild"
     ],
     "includePlatforms": [
         "Editor"

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "OasisPlayer.EditMode.Tests",
+    "rootNamespace": "OasisPlayer.Tests",
+    "references": [
+        "Assembly-CSharp"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6f98b5f8b9649e28251ae80f5676ff4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
@@ -1,0 +1,167 @@
+using NUnit.Framework;
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+
+namespace OasisPlayer.Tests
+{
+    public sealed class RuntimeFaceRendererTests
+    {
+        [Test]
+        public void ValidRuntimeFaceProducesBindingAndDoesNotMutateSharedMaterial()
+        {
+            var target = new GameObject("OasisFace_Front");
+            var sharedMaterial = new Material(Shader.Find("Standard"));
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var mask = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+
+            try
+            {
+                var renderer = target.AddComponent<MeshRenderer>();
+                renderer.sharedMaterial = sharedMaterial;
+                var face = CreateFace(target.transform, texture, mask);
+                var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+
+                var rendered = sut.TryRender(face, out var warning);
+
+                Assert.True(rendered, warning);
+                Assert.NotNull(face.RenderBinding);
+                Assert.AreSame(renderer, face.RenderBinding.Renderer);
+                Assert.AreSame(sharedMaterial, face.RenderBinding.OriginalMaterials[0]);
+                Assert.AreNotSame(sharedMaterial, renderer.sharedMaterials[0]);
+                var runtimeMaterial = renderer.sharedMaterials[0];
+                var textureProperty = runtimeMaterial.HasProperty(RuntimeFaceMaterialFactory.BaseMapProperty)
+                    ? RuntimeFaceMaterialFactory.BaseMapProperty
+                    : RuntimeFaceMaterialFactory.MainTexProperty;
+                Assert.AreSame(texture, runtimeMaterial.GetTexture(textureProperty));
+                Assert.AreEqual(Vector2.one, runtimeMaterial.GetTextureScale(textureProperty));
+                Assert.AreEqual(Vector2.zero, runtimeMaterial.GetTextureOffset(textureProperty));
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                Object.DestroyImmediate(sharedMaterial);
+                Object.DestroyImmediate(texture);
+                Object.DestroyImmediate(mask);
+            }
+        }
+
+        [Test]
+        public void TargetWithoutRendererReportsWarning()
+        {
+            var target = new GameObject("OasisFace_Front");
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var mask = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+
+            try
+            {
+                var face = CreateFace(target.transform, texture, mask);
+                var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+
+                var rendered = sut.TryRender(face, out var warning);
+
+                Assert.False(rendered);
+                Assert.That(warning, Does.Contain("has no usable renderer"));
+                Assert.Null(face.RenderBinding);
+            }
+            finally
+            {
+                Object.DestroyImmediate(target);
+                Object.DestroyImmediate(texture);
+                Object.DestroyImmediate(mask);
+            }
+        }
+
+        [Test]
+        public void MultipleFacesRenderIndependentlyAndCleanupRestoresOriginalMaterials()
+        {
+            var first = CreateTarget("OasisFace_First");
+            var second = CreateTarget("OasisFace_Second");
+            var firstOriginal = first.GetComponent<MeshRenderer>().sharedMaterial;
+            var secondOriginal = second.GetComponent<MeshRenderer>().sharedMaterial;
+            var firstTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var secondTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var firstMask = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var secondMask = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+
+            try
+            {
+                var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+                var firstFace = CreateFace(first.transform, firstTexture, firstMask, "first");
+                var secondFace = CreateFace(second.transform, secondTexture, secondMask, "second");
+
+                Assert.True(sut.TryRender(firstFace, out var firstWarning), firstWarning);
+                Assert.True(sut.TryRender(secondFace, out var secondWarning), secondWarning);
+                Assert.AreNotSame(first.GetComponent<MeshRenderer>().sharedMaterial, second.GetComponent<MeshRenderer>().sharedMaterial);
+
+                firstFace.RenderBinding.Dispose();
+                secondFace.RenderBinding.Dispose();
+
+                Assert.AreSame(firstOriginal, first.GetComponent<MeshRenderer>().sharedMaterial);
+                Assert.AreSame(secondOriginal, second.GetComponent<MeshRenderer>().sharedMaterial);
+            }
+            finally
+            {
+                Object.DestroyImmediate(firstOriginal);
+                Object.DestroyImmediate(secondOriginal);
+                Object.DestroyImmediate(first);
+                Object.DestroyImmediate(second);
+                Object.DestroyImmediate(firstTexture);
+                Object.DestroyImmediate(secondTexture);
+                Object.DestroyImmediate(firstMask);
+                Object.DestroyImmediate(secondMask);
+            }
+        }
+
+        [Test]
+        public void AmbiguousMaterialSlotsWarnWithoutReplacingMaterials()
+        {
+            var target = CreateTarget("OasisFace_Front");
+            var renderer = target.GetComponent<MeshRenderer>();
+            var first = renderer.sharedMaterial;
+            var second = new Material(Shader.Find("Standard"));
+            renderer.sharedMaterials = new[] { first, second };
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            var mask = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+
+            try
+            {
+                var face = CreateFace(target.transform, texture, mask);
+                var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+
+                var rendered = sut.TryRender(face, out var warning);
+
+                Assert.False(rendered);
+                Assert.That(warning, Does.Contain("material slots"));
+                Assert.AreSame(first, renderer.sharedMaterials[0]);
+                Assert.AreSame(second, renderer.sharedMaterials[1]);
+            }
+            finally
+            {
+                Object.DestroyImmediate(first);
+                Object.DestroyImmediate(second);
+                Object.DestroyImmediate(target);
+                Object.DestroyImmediate(texture);
+                Object.DestroyImmediate(mask);
+            }
+        }
+
+        private static GameObject CreateTarget(string name)
+        {
+            var target = new GameObject(name);
+            var renderer = target.AddComponent<MeshRenderer>();
+            renderer.sharedMaterial = new Material(Shader.Find("Standard"));
+            target.AddComponent<MeshFilter>();
+            return target;
+        }
+
+        private static RuntimeFace CreateFace(Transform target, Texture2D texture, Texture2D mask, string id = "front")
+        {
+            return new RuntimeFace(
+                new MachineRuntimeFaceReference { faceId = id, cabinetFaceTargetId = "front" },
+                new FaceRuntimeManifest { schemaVersion = 1, faceId = id, width = 1, height = 1, artwork = "artwork.png", mask = "mask.png" },
+                target,
+                new RuntimeTextureAsset("artwork.png", texture),
+                new RuntimeTextureAsset("mask.png", mask));
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
@@ -35,6 +35,10 @@ namespace OasisPlayer.Tests
                 Assert.AreSame(texture, runtimeMaterial.GetTexture(textureProperty));
                 Assert.AreEqual(Vector2.one, runtimeMaterial.GetTextureScale(textureProperty));
                 Assert.AreEqual(Vector2.zero, runtimeMaterial.GetTextureOffset(textureProperty));
+                if (runtimeMaterial.HasProperty("_Cull"))
+                {
+                    Assert.AreEqual((float)UnityEngine.Rendering.CullMode.Off, runtimeMaterial.GetFloat("_Cull"));
+                }
             }
             finally
             {

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b5b344993c447979e556188f59b4d52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
+++ b/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
@@ -18,7 +18,7 @@ Priority workstream:
 
 - Oasis Player Phase 2: Face Runtime Integration
 - Player-side loading and validation of exported Face runtime assets
-- in-memory RuntimeFace model registration after cabinet instantiation
+- static RuntimeFace artwork rendering on resolved cabinet targets
 
 Primary implementation project:
 
@@ -34,10 +34,10 @@ WindowsNetProjects/OasisEditor
 
 ## Immediate Direction
 
-Implement only Phase 2 Task 02:
+Implement only Phase 2 Task 04:
 
 ```text
-Docs/OasisPlayerPhase2/TASK_02_PLAYER_FACE_LOADING.md
+Docs/OasisPlayerPhase2/TASK_04_FACE_RENDERER_INFRASTRUCTURE.md
 ```
 
 Phase 2 Task 01 is complete. Do not modify the runtime Face export contract unless a genuine defect is discovered.
@@ -46,8 +46,7 @@ Phase 2 Task 01 is complete. Do not modify the runtime Face export contract unle
 
 Do not implement in this priority:
 
-- runtime Face rendering
-- Unity material changes
+- lamp/display dynamic Face rendering
 - RenderTextures
 - mesh replacement or mesh modification
 - lamp rendering
@@ -73,3 +72,8 @@ Prefer focused tests around:
 - continued loading after invalid Face entries
 
 Do not claim WPF, Unity Player, or visual verification unless it was actually performed locally.
+
+
+## Completed Checkpoint
+
+Phase 2 Task 03 (Static Face Rendering) is implemented and ready for local Unity verification. RuntimeFaces are rendered with runtime-owned material instances on safely resolved single-renderer/single-slot OasisFace targets.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md
@@ -5,17 +5,19 @@ Read only these Phase 2 documents before implementation unless a task requires s
 1. `PHASE_02_CONTEXT.md`
 2. The task document for the requested Phase 2 task
 
-For the current checkpoint, implement only Task 02: Player Face Loading.
+For the current checkpoint, implement only Task 04: Face Renderer Infrastructure.
 
 Respect these boundaries:
 
 - Keep the versioned runtime manifest approach established by Task 01.
 - Do not modify the Task 01 runtime Face export contract unless a genuine defect is discovered.
-- Load and validate exported Face runtime manifests after cabinet instantiation.
-- Resolve artwork and mask assets through a reusable loading abstraction.
-- Resolve Face target meshes using the existing `OasisFace_` naming convention.
-- Create/register in-memory runtime Face objects for later rendering tasks.
-- Do not implement runtime Face rendering yet.
-- Do not modify Unity materials.
+- Preserve Task 03 static Face rendering.
+- Build the durable renderer infrastructure for later dynamic Face composition.
+- Do not redesign the runtime export schema unless a genuine compatibility defect is discovered.
 - Do not create RenderTextures.
 - Do not introduce lamp rendering, display rendering, reels, buttons, shaders, or emulation.
+
+
+## Completed Checkpoint
+
+Task 03: Static Face Rendering is implemented. The Player now binds loaded RuntimeFaces to resolved OasisFace targets using runtime-owned material instances and displays the exported artwork texture statically. The exported mask remains loaded and owned by RuntimeFace for later renderer infrastructure; Task 03 does not combine it into the static material.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_03_STATIC_FACE_RENDERING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase2/TASK_03_STATIC_FACE_RENDERING.md
@@ -3,3 +3,12 @@
 Instantiate static Face surfaces on detected cabinet face targets using exported artwork and mask images.
 
 This task should not implement lamp animation, display rendering, reels, buttons, emulation, or shader-driven behavior.
+
+
+## Implementation Status
+
+Implemented. Static Face rendering now occurs after Face loading: each loaded RuntimeFace is bound to a safely resolved cabinet renderer/material slot, receives a runtime-owned URP-compatible material instance, and displays its exported artwork texture using deterministic texture scale/offset. The exported mask texture remains loaded for later dynamic renderer work and is not composited in this checkpoint.
+
+## Next Checkpoint
+
+Task 04: Face Renderer Infrastructure. Do not begin Task 04 until requested.


### PR DESCRIPTION
### Motivation

- Implement the Phase 2 Task 03 checkpoint to display exported Face artwork on resolved cabinet `OasisFace_` targets without introducing lamps, displays, animation, or RenderTexture composition. 
- Keep loading/manifest contracts intact and add a focused runtime rendering layer that owns per-Face material instances and explicit cleanup so rendering cannot mutate imported shared materials.

### Description

- Add a focused renderer and helpers: `RuntimeFaceRenderer`, `RuntimeFaceMaterialFactory`, and `RuntimeFaceRenderBinding` to bind a loaded `RuntimeFace` to a resolved cabinet renderer and create a runtime-owned material instance using the already-loaded artwork texture. (see `UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs`).
- Wire rendering into the load sequence by invoking the renderer after faces are loaded in `MachinePreviewLoader`, keeping `RuntimeFaceLoader` responsible only for loading/validation and registration (`UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs`).
- Extend the runtime model so `RuntimeFace` tracks its `RenderBinding` and disposes it during `UnloadAssets`, and ensure texture destruction uses `DestroyImmediate` when not in play mode (`UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs`).
- Material/slot resolution and safety rules: resolve the renderer by searching the target hierarchy, require exactly one usable non-`SkinnedMeshRenderer` and exactly one material slot to proceed, otherwise emit a non-fatal warning and skip that Face; create a URP `Lit` (fallback `Standard`) material, assign artwork to `_BaseMap`/`_MainTex`, force scale `(1,1)`/offset `(0,0)`, and configure transparent blending to preserve artwork alpha.
- Add Unity EditMode tests that exercise binding, material isolation (runtime material instance does not mutate imported shared material), texture assignment and scale/offset, cleanup restoration of original materials, missing-renderer warning, multiple independent Face rendering, and ambiguous-material-slot warnings (`UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs`).
- Update Phase 2 planning docs to mark Task 03 implemented and make Task 04 the next checkpoint (`WindowsNetProjects/OasisEditor/...`).

### Testing

- Added Unity EditMode tests in `UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs`, but the Unity Editor test runner was not available in this environment so the NUnit tests were not executed here.
- Ran simple repository checks that do not require the Unity editor: validated the test asmdef with `python3 -m json.tool UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef` (succeeded) and ran `git diff --check` to ensure no whitespace/diff errors (succeeded).
- The new runtime test coverage is structured to run locally in Unity Editor EditMode (NUnit) and should be executed there as part of local verification; automated Unity test execution was not performed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5cb5eaa2a88327ab1d93d5fa2382a3)