### PR TITLE
Use exposure-based face lamp lighting

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -135,10 +135,7 @@ namespace OasisPlayer.RuntimeBuild
     {
         private const float DefaultStaticBrightness = 1f;
         private const float DefaultMaskStrength = 1f;
-        private const float DefaultEmissionStrength = 1.75f;
-        private const float DefaultLampMinLuminance = 0.08f;
-        private const float DefaultLampMaxLuminance = 2f;
-        private const float DefaultLampCompression = 2.25f;
+        private const float DefaultLampExposureStops = 2.5f;
         private const float DefaultBaseAmbientStrength = 1f;
         private const float DefaultBaseMainLightStrength = 1f;
         private const float DefaultBaseAdditionalLightStrength = 1f;
@@ -177,15 +174,12 @@ namespace OasisPlayer.RuntimeBuild
             material.name = $"RuntimeFace_{(face.Reference != null ? face.Reference.faceId : "Face")}_OasisFace";
             BindTextures(material, face);
             if (lampStateTexture != null && lampStateTexture.Texture != null) AssignTexture(material, RuntimeFaceShaderProperties.LampStateTexture, lampStateTexture.Texture);
-            // Keep the base artwork scene-lit while adding alpha-independent lamp emission in the
-            // shader's single premultiplied forward pass. Lamp luminance controls preserve artwork hue
-            // without requiring per-lamp colours or illuminated artwork textures in the runtime export.
+            // Keep the base artwork scene-lit while the shader applies GEGL-style photographic
+            // exposure to lit lamp regions without requiring illuminated artwork textures in the
+            // runtime export.
             if (material.HasProperty(RuntimeFaceShaderProperties.StaticBrightness)) material.SetFloat(RuntimeFaceShaderProperties.StaticBrightness, DefaultStaticBrightness);
             if (material.HasProperty(RuntimeFaceShaderProperties.MaskStrength)) material.SetFloat(RuntimeFaceShaderProperties.MaskStrength, DefaultMaskStrength);
-            if (material.HasProperty(RuntimeFaceShaderProperties.EmissionStrength)) material.SetFloat(RuntimeFaceShaderProperties.EmissionStrength, DefaultEmissionStrength);
-            if (material.HasProperty(RuntimeFaceShaderProperties.LampMinLuminance)) material.SetFloat(RuntimeFaceShaderProperties.LampMinLuminance, DefaultLampMinLuminance);
-            if (material.HasProperty(RuntimeFaceShaderProperties.LampMaxLuminance)) material.SetFloat(RuntimeFaceShaderProperties.LampMaxLuminance, DefaultLampMaxLuminance);
-            if (material.HasProperty(RuntimeFaceShaderProperties.LampCompression)) material.SetFloat(RuntimeFaceShaderProperties.LampCompression, DefaultLampCompression);
+            if (material.HasProperty(RuntimeFaceShaderProperties.LampExposureStops)) material.SetFloat(RuntimeFaceShaderProperties.LampExposureStops, DefaultLampExposureStops);
             if (material.HasProperty(RuntimeFaceShaderProperties.BaseAmbientStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseAmbientStrength, DefaultBaseAmbientStrength);
             if (material.HasProperty(RuntimeFaceShaderProperties.BaseMainLightStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseMainLightStrength, DefaultBaseMainLightStrength);
             if (material.HasProperty(RuntimeFaceShaderProperties.BaseAdditionalLightStrength)) material.SetFloat(RuntimeFaceShaderProperties.BaseAdditionalLightStrength, DefaultBaseAdditionalLightStrength);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
@@ -11,11 +11,8 @@ namespace OasisPlayer.RuntimeBuild
         public const string LampIds0TextureName = "_OasisLampIds0Tex";
         public const string LampWeights0TextureName = "_OasisLampWeights0Tex";
         public const string LampStateTextureName = "_OasisLampStateTex";
-        public const string EmissionStrengthName = "_OasisEmissionStrength";
+        public const string LampExposureStopsName = "_OasisLampExposureStops";
         public const string StaticBrightnessName = "_OasisStaticBrightness";
-        public const string LampMinLuminanceName = "_OasisLampMinLuminance";
-        public const string LampMaxLuminanceName = "_OasisLampMaxLuminance";
-        public const string LampCompressionName = "_OasisLampCompression";
         public const string BaseAmbientStrengthName = "_OasisBaseAmbientStrength";
         public const string BaseMainLightStrengthName = "_OasisBaseMainLightStrength";
         public const string BaseAdditionalLightStrengthName = "_OasisBaseAdditionalLightStrength";
@@ -31,11 +28,8 @@ namespace OasisPlayer.RuntimeBuild
         public static readonly int LampIds0Texture = Shader.PropertyToID(LampIds0TextureName);
         public static readonly int LampWeights0Texture = Shader.PropertyToID(LampWeights0TextureName);
         public static readonly int LampStateTexture = Shader.PropertyToID(LampStateTextureName);
-        public static readonly int EmissionStrength = Shader.PropertyToID(EmissionStrengthName);
+        public static readonly int LampExposureStops = Shader.PropertyToID(LampExposureStopsName);
         public static readonly int StaticBrightness = Shader.PropertyToID(StaticBrightnessName);
-        public static readonly int LampMinLuminance = Shader.PropertyToID(LampMinLuminanceName);
-        public static readonly int LampMaxLuminance = Shader.PropertyToID(LampMaxLuminanceName);
-        public static readonly int LampCompression = Shader.PropertyToID(LampCompressionName);
         public static readonly int BaseAmbientStrength = Shader.PropertyToID(BaseAmbientStrengthName);
         public static readonly int BaseMainLightStrength = Shader.PropertyToID(BaseMainLightStrengthName);
         public static readonly int BaseAdditionalLightStrength = Shader.PropertyToID(BaseAdditionalLightStrengthName);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -8,10 +8,7 @@ Shader "Oasis/Face"
         _OasisLampIds0Tex ("Lamp IDs 0", 2D) = "black" {}
         _OasisLampWeights0Tex ("Lamp Weights 0", 2D) = "black" {}
         _OasisLampStateTex ("Lamp State", 2D) = "black" {}
-        _OasisEmissionStrength ("Emission Strength", Range(0, 8)) = 1.75
-        _OasisLampMinLuminance ("Lamp Minimum Luminance", Range(0, 1)) = 0.08
-        _OasisLampMaxLuminance ("Lamp Maximum Luminance", Range(0, 8)) = 2
-        _OasisLampCompression ("Lamp Compression", Range(0.1, 8)) = 2.25
+        _OasisLampExposureStops ("Lamp Exposure Stops", Range(0, 8)) = 2.5
         _OasisStaticBrightness ("Static Brightness", Range(0, 2)) = 1
         _OasisBaseAmbientStrength ("Base Ambient Strength", Range(0, 2)) = 1
         _OasisBaseMainLightStrength ("Base Main Light Strength", Range(0, 2)) = 1
@@ -66,10 +63,7 @@ Shader "Oasis/Face"
             float4 _OasisArtworkTex_ST;
             float _OasisStaticBrightness;
             float _OasisMaskStrength;
-            float _OasisEmissionStrength;
-            float _OasisLampMinLuminance;
-            float _OasisLampMaxLuminance;
-            float _OasisLampCompression;
+            float _OasisLampExposureStops;
             float _OasisBaseAmbientStrength;
             float _OasisBaseMainLightStrength;
             float _OasisBaseAdditionalLightStrength;
@@ -179,31 +173,11 @@ Shader "Oasis/Face"
             return max(lighting, 0.0);
         }
 
-        float3 DeriveLampColour(float3 artworkRgb)
+        float3 EvaluateLampExposure(float3 artworkRgb, float lampAmount)
         {
-            float peak = max(artworkRgb.r, max(artworkRgb.g, artworkRgb.b));
-            float3 chroma = artworkRgb / max(peak, 0.001);
-
-            // Only nearly black pixels lack a reliable source hue. Blend them toward a subdued neutral
-            // fallback; ordinary dark coloured ink keeps its artwork-derived chroma direction.
-            float colourConfidence = saturate(peak / max(_OasisLampMinLuminance, 0.001));
-            float3 fallback = float3(0.55, 0.50, 0.42);
-            return lerp(fallback, chroma, colourConfidence);
-        }
-
-        float CompressLampAmount(float lampAmount)
-        {
-            float compressed = 1.0 - exp2(-max(lampAmount, 0.0) * _OasisLampCompression);
-            return min(compressed, _OasisLampMaxLuminance);
-        }
-
-        float3 EvaluateLampEmission(float2 uv)
-        {
-            half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, uv);
-            float lampAmount = AccumulateLampAmount(uv);
-            float3 lampColour = DeriveLampColour(artwork.rgb);
-            float compressedLampAmount = CompressLampAmount(lampAmount);
-            return lampColour * compressedLampAmount * _OasisEmissionStrength;
+            float exposureStops = max(_OasisLampExposureStops, 0.0) * saturate(lampAmount);
+            float exposureGain = exp2(exposureStops);
+            return artworkRgb * exposureGain;
         }
         ENDHLSL
 
@@ -228,10 +202,11 @@ Shader "Oasis/Face"
             half4 frag(Varyings input) : SV_Target
             {
                 half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, input.uv);
+                float lampAmount = AccumulateLampAmount(input.uv);
                 float3 baseRgb = artwork.rgb * _OasisStaticBrightness * EvaluateBaseLighting(input);
-                float3 basePremultiplied = baseRgb * artwork.a;
-                float3 lampEmission = EvaluateLampEmission(input.uv);
-                return half4(basePremultiplied + lampEmission, artwork.a);
+                float3 exposedRgb = EvaluateLampExposure(artwork.rgb, lampAmount);
+                float3 lampContribution = max(exposedRgb - artwork.rgb, 0.0);
+                return half4((baseRgb + lampContribution) * artwork.a, artwork.a);
             }
             ENDHLSL
         }


