### PR TITLE
Refine Oasis/Face shader: add URP base lighting and hue‑preserving lamp emission

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -128,7 +128,11 @@ namespace OasisPlayer.RuntimeBuild
         private const float DefaultStaticBrightness = 1f;
         private const float DefaultMaskStrength = 1f;
         private const float DefaultEmissionStrength = 1.75f;
-        private const float DefaultLampLift = 0.35f;
+        private const float DefaultLampMinLuminance = 0.18f;
+        private const float DefaultLampMaxLuminance = 2.5f;
+        private const float DefaultLampCompression = 2.25f;
+        private const float DefaultBaseAmbientStrength = 1f;
+        private const float DefaultBaseMainLightStrength = 1f;
 
         private readonly string _shaderName;
 
@@ -163,13 +167,17 @@ namespace OasisPlayer.RuntimeBuild
             material.name = $"RuntimeFace_{(face.Reference != null ? face.Reference.faceId : "Face")}_OasisFace";
             BindTextures(material, face);
             if (lampStateTexture != null && lampStateTexture.Texture != null) AssignTexture(material, RuntimeFaceShaderProperties.LampStateTexture, lampStateTexture.Texture);
-            // Keep the base artwork at authored brightness while adding a separate lamp emission pass.
-            // LampLift lets masked lamps remain visible over dark artwork even though runtime exports do
-            // not yet include per-lamp colours or illuminated artwork textures.
+            // Keep the base artwork scene-lit while adding a separate lamp emission pass.
+            // Lamp luminance controls preserve artwork hue at high intensity and keep dark ink visible
+            // without requiring per-lamp colours or illuminated artwork textures in the runtime export.
             if (material.HasProperty(RuntimeFaceShaderProperties.StaticBrightness)) material.SetFloat(RuntimeFaceShaderProperties.StaticBrightness, DefaultStaticBrightness);
             if (material.HasProperty(RuntimeFaceShaderProperties.MaskStrength)) material.SetFloat(RuntimeFaceShaderProperties.MaskStrength, DefaultMaskStrength);
             if (material.HasProperty(RuntimeFaceShaderProperties.EmissionStrength)) material.SetFloat(RuntimeFaceShaderProperties.EmissionStrength, DefaultEmissionStrength);
