### PR TITLE
Implement Phase 3 runtime face lamp state

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Loading/MachinePreviewLoader.cs
@@ -54,6 +54,12 @@ namespace OasisPlayer.Loading
             _runtimeMachine = machine;
             _faceLoader.LoadFaces(machine);
             _faceRenderer.RenderFaces(machine);
+            var updater = correctionRoot.AddComponent<RuntimeMachineLampUpdater>();
+            updater.Initialize(machine);
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            var controls = correctionRoot.AddComponent<RuntimeLampDevelopmentControls>();
+            controls.Initialize(machine);
+#endif
             foreach (var warning in machine.Warnings) Debug.LogWarning(warning);
             return machine;
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
@@ -7,17 +7,34 @@ namespace OasisPlayer.RuntimeBuild
     {
         private readonly List<RuntimeFace> _faces = new List<RuntimeFace>();
         private readonly List<string> _warnings = new List<string>();
+        private RuntimeLampStateTexture _lampStateTexture;
 
         public RuntimeMachine(ResolvedRuntimeBuild build, GameObject cabinet)
         {
             Build = build;
             Cabinet = cabinet;
+            LampState = new RuntimeLampState();
         }
 
         public ResolvedRuntimeBuild Build { get; private set; }
         public GameObject Cabinet { get; private set; }
         public IReadOnlyList<RuntimeFace> Faces { get { return _faces; } }
         public IReadOnlyList<string> Warnings { get { return _warnings; } }
+        public RuntimeLampState LampState { get; private set; }
+        public RuntimeLampStateTexture LampStateTexture
+        {
+            get
+            {
+                if (_lampStateTexture == null) _lampStateTexture = new RuntimeLampStateTexture(LampState);
+                return _lampStateTexture;
+            }
+        }
+
+        public bool ApplyDynamicState()
+        {
+            if (_lampStateTexture == null) return false;
+            return _lampStateTexture.Upload(LampState);
+        }
 
         public void RegisterFace(RuntimeFace face)
         {
@@ -34,6 +51,12 @@ namespace OasisPlayer.RuntimeBuild
             foreach (var face in _faces)
             {
                 face.UnloadAssets();
+            }
+
+            if (_lampStateTexture != null)
+            {
+                _lampStateTexture.Dispose();
+                _lampStateTexture = null;
             }
 
             _faces.Clear();

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -18,13 +18,15 @@ namespace OasisPlayer.RuntimeBuild
 
             foreach (var face in machine.Faces)
             {
-                if (!TryRender(face, out var warning)) machine.AddWarning(warning);
+                if (!TryRender(machine, face, out var warning)) machine.AddWarning(warning);
             }
         }
 
-        public bool TryRender(RuntimeFace face, out string warning)
+        public bool TryRender(RuntimeMachine machine, RuntimeFace face, out string warning)
         {
             warning = string.Empty;
+            if (machine == null) throw new ArgumentNullException(nameof(machine));
+
             if (face == null)
             {
                 warning = "Runtime Face rendering skipped because the Face was null.";
@@ -51,7 +53,7 @@ namespace OasisPlayer.RuntimeBuild
 
             if (!TryResolveRenderer(face, out var renderer, out warning)) return false;
             if (!TryResolveMaterialSlot(face, renderer, out var slotIndex, out warning)) return false;
-            if (!_materialFactory.TryCreate(face, out var runtimeMaterial, out warning)) return false;
+            if (!_materialFactory.TryCreate(face, machine.LampStateTexture, out var runtimeMaterial, out warning)) return false;
 
             var originalMaterials = renderer.sharedMaterials;
             var replacementMaterials = (Material[])originalMaterials.Clone();
@@ -135,7 +137,7 @@ namespace OasisPlayer.RuntimeBuild
             _shaderName = string.IsNullOrWhiteSpace(shaderName) ? RuntimeFaceShaderProperties.ShaderName : shaderName;
         }
 
-        public bool TryCreate(RuntimeFace face, out Material material, out string warning)
+        public bool TryCreate(RuntimeFace face, RuntimeLampStateTexture lampStateTexture, out Material material, out string warning)
         {
             material = null;
             warning = string.Empty;
@@ -155,8 +157,10 @@ namespace OasisPlayer.RuntimeBuild
             material = new Material(shader);
             material.name = $"RuntimeFace_{(face.Reference != null ? face.Reference.faceId : "Face")}_OasisFace";
             BindTextures(material, face);
+            if (lampStateTexture != null && lampStateTexture.Texture != null) AssignTexture(material, RuntimeFaceShaderProperties.LampStateTexture, lampStateTexture.Texture);
             if (material.HasProperty(RuntimeFaceShaderProperties.StaticBrightness)) material.SetFloat(RuntimeFaceShaderProperties.StaticBrightness, 1f);
             if (material.HasProperty(RuntimeFaceShaderProperties.MaskStrength)) material.SetFloat(RuntimeFaceShaderProperties.MaskStrength, 1f);
+            if (material.HasProperty(RuntimeFaceShaderProperties.EmissionStrength)) material.SetFloat(RuntimeFaceShaderProperties.EmissionStrength, 1f);
             material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
             return true;
         }
@@ -198,6 +202,14 @@ namespace OasisPlayer.RuntimeBuild
         public void MarkDynamicStateDirty()
         {
             HasDynamicState = true;
+        }
+
+        public void BindLampState(RuntimeLampStateTexture lampStateTexture)
+        {
+            if (RuntimeMaterial != null && lampStateTexture != null && lampStateTexture.Texture != null && RuntimeMaterial.HasProperty(RuntimeFaceShaderProperties.LampStateTexture))
+            {
+                RuntimeMaterial.SetTexture(RuntimeFaceShaderProperties.LampStateTexture, lampStateTexture.Texture);
+            }
         }
 
         public void ApplyDynamicState()

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
@@ -10,6 +10,8 @@ namespace OasisPlayer.RuntimeBuild
         public const string TrayIdTextureName = "_OasisTrayIdTex";
         public const string LampIds0TextureName = "_OasisLampIds0Tex";
         public const string LampWeights0TextureName = "_OasisLampWeights0Tex";
+        public const string LampStateTextureName = "_OasisLampStateTex";
+        public const string EmissionStrengthName = "_OasisEmissionStrength";
         public const string StaticBrightnessName = "_OasisStaticBrightness";
         public const string MaskStrengthName = "_OasisMaskStrength";
 
@@ -18,6 +20,8 @@ namespace OasisPlayer.RuntimeBuild
         public static readonly int TrayIdTexture = Shader.PropertyToID(TrayIdTextureName);
         public static readonly int LampIds0Texture = Shader.PropertyToID(LampIds0TextureName);
         public static readonly int LampWeights0Texture = Shader.PropertyToID(LampWeights0TextureName);
+        public static readonly int LampStateTexture = Shader.PropertyToID(LampStateTextureName);
+        public static readonly int EmissionStrength = Shader.PropertyToID(EmissionStrengthName);
         public static readonly int StaticBrightness = Shader.PropertyToID(StaticBrightnessName);
         public static readonly int MaskStrength = Shader.PropertyToID(MaskStrengthName);
     }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs
@@ -1,0 +1,132 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public sealed class RuntimeLampState
+    {
+        public const int MinimumLampNumber = 1;
+        public const int MaximumLampNumber = 255;
+        private readonly float[] _brightness = new float[MaximumLampNumber + 1];
+        private int _version;
+        private bool _dirty;
+
+        public int Version { get { return _version; } }
+        public bool IsDirty { get { return _dirty; } }
+        public int Capacity { get { return _brightness.Length; } }
+
+        public bool IsValidLampNumber(int lampNumber) { return lampNumber >= MinimumLampNumber && lampNumber <= MaximumLampNumber; }
+        public float GetBrightness(int lampNumber) { return IsValidLampNumber(lampNumber) ? _brightness[lampNumber] : 0f; }
+        public void MarkClean() { _dirty = false; }
+
+        public bool SetBrightness(int lampNumber, float brightness)
+        {
+            if (!IsValidLampNumber(lampNumber)) return false;
+            var normalized = NormalizeBrightness(brightness);
+            if (Mathf.Abs(_brightness[lampNumber] - normalized) < 0.0001f) return false;
+            _brightness[lampNumber] = normalized;
+            _version++;
+            _dirty = true;
+            return true;
+        }
+
+        public bool SetBrightness(byte lampNumber, byte brightness)
+        {
+            return SetBrightness((int)lampNumber, brightness / 255f);
+        }
+
+        public bool SetBrightnessValues(System.Collections.Generic.IEnumerable<RuntimeLampBrightness> values)
+        {
+            if (values == null) return false;
+            var changed = false;
+            foreach (var value in values) changed |= SetBrightness(value.LampNumber, value.Brightness);
+            return changed;
+        }
+
+        public bool ClearAll()
+        {
+            var changed = false;
+            for (var i = MinimumLampNumber; i <= MaximumLampNumber; i++)
+            {
+                if (_brightness[i] <= 0f) continue;
+                _brightness[i] = 0f;
+                changed = true;
+            }
+            if (changed) { _version++; _dirty = true; }
+            return changed;
+        }
+
+        internal void CopyBrightnessTo(Color[] pixels)
+        {
+            if (pixels == null) throw new ArgumentNullException(nameof(pixels));
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                var brightness = i < _brightness.Length ? _brightness[i] : 0f;
+                pixels[i] = new Color(brightness, 0f, 0f, 1f);
+            }
+        }
+
+        private static float NormalizeBrightness(float brightness)
+        {
+            return float.IsNaN(brightness) || float.IsInfinity(brightness) ? 0f : Mathf.Clamp01(brightness);
+        }
+    }
+
+    public struct RuntimeLampBrightness
+    {
+        public RuntimeLampBrightness(int lampNumber, float brightness) { LampNumber = lampNumber; Brightness = brightness; }
+        public int LampNumber { get; private set; }
+        public float Brightness { get; private set; }
+    }
+
+    public sealed class RuntimeLampStateTexture : IDisposable
+    {
+        private readonly Color[] _pixels;
+        private int _uploadCount;
+        private bool _disposed;
+        public RuntimeLampStateTexture(RuntimeLampState lampState)
+        {
+            if (lampState == null) throw new ArgumentNullException(nameof(lampState));
+            Texture = new Texture2D(lampState.Capacity, 1, TextureFormat.RGBA32, false, true);
+            Texture.name = "OasisRuntimeLampState";
+            Texture.wrapMode = TextureWrapMode.Clamp;
+            Texture.filterMode = FilterMode.Point;
+            _pixels = new Color[lampState.Capacity];
+            Upload(lampState, true);
+        }
+        public Texture2D Texture { get; private set; }
+        public int UploadCount { get { return _uploadCount; } }
+        public bool IsDisposed { get { return _disposed; } }
+        public bool Upload(RuntimeLampState lampState) { return Upload(lampState, false); }
+        public bool Upload(RuntimeLampState lampState, bool force)
+        {
+            if (_disposed || lampState == null || (!force && !lampState.IsDirty)) return false;
+            lampState.CopyBrightnessTo(_pixels);
+            Texture.SetPixels(_pixels);
+            Texture.Apply(false, false);
+            lampState.MarkClean();
+            _uploadCount++;
+            return true;
+        }
+        public void Dispose()
+        {
+            if (_disposed) return;
+            if (Texture != null) { if (Application.isPlaying) UnityEngine.Object.Destroy(Texture); else UnityEngine.Object.DestroyImmediate(Texture); }
+            Texture = null; _disposed = true;
+        }
+    }
+
+    public static class RuntimeFaceLampLookupDecoder
+    {
+        public const int InvalidLampId = 0;
+        public const int ChannelCount = 3;
+        public static float DecodeByteWeight(int value) { return Mathf.Clamp(value, 0, 255) / 255f; }
+        public static int ResolveLampStateIndex(int trayId, int lampId) { return lampId >= 1 && lampId <= 255 ? lampId : InvalidLampId; }
+        public static float Accumulate(float[] lampBrightness, int[] lampIds, int[] weights)
+        {
+            var total = 0f;
+            for (var i = 0; i < ChannelCount; i++) { var id = lampIds[i]; if (id > 0 && id < lampBrightness.Length) total += lampBrightness[id] * DecodeByteWeight(weights[i]); }
+            return total;
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs
@@ -45,14 +45,27 @@ namespace OasisPlayer.RuntimeBuild
 
         public bool ClearAll()
         {
+            return SetAllBrightness(0f);
+        }
+
+        public bool SetAllBrightness(float brightness)
+        {
+            var normalized = NormalizeBrightness(brightness);
             var changed = false;
+            _brightness[0] = 0f;
             for (var i = MinimumLampNumber; i <= MaximumLampNumber; i++)
             {
-                if (_brightness[i] <= 0f) continue;
-                _brightness[i] = 0f;
+                if (Mathf.Abs(_brightness[i] - normalized) < 0.0001f) continue;
+                _brightness[i] = normalized;
                 changed = true;
             }
-            if (changed) { _version++; _dirty = true; }
+
+            if (changed)
+            {
+                _version++;
+                _dirty = true;
+            }
+
             return changed;
         }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeLampState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfafc3d8dc574446b477e50bc90f8fad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace OasisPlayer.RuntimeBuild
@@ -18,44 +19,450 @@ namespace OasisPlayer.RuntimeBuild
         }
     }
 
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public enum RuntimeLampDiagnosticMode
+    {
+        Off,
+        AutomaticSweep,
+        Manual
+    }
+
+    public enum RuntimeLampDiagnosticStage
+    {
+        Off,
+        AllOn,
+        AllOff,
+        Sweep,
+        Complete
+    }
+
+    public sealed class RuntimeLampDiagnosticSequence
+    {
+        private RuntimeLampDiagnosticSettings _settings;
+        private float _stageElapsedSeconds;
+        private int _completedFlashOnCount;
+        private int _sweepLamp;
+        private bool _sweepStarted;
+        private bool _isRunning;
+
+        public RuntimeLampDiagnosticSequence(RuntimeLampDiagnosticSettings settings)
+        {
+            Configure(settings);
+        }
+
+        public RuntimeLampDiagnosticSettings Settings { get { return _settings; } }
+        public RuntimeLampDiagnosticStage CurrentStage { get; private set; }
+        public int CurrentLamp { get { return CurrentStage == RuntimeLampDiagnosticStage.Sweep ? _sweepLamp : 0; } }
+        public int CompletedCycles { get; private set; }
+        public bool IsRunning { get { return _isRunning; } }
+        public bool IsSweepStarted { get { return _sweepStarted; } }
+
+        public void Configure(RuntimeLampDiagnosticSettings settings)
+        {
+            _settings = settings.Clamped();
+            Reset();
+        }
+
+        public void Reset()
+        {
+            _stageElapsedSeconds = 0f;
+            _completedFlashOnCount = 0;
+            _sweepLamp = _settings.FirstLamp;
+            _sweepStarted = false;
+            _isRunning = false;
+            CurrentStage = RuntimeLampDiagnosticStage.Off;
+            CompletedCycles = 0;
+        }
+
+        public bool Start(RuntimeLampState lampState)
+        {
+            if (_settings.Mode != RuntimeLampDiagnosticMode.AutomaticSweep || lampState == null)
+            {
+                CurrentStage = RuntimeLampDiagnosticStage.Off;
+                _isRunning = false;
+                return false;
+            }
+
+            _isRunning = true;
+            _stageElapsedSeconds = 0f;
+            _completedFlashOnCount = 0;
+            _sweepLamp = _settings.FirstLamp;
+            _sweepStarted = false;
+            CurrentStage = RuntimeLampDiagnosticStage.AllOn;
+            lampState.SetAllBrightness(1f);
+            return true;
+        }
+
+        public RuntimeLampDiagnosticTransition Advance(RuntimeLampState lampState, float unscaledDeltaSeconds)
+        {
+            if (!_isRunning || lampState == null || _settings.Mode != RuntimeLampDiagnosticMode.AutomaticSweep)
+            {
+                return RuntimeLampDiagnosticTransition.None;
+            }
+
+            _stageElapsedSeconds += Math.Max(0f, unscaledDeltaSeconds);
+            switch (CurrentStage)
+            {
+                case RuntimeLampDiagnosticStage.AllOn:
+                    if (_stageElapsedSeconds < _settings.AllOnSeconds) return RuntimeLampDiagnosticTransition.None;
+                    _stageElapsedSeconds = 0f;
+                    _completedFlashOnCount++;
+                    CurrentStage = RuntimeLampDiagnosticStage.AllOff;
+                    lampState.ClearAll();
+                    return RuntimeLampDiagnosticTransition.AllOff;
+
+                case RuntimeLampDiagnosticStage.AllOff:
+                    if (_stageElapsedSeconds < _settings.AllOffSeconds) return RuntimeLampDiagnosticTransition.None;
+                    _stageElapsedSeconds = 0f;
+                    if (_completedFlashOnCount < _settings.AllFlashCount)
+                    {
+                        CurrentStage = RuntimeLampDiagnosticStage.AllOn;
+                        lampState.SetAllBrightness(1f);
+                        return RuntimeLampDiagnosticTransition.AllOn;
+                    }
+
+                    CurrentStage = RuntimeLampDiagnosticStage.Sweep;
+                    _sweepLamp = _settings.FirstLamp;
+                    _sweepStarted = true;
+                    lampState.ClearAll();
+                    lampState.SetBrightness(_sweepLamp, 1f);
+                    return RuntimeLampDiagnosticTransition.BeginSweep;
+
+                case RuntimeLampDiagnosticStage.Sweep:
+                    if (_stageElapsedSeconds < _settings.SecondsPerLamp) return RuntimeLampDiagnosticTransition.None;
+                    _stageElapsedSeconds = 0f;
+                    if (_sweepLamp >= _settings.LastLamp)
+                    {
+                        lampState.ClearAll();
+                        CompletedCycles++;
+                        if (!_settings.Repeat)
+                        {
+                            CurrentStage = RuntimeLampDiagnosticStage.Complete;
+                            _isRunning = false;
+                            return RuntimeLampDiagnosticTransition.Complete;
+                        }
+
+                        _completedFlashOnCount = 0;
+                        _sweepLamp = _settings.FirstLamp;
+                        _sweepStarted = false;
+                        CurrentStage = RuntimeLampDiagnosticStage.AllOn;
+                        lampState.SetAllBrightness(1f);
+                        return RuntimeLampDiagnosticTransition.RepeatAllOn;
+                    }
+
+                    lampState.ClearAll();
+                    _sweepLamp++;
+                    lampState.SetBrightness(_sweepLamp, 1f);
+                    return RuntimeLampDiagnosticTransition.SweepLamp;
+            }
+
+            return RuntimeLampDiagnosticTransition.None;
+        }
+    }
+
+    public enum RuntimeLampDiagnosticTransition
+    {
+        None,
+        AllOn,
+        AllOff,
+        BeginSweep,
+        SweepLamp,
+        RepeatAllOn,
+        Complete
+    }
+
+    [Serializable]
+    public struct RuntimeLampDiagnosticSettings
+    {
+        public RuntimeLampDiagnosticMode Mode;
+        public int FirstLamp;
+        public int LastLamp;
+        public float SecondsPerLamp;
+        public float AllOnSeconds;
+        public float AllOffSeconds;
+        public int AllFlashCount;
+        public bool Repeat;
+
+        public static RuntimeLampDiagnosticSettings DefaultAutomatic()
+        {
+            return new RuntimeLampDiagnosticSettings
+            {
+                Mode = RuntimeLampDiagnosticMode.AutomaticSweep,
+                FirstLamp = RuntimeLampState.MinimumLampNumber,
+                LastLamp = RuntimeLampState.MaximumLampNumber,
+                SecondsPerLamp = 0.1f,
+                AllOnSeconds = 0.5f,
+                AllOffSeconds = 0.5f,
+                AllFlashCount = 2,
+                Repeat = true
+            };
+        }
+
+        public RuntimeLampDiagnosticSettings Clamped()
+        {
+            var first = Mathf.Clamp(FirstLamp, RuntimeLampState.MinimumLampNumber, RuntimeLampState.MaximumLampNumber);
+            var last = Mathf.Clamp(LastLamp, RuntimeLampState.MinimumLampNumber, RuntimeLampState.MaximumLampNumber);
+            if (last < first)
+            {
+                var temp = first;
+                first = last;
+                last = temp;
+            }
+
+            return new RuntimeLampDiagnosticSettings
+            {
+                Mode = Mode,
+                FirstLamp = first,
+                LastLamp = last,
+                SecondsPerLamp = Mathf.Max(0.001f, SecondsPerLamp),
+                AllOnSeconds = Mathf.Max(0.001f, AllOnSeconds),
+                AllOffSeconds = Mathf.Max(0.001f, AllOffSeconds),
+                AllFlashCount = Mathf.Max(1, AllFlashCount),
+                Repeat = Repeat
+            };
+        }
+    }
+
     public sealed class RuntimeLampDevelopmentControls : MonoBehaviour
     {
-        [SerializeField] private int lampNumber = 1;
-        [SerializeField] private int cycleStartLampNumber = 1;
-        [SerializeField] private int cycleEndLampNumber = 8;
-        [SerializeField] private float cycleSecondsPerLamp = 0.5f;
-        private RuntimeMachine _machine;
-        private float _cycleTimer;
-        private int _cycleLamp;
+        [SerializeField] private RuntimeLampDiagnosticMode mode = RuntimeLampDiagnosticMode.AutomaticSweep;
+        [SerializeField] private int firstLamp = RuntimeLampState.MinimumLampNumber;
+        [SerializeField] private int lastLamp = RuntimeLampState.MaximumLampNumber;
+        [SerializeField] private float secondsPerLamp = 0.1f;
+        [SerializeField] private float allOnSeconds = 0.5f;
+        [SerializeField] private float allOffSeconds = 0.5f;
+        [SerializeField] private int allFlashCount = 2;
+        [SerializeField] private bool repeat = true;
+        [SerializeField] private int manualLampNumber = 1;
+        [SerializeField] private RuntimeLampDiagnosticStage currentStage;
+        [SerializeField] private int currentLamp;
+        [SerializeField] private bool running;
+        [SerializeField] private int completedCycles;
 
+        private RuntimeMachine _machine;
+        private RuntimeLampDiagnosticSequence _sequence;
         public void Initialize(RuntimeMachine machine)
         {
             _machine = machine;
-            _cycleLamp = Mathf.Clamp(cycleStartLampNumber, RuntimeLampState.MinimumLampNumber, RuntimeLampState.MaximumLampNumber);
+            _sequence = new RuntimeLampDiagnosticSequence(CreateSettings());
+            RuntimeLampDiagnosticReporter.LogReady(machine);
+            if (_sequence.Start(machine != null ? machine.LampState : null))
+            {
+                Debug.Log($"Oasis lamp diagnostic started: all-flash x{_sequence.Settings.AllFlashCount}, then sweep lamps {_sequence.Settings.FirstLamp}–{_sequence.Settings.LastLamp} at {_sequence.Settings.SecondsPerLamp:0.###}s per lamp.");
+                Debug.Log("Oasis lamp diagnostic: all lamps ON");
+            }
+            RefreshStatus();
         }
 
         private void Update()
         {
             if (_machine == null) return;
-            if (Input.GetKeyDown(KeyCode.LeftBracket)) lampNumber = Mathf.Max(RuntimeLampState.MinimumLampNumber, lampNumber - 1);
-            if (Input.GetKeyDown(KeyCode.RightBracket)) lampNumber = Mathf.Min(RuntimeLampState.MaximumLampNumber, lampNumber + 1);
-            if (Input.GetKeyDown(KeyCode.Alpha0)) _machine.LampState.SetBrightness(lampNumber, 0f);
-            if (Input.GetKeyDown(KeyCode.Alpha1)) _machine.LampState.SetBrightness(lampNumber, 0.25f);
-            if (Input.GetKeyDown(KeyCode.Alpha2)) _machine.LampState.SetBrightness(lampNumber, 0.5f);
-            if (Input.GetKeyDown(KeyCode.Alpha3)) _machine.LampState.SetBrightness(lampNumber, 1f);
-            if (Input.GetKeyDown(KeyCode.C)) _machine.LampState.ClearAll();
-            if (Input.GetKey(KeyCode.L)) CycleLamps();
+            if (_sequence == null) _sequence = new RuntimeLampDiagnosticSequence(CreateSettings());
+
+            if (mode == RuntimeLampDiagnosticMode.Manual)
+            {
+                RunManualControls();
+                RefreshStatus();
+                return;
+            }
+
+            if (mode == RuntimeLampDiagnosticMode.Off)
+            {
+                RefreshStatus();
+                return;
+            }
+
+            var transition = _sequence.Advance(_machine.LampState, Time.unscaledDeltaTime);
+            LogTransition(transition);
+            RefreshStatus();
         }
 
-        private void CycleLamps()
+        private RuntimeLampDiagnosticSettings CreateSettings()
         {
-            _cycleTimer += Time.deltaTime;
-            if (_cycleTimer < Mathf.Max(0.05f, cycleSecondsPerLamp)) return;
-            _cycleTimer = 0f;
-            _machine.LampState.ClearAll();
-            _machine.LampState.SetBrightness(_cycleLamp, 1f);
-            _cycleLamp++;
-            if (_cycleLamp > cycleEndLampNumber) _cycleLamp = cycleStartLampNumber;
+            return new RuntimeLampDiagnosticSettings
+            {
+                Mode = mode,
+                FirstLamp = firstLamp,
+                LastLamp = lastLamp,
+                SecondsPerLamp = secondsPerLamp,
+                AllOnSeconds = allOnSeconds,
+                AllOffSeconds = allOffSeconds,
+                AllFlashCount = allFlashCount,
+                Repeat = repeat
+            }.Clamped();
+        }
+
+        private void RunManualControls()
+        {
+            if (Input.GetKeyDown(KeyCode.LeftBracket)) manualLampNumber = Mathf.Max(RuntimeLampState.MinimumLampNumber, manualLampNumber - 1);
+            if (Input.GetKeyDown(KeyCode.RightBracket)) manualLampNumber = Mathf.Min(RuntimeLampState.MaximumLampNumber, manualLampNumber + 1);
+            if (Input.GetKeyDown(KeyCode.Alpha0)) _machine.LampState.SetBrightness(manualLampNumber, 0f);
+            if (Input.GetKeyDown(KeyCode.Alpha1)) _machine.LampState.SetBrightness(manualLampNumber, 0.25f);
+            if (Input.GetKeyDown(KeyCode.Alpha2)) _machine.LampState.SetBrightness(manualLampNumber, 0.5f);
+            if (Input.GetKeyDown(KeyCode.Alpha3)) _machine.LampState.SetBrightness(manualLampNumber, 1f);
+            if (Input.GetKeyDown(KeyCode.C)) _machine.LampState.ClearAll();
+        }
+
+        private void LogTransition(RuntimeLampDiagnosticTransition transition)
+        {
+            switch (transition)
+            {
+                case RuntimeLampDiagnosticTransition.AllOn:
+                    Debug.Log("Oasis lamp diagnostic: all lamps ON");
+                    break;
+                case RuntimeLampDiagnosticTransition.AllOff:
+                    Debug.Log("Oasis lamp diagnostic: all lamps OFF");
+                    break;
+                case RuntimeLampDiagnosticTransition.BeginSweep:
+                    Debug.Log("Oasis lamp diagnostic: beginning sweep");
+                    Debug.Log($"Oasis lamp diagnostic: sweeping lamp {_sequence.CurrentLamp}");
+                    break;
+                case RuntimeLampDiagnosticTransition.SweepLamp:
+                    if (_sequence.CurrentLamp % 32 == 0 || _sequence.CurrentLamp == _sequence.Settings.LastLamp)
+                    {
+                        Debug.Log($"Oasis lamp diagnostic: sweeping lamp {_sequence.CurrentLamp}");
+                    }
+                    break;
+                case RuntimeLampDiagnosticTransition.RepeatAllOn:
+                    Debug.Log("Oasis lamp diagnostic: sequence repeating");
+                    Debug.Log("Oasis lamp diagnostic: all lamps ON");
+                    break;
+                case RuntimeLampDiagnosticTransition.Complete:
+                    Debug.Log("Oasis lamp diagnostic: complete");
+                    break;
+            }
+        }
+
+        private void RefreshStatus()
+        {
+            if (_sequence == null)
+            {
+                currentStage = RuntimeLampDiagnosticStage.Off;
+                currentLamp = 0;
+                running = false;
+                completedCycles = 0;
+                return;
+            }
+
+            currentStage = _sequence.CurrentStage;
+            currentLamp = _sequence.CurrentLamp;
+            running = _sequence.IsRunning;
+            completedCycles = _sequence.CompletedCycles;
+        }
+
+        private void OnDisable()
+        {
+            if (_machine != null) _machine.LampState.ClearAll();
         }
     }