### PR DESCRIPTION
### Motivation
- Replace the existing washed-out additive/emission lamp algorithm with a photographic exposure-based treatment that brightens artwork while preserving hue, saturation and detail.
- Keep the existing lamp-state lookup (lamp IDs, weights, mask sampling and UV transforms) and the single-sided Face shader architecture unchanged.

### Description
- Replaced the old lamp emission path in `UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader` with an exposure-based implementation that computes `exposureGain = exp2(exposureStops * saturate(lampAmount))` and multiplies the original linear artwork colour by that gain, then adds only the positive exposure delta to the scene-lit base color.
- Removed obsolete lamp controls and helpers: `_OasisEmissionStrength`, `_OasisLampMinLuminance`, `_OasisLampMaxLuminance`, `_OasisLampCompression`, `DeriveLampColour`, `CompressLampAmount`, and `EvaluateLampEmission` from the shader; folded HDR contribution into the exposure path instead of a separate emission path.
- Added a single retained shader/material parameter `_OasisLampExposureStops` (default `2.5`) and updated `RuntimeFaceShaderProperties.cs` and `RuntimeFaceRendering.cs` to use `LampExposureStops` and set a default `DefaultLampExposureStops` when materials are created.
- Preserved base lighting evaluation (`EvaluateBaseLighting`), mask/lamp lookup pipeline (`AccumulateLampAmount`), UV transforms and Face orientation properties; updated fragment to compute lamp contribution as `max(exposed - original, 0)` so original artwork chroma is preserved.

### Testing
- Ran `git diff --check` to validate whitespace and diff issues, which completed with no reported problems.
- Performed code-level searches (`rg`) to confirm removal of the old emission/luminance/compression identifiers and presence of the new `LampExposureStops`/`EvaluateLampExposure` symbols, which succeeded.
- No Unity Editor or PlayMode graphics tests were executed in this environment; visual verification (lamp off/partial/full intensity, saturated/dark/bright artwork, bloom and tone-mapping on/off, mask/lookup alignment, and face orientation) must be performed locally in the Unity Editor and reported back.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d123ace6883279f039d4691dfd676)