-            if (material.HasProperty(RuntimeFaceShaderProperties.LampLift)) material.SetFloat(RuntimeFaceShaderProperties.LampLift, DefaultLampLift);
+            if (material.HasProperty(RuntimeFaceShaderProperties.LampMinLuminance)) material.SetFloat(RuntimeFaceShaderProperties.LampMinLuminance, DefaultLampMinLuminance);
+            if (material.HasProperty(RuntimeFaceShaderProperties.LampMaxLuminance)) material.SetFloat(RuntimeFaceShaderProperties.LampMaxLuminance, DefaultLampMaxLuminance);
+            if (material.HasProperty(RuntimeFaceShaderProperties.LampCompression)) material.SetFloat(RuntimeFaceShaderProperties.LampCompression, DefaultLampCompression);
+            if (material.HasProperty(RuntimeFaceShaderProperties.BaseAmbientStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseAmbientStrength, DefaultBaseAmbientStrength);
+            if (material.HasProperty(RuntimeFaceShaderProperties.BaseMainLightStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseMainLightStrength, DefaultBaseMainLightStrength);
             material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
             return true;
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -168,8 +168,8 @@ namespace OasisPlayer.RuntimeBuild
             material.name = $"RuntimeFace_{(face.Reference != null ? face.Reference.faceId : "Face")}_OasisFace";
             BindTextures(material, face);
             if (lampStateTexture != null && lampStateTexture.Texture != null) AssignTexture(material, RuntimeFaceShaderProperties.LampStateTexture, lampStateTexture.Texture);
-            // Keep the base artwork scene-lit while adding a separate lamp emission pass.
-            // Lamp luminance controls preserve artwork hue at high intensity and keep dark ink visible
+            // Keep the base artwork scene-lit while adding alpha-independent lamp emission in the
+            // shader's single premultiplied forward pass. Lamp luminance controls preserve artwork hue
             // without requiring per-lamp colours or illuminated artwork textures in the runtime export.
             if (material.HasProperty(RuntimeFaceShaderProperties.StaticBrightness)) material.SetFloat(RuntimeFaceShaderProperties.StaticBrightness, DefaultStaticBrightness);
             if (material.HasProperty(RuntimeFaceShaderProperties.MaskStrength)) material.SetFloat(RuntimeFaceShaderProperties.MaskStrength, DefaultMaskStrength);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -128,11 +128,12 @@ namespace OasisPlayer.RuntimeBuild
         private const float DefaultStaticBrightness = 1f;
         private const float DefaultMaskStrength = 1f;
         private const float DefaultEmissionStrength = 1.75f;
-        private const float DefaultLampMinLuminance = 0.18f;
-        private const float DefaultLampMaxLuminance = 2.5f;
+        private const float DefaultLampMinLuminance = 0.08f;
+        private const float DefaultLampMaxLuminance = 2f;
         private const float DefaultLampCompression = 2.25f;
         private const float DefaultBaseAmbientStrength = 1f;
         private const float DefaultBaseMainLightStrength = 1f;
+        private const float DefaultBaseAdditionalLightStrength = 1f;
 
         private readonly string _shaderName;
 
@@ -178,6 +179,7 @@ namespace OasisPlayer.RuntimeBuild
             if (material.HasProperty(RuntimeFaceShaderProperties.LampCompression)) material.SetFloat(RuntimeFaceShaderProperties.LampCompression, DefaultLampCompression);
             if (material.HasProperty(RuntimeFaceShaderProperties.BaseAmbientStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseAmbientStrength, DefaultBaseAmbientStrength);
             if (material.HasProperty(RuntimeFaceShaderProperties.BaseMainLightStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseMainLightStrength, DefaultBaseMainLightStrength);
+            if (material.HasProperty(RuntimeFaceShaderProperties.BaseAdditionalLightStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseAdditionalLightStrength, DefaultBaseAdditionalLightStrength);
             material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
             return true;
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
@@ -18,6 +18,7 @@ namespace OasisPlayer.RuntimeBuild
         public const string LampCompressionName = "_OasisLampCompression";
         public const string BaseAmbientStrengthName = "_OasisBaseAmbientStrength";
         public const string BaseMainLightStrengthName = "_OasisBaseMainLightStrength";
+        public const string BaseAdditionalLightStrengthName = "_OasisBaseAdditionalLightStrength";
         public const string MaskStrengthName = "_OasisMaskStrength";
 
         public static readonly int ArtworkTexture = Shader.PropertyToID(ArtworkTextureName);
@@ -33,6 +34,7 @@ namespace OasisPlayer.RuntimeBuild
         public static readonly int LampCompression = Shader.PropertyToID(LampCompressionName);
         public static readonly int BaseAmbientStrength = Shader.PropertyToID(BaseAmbientStrengthName);
         public static readonly int BaseMainLightStrength = Shader.PropertyToID(BaseMainLightStrengthName);
+        public static readonly int BaseAdditionalLightStrength = Shader.PropertyToID(BaseAdditionalLightStrengthName);
         public static readonly int MaskStrength = Shader.PropertyToID(MaskStrengthName);
     }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
@@ -13,7 +13,11 @@ namespace OasisPlayer.RuntimeBuild
         public const string LampStateTextureName = "_OasisLampStateTex";
         public const string EmissionStrengthName = "_OasisEmissionStrength";
         public const string StaticBrightnessName = "_OasisStaticBrightness";
-        public const string LampLiftName = "_OasisLampLift";
+        public const string LampMinLuminanceName = "_OasisLampMinLuminance";
+        public const string LampMaxLuminanceName = "_OasisLampMaxLuminance";
+        public const string LampCompressionName = "_OasisLampCompression";
+        public const string BaseAmbientStrengthName = "_OasisBaseAmbientStrength";
+        public const string BaseMainLightStrengthName = "_OasisBaseMainLightStrength";
         public const string MaskStrengthName = "_OasisMaskStrength";
 
         public static readonly int ArtworkTexture = Shader.PropertyToID(ArtworkTextureName);
@@ -24,7 +28,11 @@ namespace OasisPlayer.RuntimeBuild
         public static readonly int LampStateTexture = Shader.PropertyToID(LampStateTextureName);
         public static readonly int EmissionStrength = Shader.PropertyToID(EmissionStrengthName);
         public static readonly int StaticBrightness = Shader.PropertyToID(StaticBrightnessName);
-        public static readonly int LampLift = Shader.PropertyToID(LampLiftName);
+        public static readonly int LampMinLuminance = Shader.PropertyToID(LampMinLuminanceName);
+        public static readonly int LampMaxLuminance = Shader.PropertyToID(LampMaxLuminanceName);
+        public static readonly int LampCompression = Shader.PropertyToID(LampCompressionName);
+        public static readonly int BaseAmbientStrength = Shader.PropertyToID(BaseAmbientStrengthName);
+        public static readonly int BaseMainLightStrength = Shader.PropertyToID(BaseMainLightStrengthName);
         public static readonly int MaskStrength = Shader.PropertyToID(MaskStrengthName);
     }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -9,12 +9,13 @@ Shader "Oasis/Face"
         _OasisLampWeights0Tex ("Lamp Weights 0", 2D) = "black" {}
         _OasisLampStateTex ("Lamp State", 2D) = "black" {}
         _OasisEmissionStrength ("Emission Strength", Range(0, 8)) = 1.75
-        _OasisLampMinLuminance ("Lamp Minimum Luminance", Range(0, 1)) = 0.18
-        _OasisLampMaxLuminance ("Lamp Maximum Luminance", Range(0, 8)) = 2.5
+        _OasisLampMinLuminance ("Lamp Minimum Luminance", Range(0, 1)) = 0.08
+        _OasisLampMaxLuminance ("Lamp Maximum Luminance", Range(0, 8)) = 2
         _OasisLampCompression ("Lamp Compression", Range(0.1, 8)) = 2.25
         _OasisStaticBrightness ("Static Brightness", Range(0, 2)) = 1
         _OasisBaseAmbientStrength ("Base Ambient Strength", Range(0, 2)) = 1
         _OasisBaseMainLightStrength ("Base Main Light Strength", Range(0, 2)) = 1
+        _OasisBaseAdditionalLightStrength ("Base Additional Light Strength", Range(0, 2)) = 1
         _OasisMaskStrength ("Mask Strength", Range(0, 4)) = 1
     }
 
@@ -23,144 +24,201 @@ Shader "Oasis/Face"
         Tags { "RenderType" = "Transparent" "Queue" = "Transparent" "RenderPipeline" = "UniversalPipeline" }
         LOD 100
 
+        HLSLINCLUDE
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+        struct Attributes
+        {
+            float4 positionOS : POSITION;
+            float3 normalOS : NORMAL;
+            float2 uv : TEXCOORD0;
+        };
+
+        struct Varyings
+        {
+            float4 positionHCS : SV_POSITION;
+            float3 positionWS : TEXCOORD0;
+            half3 normalWS : TEXCOORD1;
+            float2 uv : TEXCOORD2;
+            float4 shadowCoord : TEXCOORD3;
+            float4 screenPos : TEXCOORD4;
+        };
+
+        TEXTURE2D(_OasisArtworkTex);
+        SAMPLER(sampler_OasisArtworkTex);
+        TEXTURE2D(_OasisMaskTex);
+        SAMPLER(sampler_OasisMaskTex);
+        TEXTURE2D(_OasisTrayIdTex);
+        SAMPLER(sampler_OasisTrayIdTex);
+        TEXTURE2D(_OasisLampIds0Tex);
+        SAMPLER(sampler_OasisLampIds0Tex);
+        TEXTURE2D(_OasisLampWeights0Tex);
+        SAMPLER(sampler_OasisLampWeights0Tex);
+        TEXTURE2D(_OasisLampStateTex);
+        SAMPLER(sampler_OasisLampStateTex);
+
+        CBUFFER_START(UnityPerMaterial)
+            float4 _OasisArtworkTex_ST;
+            float _OasisStaticBrightness;
+            float _OasisMaskStrength;
+            float _OasisEmissionStrength;
+            float _OasisLampMinLuminance;
+            float _OasisLampMaxLuminance;
+            float _OasisLampCompression;
+            float _OasisBaseAmbientStrength;
+            float _OasisBaseMainLightStrength;
+            float _OasisBaseAdditionalLightStrength;
+        CBUFFER_END
+
+        Varyings vert(Attributes input)
+        {
+            Varyings output;
+            VertexPositionInputs positionInputs = GetVertexPositionInputs(input.positionOS.xyz);
+            VertexNormalInputs normalInputs = GetVertexNormalInputs(input.normalOS);
+            output.positionHCS = positionInputs.positionCS;
+            output.positionWS = positionInputs.positionWS;
+            output.normalWS = NormalizeNormalPerVertex(normalInputs.normalWS);
+            output.uv = TRANSFORM_TEX(input.uv, _OasisArtworkTex);
+            output.shadowCoord = TransformWorldToShadowCoord(positionInputs.positionWS);
+            output.screenPos = ComputeScreenPos(positionInputs.positionCS);
+            return output;
+        }
+
+        float DecodeLampBrightness(float lampId)
+        {
+            float decoded = floor(saturate(lampId) * 255.0 + 0.5);
+            if (decoded < 1.0 || decoded > 255.0) return 0.0;
+            float u = (decoded + 0.5) / 256.0;
+            return SAMPLE_TEXTURE2D(_OasisLampStateTex, sampler_OasisLampStateTex, float2(u, 0.5)).r;
+        }
+
+        float DecodeWeight(float weight)
+        {
+            return floor(saturate(weight) * 255.0 + 0.5) / 255.0;
+        }
+
+        float DecodeMask(half4 mask)
+        {
+            float grayscale = max(mask.r, max(mask.g, mask.b));
+            return saturate(grayscale * mask.a * _OasisMaskStrength);
+        }
+
+        float AccumulateLampAmount(float2 uv)
+        {
+            half4 mask = SAMPLE_TEXTURE2D(_OasisMaskTex, sampler_OasisMaskTex, uv);
+            half4 lampIds = SAMPLE_TEXTURE2D(_OasisLampIds0Tex, sampler_OasisLampIds0Tex, uv);
+            half4 weights = SAMPLE_TEXTURE2D(_OasisLampWeights0Tex, sampler_OasisLampWeights0Tex, uv);
+
+            float visibleLight = 0.0;
+            visibleLight += DecodeLampBrightness(lampIds.r) * DecodeWeight(weights.r);
+            visibleLight += DecodeLampBrightness(lampIds.g) * DecodeWeight(weights.g);
+            visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
+            return DecodeMask(mask) * saturate(visibleLight);
+        }
+
+        float3 EvaluateDiffuseLight(Light light, half3 normalWS, float strength)
+        {
+            float ndotl = saturate(dot(normalWS, light.direction));
+            return light.color * ndotl * light.distanceAttenuation * light.shadowAttenuation * strength;
+        }
+
+        float3 EvaluateBaseLighting(Varyings input)
+        {
+            half3 normalizedNormal = NormalizeNormalPerPixel(input.normalWS);
+            float3 lighting = SampleSH(normalizedNormal) * _OasisBaseAmbientStrength;
+
+            Light mainLight = GetMainLight(input.shadowCoord);
+            lighting += EvaluateDiffuseLight(mainLight, normalizedNormal, _OasisBaseMainLightStrength);
+
+            InputData inputData = (InputData)0;
+            inputData.positionWS = input.positionWS;
+            inputData.normalWS = normalizedNormal;
+            inputData.viewDirectionWS = GetWorldSpaceNormalizeViewDir(input.positionWS);
+            inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionHCS);
+            inputData.shadowCoord = input.shadowCoord;
+
+            uint additionalLightsCount = GetAdditionalLightsCount();
+            LIGHT_LOOP_BEGIN(additionalLightsCount)
+                Light additionalLight = GetAdditionalLight(lightIndex, input.positionWS, half4(1.0, 1.0, 1.0, 1.0));
+                lighting += EvaluateDiffuseLight(additionalLight, normalizedNormal, _OasisBaseAdditionalLightStrength);
+            LIGHT_LOOP_END
+
+            return max(lighting, 0.0);
+        }
+
+        float3 DeriveLampColour(float3 artworkRgb)
+        {
+            float peak = max(artworkRgb.r, max(artworkRgb.g, artworkRgb.b));
+            float3 chroma = artworkRgb / max(peak, 0.001);
+
+            // Only nearly black pixels lack a reliable source hue. Blend them toward a subdued neutral
+            // fallback; ordinary dark coloured ink keeps its artwork-derived chroma direction.
+            float colourConfidence = saturate(peak / max(_OasisLampMinLuminance, 0.001));
+            float3 fallback = float3(0.55, 0.50, 0.42);
+            return lerp(fallback, chroma, colourConfidence);
+        }
+
+        float CompressLampAmount(float lampAmount)
+        {
+            float compressed = 1.0 - exp2(-max(lampAmount, 0.0) * _OasisLampCompression);
+            return min(compressed, _OasisLampMaxLuminance);
+        }
+
+        float3 EvaluateLampEmission(float2 uv)
+        {
+            half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, uv);
+            float lampAmount = AccumulateLampAmount(uv);
+            float3 lampColour = DeriveLampColour(artwork.rgb);
+            float compressedLampAmount = CompressLampAmount(lampAmount);
+            return lampColour * compressedLampAmount * _OasisEmissionStrength;
+        }
+        ENDHLSL
+
         Pass
         {
-            Name "OasisFaceForwardLit"
+            Name "OasisFaceBaseForwardLit"
             Tags { "LightMode" = "UniversalForward" }
             Blend SrcAlpha OneMinusSrcAlpha
-            Cull Off
+            Cull Back
             ZWrite Off
             ZTest LEqual
 
             HLSLPROGRAM
             #pragma vertex vert
             #pragma fragment frag
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-
-            struct Attributes
-            {
-                float4 positionOS : POSITION;
-                float3 normalOS : NORMAL;
-                float2 uv : TEXCOORD0;
-            };
-
-            struct Varyings
-            {
-                float4 positionHCS : SV_POSITION;
-                float3 positionWS : TEXCOORD0;
-                half3 normalWS : TEXCOORD1;
-                float2 uv : TEXCOORD2;
-            };
-
-            TEXTURE2D(_OasisArtworkTex);
-            SAMPLER(sampler_OasisArtworkTex);
-            TEXTURE2D(_OasisMaskTex);
-            SAMPLER(sampler_OasisMaskTex);
-            TEXTURE2D(_OasisTrayIdTex);
-            SAMPLER(sampler_OasisTrayIdTex);
-            TEXTURE2D(_OasisLampIds0Tex);
-            SAMPLER(sampler_OasisLampIds0Tex);
-            TEXTURE2D(_OasisLampWeights0Tex);
-            SAMPLER(sampler_OasisLampWeights0Tex);
-            TEXTURE2D(_OasisLampStateTex);
-            SAMPLER(sampler_OasisLampStateTex);
-
-            CBUFFER_START(UnityPerMaterial)
-                float4 _OasisArtworkTex_ST;
-                float _OasisStaticBrightness;
-                float _OasisMaskStrength;
-                float _OasisEmissionStrength;
-                float _OasisLampMinLuminance;
-                float _OasisLampMaxLuminance;
-                float _OasisLampCompression;
-                float _OasisBaseAmbientStrength;
-                float _OasisBaseMainLightStrength;
-            CBUFFER_END
-
-            static const float3 OasisLuminanceWeights = float3(0.2126, 0.7152, 0.0722);
-
-            Varyings vert(Attributes input)
-            {
-                Varyings output;
-                VertexPositionInputs positionInputs = GetVertexPositionInputs(input.positionOS.xyz);
-                VertexNormalInputs normalInputs = GetVertexNormalInputs(input.normalOS);
-                output.positionHCS = positionInputs.positionCS;
-                output.positionWS = positionInputs.positionWS;
-                output.normalWS = NormalizeNormalPerVertex(normalInputs.normalWS);
-                output.uv = TRANSFORM_TEX(input.uv, _OasisArtworkTex);
-                return output;
-            }
-
-            float DecodeLampBrightness(float lampId)
-            {
-                float decoded = floor(saturate(lampId) * 255.0 + 0.5);
-                if (decoded < 1.0 || decoded > 255.0) return 0.0;
-                float u = (decoded + 0.5) / 256.0;
-                return SAMPLE_TEXTURE2D(_OasisLampStateTex, sampler_OasisLampStateTex, float2(u, 0.5)).r;
-            }
-
-            float DecodeWeight(float weight)
-            {
-                return floor(saturate(weight) * 255.0 + 0.5) / 255.0;
-            }
-
-            float DecodeMask(half4 mask)
-            {
-                float grayscale = max(mask.r, max(mask.g, mask.b));
-                return saturate(grayscale * mask.a * _OasisMaskStrength);
-            }
-
-            float3 EvaluateBaseLighting(half3 normalWS)
-            {
-                half3 normalizedNormal = NormalizeNormalPerPixel(normalWS);
-                float3 ambient = SampleSH(normalizedNormal) * _OasisBaseAmbientStrength;
-
-                Light mainLight = GetMainLight();
-                // Face targets can be double-sided or exported with either winding. Use an absolute
-                // Lambert term so the printed base responds to the main light without changing culling.
-                float ndotl = abs(dot(normalizedNormal, mainLight.direction));
-                float3 main = mainLight.color * ndotl * mainLight.distanceAttenuation * _OasisBaseMainLightStrength;
-                return max(ambient + main, 0.0);
-            }
-
-            float3 DeriveLampColourDirection(float3 artworkRgb)
-            {
-                float artworkLuminance = max(dot(artworkRgb, OasisLuminanceWeights), 0.001);
-                float3 hueDirection = artworkRgb / artworkLuminance;
-                float3 neutralFallback = float3(1.0, 0.82, 0.55);
-                float darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / max(_OasisLampMinLuminance, 0.001));
-                return lerp(hueDirection, neutralFallback, darkBlend);
-            }
-
-            float CompressLampLuminance(float maskedLamp)
-            {
-                float compressed = 1.0 - exp2(-max(maskedLamp, 0.0) * _OasisLampCompression);
-                return min(compressed * _OasisEmissionStrength, _OasisLampMaxLuminance);
-            }
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile _ _FORWARD_PLUS
 
             half4 frag(Varyings input) : SV_Target
             {
                 half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, input.uv);
-                half4 mask = SAMPLE_TEXTURE2D(_OasisMaskTex, sampler_OasisMaskTex, input.uv);
-                half4 lampIds = SAMPLE_TEXTURE2D(_OasisLampIds0Tex, sampler_OasisLampIds0Tex, input.uv);
-                half4 weights = SAMPLE_TEXTURE2D(_OasisLampWeights0Tex, sampler_OasisLampWeights0Tex, input.uv);
+                float3 baseRgb = artwork.rgb * _OasisStaticBrightness * EvaluateBaseLighting(input);
+                return half4(baseRgb, artwork.a);
+            }
+            ENDHLSL
+        }
 