+
+    public static class RuntimeLampDiagnosticReporter
+    {
+        public static string BuildReadySummary(RuntimeMachine machine)
+        {
+            if (machine == null) return "Oasis lamp diagnostic ready: no machine loaded";
+
+            var rendered = 0;
+            var bound = 0;
+            foreach (var face in machine.Faces)
+            {
+                if (face == null || face.RenderBinding == null || face.RenderBinding.RuntimeMaterial == null) continue;
+                rendered++;
+                var material = face.RenderBinding.RuntimeMaterial;
+                if (material.HasProperty(RuntimeFaceShaderProperties.LampStateTexture)
+                    && material.GetTexture(RuntimeFaceShaderProperties.LampStateTexture) == machine.LampStateTexture.Texture)
+                {
+                    bound++;
+                }
+            }
+
+            var texture = machine.LampStateTexture.Texture;
+            var textureText = texture != null ? $"{texture.width}x{texture.height}" : "missing";
+            return $"Oasis lamp diagnostic ready:\nFaces loaded: {machine.Faces.Count}\nFaces rendered: {rendered}\nLamp-state texture: {textureText}\nFace materials bound to lamp state: {bound}";
+        }
+
+        public static void LogReady(RuntimeMachine machine)
+        {
+            Debug.Log(BuildReadySummary(machine));
+            if (machine == null) return;
+            var faceIndex = 1;
+            foreach (var face in machine.Faces)
+            {
+                if (face == null || face.RenderBinding == null) continue;
+                Debug.Log(RuntimeFaceLookupDiagnostic.BuildSummary(face, faceIndex));
+                faceIndex++;
+            }
+        }
+    }
+
+    public struct RuntimeFaceLookupDiagnosticSummary
+    {
+        public bool HasLampIdData;
+        public bool HasLampWeightData;
+        public int AssignedPixels;
+        public int MinimumLampId;
+        public int MaximumLampId;
+        public int InvalidIdCount;
+        public bool HasNonZeroWeights;
+    }
+
+    public static class RuntimeFaceLookupDiagnostic
+    {
+        public static RuntimeFaceLookupDiagnosticSummary Analyze(RuntimeFace face)
+        {
+            var summary = new RuntimeFaceLookupDiagnosticSummary();
+            if (face == null || face.LampIds0 == null || face.LampIds0.Texture == null)
+            {
+                return summary;
+            }
+
+            summary.HasLampIdData = true;
+            summary.HasLampWeightData = face.LampWeights0 != null && face.LampWeights0.Texture != null;
+            if (!summary.HasLampWeightData) return summary;
+
+            var ids = face.LampIds0.Texture.GetPixels32();
+            var weights = face.LampWeights0.Texture.GetPixels32();
+            var length = Math.Min(ids.Length, weights.Length);
+            summary.MinimumLampId = RuntimeLampState.MaximumLampNumber + 1;
+            for (var i = 0; i < length; i++)
+            {
+                var assigned = false;
+                AnalyzeChannel(ids[i].r, weights[i].r, ref summary, ref assigned);
+                AnalyzeChannel(ids[i].g, weights[i].g, ref summary, ref assigned);
+                AnalyzeChannel(ids[i].b, weights[i].b, ref summary, ref assigned);
+                if (assigned) summary.AssignedPixels++;
+            }
+
+            if (summary.MinimumLampId > RuntimeLampState.MaximumLampNumber) summary.MinimumLampId = 0;
+            return summary;
+        }
+
+        public static string BuildSummary(RuntimeFace face, int faceIndex)
+        {
+            var summary = Analyze(face);
+            var range = summary.MinimumLampId > 0 ? $"{summary.MinimumLampId}–{summary.MaximumLampId}" : "none";
+            return $"Face {faceIndex} lamp lookup:\nID data: {FormatBool(summary.HasLampIdData)}\nWeight data: {FormatBool(summary.HasLampWeightData)}\nassigned pixels: {summary.AssignedPixels}\nlamp range: {range}\ninvalid IDs: {summary.InvalidIdCount}\nnon-zero weights: {FormatBool(summary.HasNonZeroWeights)}";
+        }
+
+        private static void AnalyzeChannel(byte lampId, byte weight, ref RuntimeFaceLookupDiagnosticSummary summary, ref bool assigned)
+        {
+            if (lampId == 0) return;
+            assigned = true;
+            if (lampId < RuntimeLampState.MinimumLampNumber || lampId > RuntimeLampState.MaximumLampNumber)
+            {
+                summary.InvalidIdCount++;
+                return;
+            }
+
+            if (lampId < summary.MinimumLampId) summary.MinimumLampId = lampId;
+            if (lampId > summary.MaximumLampId) summary.MaximumLampId = lampId;
+            if (weight > 0) summary.HasNonZeroWeights = true;
+        }
+
+        private static string FormatBool(bool value)
+        {
+            return value ? "yes" : "no";
+        }
+    }
+#endif
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public sealed class RuntimeMachineLampUpdater : MonoBehaviour
+    {
+        public RuntimeMachine Machine { get; private set; }
+
+        public void Initialize(RuntimeMachine machine)
+        {
+            Machine = machine;
+        }
+
+        private void LateUpdate()
+        {
+            if (Machine == null) return;
+            Machine.ApplyDynamicState();
+        }
+    }
+
+    public sealed class RuntimeLampDevelopmentControls : MonoBehaviour
+    {
+        [SerializeField] private int lampNumber = 1;
+        [SerializeField] private int cycleStartLampNumber = 1;
+        [SerializeField] private int cycleEndLampNumber = 8;
+        [SerializeField] private float cycleSecondsPerLamp = 0.5f;
+        private RuntimeMachine _machine;
+        private float _cycleTimer;
+        private int _cycleLamp;
+
+        public void Initialize(RuntimeMachine machine)
+        {
+            _machine = machine;
+            _cycleLamp = Mathf.Clamp(cycleStartLampNumber, RuntimeLampState.MinimumLampNumber, RuntimeLampState.MaximumLampNumber);
+        }
+
+        private void Update()
+        {
+            if (_machine == null) return;
+            if (Input.GetKeyDown(KeyCode.LeftBracket)) lampNumber = Mathf.Max(RuntimeLampState.MinimumLampNumber, lampNumber - 1);
+            if (Input.GetKeyDown(KeyCode.RightBracket)) lampNumber = Mathf.Min(RuntimeLampState.MaximumLampNumber, lampNumber + 1);
+            if (Input.GetKeyDown(KeyCode.Alpha0)) _machine.LampState.SetBrightness(lampNumber, 0f);
+            if (Input.GetKeyDown(KeyCode.Alpha1)) _machine.LampState.SetBrightness(lampNumber, 0.25f);
+            if (Input.GetKeyDown(KeyCode.Alpha2)) _machine.LampState.SetBrightness(lampNumber, 0.5f);
+            if (Input.GetKeyDown(KeyCode.Alpha3)) _machine.LampState.SetBrightness(lampNumber, 1f);
+            if (Input.GetKeyDown(KeyCode.C)) _machine.LampState.ClearAll();
+            if (Input.GetKey(KeyCode.L)) CycleLamps();
+        }
+
+        private void CycleLamps()
+        {
+            _cycleTimer += Time.deltaTime;
+            if (_cycleTimer < Mathf.Max(0.05f, cycleSecondsPerLamp)) return;
+            _cycleTimer = 0f;
+            _machine.LampState.ClearAll();
+            _machine.LampState.SetBrightness(_cycleLamp, 1f);
+            _cycleLamp++;
+            if (_cycleLamp > cycleEndLampNumber) _cycleLamp = cycleStartLampNumber;
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8ee9167f1de453596991f7be2f92316
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -7,6 +7,8 @@ Shader "Oasis/Face"
         _OasisTrayIdTex ("Tray ID", 2D) = "black" {}
         _OasisLampIds0Tex ("Lamp IDs 0", 2D) = "black" {}
         _OasisLampWeights0Tex ("Lamp Weights 0", 2D) = "black" {}
+        _OasisLampStateTex ("Lamp State", 2D) = "black" {}
+        _OasisEmissionStrength ("Emission Strength", Range(0, 8)) = 1
         _OasisStaticBrightness ("Static Brightness", Range(0, 2)) = 1
         _OasisMaskStrength ("Mask Strength", Range(0, 4)) = 1
     }
@@ -52,11 +54,14 @@ Shader "Oasis/Face"
             SAMPLER(sampler_OasisLampIds0Tex);
             TEXTURE2D(_OasisLampWeights0Tex);
             SAMPLER(sampler_OasisLampWeights0Tex);
+            TEXTURE2D(_OasisLampStateTex);
+            SAMPLER(sampler_OasisLampStateTex);
 
             CBUFFER_START(UnityPerMaterial)
                 float4 _OasisArtworkTex_ST;
                 float _OasisStaticBrightness;
                 float _OasisMaskStrength;
+                float _OasisEmissionStrength;
             CBUFFER_END
 
             Varyings vert(Attributes input)
@@ -67,10 +72,40 @@ Shader "Oasis/Face"
                 return output;
             }
 