-                float visibleLight = 0.0;
-                visibleLight += DecodeLampBrightness(lampIds.r) * DecodeWeight(weights.r);
-                visibleLight += DecodeLampBrightness(lampIds.g) * DecodeWeight(weights.g);
-                visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
+        Pass
+        {
+            Name "OasisFaceLampEmission"
+            Tags { "LightMode" = "SRPDefaultUnlit" }
+            Blend One One
+            ColorMask RGB
+            Cull Back
+            ZWrite Off
+            ZTest LEqual
 
-                float maskedLamp = DecodeMask(mask) * saturate(visibleLight);
-                float3 baseRgb = artwork.rgb * _OasisStaticBrightness * EvaluateBaseLighting(input.normalWS);
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
 
-                // Separate colour direction from lamp luminance. This keeps saturated artwork chroma
-                // useful at high intensity, while a warm fallback lets nearly black ink still glow.
-                float3 lampColourDirection = DeriveLampColourDirection(artwork.rgb);
-                float lampLuminance = max(dot(artwork.rgb, OasisLuminanceWeights), _OasisLampMinLuminance) * CompressLampLuminance(maskedLamp);
-                float3 lampEmission = lampColourDirection * lampLuminance;
-
-                return half4(baseRgb + lampEmission, artwork.a);
+            half4 frag(Varyings input) : SV_Target
+            {
+                return half4(EvaluateLampEmission(input.uv), 0.0);
             }
             ENDHLSL
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -177,9 +177,9 @@ Shader "Oasis/Face"
 
         Pass
         {
-            Name "OasisFaceBaseForwardLit"
+            Name "OasisFaceForwardLit"
             Tags { "LightMode" = "UniversalForward" }
-            Blend SrcAlpha OneMinusSrcAlpha
+            Blend One OneMinusSrcAlpha
             Cull Back
             ZWrite Off
             ZTest LEqual
@@ -197,28 +197,9 @@ Shader "Oasis/Face"
             {
                 half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, input.uv);
                 float3 baseRgb = artwork.rgb * _OasisStaticBrightness * EvaluateBaseLighting(input);
-                return half4(baseRgb, artwork.a);
-            }
-            ENDHLSL
-        }
-
-        Pass
-        {
-            Name "OasisFaceLampEmission"
-            Tags { "LightMode" = "SRPDefaultUnlit" }
-            Blend One One
-            ColorMask RGB
-            Cull Back
-            ZWrite Off
-            ZTest LEqual
-
-            HLSLPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-
-            half4 frag(Varyings input) : SV_Target
-            {
-                return half4(EvaluateLampEmission(input.uv), 0.0);
+                float3 basePremultiplied = baseRgb * artwork.a;
+                float3 lampEmission = EvaluateLampEmission(input.uv);
+                return half4(basePremultiplied + lampEmission, artwork.a);
             }
             ENDHLSL
         }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -9,8 +9,12 @@ Shader "Oasis/Face"
         _OasisLampWeights0Tex ("Lamp Weights 0", 2D) = "black" {}
         _OasisLampStateTex ("Lamp State", 2D) = "black" {}
         _OasisEmissionStrength ("Emission Strength", Range(0, 8)) = 1.75
-        _OasisLampLift ("Lamp Lift", Range(0, 1)) = 0.35
+        _OasisLampMinLuminance ("Lamp Minimum Luminance", Range(0, 1)) = 0.18
+        _OasisLampMaxLuminance ("Lamp Maximum Luminance", Range(0, 8)) = 2.5
+        _OasisLampCompression ("Lamp Compression", Range(0.1, 8)) = 2.25
         _OasisStaticBrightness ("Static Brightness", Range(0, 2)) = 1
+        _OasisBaseAmbientStrength ("Base Ambient Strength", Range(0, 2)) = 1
+        _OasisBaseMainLightStrength ("Base Main Light Strength", Range(0, 2)) = 1
         _OasisMaskStrength ("Mask Strength", Range(0, 4)) = 1
     }
 
@@ -21,7 +25,7 @@ Shader "Oasis/Face"
 
         Pass
         {
-            Name "OasisFaceUnlit"
+            Name "OasisFaceForwardLit"
             Tags { "LightMode" = "UniversalForward" }
             Blend SrcAlpha OneMinusSrcAlpha
             Cull Off
@@ -32,17 +36,21 @@ Shader "Oasis/Face"
             #pragma vertex vert
             #pragma fragment frag
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
             struct Attributes
             {
                 float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
                 float2 uv : TEXCOORD0;
             };
 
             struct Varyings
             {
                 float4 positionHCS : SV_POSITION;
-                float2 uv : TEXCOORD0;
+                float3 positionWS : TEXCOORD0;
+                half3 normalWS : TEXCOORD1;
+                float2 uv : TEXCOORD2;
             };
 
             TEXTURE2D(_OasisArtworkTex);
@@ -63,13 +71,23 @@ Shader "Oasis/Face"
                 float _OasisStaticBrightness;
                 float _OasisMaskStrength;
                 float _OasisEmissionStrength;
-                float _OasisLampLift;
+                float _OasisLampMinLuminance;
+                float _OasisLampMaxLuminance;
+                float _OasisLampCompression;
+                float _OasisBaseAmbientStrength;
+                float _OasisBaseMainLightStrength;
             CBUFFER_END
+
+            static const float3 OasisLuminanceWeights = float3(0.2126, 0.7152, 0.0722);
 
             Varyings vert(Attributes input)
             {
                 Varyings output;
-                output.positionHCS = TransformObjectToHClip(input.positionOS.xyz);
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(input.positionOS.xyz);
+                VertexNormalInputs normalInputs = GetVertexNormalInputs(input.normalOS);
+                output.positionHCS = positionInputs.positionCS;
+                output.positionWS = positionInputs.positionWS;
+                output.normalWS = NormalizeNormalPerVertex(normalInputs.normalWS);
                 output.uv = TRANSFORM_TEX(input.uv, _OasisArtworkTex);
                 return output;
             }
@@ -93,6 +111,34 @@ Shader "Oasis/Face"
                 return saturate(grayscale * mask.a * _OasisMaskStrength);
             }
 
+            float3 EvaluateBaseLighting(half3 normalWS)
+            {
+                half3 normalizedNormal = NormalizeNormalPerPixel(normalWS);
+                float3 ambient = SampleSH(normalizedNormal) * _OasisBaseAmbientStrength;
+
+                Light mainLight = GetMainLight();
+                // Face targets can be double-sided or exported with either winding. Use an absolute
+                // Lambert term so the printed base responds to the main light without changing culling.
+                float ndotl = abs(dot(normalizedNormal, mainLight.direction));
+                float3 main = mainLight.color * ndotl * mainLight.distanceAttenuation * _OasisBaseMainLightStrength;
+                return max(ambient + main, 0.0);
+            }
+
+            float3 DeriveLampColourDirection(float3 artworkRgb)
+            {
+                float artworkLuminance = max(dot(artworkRgb, OasisLuminanceWeights), 0.001);
+                float3 hueDirection = artworkRgb / artworkLuminance;
+                float3 neutralFallback = float3(1.0, 0.82, 0.55);
+                float darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / max(_OasisLampMinLuminance, 0.001));
+                return lerp(hueDirection, neutralFallback, darkBlend);
+            }
+
+            float CompressLampLuminance(float maskedLamp)
+            {
+                float compressed = 1.0 - exp2(-max(maskedLamp, 0.0) * _OasisLampCompression);
+                return min(compressed * _OasisEmissionStrength, _OasisLampMaxLuminance);
+            }
+
             half4 frag(Varyings input) : SV_Target
             {
                 half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, input.uv);
@@ -106,14 +152,14 @@ Shader "Oasis/Face"
                 visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
 
                 float maskedLamp = DecodeMask(mask) * saturate(visibleLight);
-                float3 baseRgb = artwork.rgb * _OasisStaticBrightness;
+                float3 baseRgb = artwork.rgb * _OasisStaticBrightness * EvaluateBaseLighting(input.normalWS);
 
-                // Runtime Face exports currently provide artwork, mask coverage, lamp IDs, and weights,
-                // but no separate per-lamp colour or illuminated artwork layer. Derive a controllable
-                // emission colour from the source artwork, lifting dark pixels so masked lamps can read
-                // as luminous instead of only multiplying already-dark source texels.
-                float3 lampColour = lerp(artwork.rgb, float3(1.0, 1.0, 1.0), _OasisLampLift);
-                float3 lampEmission = lampColour * maskedLamp * _OasisEmissionStrength;
+                // Separate colour direction from lamp luminance. This keeps saturated artwork chroma
+                // useful at high intensity, while a warm fallback lets nearly black ink still glow.
+                float3 lampColourDirection = DeriveLampColourDirection(artwork.rgb);
+                float lampLuminance = max(dot(artwork.rgb, OasisLuminanceWeights), _OasisLampMinLuminance) * CompressLampLuminance(maskedLamp);
+                float3 lampEmission = lampColourDirection * lampLuminance;
+
                 return half4(baseRgb + lampEmission, artwork.a);
             }
             ENDHLSL

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
@@ -5,7 +5,7 @@ Read:
 1. `PHASE_03_CONTEXT.md`
 2. The current task document named by `00_CURRENT_PRIORITY.md`
 
-Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning, including the PR 561 follow-up `Oasis/Face` refinement. The Player shader now uses single-sided URP ambient/main/additional-light diffuse lighting for base artwork plus a separate additive, alpha-independent, bounded-chroma lamp emission pass; the Editor preview remains an SDR authoring preview.
+Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning, including the PR 561 follow-up `Oasis/Face` refinement. The Player shader now uses single-sided URP ambient/main/additional-light diffuse lighting for base artwork plus alpha-independent, bounded-chroma lamp emission in one premultiplied forward pass; the Editor preview remains an SDR authoring preview.
 
 Next checkpoint:
 

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
@@ -5,7 +5,7 @@ Read:
 1. `PHASE_03_CONTEXT.md`
 2. The current task document named by `00_CURRENT_PRIORITY.md`
 
-Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning, including the second-pass `Oasis/Face` refinement. The Player shader now uses URP ambient/main-light diffuse lighting for base artwork plus hue-preserving, soft-knee dynamic lamp emission; the Editor preview remains an SDR authoring preview.
+Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning, including the PR 561 follow-up `Oasis/Face` refinement. The Player shader now uses single-sided URP ambient/main/additional-light diffuse lighting for base artwork plus a separate additive, alpha-independent, bounded-chroma lamp emission pass; the Editor preview remains an SDR authoring preview.
 
 Next checkpoint:
 

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/CODEX_START_PROMPT.md
@@ -5,7 +5,7 @@ Read:
 1. `PHASE_03_CONTEXT.md`
 2. The current task document named by `00_CURRENT_PRIORITY.md`
 
-Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning. The Player shader now uses additive lamp emission derived from artwork plus `_OasisLampLift`; the Editor preview remains an SDR authoring preview.
+Current checkpoint complete: Task 03 Lamp Rendering Validation and Tuning, including the second-pass `Oasis/Face` refinement. The Player shader now uses URP ambient/main-light diffuse lighting for base artwork plus hue-preserving, soft-knee dynamic lamp emission; the Editor preview remains an SDR authoring preview.
 
 Next checkpoint:
 

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
@@ -32,27 +32,34 @@ The first Task 03 pass kept the Phase 3 runtime data contract intact and tuned o
 
 The Editor texture preview was inspected and continues to provide an SDR authoring preview using `artwork.rgb * (ambientStrength + mask * visibleLight * emissionStrength)`, clamped to 8-bit output, with no per-lamp colours, illuminated artwork layer, exposure, HDR, bloom, or tonemapping controls.
 
-## Task 03 second-pass Face shader refinement
+## Task 03 second-pass and PR 561 follow-up Face shader refinement
 
-The Player `Oasis/Face` shader now separates scene-lit printed artwork from dynamic lamp emission:
+The Player `Oasis/Face` shader now renders Face output in two transparent passes. The base pass is single-sided (`Cull Back`) and scene-lit by URP spherical-harmonic ambient lighting, the main light, and URP additional per-pixel lights such as point/spot lights. The emission pass is also single-sided/depth-tested but additive (`Blend One One`, `ColorMask RGB`), so lamp RGB is not multiplied by artwork alpha.
+
+The final base formula is:
+
+```text
+baseLighting = SampleSH(normalWS) * _OasisBaseAmbientStrength
+             + mainLight.color * saturate(dot(normalWS, mainLight.direction))
+               * mainLight.distanceAttenuation * mainLight.shadowAttenuation
+               * _OasisBaseMainLightStrength
+             + sum(additionalLight.color * saturate(dot(normalWS, additionalLight.direction))
+                   * additionalLight.distanceAttenuation * additionalLight.shadowAttenuation
+                   * _OasisBaseAdditionalLightStrength)
+baseRgb = artwork.rgb * _OasisStaticBrightness * max(baseLighting, 0)
+```
+
+The final lamp formula keeps the existing lookup contract and uses bounded artwork chroma rather than luminance-normalized colour directions:
 
 ```text
 visibleLight = sum(lampBrightness[lampId] * weight)
-maskedLamp = mask * saturate(visibleLight)
-baseLighting = SampleSH(normalWS) * _OasisBaseAmbientStrength
-             + mainLight.color * abs(dot(normalWS, mainLight.direction))
-               * mainLight.distanceAttenuation * _OasisBaseMainLightStrength
-baseRgb = artwork.rgb * _OasisStaticBrightness * max(baseLighting, 0)
-artworkLuminance = max(dot(artwork.rgb, Rec709Luminance), 0.001)
-hueDirection = artwork.rgb / artworkLuminance
-darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / _OasisLampMinLuminance)
-lampColourDirection = lerp(hueDirection, warmNeutralFallback, darkBlend)
-compressedLamp = 1 - exp2(-maskedLamp * _OasisLampCompression)
-lampLuminance = max(dot(artwork.rgb, Rec709Luminance), _OasisLampMinLuminance)
-              * min(compressedLamp * _OasisEmissionStrength, _OasisLampMaxLuminance)
-lampEmission = lampColourDirection * lampLuminance
-finalRgb = baseRgb + lampEmission
-finalAlpha = artwork.a
+lampAmount = max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength * saturate(visibleLight)
+peak = max(artwork.r, artwork.g, artwork.b)
+chroma = artwork.rgb / max(peak, 0.001)
+colourConfidence = saturate(peak / _OasisLampMinLuminance)
+lampColour = lerp(float3(0.55, 0.50, 0.42), chroma, colourConfidence)
+compressedLampAmount = min(1 - exp2(-lampAmount * _OasisLampCompression), _OasisLampMaxLuminance)
+lampEmission = lampColour * compressedLampAmount * _OasisEmissionStrength
 ```
 
 Default runtime controls are centralized in `RuntimeFaceMaterialFactory` and mirrored by shader defaults:
@@ -60,14 +67,15 @@ Default runtime controls are centralized in `RuntimeFaceMaterialFactory` and mir
 - `_OasisStaticBrightness = 1.0`: authored albedo scale for lamps-off artwork before local lighting.
 - `_OasisBaseAmbientStrength = 1.0`: scale for URP spherical-harmonic ambient lighting.
 - `_OasisBaseMainLightStrength = 1.0`: scale for the URP main-light diffuse term.
+- `_OasisBaseAdditionalLightStrength = 1.0`: scale for URP additional per-pixel lights.
 - `_OasisMaskStrength = 1.0`: preserves exported mask semantics.
-- `_OasisEmissionStrength = 1.75`: overall emissive lamp luminance scale.
-- `_OasisLampMinLuminance = 0.18`: minimum source luminance used for active lamps so dark artwork can still illuminate.
-- `_OasisLampMaxLuminance = 2.5`: practical cap for lamp luminance contribution before output, still allowing HDR values.
-- `_OasisLampCompression = 2.25`: soft-knee response; higher lamp controls produce diminishing luminance growth rather than immediate channel saturation.
+- `_OasisEmissionStrength = 1.75`: explicit dynamic lamp emission scale.
+- `_OasisLampMinLuminance = 0.08`: near-black fallback threshold.
+- `_OasisLampMaxLuminance = 2.0`: practical soft-knee cap before emission scaling, still allowing controlled HDR output.
+- `_OasisLampCompression = 2.25`: soft-knee response.
+
+Oasis Editor Face orientation controls were investigated. `CabinetTargetOverride` stores `FrontSide` (`normal`/`inverted`), `FaceRotation`, and `FaceFlipHorizontal`, and the Editor preview uses those values to reorder quad corners and reverse winding. Those values are not currently exported in runtime Face references or Face manifests, and Oasis Player only replaces materials on existing `OasisFace_` targets. This pass keeps normal Face geometry correctly single-sided and documents a future backward-compatible manifest extension as the lowest-complexity way to preserve Editor inversion semantics in Player without shader branches.
 
 Colour-space assumptions remain unchanged: artwork is loaded as colour/sRGB-style data; mask, lamp lookup, and lamp-state textures are loaded or created as linear data. Lookup textures remain point-filtered; artwork and mask remain bilinear-filtered; runtime textures remain clamped and mip-free.
-
-The transparent render state remains `Blend SrcAlpha OneMinusSrcAlpha`, `ZWrite Off`, `ZTest LEqual`, and `Cull Off`. The shader preserves `artwork.a` and does not let lamp state alter alpha. RGB, including emissive RGB, is still source-alpha blended by Unity's transparent blending at antialiased edges; this preserves existing transparent-edge behaviour rather than creating opaque glow fringes.
 
 Bloom, glow halos, post-processing, and the emulator lamp bridge remain future work. The emulator bridge is not complete.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
@@ -34,7 +34,18 @@ The Editor texture preview was inspected and continues to provide an SDR authori
 
 ## Task 03 second-pass and PR 561 follow-up Face shader refinement
 
-The Player `Oasis/Face` shader now renders Face output in two transparent passes. The base pass is single-sided (`Cull Back`) and scene-lit by URP spherical-harmonic ambient lighting, the main light, and URP additional per-pixel lights such as point/spot lights. The emission pass is also single-sided/depth-tested but additive (`Blend One One`, `ColorMask RGB`), so lamp RGB is not multiplied by artwork alpha.
+The Player `Oasis/Face` shader now renders Face output in one premultiplied transparent `UniversalForward` pass. The pass is single-sided (`Cull Back`) and scene-lit by URP spherical-harmonic ambient lighting, the main light, and URP additional per-pixel lights such as point/spot lights. A previous two-pass attempt used a `SRPDefaultUnlit` additive lamp pass, but manual Unity testing showed no visible dynamic lamp output while the base `UniversalForward` pass rendered. The single-pass design guarantees base and lamp calculations execute together without adding renderer features or duplicate draw infrastructure.
+
+The final blend/output equation is:
+
+```text
+outputRgb = baseRgb * artwork.a + lampEmission
+outputAlpha = artwork.a
+Blend One OneMinusSrcAlpha
+dst.rgb = outputRgb + dst.rgb * (1 - outputAlpha)
+```
+
+Only the base artwork is premultiplied by artwork alpha. Dynamic lamp emission is not attenuated by artwork alpha, scene lighting, light attenuation, or normal direction; it is attenuated by the exported lamp mask, decoded lamp IDs/weights, runtime lamp brightness, and explicit emission controls.
 
 The final base formula is:
 

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/PHASE_03_CONTEXT.md
@@ -24,22 +24,50 @@ Semantics:
 
 - Task 01 proves dynamic lamp rendering without emulator integration.
 - Task 02 will bridge emulation output into the runtime lamp-state model.
-- Task 03 will validate and tune rendering behaviour visually and with more robust render tests.
+- Task 03 validates and tunes rendering behaviour visually and with more robust render tests.
 
-## Task 03 lamp rendering tuning result
+## Task 03 first-pass lamp rendering tuning result
 
-Task 03 kept the Phase 3 runtime data contract intact and tuned only the Player Face composition model. The Editor texture preview was inspected and continues to provide an SDR authoring preview using `artwork.rgb * (ambientStrength + mask * visibleLight * emissionStrength)`, clamped to 8-bit output, with no per-lamp colours, illuminated artwork layer, exposure, HDR, bloom, or tonemapping controls.
+The first Task 03 pass kept the Phase 3 runtime data contract intact and tuned only the Player Face composition model. It changed Player rendering from a clamped multiplier to additive lamp emission derived from artwork plus `_OasisLampLift`. That made dynamic lamp regions clearly visible, but the shader was still unlit and bright lamps could trend toward white because `_OasisLampLift` deliberately mixed every lamp colour toward white before adding HDR emission.
 
-The Player shader now separates lamp-off artwork from dynamic lamp emission. The final runtime formula is:
+The Editor texture preview was inspected and continues to provide an SDR authoring preview using `artwork.rgb * (ambientStrength + mask * visibleLight * emissionStrength)`, clamped to 8-bit output, with no per-lamp colours, illuminated artwork layer, exposure, HDR, bloom, or tonemapping controls.
+
+## Task 03 second-pass Face shader refinement
+
+The Player `Oasis/Face` shader now separates scene-lit printed artwork from dynamic lamp emission:
 
 ```text
 visibleLight = sum(lampBrightness[lampId] * weight)
 maskedLamp = mask * saturate(visibleLight)
-baseRgb = artwork.rgb * _OasisStaticBrightness
-lampColour = lerp(artwork.rgb, white, _OasisLampLift)
-lampEmission = lampColour * maskedLamp * _OasisEmissionStrength
+baseLighting = SampleSH(normalWS) * _OasisBaseAmbientStrength
+             + mainLight.color * abs(dot(normalWS, mainLight.direction))
+               * mainLight.distanceAttenuation * _OasisBaseMainLightStrength
+baseRgb = artwork.rgb * _OasisStaticBrightness * max(baseLighting, 0)
+artworkLuminance = max(dot(artwork.rgb, Rec709Luminance), 0.001)
+hueDirection = artwork.rgb / artworkLuminance
+darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / _OasisLampMinLuminance)
+lampColourDirection = lerp(hueDirection, warmNeutralFallback, darkBlend)
+compressedLamp = 1 - exp2(-maskedLamp * _OasisLampCompression)
+lampLuminance = max(dot(artwork.rgb, Rec709Luminance), _OasisLampMinLuminance)
+              * min(compressedLamp * _OasisEmissionStrength, _OasisLampMaxLuminance)
+lampEmission = lampColourDirection * lampLuminance
 finalRgb = baseRgb + lampEmission
 finalAlpha = artwork.a
 ```
 
-The default runtime controls are `_OasisStaticBrightness = 1.0`, `_OasisMaskStrength = 1.0`, `_OasisEmissionStrength = 1.75`, and `_OasisLampLift = 0.35`. `_OasisLampLift` compensates for the current lack of separate lamp colours or illuminated artwork textures by lifting dark artwork pixels toward white only in masked, assigned lamp regions. The shader intentionally does not clamp final RGB before return, so HDR/overbright output is available where supported. Bloom and post-processing remain optional future work and were not enabled as part of this task.
+Default runtime controls are centralized in `RuntimeFaceMaterialFactory` and mirrored by shader defaults:
+
+- `_OasisStaticBrightness = 1.0`: authored albedo scale for lamps-off artwork before local lighting.
+- `_OasisBaseAmbientStrength = 1.0`: scale for URP spherical-harmonic ambient lighting.
+- `_OasisBaseMainLightStrength = 1.0`: scale for the URP main-light diffuse term.
+- `_OasisMaskStrength = 1.0`: preserves exported mask semantics.
+- `_OasisEmissionStrength = 1.75`: overall emissive lamp luminance scale.
+- `_OasisLampMinLuminance = 0.18`: minimum source luminance used for active lamps so dark artwork can still illuminate.
+- `_OasisLampMaxLuminance = 2.5`: practical cap for lamp luminance contribution before output, still allowing HDR values.
+- `_OasisLampCompression = 2.25`: soft-knee response; higher lamp controls produce diminishing luminance growth rather than immediate channel saturation.
+
+Colour-space assumptions remain unchanged: artwork is loaded as colour/sRGB-style data; mask, lamp lookup, and lamp-state textures are loaded or created as linear data. Lookup textures remain point-filtered; artwork and mask remain bilinear-filtered; runtime textures remain clamped and mip-free.
+
+The transparent render state remains `Blend SrcAlpha OneMinusSrcAlpha`, `ZWrite Off`, `ZTest LEqual`, and `Cull Off`. The shader preserves `artwork.a` and does not let lamp state alter alpha. RGB, including emissive RGB, is still source-alpha blended by Unity's transparent blending at antialiased edges; this preserves existing transparent-edge behaviour rather than creating opaque glow fringes.
+
+Bloom, glow halos, post-processing, and the emulator lamp bridge remain future work. The emulator bridge is not complete.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
@@ -2,112 +2,191 @@
 
 Implemented checkpoint for validating and tuning Player lamp rendering after the dynamic lamp pipeline was proven end-to-end.
 