+            float DecodeLampBrightness(float lampId)
+            {
+                float decoded = floor(saturate(lampId) * 255.0 + 0.5);
+                if (decoded < 1.0 || decoded > 255.0) return 0.0;
+                float u = (decoded + 0.5) / 256.0;
+                return SAMPLE_TEXTURE2D(_OasisLampStateTex, sampler_OasisLampStateTex, float2(u, 0.5)).r;
+            }
+
+            float DecodeWeight(float weight)
+            {
+                return floor(saturate(weight) * 255.0 + 0.5) / 255.0;
+            }
+
+            float DecodeMask(half4 mask)
+            {
+                float grayscale = max(mask.r, max(mask.g, mask.b));
+                return saturate(grayscale * mask.a * _OasisMaskStrength);
+            }
+
             half4 frag(Varyings input) : SV_Target
             {
                 half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, input.uv);
-                return half4(artwork.rgb * _OasisStaticBrightness, artwork.a);
+                half4 mask = SAMPLE_TEXTURE2D(_OasisMaskTex, sampler_OasisMaskTex, input.uv);
+                half4 lampIds = SAMPLE_TEXTURE2D(_OasisLampIds0Tex, sampler_OasisLampIds0Tex, input.uv);
+                half4 weights = SAMPLE_TEXTURE2D(_OasisLampWeights0Tex, sampler_OasisLampWeights0Tex, input.uv);
+
+                float visibleLight = 0.0;
+                visibleLight += DecodeLampBrightness(lampIds.r) * DecodeWeight(weights.r);
+                visibleLight += DecodeLampBrightness(lampIds.g) * DecodeWeight(weights.g);
+                visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
+
+                float light = DecodeMask(mask) * visibleLight * _OasisEmissionStrength;
+                float multiplier = _OasisStaticBrightness + light;
+                return half4(saturate(artwork.rgb * multiplier), artwork.a);
             }
             ENDHLSL
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
@@ -20,8 +20,9 @@ namespace OasisPlayer.Tests
                 renderer.sharedMaterial = sharedMaterial;
                 var face = CreateFace(target.transform, texture, mask);
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+                var machine = CreateMachine(face);
 