-## Second-pass investigation findings
+## Follow-up investigation findings for PR 561
 
-### Current Player shader before this pass
+### Why point lights were ignored
 
-- `Oasis/Face` was a dedicated URP transparent shader with `Blend SrcAlpha OneMinusSrcAlpha`, `Cull Off`, `ZWrite Off`, and `ZTest LEqual`.
-- The pass was named `OasisFaceUnlit` and included only URP `Core.hlsl`; no URP lighting functions were used.
-- The shader sampled `artwork.png`, `mask.png`, `lampIds0.png`, `lampWeights0.png`, and the machine-owned `256x1` lamp-state texture. It did not use `lampIds1` or `lampWeights1`.
-- Lamp IDs were decoded as one-based byte values. ID `0` was ignored; valid IDs `1..255` sampled the lamp-state texture at `(lampId + 0.5) / 256`.
-- Weights were decoded as byte-normalized `weight / 255` values. RGB contributions accumulated as `sum(lampBrightness[lampId] * weight)` and were bounded with `saturate` before emission.
-- The mask formula was already correct: `max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength`.
-- Runtime texture loading already matched the colour-space contract: artwork is created as sRGB/colour data, while mask and lookup textures use Unity's linear texture constructor flag; lamp-state texture is also linear. Lookup and lamp-state textures use point filtering; artwork and mask use bilinear filtering; all runtime textures clamp and have no mipmaps.
+- The first PR 561 shader pass sampled URP spherical-harmonic ambient lighting and `GetMainLight()`, but it did not compile or execute an additional-light loop.
+- The Player project uses Universal Render Pipeline `17.0.4`.
+- The PC URP asset has additional lights enabled with an additional-lights-per-object limit of `4` and additional-light shadows enabled. The mobile URP asset also enables additional lights with a per-object limit of `4`, but disables additional-light shadows.
+- The PC renderer asset is configured for rendering mode `2`, so the custom shader needs the standard URP additional-light variants, including the Forward+ keyword path, rather than relying on a main-light-only custom pass.
+- The only other project shader is a legacy surface shader for carpet; there is no existing local URP custom-lighting shader to copy.
 
-### Root causes of the remaining defects
+### Face winding, culling, and Editor inversion semantics
 
-1. **The Face background ignored room lighting.** The base artwork path was `artwork.rgb * _OasisStaticBrightness`, so ambient intensity, main-light colour, main-light intensity, and surface normals had no effect. The cabinet could react to scene light changes while the Face stayed visually flat.
-2. **Bright lamps trended toward white.** The first-pass formula used `lampColour = lerp(artwork.rgb, white, _OasisLampLift)`, then added `lampColour * maskedLamp * _OasisEmissionStrength`. The lift helped dark pixels illuminate but also injected neutral white into every active lamp region. Additive HDR output then pushed already-bright channels toward display/tonemap saturation earlier than weaker channels, reducing chroma in saturated red, yellow, blue, and purple artwork.
-3. **Transparent alpha was not the primary whitening cause.** The shader preserved `artwork.a`, and the transparent blend mode multiplies the entire source RGB by source alpha. That can soften emission at antialiased edges, but it does not explain interior lamp regions moving toward white. Keeping alpha unchanged avoids opaque fringes and preserves existing transparent-edge behaviour.
-4. **Normals and double-sided rendering need a local shader accommodation.** Face targets are rendered with `Cull Off`; depending on exported winding and cabinet orientation, the visible side can have either normal direction relative to the main light. The base-lighting term therefore uses an absolute Lambert factor so the printed artwork reacts to the main light without changing geometry, culling, sorting, or material queue behaviour.
-5. **URP version and APIs.** The Player uses Universal Render Pipeline `17.0.4`, so the shader now uses `Lighting.hlsl`, `GetVertexPositionInputs`, `GetVertexNormalInputs`, `SampleSH`, and `GetMainLight()` from the installed URP shader libraries.
+- Oasis Editor stores Face orientation overrides in `CabinetTargetOverride`: `FrontSide` is either `normal` or `inverted`, `FaceRotation` is `0/90/180/270`, and `FaceFlipHorizontal` is a horizontal Face flip.
+- Editor preview geometry applies rotation/flip to the quad corner order, then computes `reverseWinding = FaceFlipHorizontal XOR isInverted` so its WPF preview can render the intended side.
+- Runtime machine export currently writes each Face reference with only `FaceId`, `AssetName`, `CabinetFaceTargetId`, and `Manifest`. The Editor's `FrontSide`, `FaceRotation`, and `FaceFlipHorizontal` values are not present in `machine.runtime.json`, `face.runtime.json`, or the Unity `MachineRuntimeFaceReference` model.
+- Oasis Player currently resolves an existing `OasisFace_` cabinet target and replaces its material; it does not rebuild Face geometry, flip UVs, reverse winding, or read any inversion metadata.
+- Because the inversion data is not exported today, carrying the Editor option through would require a small but real runtime schema/export/Player-model change. This pass does not change runtime schemas. The shader is now correctly single-sided for normal exported Face geometry, and the documented lowest-complexity future approach is to export the three existing target override fields backward-compatibly on `MachineRuntimeFaceReference` and apply them by adjusting target geometry/UVs or culling outside the fragment shader.
 
-## Final Player rendering model
+### Root causes corrected in this pass
 
-The Unity `Oasis/Face` shader now separates scene-lit printed artwork from dynamic lamp emission:
+1. **Local point and spot lights were missing.** The shader had no `GetAdditionalLightsCount()`/`GetAdditionalLight(...)` path, so additional URP lights that lit the cabinet could not affect the Face base artwork.
+2. **The Face was treated as double-sided.** `Cull Off` plus `abs(dot(normal, lightDirection))` made both sides light as if front-facing. This hid orientation errors and did not match the single-sided printed-artwork model.
+3. **Lamp emission was attenuated by artwork alpha.** Returning `baseRgb + lampEmission` through `Blend SrcAlpha OneMinusSrcAlpha` multiplied all source RGB, including emission, by `artwork.a`. This violated the rule that lamps are attenuated only by mask, lamp lookup/state, and explicit lamp controls.
+4. **Lamp colour could still become pale/white.** Luminance normalization (`artwork.rgb / artworkLuminance`) can produce colour-direction channels far above `1.0`, and the broad warm fallback blended dark coloured regions toward cream. Additive HDR output and tonemapping then had an easier path to white/pale results.
+
+## Final Player pass design and blend equations
+
+`Oasis/Face` now uses two transparent passes with identical UVs, depth test, and single-sided culling:
+
+### Pass 1: `OasisFaceBaseForwardLit`
+
+- `LightMode = UniversalForward`
+- `Blend SrcAlpha OneMinusSrcAlpha`
+- `Cull Back`
+- `ZWrite Off`
+- `ZTest LEqual`
+- Output: `half4(baseRgb, artwork.a)`
+
+Blend equation:
 
 ```text
-visibleLight = sum(lampBrightness[lampId] * weight)
-maskedLamp = max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength * saturate(visibleLight)
-
-baseLighting = SampleSH(normalWS) * _OasisBaseAmbientStrength
-             + mainLight.color * abs(dot(normalWS, mainLight.direction))
-               * mainLight.distanceAttenuation * _OasisBaseMainLightStrength
-baseRgb = artwork.rgb * _OasisStaticBrightness * max(baseLighting, 0)
-
-artworkLuminance = max(dot(artwork.rgb, float3(0.2126, 0.7152, 0.0722)), 0.001)
-hueDirection = artwork.rgb / artworkLuminance
-darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / _OasisLampMinLuminance)
-lampColourDirection = lerp(hueDirection, float3(1.0, 0.82, 0.55), darkBlend)
-compressedLamp = 1 - exp2(-maskedLamp * _OasisLampCompression)
-lampLuminance = max(dot(artwork.rgb, Rec709Luminance), _OasisLampMinLuminance)
-              * min(compressedLamp * _OasisEmissionStrength, _OasisLampMaxLuminance)
-lampEmission = lampColourDirection * lampLuminance
-
-finalRgb = baseRgb + lampEmission
-finalAlpha = artwork.a
+dst.rgb = baseRgb * artwork.a + dst.rgb * (1 - artwork.a)
+dst.a   = artwork.a + dst.a * (1 - artwork.a)
 ```
 
-### Shader properties and defaults
+This keeps normal transparent Face artwork and antialiased base edges alpha-controlled.
+
+### Pass 2: `OasisFaceLampEmission`
+
+- `LightMode = SRPDefaultUnlit`
+- `Blend One One`
+- `ColorMask RGB`
+- `Cull Back`
+- `ZWrite Off`
+- `ZTest LEqual`
+- Output: `half4(lampEmission, 0)`
+
+Blend equation:
+
+```text
+dst.rgb = lampEmission + dst.rgb
+dst.a   = unchanged because ColorMask RGB disables alpha writes
+```
+
+This makes lamp emission independent of artwork alpha, scene lighting, light attenuation, normal direction, and ambient lighting. It is still spatially restricted by the rendered single-sided Face geometry, depth-tested against the scene, and numerically restricted by the exported lamp mask, decoded lamp IDs, decoded lamp weights, runtime brightness, and explicit lamp controls.
+
+## Final base-lighting formula
+
+```text
+normalWS = NormalizeNormalPerPixel(input.normalWS)
+ambient = SampleSH(normalWS) * _OasisBaseAmbientStrength
+
+main = GetMainLight(input.shadowCoord)
+mainDiffuse = main.color
+            * saturate(dot(normalWS, main.direction))
+            * main.distanceAttenuation
+            * main.shadowAttenuation
+            * _OasisBaseMainLightStrength
+
+additionalDiffuse = 0
+for each URP additional per-pixel light visible to the object:
+    light = GetAdditionalLight(lightIndex, positionWS, half4(1,1,1,1))
+    additionalDiffuse += light.color
+                       * saturate(dot(normalWS, light.direction))
+                       * light.distanceAttenuation
+                       * light.shadowAttenuation
+                       * _OasisBaseAdditionalLightStrength
+
+baseLighting = max(ambient + mainDiffuse + additionalDiffuse, 0)
+baseRgb = artwork.rgb * _OasisStaticBrightness * baseLighting
+```
+
+The base pass compiles the URP variants for main-light shadows, additional lights, additional-light shadows, soft shadows, and Forward+ so point and spot lights can affect the printed Face base through the same additional-light path as supported URP lit objects.
+
+## Final lamp-emission formula
+
+Lamp lookup semantics are unchanged:
+
+```text
+visibleLight = sum(DecodeLampBrightness(lampIds0.rgb) * DecodeWeight(lampWeights0.rgb))
+lampAmount = max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength * saturate(visibleLight)
+```
+
+Colour preservation now uses bounded peak-normalized chroma rather than luminance-normalized overbright direction:
+
+```text
+peak = max(artwork.r, artwork.g, artwork.b)
+chroma = artwork.rgb / max(peak, 0.001)
+colourConfidence = saturate(peak / _OasisLampMinLuminance)
+fallback = float3(0.55, 0.50, 0.42)
+lampColour = lerp(fallback, chroma, colourConfidence)
+```
+
+Lamp intensity remains monotonic and softly compressed:
+
+```text
+compressedLampAmount = min(1 - exp2(-lampAmount * _OasisLampCompression), _OasisLampMaxLuminance)
+lampEmission = lampColour * compressedLampAmount * _OasisEmissionStrength
+```
+
+The dominant artwork colour channel is bounded to `1.0` before explicit emission scaling, so saturated reds, yellows, blues, and purples retain channel ratios better. The fallback activates only when peak RGB is very low, is subdued rather than near-white, and does not override ordinary dark coloured artwork that still has measurable chroma.
+
+## Shader properties and defaults
+
+Defaults are centralized in `RuntimeFaceMaterialFactory` and mirrored in the shader:
 
 - `_OasisStaticBrightness = 1.0`: authored albedo scale for lamps-off artwork before local lighting.
-- `_OasisBaseAmbientStrength = 1.0`: scale for URP spherical-harmonic ambient lighting on the base artwork.
-- `_OasisBaseMainLightStrength = 1.0`: scale for the URP main-light diffuse term on the base artwork.
-- `_OasisMaskStrength = 1.0`: preserves the exported Face mask semantics.
-- `_OasisEmissionStrength = 1.75`: overall dynamic lamp luminance scale.
-- `_OasisLampMinLuminance = 0.18`: minimum source luminance for active lamps, allowing dark ink to glow visibly.
-- `_OasisLampMaxLuminance = 2.5`: practical upper bound for lamp luminance before output. The final RGB is still not clamped, so HDR output remains available where the pipeline supports it.
-- `_OasisLampCompression = 2.25`: soft-knee response for active lamps. Increasing lamp control produces diminishing luminance growth instead of immediate linear overdrive.
+- `_OasisBaseAmbientStrength = 1.0`: scale for URP spherical-harmonic ambient lighting.
+- `_OasisBaseMainLightStrength = 1.0`: scale for the URP main-light diffuse term.
+- `_OasisBaseAdditionalLightStrength = 1.0`: scale for URP additional per-pixel lights such as point and spot lights.
+- `_OasisMaskStrength = 1.0`: preserves exported mask semantics.
+- `_OasisEmissionStrength = 1.75`: explicit dynamic lamp emission scale.
+- `_OasisLampMinLuminance = 0.08`: low colour-confidence threshold for near-black fallback activation.
+- `_OasisLampMaxLuminance = 2.0`: practical soft-knee cap before emission scaling, still allowing controlled HDR output.
+- `_OasisLampCompression = 2.25`: soft-knee response; higher lamp controls produce diminishing growth rather than immediate linear overdrive.
 
-`_OasisLampLift` was removed because its previous meaning was specifically to mix lamp colour toward white, which is the washed-out behaviour this pass fixes.
-
-### Why hue and saturation are preserved
-
-The lamp path no longer multiplies raw artwork by an arbitrarily large scalar and no longer mixes all active lamps toward white. It derives a luminance-normalized colour direction from the artwork, computes lamp brightness as a separate scalar luminance, and then recombines them. Saturated colours therefore keep their chroma ratios longer under HDR/tonemapping. Very dark artwork uses a controlled warm fallback only when the source luminance is below `_OasisLampMinLuminance`, so black or near-black ink can still produce visible illumination without turning every coloured lamp white.
-
-### Transparent rendering considerations
-
-The render state remains transparent and unchanged. Alpha output remains `artwork.a`; lamp calculations do not alter alpha. With `Blend SrcAlpha OneMinusSrcAlpha`, source RGB including HDR emission is still alpha-weighted by Unity during transparent blending. This is intentional for antialiased Face edges and avoids white or opaque fringes. Interior opaque pixels retain the full base-plus-emission result.
+`_OasisLampLift` remains removed because mixing active lamp colour toward white was one cause of the washed-out result.
 
 ## Editor decision
 
-No Oasis Editor code was changed in this pass. The defect is local to the Unity Player shader: the Editor preview remains a non-HDR SDR authoring preview and does not participate in URP scene lighting. Its lamp assignment, coverage, weighting, and relative colour remain useful for authoring validation, while the Player owns the runtime scene-lit diffuse base and HDR-capable emission path. Matching the Player's lighting and tonemapping in WPF/Skia would be a broader preview-rendering feature, not a required schema or shared-calculation fix.
+No Editor rendering code was changed. The Editor preview remains an SDR authoring preview for lamp assignment, coverage, weighting, and relative colour. The existing Editor Face inversion controls were investigated, but their metadata is not exported to the Player runtime manifests. Preserving those inversion semantics in Player should be handled by a future backward-compatible manifest extension and a geometry/UV/culling adjustment outside the fragment shader, not by reintroducing double-sided lighting.
 
 ## Preserved runtime behaviour
 
 - No emulator, MAME, or native backend lamp bridge was implemented.
-- Runtime manifests, Face manifests, machine manifests, lookup formats, lamp numbering, and lamp texture dimensions were not changed.
-- Runtime Face texture ownership, cleanup, material replacement, and shared machine lamp-state texture ownership were not changed.
-- The automatic diagnostic remains guarded by `#if UNITY_EDITOR || DEVELOPMENT_BUILD` and its sequence remains all-on/all-off/all-on/all-off followed by a `1..255` sweep at `0.1` seconds per lamp.
-- Bloom, glow halos, camera HDR settings, tonemapping, post-processing, and project-wide lighting settings remain future work.
+- Runtime lamp numbering, lamp-state texture dimensions, lookup texture formats, lamp-state ownership, update scheduling, cleanup, and material replacement remain unchanged.
+- The shader still reads only `lampIds0` and `lampWeights0`; it does not add `lampIds1` or `lampWeights1` support.
+- The automatic diagnostic remains guarded by `#if UNITY_EDITOR || DEVELOPMENT_BUILD` and its automatic sequence remains all-on/all-off/all-on/all-off followed by a `1..255` sweep at `0.1` seconds per lamp.
+- Bloom, glow halos, camera HDR settings, tonemapping, post-processing, and project-wide URP/colour-space settings remain outside scope.
 
 ## Manual Unity verification checklist
 
 For all visual checks, compare hue preservation, saturation, luminance, detail retention, response to scene lights, visibility with lamps off, and visibility with lamps on.
 
-1. Lamps off, low room-light intensity: Face artwork should dim like printed cabinet artwork but remain readable from ambient light.
-2. Lamps off, high room-light intensity: Face artwork should brighten coherently with the cabinet and should not look self-lit.
-3. Confirm that the Face base artwork changes when ambient/main-light intensity changes.
-4. Confirm that the cabinet and Face react in the same visual direction to room-light edits.
-5. All-lamp flash in a dark room: masked assigned lamp regions should remain visible because lamp emission is independent of scene lighting.
-6. All-lamp flash in a brightly lit room: lamps should still add visible illumination without turning broad regions white.
-7. Individual lamp sweep: each ID from `1` through `255` should affect only pixels assigned to that ID; ID `0` pixels should stay dark/off.
-8. Saturated red lamp regions: red hue and saturation should remain identifiable at high brightness.
-9. Saturated yellow lamp regions: yellow should brighten without collapsing immediately to flat white.
-10. Saturated blue lamp regions: blue should retain useful chroma and not be over-neutralized.
-11. Saturated purple lamp regions: both red/blue character and detail should remain visible.
-12. Dark artwork regions with active lamps: regions should illuminate visibly via minimum lamp luminance rather than staying black.
-13. Bright artwork regions with active lamps: detail should remain useful under the soft-knee response.
-14. Pixels influenced by multiple weighted lamps: accumulated weights should increase local brightness predictably up to the bounded full contribution.
-15. Transparent and antialiased Face edges: alpha should remain correct with no opaque white fringes.
-16. Multiple Faces sharing one machine lamp-state texture: all Faces should react to the shared state while retaining independent masks and lookups.
-17. Development Build diagnostic behaviour: automatic all-on/all-off/all-on/all-off and single-lamp sweep should run with no keyboard dependency.
-18. Production build with no diagnostic activity: no automatic diagnostic component or lamp sweep should run.
+1. Lamps off with low ambient light: printed Face base should dim but remain ambient-lit.
+2. Lamps off with high ambient light: printed Face base should brighten coherently with the cabinet.
+3. Point light off: confirm the Face lacks the local point-light contribution.
+4. Point light on near the Face: Face base should brighten like nearby cabinet surfaces.
+5. Point light moved closer and farther: distance attenuation should visibly change Face brightness.
+6. Point light moved across the Face: local diffuse response should move across the Face consistently with normals.
+7. Cabinet and Face comparison under the same point light: both should react in the same direction, allowing for material differences.
+8. Main directional light response: rotating or changing intensity should affect the Face base through one-sided Lambert lighting.
+9. Face viewed from the back: normal geometry should not render from the back with `Cull Back`.
+10. Normal Face quad orientation: intended front side should render and light correctly.
+11. Inverted Face quad using the Editor inversion option: currently document as a known Player export gap unless a future manifest extension is implemented.
+12. All-lamp flash with dark room lighting: lamps should remain visible because emission is independent of scene lighting.
+13. All-lamp flash with bright room lighting: lamps should add visible colour without washing out broad regions.
+14. Individual lamp sweep: IDs `1..255` should affect only assigned pixels; ID `0` remains ignored.
+15. Saturated red regions: red should stay red at high lamp state.
+16. Saturated yellow regions: yellow should brighten without becoming white prematurely.
+17. Saturated blue regions: blue should retain useful chroma.
+18. Saturated purple regions: purple should retain its red/blue character.
+19. Very dark coloured artwork: detectable colour should remain the dominant lamp hue.
+20. Near-black artwork: fallback should be restrained and not appear cream/white over normal dark colours.
+21. Transparent artwork edges: base alpha edges should remain smooth with no white fringes.
+22. Pixels influenced by multiple lamp weights: brightness should accumulate predictably up to the bounded soft-knee response.
+23. Multiple Faces sharing one lamp-state texture: all Faces should react to the shared texture with independent masks/lookups.
+24. Development Build diagnostic: automatic all-on/all-off/all-on/all-off and sweep should run without keyboard dependency.
+25. Production build without diagnostic: automatic diagnostic code should not run.
 
 ## Remaining limitations and follow-up
 
-- Unity shader compilation and visual tone mapping must still be verified inside the Unity Editor or a Player build because this repository environment does not provide a Unity batchmode compiler.
-- Runtime exports still do not include separate per-lamp colours or illuminated artwork textures; the Player therefore derives lamp colour from underlying artwork plus a dark-pixel fallback.
-- The shader accounts for ambient spherical harmonics and the URP main light only. Additional per-pixel additional lights, shadows, normal maps, metallic, and glossy PBR behaviour remain intentionally out of scope.
-- Bloom/glow halos are not configured by this task and remain optional future polish.
-- Emulator lamp integration remains the next Phase 3 bridge task and is not marked complete here.
+- Unity shader compilation and visual tone mapping must still be verified inside Unity because this repository environment does not include the Unity editor/batchmode compiler.
+- Runtime manifests still lack the Editor's Face target orientation overrides. A future small, backward-compatible export should carry `FrontSide`, `FaceRotation`, and `FaceFlipHorizontal` to Player and apply them outside the fragment shader.
+- The custom Face shader now covers ambient, main light, and URP additional per-pixel lights; it intentionally does not implement normal maps, metallic/glossy PBR, cookies, or custom glow halos.
+- Additional-light shadows depend on the active URP asset/platform support; the PC asset supports them, while the mobile asset currently does not.
+- Bloom/glow halos remain optional future polish.
+- Emulator lamp integration remains the next Phase 3 bridge task and is not complete.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
@@ -2,75 +2,112 @@
 
 Implemented checkpoint for validating and tuning Player lamp rendering after the dynamic lamp pipeline was proven end-to-end.
 
-## Investigation findings
+## Second-pass investigation findings
 
-### Editor Face preview path
+### Current Player shader before this pass
 