-                var rendered = sut.TryRender(face, out var warning);
+                var rendered = sut.TryRender(machine, face, out var warning);
 
                 Assert.True(rendered, warning);
                 Assert.NotNull(face.RenderBinding);
@@ -57,8 +58,9 @@ namespace OasisPlayer.Tests
             {
                 var face = CreateFace(target.transform, texture, mask);
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+                var machine = CreateMachine(face);
 
-                var rendered = sut.TryRender(face, out var warning);
+                var rendered = sut.TryRender(machine, face, out var warning);
 
                 Assert.False(rendered);
                 Assert.That(warning, Does.Contain("has no usable renderer"));
@@ -90,8 +92,10 @@ namespace OasisPlayer.Tests
                 var firstFace = CreateFace(first.transform, firstTexture, firstMask, "first");
                 var secondFace = CreateFace(second.transform, secondTexture, secondMask, "second");
 
-                Assert.True(sut.TryRender(firstFace, out var firstWarning), firstWarning);
-                Assert.True(sut.TryRender(secondFace, out var secondWarning), secondWarning);
+                var firstMachine = CreateMachine(firstFace);
+                var secondMachine = CreateMachine(secondFace);
+                Assert.True(sut.TryRender(firstMachine, firstFace, out var firstWarning), firstWarning);
+                Assert.True(sut.TryRender(secondMachine, secondFace, out var secondWarning), secondWarning);
                 Assert.AreNotSame(first.GetComponent<MeshRenderer>().sharedMaterial, second.GetComponent<MeshRenderer>().sharedMaterial);
 
                 firstFace.RenderBinding.Dispose();
@@ -128,8 +132,9 @@ namespace OasisPlayer.Tests
             {
                 var face = CreateFace(target.transform, texture, mask);
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
+                var machine = CreateMachine(face);
 
-                var rendered = sut.TryRender(face, out var warning);
+                var rendered = sut.TryRender(machine, face, out var warning);
 
                 Assert.False(rendered);
                 Assert.That(warning, Does.Contain("material slots"));
@@ -153,6 +158,13 @@ namespace OasisPlayer.Tests
             renderer.sharedMaterial = new Material(Shader.Find("Standard"));
             target.AddComponent<MeshFilter>();
             return target;
+        }
+
+        private static RuntimeMachine CreateMachine(RuntimeFace face)
+        {
+            var machine = new RuntimeMachine(new ResolvedRuntimeBuild(string.Empty, new MachineRuntimeManifest(), string.Empty, new CabinetRuntimeManifest(), string.Empty, new MachineRuntimeFaceReference[0]), null);
+            machine.RegisterFace(face);
+            return machine;
         }
 
         private static RuntimeFace CreateFace(Transform target, Texture2D texture, Texture2D mask, string id = "front")
@@ -189,7 +201,7 @@ namespace OasisPlayer.Tests
                     new RuntimeTextureAsset("lampWeights0.png", lampWeights0));
 
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
-                Assert.True(sut.TryRender(face, out var warning), warning);
+                Assert.True(sut.TryRender(CreateMachine(face), face, out var warning), warning);
                 var runtimeMaterial = face.RenderBinding.RuntimeMaterial;
 
                 Assert.AreSame(trayId, runtimeMaterial.GetTexture(RuntimeFaceShaderProperties.TrayIdTexture));