-- Cabinet Face previews use `FaceDocumentArtworkPreviewRenderer`, which delegates texture-backed lamp previews to `FaceCompositor` and `FaceTexturePreviewRenderer` when runtime render assets are available.
-- Static cabinet preview modes support `Live`, `BackgroundOnly`, `LampsOff`, and `LampsAllOn`; `LampsAllOn` creates a temporary runtime state with linked lamp references set to intensity `1.0`.
-- Live cabinet preview caches the static Face base, then calls `FaceCompositor.Shared.RenderLampOverlay(...)` so changing lamp intensities only recompose affected pixels.
-- The texture preview loads `artwork.png`, `mask.png`, `trayId.png`, `lampIds0.png`, and `lampWeights0.png`; it does not consume `lampIds1` or `lampWeights1`.
-- The Editor has no per-lamp colour data and no alternate illuminated artwork layer in the runtime texture preview path. Lamp colour is the authored artwork colour.
-- The Editor precomputes an ambient/base image as `artwork.rgb * AmbientStrength`, preserving artwork alpha.
-- Runtime lamp intensity is clamped to `0.0..1.0`. Lamp ID `0` and zero weights are skipped. Valid lamp IDs are `1..255`.
-- Mask strength is applied as `max(mask.r, mask.g, mask.b) * mask.a * MaskStrength`, quantized to a byte.
-- Lamp output is computed as `artwork.rgb * (AmbientStrength + mask * visibleLight * EmissionStrength)` and clamped to 8-bit channel output.
-- Default Editor texture-preview controls are `AmbientStrength = 1.0`, `EmissionStrength = 1.15`, `MaskStrength = 1.0`, and `LampIds0ChannelCount = 3`. There is no exposure or HDR/bloom control in this CPU/WPF preview path.
-- Skia/WPF preview composition produces SDR 8-bit bitmap output; it is a gamma-space authoring preview rather than an HDR output path.
+- `Oasis/Face` was a dedicated URP transparent shader with `Blend SrcAlpha OneMinusSrcAlpha`, `Cull Off`, `ZWrite Off`, and `ZTest LEqual`.
+- The pass was named `OasisFaceUnlit` and included only URP `Core.hlsl`; no URP lighting functions were used.
+- The shader sampled `artwork.png`, `mask.png`, `lampIds0.png`, `lampWeights0.png`, and the machine-owned `256x1` lamp-state texture. It did not use `lampIds1` or `lampWeights1`.
+- Lamp IDs were decoded as one-based byte values. ID `0` was ignored; valid IDs `1..255` sampled the lamp-state texture at `(lampId + 0.5) / 256`.
+- Weights were decoded as byte-normalized `weight / 255` values. RGB contributions accumulated as `sum(lampBrightness[lampId] * weight)` and were bounded with `saturate` before emission.
+- The mask formula was already correct: `max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength`.
+- Runtime texture loading already matched the colour-space contract: artwork is created as sRGB/colour data, while mask and lookup textures use Unity's linear texture constructor flag; lamp-state texture is also linear. Lookup and lamp-state textures use point filtering; artwork and mask use bilinear filtering; all runtime textures clamp and have no mipmaps.
 
-### Cause of dim Player lamps
+### Root causes of the remaining defects
 
-The Player shader used the same weak family of model as the Editor preview:
+1. **The Face background ignored room lighting.** The base artwork path was `artwork.rgb * _OasisStaticBrightness`, so ambient intensity, main-light colour, main-light intensity, and surface normals had no effect. The cabinet could react to scene light changes while the Face stayed visually flat.
+2. **Bright lamps trended toward white.** The first-pass formula used `lampColour = lerp(artwork.rgb, white, _OasisLampLift)`, then added `lampColour * maskedLamp * _OasisEmissionStrength`. The lift helped dark pixels illuminate but also injected neutral white into every active lamp region. Additive HDR output then pushed already-bright channels toward display/tonemap saturation earlier than weaker channels, reducing chroma in saturated red, yellow, blue, and purple artwork.
+3. **Transparent alpha was not the primary whitening cause.** The shader preserved `artwork.a`, and the transparent blend mode multiplies the entire source RGB by source alpha. That can soften emission at antialiased edges, but it does not explain interior lamp regions moving toward white. Keeping alpha unchanged avoids opaque fringes and preserves existing transparent-edge behaviour.
+4. **Normals and double-sided rendering need a local shader accommodation.** Face targets are rendered with `Cull Off`; depending on exported winding and cabinet orientation, the visible side can have either normal direction relative to the main light. The base-lighting term therefore uses an absolute Lambert factor so the printed artwork reacts to the main light without changing geometry, culling, sorting, or material queue behaviour.
+5. **URP version and APIs.** The Player uses Universal Render Pipeline `17.0.4`, so the shader now uses `Lighting.hlsl`, `GetVertexPositionInputs`, `GetVertexNormalInputs`, `SampleSH`, and `GetMainLight()` from the installed URP shader libraries.
 
-```text
-artwork.rgb * (staticBrightness + mask * visibleLampContribution * emissionStrength)
-```
+## Final Player rendering model
 
-with default `emissionStrength = 1.0`, then saturated the result before returning it. This means dark artwork pixels remain dark under moderate multipliers, output cannot exceed `1.0`, and transparent blending cannot create a convincing glow by itself. The runtime data and lookup semantics are working; the dimness is caused primarily by the composition model and SDR clamp, not by lamp numbering, mask lookup, weight decoding, ownership, or lamp-state upload.
-
-## Implementation
-
-The Unity `Oasis/Face` shader now separates base artwork from dynamic lamp emission:
+The Unity `Oasis/Face` shader now separates scene-lit printed artwork from dynamic lamp emission:
 
 ```text
 visibleLight = sum(lampBrightness[lampId] * weight)
-maskedLamp = mask * saturate(visibleLight)
-baseRgb = artwork.rgb * _OasisStaticBrightness
-lampColour = lerp(artwork.rgb, white, _OasisLampLift)
-lampEmission = lampColour * maskedLamp * _OasisEmissionStrength
+maskedLamp = max(mask.r, mask.g, mask.b) * mask.a * _OasisMaskStrength * saturate(visibleLight)
+
+baseLighting = SampleSH(normalWS) * _OasisBaseAmbientStrength
+             + mainLight.color * abs(dot(normalWS, mainLight.direction))
+               * mainLight.distanceAttenuation * _OasisBaseMainLightStrength
+baseRgb = artwork.rgb * _OasisStaticBrightness * max(baseLighting, 0)
+
+artworkLuminance = max(dot(artwork.rgb, float3(0.2126, 0.7152, 0.0722)), 0.001)
+hueDirection = artwork.rgb / artworkLuminance
+darkBlend = saturate((_OasisLampMinLuminance - artworkLuminance) / _OasisLampMinLuminance)
+lampColourDirection = lerp(hueDirection, float3(1.0, 0.82, 0.55), darkBlend)
+compressedLamp = 1 - exp2(-maskedLamp * _OasisLampCompression)
+lampLuminance = max(dot(artwork.rgb, Rec709Luminance), _OasisLampMinLuminance)
+              * min(compressedLamp * _OasisEmissionStrength, _OasisLampMaxLuminance)
+lampEmission = lampColourDirection * lampLuminance
+
 finalRgb = baseRgb + lampEmission
 finalAlpha = artwork.a
 ```
 
-Defaults:
+### Shader properties and defaults
 
-- `_OasisStaticBrightness = 1.0`: keeps lamp-off artwork at authored brightness.
-- `_OasisMaskStrength = 1.0`: preserves the exported mask semantics.
-- `_OasisEmissionStrength = 1.75`: makes assigned lamp regions deliberately brighter without requiring bloom.
-- `_OasisLampLift = 0.35`: derives an emission colour from available artwork while lifting dark source pixels toward white so dark masked regions can become visibly luminous.
+- `_OasisStaticBrightness = 1.0`: authored albedo scale for lamps-off artwork before local lighting.
+- `_OasisBaseAmbientStrength = 1.0`: scale for URP spherical-harmonic ambient lighting on the base artwork.
+- `_OasisBaseMainLightStrength = 1.0`: scale for the URP main-light diffuse term on the base artwork.
+- `_OasisMaskStrength = 1.0`: preserves the exported Face mask semantics.
+- `_OasisEmissionStrength = 1.75`: overall dynamic lamp luminance scale.
+- `_OasisLampMinLuminance = 0.18`: minimum source luminance for active lamps, allowing dark ink to glow visibly.
+- `_OasisLampMaxLuminance = 2.5`: practical upper bound for lamp luminance before output. The final RGB is still not clamped, so HDR output remains available where the pipeline supports it.
+- `_OasisLampCompression = 2.25`: soft-knee response for active lamps. Increasing lamp control produces diminishing luminance growth instead of immediate linear overdrive.
 
-The shader no longer clamps the final RGB before return, allowing HDR/overbright output where the active URP/camera pipeline supports it. Without HDR/bloom, the additive emission is still stronger than multiplying dark artwork alone. Bloom and post-processing remain optional future polish and were not enabled as part of this task.
+`_OasisLampLift` was removed because its previous meaning was specifically to mix lamp colour toward white, which is the washed-out behaviour this pass fixes.
+
+### Why hue and saturation are preserved
+
+The lamp path no longer multiplies raw artwork by an arbitrarily large scalar and no longer mixes all active lamps toward white. It derives a luminance-normalized colour direction from the artwork, computes lamp brightness as a separate scalar luminance, and then recombines them. Saturated colours therefore keep their chroma ratios longer under HDR/tonemapping. Very dark artwork uses a controlled warm fallback only when the source luminance is below `_OasisLampMinLuminance`, so black or near-black ink can still produce visible illumination without turning every coloured lamp white.
+
+### Transparent rendering considerations
+
+The render state remains transparent and unchanged. Alpha output remains `artwork.a`; lamp calculations do not alter alpha. With `Blend SrcAlpha OneMinusSrcAlpha`, source RGB including HDR emission is still alpha-weighted by Unity during transparent blending. This is intentional for antialiased Face edges and avoids white or opaque fringes. Interior opaque pixels retain the full base-plus-emission result.
 
 ## Editor decision
 
-No Editor code was changed in this pass. The Editor preview was useful for confirming texture semantics and relative lamp coverage, but its current 8-bit Skia/WPF renderer is inherently an SDR authoring preview with no HDR, bloom, tonemapping, exposure, per-lamp colour, or illuminated-artwork layer. Matching the new Unity HDR-capable shader exactly would require a broader preview-rendering design change. The current Editor remains acceptable as a subdued preview, while Player now owns the stronger runtime lamp appearance.
+No Oasis Editor code was changed in this pass. The defect is local to the Unity Player shader: the Editor preview remains a non-HDR SDR authoring preview and does not participate in URP scene lighting. Its lamp assignment, coverage, weighting, and relative colour remain useful for authoring validation, while the Player owns the runtime scene-lit diffuse base and HDR-capable emission path. Matching the Player's lighting and tonemapping in WPF/Skia would be a broader preview-rendering feature, not a required schema or shared-calculation fix.
 
-## Remaining limitations and follow-up
+## Preserved runtime behaviour
 
-- Runtime exports still do not include separate per-lamp colours or illuminated artwork textures, so Player lamp colour is deliberately derived from artwork plus `_OasisLampLift`.
-- `visibleLight` is bounded before emission so overlapping weighted lamps remain predictable; this avoids runaway output but does not model physical additive bulbs beyond full local intensity.
-- Bloom, camera HDR verification, tonemapping, and post-processing authoring controls remain optional future work.
-- Emulator lamp integration is not marked complete by this task.
+- No emulator, MAME, or native backend lamp bridge was implemented.
+- Runtime manifests, Face manifests, machine manifests, lookup formats, lamp numbering, and lamp texture dimensions were not changed.
+- Runtime Face texture ownership, cleanup, material replacement, and shared machine lamp-state texture ownership were not changed.
+- The automatic diagnostic remains guarded by `#if UNITY_EDITOR || DEVELOPMENT_BUILD` and its sequence remains all-on/all-off/all-on/all-off followed by a `1..255` sweep at `0.1` seconds per lamp.
+- Bloom, glow halos, camera HDR settings, tonemapping, post-processing, and project-wide lighting settings remain future work.
 
 ## Manual Unity verification checklist
 
-1. Run a Development Build or the Unity Editor and confirm the automatic lamp diagnostic still starts only under `UNITY_EDITOR || DEVELOPMENT_BUILD`.
-2. Verify an all-lamp flash makes lamp regions clearly brighter than lamp-off base artwork.
-3. Verify the single-lamp sweep lights the expected authored regions and does not illuminate unassigned pixels.
-4. Check lamps over dark artwork regions; they should become visibly luminous rather than remaining nearly black.
-5. Check lamps over bright artwork regions; detail should remain useful and should not wash out the entire Face.
-6. Check overlapping weighted lamps; intensity should rise predictably up to full local lamp amount without unstable runaway output.
-7. Set all lamps off and confirm base artwork remains visible at authored brightness.
-8. Inspect alpha edges and transparent Face regions; artwork alpha should be preserved.
-9. Load a machine with multiple Faces and confirm they share the same machine-owned `256x1` lamp-state texture while retaining independent masks/lookups.
-10. Run a non-development build and confirm automatic diagnostics are absent.
+For all visual checks, compare hue preservation, saturation, luminance, detail retention, response to scene lights, visibility with lamps off, and visibility with lamps on.
+
+1. Lamps off, low room-light intensity: Face artwork should dim like printed cabinet artwork but remain readable from ambient light.
+2. Lamps off, high room-light intensity: Face artwork should brighten coherently with the cabinet and should not look self-lit.
+3. Confirm that the Face base artwork changes when ambient/main-light intensity changes.
+4. Confirm that the cabinet and Face react in the same visual direction to room-light edits.
+5. All-lamp flash in a dark room: masked assigned lamp regions should remain visible because lamp emission is independent of scene lighting.
+6. All-lamp flash in a brightly lit room: lamps should still add visible illumination without turning broad regions white.
+7. Individual lamp sweep: each ID from `1` through `255` should affect only pixels assigned to that ID; ID `0` pixels should stay dark/off.
+8. Saturated red lamp regions: red hue and saturation should remain identifiable at high brightness.
+9. Saturated yellow lamp regions: yellow should brighten without collapsing immediately to flat white.
+10. Saturated blue lamp regions: blue should retain useful chroma and not be over-neutralized.
+11. Saturated purple lamp regions: both red/blue character and detail should remain visible.
+12. Dark artwork regions with active lamps: regions should illuminate visibly via minimum lamp luminance rather than staying black.
+13. Bright artwork regions with active lamps: detail should remain useful under the soft-knee response.
+14. Pixels influenced by multiple weighted lamps: accumulated weights should increase local brightness predictably up to the bounded full contribution.
+15. Transparent and antialiased Face edges: alpha should remain correct with no opaque white fringes.
+16. Multiple Faces sharing one machine lamp-state texture: all Faces should react to the shared state while retaining independent masks and lookups.
+17. Development Build diagnostic behaviour: automatic all-on/all-off/all-on/all-off and single-lamp sweep should run with no keyboard dependency.
+18. Production build with no diagnostic activity: no automatic diagnostic component or lamp sweep should run.
+
+## Remaining limitations and follow-up
+
+- Unity shader compilation and visual tone mapping must still be verified inside the Unity Editor or a Player build because this repository environment does not provide a Unity batchmode compiler.
+- Runtime exports still do not include separate per-lamp colours or illuminated artwork textures; the Player therefore derives lamp colour from underlying artwork plus a dark-pixel fallback.
+- The shader accounts for ambient spherical harmonics and the URP main light only. Additional per-pixel additional lights, shadows, normal maps, metallic, and glossy PBR behaviour remain intentionally out of scope.
+- Bloom/glow halos are not configured by this task and remain optional future polish.
+- Emulator lamp integration remains the next Phase 3 bridge task and is not marked complete here.

--- a/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
+++ b/WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/TASK_03_LAMP_RENDERING_VALIDATION_AND_TUNING.md
@@ -24,49 +24,30 @@ Implemented checkpoint for validating and tuning Player lamp rendering after the
 
 1. **Local point and spot lights were missing.** The shader had no `GetAdditionalLightsCount()`/`GetAdditionalLight(...)` path, so additional URP lights that lit the cabinet could not affect the Face base artwork.
 2. **The Face was treated as double-sided.** `Cull Off` plus `abs(dot(normal, lightDirection))` made both sides light as if front-facing. This hid orientation errors and did not match the single-sided printed-artwork model.
-3. **Lamp emission was attenuated by artwork alpha.** Returning `baseRgb + lampEmission` through `Blend SrcAlpha OneMinusSrcAlpha` multiplied all source RGB, including emission, by `artwork.a`. This violated the rule that lamps are attenuated only by mask, lamp lookup/state, and explicit lamp controls.
+3. **Lamp emission was attenuated by artwork alpha, then briefly regressed to no visible output.** Returning `baseRgb + lampEmission` through `Blend SrcAlpha OneMinusSrcAlpha` multiplied all source RGB, including emission, by `artwork.a`. The attempted two-pass fix moved lamps into a second `SRPDefaultUnlit` pass, but manual Unity testing showed URP was submitting the visible `UniversalForward` base pass and not producing visible output from the second pass for this material/renderer path. A single `UniversalForward` pass with premultiplied-alpha blending guarantees base and lamp calculations run in the same forward draw.
 4. **Lamp colour could still become pale/white.** Luminance normalization (`artwork.rgb / artworkLuminance`) can produce colour-direction channels far above `1.0`, and the broad warm fallback blended dark coloured regions toward cream. Additive HDR output and tonemapping then had an easier path to white/pale results.
 
-## Final Player pass design and blend equations
+## Final Player pass design and blend equation
 
-`Oasis/Face` now uses two transparent passes with identical UVs, depth test, and single-sided culling:
-
-### Pass 1: `OasisFaceBaseForwardLit`
+`Oasis/Face` now uses one transparent `UniversalForward` pass so URP submits both the scene-lit base artwork and dynamic lamp emission in the same forward material draw:
 
 - `LightMode = UniversalForward`
-- `Blend SrcAlpha OneMinusSrcAlpha`
+- `Blend One OneMinusSrcAlpha`
 - `Cull Back`
 - `ZWrite Off`
 - `ZTest LEqual`
-- Output: `half4(baseRgb, artwork.a)`
+- Output: `half4(baseRgb * artwork.a + lampEmission, artwork.a)`
 
 Blend equation:
 
 ```text
-dst.rgb = baseRgb * artwork.a + dst.rgb * (1 - artwork.a)
+dst.rgb = (baseRgb * artwork.a + lampEmission) + dst.rgb * (1 - artwork.a)
 dst.a   = artwork.a + dst.a * (1 - artwork.a)
 ```
 
-This keeps normal transparent Face artwork and antialiased base edges alpha-controlled.
+This preserves normal alpha-controlled base artwork edges while keeping lamp emission independent of artwork alpha. Lamp emission is still spatially restricted to rendered single-sided Face geometry and numerically restricted by the exported lamp mask, decoded lamp IDs, decoded lamp weights, runtime lamp brightness, and explicit emission controls.
 
-### Pass 2: `OasisFaceLampEmission`
-
-- `LightMode = SRPDefaultUnlit`
-- `Blend One One`
-- `ColorMask RGB`
-- `Cull Back`
-- `ZWrite Off`
-- `ZTest LEqual`
-- Output: `half4(lampEmission, 0)`
-
-Blend equation:
-
-```text
-dst.rgb = lampEmission + dst.rgb
-dst.a   = unchanged because ColorMask RGB disables alpha writes
-```
-
-This makes lamp emission independent of artwork alpha, scene lighting, light attenuation, normal direction, and ambient lighting. It is still spatially restricted by the rendered single-sided Face geometry, depth-tested against the scene, and numerically restricted by the exported lamp mask, decoded lamp IDs, decoded lamp weights, runtime brightness, and explicit lamp controls.
+The abandoned two-pass approach used a `UniversalForward` base pass plus a `SRPDefaultUnlit` additive emission pass. Manual Unity validation showed the base pass rendered but no lamp emission appeared during the automatic diagnostic, consistent with the second pass not being submitted through the active URP transparent draw path. The final implementation removes that separate pass instead of adding renderer features, command buffers, duplicate geometry, second materials, bloom, or post-processing.
 
 ## Final base-lighting formula
 
@@ -186,7 +167,7 @@ For all visual checks, compare hue preservation, saturation, luminance, detail r
 
 - Unity shader compilation and visual tone mapping must still be verified inside Unity because this repository environment does not include the Unity editor/batchmode compiler.
 - Runtime manifests still lack the Editor's Face target orientation overrides. A future small, backward-compatible export should carry `FrontSide`, `FaceRotation`, and `FaceFlipHorizontal` to Player and apply them outside the fragment shader.
-- The custom Face shader now covers ambient, main light, and URP additional per-pixel lights; it intentionally does not implement normal maps, metallic/glossy PBR, cookies, or custom glow halos.
+- The custom Face shader now covers ambient, main light, and URP additional per-pixel lights in a single forward pass; it intentionally does not implement normal maps, metallic/glossy PBR, cookies, or custom glow halos.
 - Additional-light shadows depend on the active URP asset/platform support; the PC asset supports them, while the mobile asset currently does not.
 - Bloom/glow halos remain optional future polish.
 - Emulator lamp integration remains the next Phase 3 bridge task and is not complete.


### PR DESCRIPTION
### Motivation
- Make Face background artwork respond to scene lighting while keeping dynamic lamps emissive and visible in dark scenes. 
- Prevent high lamp intensities from washing out chroma by replacing the prior white-lift emission model with a colour‑preserving luminance + direction approach. 
- Preserve the existing runtime lamp pipeline, lookup semantics, texture formats, alpha behavior, and development-only diagnostic.

### Description
- Replace the unlit Oasis/Face pass with a URP forward-lit pass that samples spherical-harmonic ambient (`SampleSH`) and the URP main light (`GetMainLight()`), using an absolute Lambert term to handle double-sided faces. 
- Replace `_OasisLampLift` emission with a hue-preserving model that derives a luminance-normalized colour direction from `artwork.rgb`, applies a warm fallback for very dark artwork, and computes lamp luminance via a soft-knee compression (`1 - exp2(-x * compression)`) with an upper cap. 
- Add and synchronize new shader properties (`_OasisLampMinLuminance`, `_OasisLampMaxLuminance`, `_OasisLampCompression`, `_OasisBaseAmbientStrength`, `_OasisBaseMainLightStrength`) and update `RuntimeFaceMaterialFactory` defaults to initialize them. 
- Keep lamp lookup, weight decoding, mask semantics (`max(r,g,b) * a * maskStrength`), texture filtering/wrap/mip rules, transparent blend state (`Blend SrcAlpha OneMinusSrcAlpha`), and artwork alpha unchanged. 
- Document the investigation, final formulas, property meanings/defaults, validation checklist, and rationale in Phase 3 docs under `WindowsNetProjects/OasisEditor/Docs/OasisPlayerPhase3/`.

### Testing
- Ran a synchronization check script that verified the shader contains and the runtime property constants expose the new properties, and it succeeded. 
- Ran repository searches (`rg`) to confirm URP package version, property usage, runtime texture creation/filtering settings, and development-diagnostic guards, and all checks passed. 
- Ran `git diff --check` and basic whitespace/patch validations which returned no issues. 
- Note: Unity is not available in this environment so actual shader compilation and visual verification were not performed here; a manual Unity test checklist is included in the updated docs and must be executed in the Editor or a Player build to verify shader compilation, lighting response, hue/saturation preservation, and diagnostic behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5ccff143488327bc638487b91fa04d)