@@ -223,7 +235,7 @@ namespace OasisPlayer.Tests
                 var face = CreateFace(target.transform, texture, mask);
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory("Oasis/MissingFaceShaderForTest"));
 
-                var rendered = sut.TryRender(face, out var warning);
+                var rendered = sut.TryRender(CreateMachine(face), face, out var warning);
 
                 Assert.False(rendered);
                 Assert.That(warning, Does.Contain("dedicated"));
@@ -250,7 +262,7 @@ namespace OasisPlayer.Tests
             {
                 var face = CreateFace(target.transform, texture, mask);
                 var sut = new RuntimeFaceRenderer(new RuntimeFaceMaterialFactory());
-                Assert.True(sut.TryRender(face, out var warning), warning);
+                Assert.True(sut.TryRender(CreateMachine(face), face, out var warning), warning);
 
                 face.RenderBinding.MarkDynamicStateDirty();
                 Assert.True(face.RenderBinding.HasDynamicState);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+
+namespace OasisPlayer.Tests
+{
+    public sealed class RuntimeLampStateTests
+    {
+        [Test]
+        public void LampBrightnessDefaultsToZeroAndSupportsSetGetClampAndClear()
+        {
+            var state = new RuntimeLampState();
+            Assert.AreEqual(0f, state.GetBrightness(7));
+            Assert.True(state.SetBrightness(7, 0.5f));
+            Assert.AreEqual(0.5f, state.GetBrightness(7), 0.0001f);
+            Assert.True(state.SetBrightness(7, 2f));
+            Assert.AreEqual(1f, state.GetBrightness(7), 0.0001f);
+            Assert.True(state.ClearAll());
+            Assert.AreEqual(0f, state.GetBrightness(7), 0.0001f);
+        }
+
+        [Test]
+        public void InvalidAndUnchangedLampValuesDoNotDirtyState()
+        {
+            var state = new RuntimeLampState();
+            Assert.False(state.SetBrightness(0, 1f));
+            Assert.False(state.SetBrightness(256, 1f));
+            Assert.False(state.IsDirty);
+            Assert.True(state.SetBrightness(1, 1f));
+            state.MarkClean();
+            Assert.False(state.SetBrightness(1, 1f));
+            Assert.False(state.IsDirty);
+        }
+
+        [Test]
+        public void TextureUploadCoalescesMultipleStateChanges()
+        {
+            var state = new RuntimeLampState();
+            using (var texture = new RuntimeLampStateTexture(state))
+            {
+                var initialUploads = texture.UploadCount;
+                state.SetBrightness(1, 0.25f);
+                state.SetBrightness(2, 0.5f);
+                Assert.True(texture.Upload(state));
+                Assert.AreEqual(initialUploads + 1, texture.UploadCount);
+                Assert.False(texture.Upload(state));
+                Assert.AreEqual(initialUploads + 1, texture.UploadCount);
+            }
+        }
+
+        [Test]
+        public void LookupDecoderUsesOneBasedLampIdsAndThreeRgbContributions()
+        {
+            var brightness = new float[256];
+            brightness[1] = 1f;
+            brightness[2] = 0.5f;
+            brightness[3] = 0.25f;
+            var value = RuntimeFaceLampLookupDecoder.Accumulate(brightness, new[] { 1, 2, 0 }, new[] { 255, 128, 255 });
+            Assert.AreEqual(1.25098f, value, 0.0002f);
+            Assert.AreEqual(0, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(1, 0));
+            Assert.AreEqual(7, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(99, 7));
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
@@ -60,5 +60,194 @@ namespace OasisPlayer.Tests
             Assert.AreEqual(0, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(1, 0));
             Assert.AreEqual(7, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(99, 7));
         }
+
+        [Test]
+        public void SetAllBrightnessSetsValidLampsAndLeavesSentinelZeroWithoutRedirtyingUnchangedState()
+        {
+            var state = new RuntimeLampState();
+            Assert.True(state.SetAllBrightness(1f));
+            Assert.AreEqual(0f, state.GetBrightness(0));
+            Assert.AreEqual(1f, state.GetBrightness(1));
+            Assert.AreEqual(1f, state.GetBrightness(255));
+            state.MarkClean();
+            Assert.False(state.SetAllBrightness(1f));
+            Assert.False(state.IsDirty);
+            Assert.True(state.SetAllBrightness(0f));
+            Assert.AreEqual(0f, state.GetBrightness(1));
+            Assert.AreEqual(0f, state.GetBrightness(255));
+        }
+
+        [Test]
+        public void AutomaticDiagnosticDefaultsAndClampsLampRange()
+        {
+            var defaults = RuntimeLampDiagnosticSettings.DefaultAutomatic();
+            Assert.AreEqual(RuntimeLampDiagnosticMode.AutomaticSweep, defaults.Mode);
+            Assert.AreEqual(1, defaults.FirstLamp);
+            Assert.AreEqual(255, defaults.LastLamp);
+            Assert.AreEqual(0.1f, defaults.SecondsPerLamp, 0.0001f);
+
+            var clamped = new RuntimeLampDiagnosticSettings
+            {
+                Mode = RuntimeLampDiagnosticMode.AutomaticSweep,
+                FirstLamp = 0,
+                LastLamp = 999,
+                SecondsPerLamp = 0f,
+                AllOnSeconds = 0f,
+                AllOffSeconds = 0f,
+                AllFlashCount = 0,
+                Repeat = true
+            }.Clamped();
+
+            Assert.AreEqual(1, clamped.FirstLamp);
+            Assert.AreEqual(255, clamped.LastLamp);
+            Assert.Greater(clamped.SecondsPerLamp, 0f);
+            Assert.AreEqual(1, clamped.AllFlashCount);
+        }
+
+        [Test]
+        public void AutomaticSequenceRunsTwoAllOnFlashesBeforeSweepAndRepeats()
+        {
+            var state = new RuntimeLampState();
+            var settings = RuntimeLampDiagnosticSettings.DefaultAutomatic();
+            settings.FirstLamp = 1;
+            settings.LastLamp = 3;
+            settings.SecondsPerLamp = 0.1f;
+            settings.AllOnSeconds = 0.5f;
+            settings.AllOffSeconds = 0.5f;
+            settings.AllFlashCount = 2;
+            settings.Repeat = true;
+            var sequence = new RuntimeLampDiagnosticSequence(settings);
+
+            Assert.True(sequence.Start(state));
+            Assert.AreEqual(RuntimeLampDiagnosticStage.AllOn, sequence.CurrentStage);
+            Assert.AreEqual(1f, state.GetBrightness(1));
+            Assert.AreEqual(1f, state.GetBrightness(255));
+
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.AllOff, sequence.Advance(state, 0.5f));
+            Assert.AreEqual(0f, state.GetBrightness(1));
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.AllOn, sequence.Advance(state, 0.5f));
+            Assert.AreEqual(1f, state.GetBrightness(2));
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.AllOff, sequence.Advance(state, 0.5f));
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.BeginSweep, sequence.Advance(state, 0.5f));
+            Assert.AreEqual(RuntimeLampDiagnosticStage.Sweep, sequence.CurrentStage);
+            Assert.AreEqual(1, sequence.CurrentLamp);
+            AssertOnlyLampEnabled(state, 1, 3, 1);
+
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.SweepLamp, sequence.Advance(state, 0.1f));
+            Assert.AreEqual(2, sequence.CurrentLamp);
+            AssertOnlyLampEnabled(state, 1, 3, 2);
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.SweepLamp, sequence.Advance(state, 0.1f));
+            Assert.AreEqual(3, sequence.CurrentLamp);
+            AssertOnlyLampEnabled(state, 1, 3, 3);
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.RepeatAllOn, sequence.Advance(state, 0.1f));
+            Assert.AreEqual(1, sequence.CompletedCycles);
+            Assert.AreEqual(RuntimeLampDiagnosticStage.AllOn, sequence.CurrentStage);
+            Assert.AreEqual(1f, state.GetBrightness(1));
+        }
+
+
+        [Test]
+        public void AutomaticSweepReachesLamp255()
+        {
+            var state = new RuntimeLampState();
+            var settings = RuntimeLampDiagnosticSettings.DefaultAutomatic();
+            settings.AllOnSeconds = 0.01f;
+            settings.AllOffSeconds = 0.01f;
+            settings.SecondsPerLamp = 0.1f;
+            var sequence = new RuntimeLampDiagnosticSequence(settings);
+            sequence.Start(state);
+            sequence.Advance(state, 0.01f);
+            sequence.Advance(state, 0.01f);
+            sequence.Advance(state, 0.01f);
+            sequence.Advance(state, 0.01f);
+
+            Assert.AreEqual(RuntimeLampDiagnosticStage.Sweep, sequence.CurrentStage);
+            Assert.AreEqual(1, sequence.CurrentLamp);
+            for (var i = 2; i <= 255; i++)
+            {
+                sequence.Advance(state, 0.1f);
+            }
+
+            Assert.AreEqual(255, sequence.CurrentLamp);
+            Assert.AreEqual(1f, state.GetBrightness(255));
+            Assert.AreEqual(0f, state.GetBrightness(254));
+        }
+
+        [Test]
+        public void AutomaticSequenceDoesNothingWhenOff()
+        {
+            var state = new RuntimeLampState();
+            var settings = RuntimeLampDiagnosticSettings.DefaultAutomatic();
+            settings.Mode = RuntimeLampDiagnosticMode.Off;
+            var sequence = new RuntimeLampDiagnosticSequence(settings);
+
+            Assert.False(sequence.Start(state));
+            Assert.AreEqual(RuntimeLampDiagnosticTransition.None, sequence.Advance(state, 1f));
+            Assert.AreEqual(0f, state.GetBrightness(1));
+        }
+
+        [Test]
+        public void LookupDiagnosticReportsEmptyAndValidLookupData()
+        {
+            var emptyIds = new Texture2D(1, 1, TextureFormat.RGBA32, false, true);
+            var emptyWeights = new Texture2D(1, 1, TextureFormat.RGBA32, false, true);
+            var validIds = new Texture2D(2, 1, TextureFormat.RGBA32, false, true);
+            var validWeights = new Texture2D(2, 1, TextureFormat.RGBA32, false, true);
+
+            try
+            {
+                emptyIds.SetPixel(0, 0, Color.clear);
+                emptyIds.Apply();
+                emptyWeights.SetPixel(0, 0, Color.clear);
+                emptyWeights.Apply();
+                var emptyFace = CreateLookupFace(emptyIds, emptyWeights);
+                var empty = RuntimeFaceLookupDiagnostic.Analyze(emptyFace);
+                Assert.True(empty.HasLampIdData);
+                Assert.True(empty.HasLampWeightData);
+                Assert.AreEqual(0, empty.AssignedPixels);
+                Assert.False(empty.HasNonZeroWeights);
+
+                validIds.SetPixels32(new[] { new Color32(3, 0, 0, 255), new Color32(217, 5, 0, 255) });
+                validIds.Apply();
+                validWeights.SetPixels32(new[] { new Color32(128, 0, 0, 255), new Color32(255, 0, 0, 255) });
+                validWeights.Apply();
+                var validFace = CreateLookupFace(validIds, validWeights);
+                var valid = RuntimeFaceLookupDiagnostic.Analyze(validFace);
+                Assert.AreEqual(2, valid.AssignedPixels);
+                Assert.AreEqual(3, valid.MinimumLampId);
+                Assert.AreEqual(217, valid.MaximumLampId);
+                Assert.AreEqual(0, valid.InvalidIdCount);
+                Assert.True(valid.HasNonZeroWeights);
+            }
+            finally
+            {
+                Object.DestroyImmediate(emptyIds);
+                Object.DestroyImmediate(emptyWeights);
+                Object.DestroyImmediate(validIds);
+                Object.DestroyImmediate(validWeights);
+            }
+        }
+
+        private static void AssertOnlyLampEnabled(RuntimeLampState state, int firstLamp, int lastLamp, int expectedLamp)
+        {
+            for (var lamp = firstLamp; lamp <= lastLamp; lamp++)
+            {
+                Assert.AreEqual(lamp == expectedLamp ? 1f : 0f, state.GetBrightness(lamp), 0.0001f, $"Lamp {lamp}");
+            }
+        }
+
+        private static RuntimeFace CreateLookupFace(Texture2D ids, Texture2D weights)
+        {
+            return new RuntimeFace(
+                new MachineRuntimeFaceReference { faceId = "lookup", cabinetFaceTargetId = "front" },
+                new FaceRuntimeManifest { schemaVersion = 1, faceId = "lookup", width = ids.width, height = ids.height },
+                null,
+                null,
+                null,
+                null,
+                new RuntimeTextureAsset("lampIds0.png", ids),
+                new RuntimeTextureAsset("lampWeights0.png", weights));
+        }
+
     }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a76da765f31142f798bfff5f23950d1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
+++ b/WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md
@@ -6,19 +6,16 @@ Read only:
 
 1. `AGENTS.md`
 2. `00_CURRENT_PRIORITY.md`
-3. `Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md`
+3. `Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md`
 
-Do not scan all Markdown files in this directory.
-
-Open additional Phase 2 task documents only as directed by `Docs/OasisPlayerPhase2/CODEX_START_PROMPT.md` or when directly relevant to the requested work.
+Open additional Phase 3 task documents only as directed by `Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md` or when directly relevant to the requested work.
 
 ## Current Focus
 
 Priority workstream:
 
-- Oasis Player Phase 2: Face Runtime Integration
-- Player-side loading and validation of exported Face runtime assets
-- static RuntimeFace artwork rendering on resolved cabinet targets
+- Oasis Player Phase 3: Dynamic Face Lamps
+- Next checkpoint: `Docs/OasisPlayerPhase3/TASK_02_EMULATION_LAMP_BRIDGE.md`
 
 Primary implementation project:
 
@@ -32,47 +29,22 @@ Related contract producer:
 WindowsNetProjects/OasisEditor
 ```
 
-## Immediate Direction
+## Completed Checkpoints
 
-Phase 2 Task 04 is complete:
+- Phase 2 is complete and should not be expanded for new lamp planning.
+- Phase 3 Task 01 (`Docs/OasisPlayerPhase3/TASK_01_RUNTIME_LAMP_STATE_AND_SHADER_DECODING.md`) is complete.
 
-```text
-Docs/OasisPlayerPhase2/TASK_04_FACE_RENDERER_INFRASTRUCTURE.md
-```
+## Explicit Non-Goals Until Requested
 
-Phase 2 Task 01 is complete. Do not modify the runtime Face export contract unless a genuine defect is discovered.
+Do not implement:
 
-## Explicit Non-Goals
-
-Do not implement in this priority:
-
-- lamp/display dynamic Face rendering
-- RenderTextures
-- mesh replacement or mesh modification
-- lamp rendering
-- display rendering
-- reels
+- reel rendering
 - buttons
-- emulation integration
-- Player hot reload or IPC
-
-## Testing Direction
-
-Prefer focused tests around:
-
-- valid machine manifests with multiple Faces
-- missing `face.runtime.json`
-- unsupported Face manifest schema version
-- missing artwork or mask image files
-- duplicate Face identifiers
-- duplicate cabinet target assignments
-- missing cabinet target mesh warnings
-- successful RuntimeFace registration
-- continued loading after invalid Face entries
-
-Do not claim WPF, Unity Player, or visual verification unless it was actually performed locally.
-
-
-## Completed Checkpoint
-
-Phase 2 Task 04 (Face Renderer Infrastructure) is implemented and ready for local Unity verification. RuntimeFaces render static artwork through the dedicated Oasis/Face shader with explicit texture binding, cleanup, and future dynamic-state infrastructure.
+- segment displays
+- VFD
+- dot matrix
+- sound
+- cabinet input
+- Player scene redesign
+- new Face export schemas
+- Blender changes

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
@@ -1,0 +1,14 @@
+# Codex Start Prompt: Oasis Player Phase 3
+
+Read:
+
+1. `PHASE_03_CONTEXT.md`
+2. The current task document named by `00_CURRENT_PRIORITY.md`
+
+Current checkpoint complete: Task 01 Runtime Lamp State and Shader Decoding.
+
+Next checkpoint:
+
+`TASK_02_EMULATION_LAMP_BRIDGE.md`
+
+Respect boundaries: do not redesign Face export textures, do not add reels/buttons/displays, and do not begin broad rendering tuning until Task 03.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
@@ -1,0 +1,27 @@
+# Oasis Player Phase 3 Context: Dynamic Face Lamps
+
+Phase 2 is complete: the Player loads cabinet GLB content, loads Face runtime manifests and production textures, resolves `OasisFace_` targets, binds static Face artwork through the dedicated `Oasis/Face` shader, and owns/cleans up Face materials and textures explicitly.
+
+Phase 3 adds dynamic Face lamps without changing the Phase 2 runtime export contract. The production textures remain `artwork.png`, `mask.png`, `trayId.png`, `lampIds0.png`, and `lampWeights0.png`.
+
+## Authoritative runtime texture contract discovered in Editor code
+
+Source of truth:
+
+- `FaceRuntimeTextureGenerator` writes `trayId.png`, `lampIds0.png`, and `lampWeights0.png`.
+- `FaceTexturePreviewRenderer` consumes those textures for the Editor texture-driven preview.
+
+Semantics:
+
+- `trayId.png`: RGBA PNG. Red stores the tray ID as an integer byte. Green and blue are zero. Alpha is 255 for tray-owned pixels and 0 for unowned transparent pixels. Tray IDs are one-based in generated bridge trays; ownership prevents later overlapping trays from overwriting earlier tray pixels. The current Player lamp lookup does not bank lamp states by tray; tray is metadata/ownership for the exported pixel region.
+- `lampIds0.png`: RGBA PNG. RGB store up to three lamp IDs affecting that pixel. Alpha is 255 for tray-owned pixels and 0 outside authored tray pixels, but alpha is not a fourth lamp contribution in the current production writer. Lamp ID 0 is the invalid/unassigned sentinel. Valid exported lamp IDs are 1 through 255.
+- `lampWeights0.png`: RGBA PNG. RGB store the matching contribution weights for the lamp IDs in `lampIds0.png`, quantized as `round(rawWeight * 255)` and decoded as byte/255. Alpha is 255 for tray-owned pixels and 0 outside authored tray pixels; the current production writer preserves RGB data channels plus opaque alpha and supports up to three emitters per tray.
+- `mask.png`: RGBA image. The lamp mask value is `max(R,G,B) * alpha * maskStrength`, using normalized channel values. It gates illumination, not artwork opacity.
+- Multiple contributions: the current production contract supports up to three contributions per pixel through the RGB channels of `lampIds0.png` and `lampWeights0.png`. Additional `lampIds1`/`lampWeights1` fields exist in manifests but the current export sets them to null and the production writer does not generate them.
+- Illumination formula: the Editor texture preview computes `visibleLight = sum(lampBrightness[lampId] * weightByte / 255)`, `light = maskValue * visibleLight * emissionStrength`, then outputs `artworkRgb * (ambientStrength + light)` clamped to 0..255 while preserving artwork alpha.
+
+## Phase boundaries
+
+- Task 01 proves dynamic lamp rendering without emulator integration.
+- Task 02 will bridge emulation output into the runtime lamp-state model.
+- Task 03 will validate and tune rendering behaviour visually and with more robust render tests.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_01_RUNTIME_LAMP_STATE_AND_SHADER_DECODING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_01_RUNTIME_LAMP_STATE_AND_SHADER_DECODING.md
@@ -1,0 +1,44 @@
+# Task 01: Runtime Lamp State and Shader Decoding — Complete
+
+## Objective
+
+Implement a machine-owned runtime lamp-state model, bind it to Face materials, and extend `Oasis/Face` so manual lamp brightness changes illuminate the correct exported Face pixels without emulator integration.
+
+## Implementation summary
+
+- Added `RuntimeLampState` with normalized 0..1 brightness indexed by Oasis lamp number.
+- Valid lamp numbers are 1..255, matching the current Editor writer and native backend practical maximum. Lamp 0 remains the invalid/unassigned sentinel.
+- Added a machine-owned `RuntimeLampStateTexture`, a 256x1 point-filtered linear texture with brightness in the red channel. Index 0 is reserved/zero; lamp N samples texel N.
+- `RuntimeMachine` owns CPU lamp state and the GPU lamp texture; Faces only bind references to that machine-owned texture.
+- `RuntimeMachine.ApplyDynamicState()` uploads only when the lamp state is dirty, coalescing multiple changes into one upload.
+- `RuntimeFaceMaterialFactory` binds the machine lamp texture and centralizes the new shader property IDs.
+- `Oasis/Face` now decodes RGB lamp ID/weight contributions, gates by the runtime mask formula, multiplies artwork by static brightness plus lamp light, clamps RGB, and preserves artwork alpha.
+- Added `RuntimeMachineLampUpdater` to upload dirty lamp data during `LateUpdate`.
+- Added guarded `RuntimeLampDevelopmentControls` in Editor/development builds for deterministic manual verification.
+
+## Development controls
+
+In Preview/Player development builds:
+
+- `[` selects the previous lamp number.
+- `]` selects the next lamp number.
+- `0` sets the selected lamp to 0%.
+- `1` sets the selected lamp to 25%.
+- `2` sets the selected lamp to 50%.
+- `3` sets the selected lamp to 100%.
+- `C` clears all lamps.
+- Hold `L` to cycle the configured small lamp range.
+
+## Backward compatibility
+
+Faces missing lookup textures remain non-fatal and keep static artwork. Missing lookup texture defaults sample as black, so no dynamic light is added. Machine builds without Faces continue to load. No schema changes were introduced.
+
+## Known limitations
+
+- No emulator bridge is implemented.
+- No support is added for speculative `lampIds1`/`lampWeights1` textures because the current production exporter does not write them.
+- Tray IDs are decoded/documented but do not bank lamp state because the authoritative current Editor preview uses lamp ID directly.
+
+## Next checkpoint
+
+`TASK_02_EMULATION_LAMP_BRIDGE.md`

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_01_RUNTIME_LAMP_STATE_AND_SHADER_DECODING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_01_RUNTIME_LAMP_STATE_AND_SHADER_DECODING.md
@@ -14,11 +14,23 @@ Implement a machine-owned runtime lamp-state model, bind it to Face materials, a
 - `RuntimeFaceMaterialFactory` binds the machine lamp texture and centralizes the new shader property IDs.
 - `Oasis/Face` now decodes RGB lamp ID/weight contributions, gates by the runtime mask formula, multiplies artwork by static brightness plus lamp light, clamps RGB, and preserves artwork alpha.
 - Added `RuntimeMachineLampUpdater` to upload dirty lamp data during `LateUpdate`.
-- Added guarded `RuntimeLampDevelopmentControls` in Editor/development builds for deterministic manual verification.
+- Added guarded `RuntimeLampDevelopmentControls` in Editor/development builds for deterministic manual verification. The component now defaults to automatic no-keyboard diagnostics rather than manual keyboard cycling.
 
-## Development controls
+## Development diagnostics
 
-In Preview/Player development builds:
+In Unity Editor or Development builds, `MachinePreviewLoader` automatically attaches the runtime lamp diagnostic component after Faces render. The default mode is `AutomaticSweep` and requires no keyboard input.
+
+Default automatic sequence:
+
+1. All valid lamps `1–255` on for `0.5` seconds.
+2. All lamps off for `0.5` seconds.
+3. Repeat the all-on/all-off flash once more.
+4. Sweep one lamp at a time from `1` through `255`, holding each lamp at full brightness for `0.1` seconds.
+5. Clear all lamps and repeat the sequence.
+
+The diagnostic logs startup state, Face/material binding counts, lamp-state texture dimensions, lookup-data summaries, all-on/all-off transitions, beginning sweep, periodic sweep progress, and sequence repeats. If an all-lamp flash has no visual effect, use these Console summaries to distinguish no rendered Face binding, missing lamp-state material binding, empty lookup textures, zero lookup weights, or shader illumination failure.
+
+Manual mode remains available by changing the component mode in the Inspector. In Manual mode:
 
 - `[` selects the previous lamp number.
 - `]` selects the next lamp number.
@@ -27,7 +39,18 @@ In Preview/Player development builds:
 - `2` sets the selected lamp to 50%.
 - `3` sets the selected lamp to 100%.
 - `C` clears all lamps.
-- Hold `L` to cycle the configured small lamp range.
+
+## Manual no-keyboard verification
+
+1. Open the Oasis Player Unity project.
+2. Enter Play Mode with the existing machine-preview arguments/configuration.
+3. Wait for the cabinet and Face to load.
+4. Do not press any keys.
+5. Observe two all-lamp flashes.
+6. Observe the Player sweep lamps `1–255`, one every `0.1` seconds.
+7. Watch the Console for diagnostic startup, Face/material binding counts, lookup-data validation, all-on/all-off transitions, periodic sweep progress, and sequence repeats.
+8. Confirm the sequence repeats.
+9. Confirm exiting Play Mode produces no cleanup errors.
 
 ## Backward compatibility
 

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_02_EMULATION_LAMP_BRIDGE.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_02_EMULATION_LAMP_BRIDGE.md
@@ -1,0 +1,5 @@
+# Task 02: Emulation Lamp Bridge
+
+Next checkpoint. Bridge emulator/backend lamp output into `RuntimeLampState` without changing the Face export texture contract.
+
+Do not implement in Task 01.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
@@ -1,0 +1,5 @@
+# Task 03: Lamp Rendering Validation and Tuning
+
+Future checkpoint. Validate Player lamp rendering against known Face assets and tune only documented constants after Task 01 runtime decoding and Task 02 lamp bridging are in place.
+
+Do not implement in Task 01.


### PR DESCRIPTION
### Motivation

- Complete Phase 3 Task 01 by proving dynamic lamp rendering in the Player independent of any emulator backend via a machine-owned runtime lamp model and shader decoding. 
- Preserve the Phase 2 runtime Face export contract and reuse the authoritative Editor encoding for `trayId.png`, `lampIds0.png`, `lampWeights0.png`, and `mask.png` rather than redesigning textures.

### Description

- Added a machine-owned lamp model: `RuntimeLampState` (normalized `0.0..1.0`, valid lamp IDs `1..255`, `0` = sentinel) and `RuntimeLampStateTexture` (256×1 `Texture2D`, point-filtered, red channel holds brightness) and integrated them into `RuntimeMachine` with lazy GPU creation and explicit disposal. 
- Implemented efficient dirty/coalesced GPU uploads via `RuntimeMachine.ApplyDynamicState()` and a `RuntimeMachineLampUpdater` MonoBehaviour that invokes uploads in `LateUpdate()`; added guarded development-only `RuntimeLampDevelopmentControls` to manually set/cycle lamp brightness in Editor/Dev builds. 
- Bound the shared machine lamp-state texture to per-Face materials without material recreation or shared-material contamination by extending `RuntimeFaceMaterialFactory` and `RuntimeFaceRenderBinding`; added centralized shader property IDs in `RuntimeFaceShaderProperties` (`_OasisLampStateTex`, `_OasisEmissionStrength`).
- Extended the `Oasis/Face` shader to decode the exact Editor-export semantics: RGB channels of `lampIds0.png` provide up to three one-based lamp IDs, RGB of `lampWeights0.png` are byte-quantized weights decoded as `byte/255`, mask is `max(R,G,B) * alpha * maskStrength`, contributions accumulate as `visibleLight = sum(lampBrightness[lampId] * weight)`, and final artwork is multiplied by `(_OasisStaticBrightness + mask * visibleLight * _OasisEmissionStrength)` while preserving artwork alpha. No speculative support for unused `lampIds1`/`lampWeights1` was added. 
- Added focused EditMode tests and minor test adaptations: new `RuntimeLampStateTests` (defaults, set/get/clamp/clear, invalid indices, coalesced texture uploads, decoder semantics) and updated `RuntimeFaceRendererTests` to exercise the machine-owned lamp binding path. 
- Created Phase 3 planning docs and updated `WindowsNetProjects/OasisEditor/00_CURRENT_PRIORITY.md` to point to Phase 3 Task 02; recorded authoritative lookup semantics in `Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md`.

### Testing

- Added EditMode tests: `RuntimeLampStateTests` and updated `RuntimeFaceRendererTests` to create `RuntimeMachine` instances that exercise the new lamp binding; these tests were added to the repo but Unity EditMode tests were not executed in this environment per repository constraints. 
- Ran repository checks: `git diff --check` (no whitespace errors) and committed changes successfully. 
- Note: Unity build, EditMode execution, and Player visual verification were intentionally not run in this Codex environment per `AGENTS.md`; local Unity verification steps are documented in the Phase 3 task doc and the PR description for manual validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5cc438919c83278a8b9204770e4c8b)