### PR TITLE
Add UI Toolkit Graphics Settings and Player Settings infrastructure

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/Resources/UI.meta
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6276829967414eb292cbcb4fa13dc2f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles.meta
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6248c1c0e12e47419e6aa06c2beff226
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles/OasisPlayerTheme.uss
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles/OasisPlayerTheme.uss
@@ -1,0 +1,12 @@
+.oasis-overlay { flex-grow: 1; align-items: center; justify-content: center; background-color: rgba(0, 0, 0, 0.65); }
+.oasis-panel { width: 720px; max-width: 90%; padding: 28px; background-color: rgb(22, 24, 30); border-radius: 10px; color: rgb(235, 238, 245); }
+.oasis-title { font-size: 30px; -unity-font-style: bold; margin-bottom: 20px; }
+.oasis-section { font-size: 17px; -unity-font-style: bold; margin-top: 14px; margin-bottom: 8px; color: rgb(166, 206, 255); }
+.oasis-row { flex-direction: row; align-items: center; margin-top: 8px; margin-bottom: 8px; }
+.oasis-label { width: 190px; }
+.oasis-slider { flex-grow: 1; margin-left: 8px; margin-right: 12px; }
+.oasis-value { width: 90px; -unity-text-align: middle-right; }
+.oasis-toggle { margin-top: 8px; margin-bottom: 8px; }
+.oasis-buttons { flex-direction: row; justify-content: flex-end; margin-top: 28px; }
+.oasis-buttons Button { margin-left: 10px; min-width: 130px; }
+Button:focus, Slider:focus, Toggle:focus { border-top-color: rgb(122, 177, 255); border-right-color: rgb(122, 177, 255); border-bottom-color: rgb(122, 177, 255); border-left-color: rgb(122, 177, 255); }

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles/OasisPlayerTheme.uss.meta
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Styles/OasisPlayerTheme.uss.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca41cdd6a41446088c47b96e3cf8d2a5

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml.meta
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90bba04991b84b29bb23b36ce2886f20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml/GraphicsSettings.uxml
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml/GraphicsSettings.uxml
@@ -1,0 +1,26 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" editor-extension-mode="False">
+  <Style src="project://database/Assets/Resources/UI/Styles/OasisPlayerTheme.uss" />
+  <ui:VisualElement name="graphics-settings-root" class="oasis-overlay">
+    <ui:VisualElement class="oasis-panel">
+      <ui:Label text="Graphics Settings" class="oasis-title" />
+      <ui:Label text="Face Lamps" class="oasis-section" />
+      <ui:VisualElement class="oasis-row">
+        <ui:Label text="Lamp Exposure" class="oasis-label" />
+        <ui:Slider name="lamp-exposure" low-value="0" high-value="8" direction="Horizontal" class="oasis-slider" />
+        <ui:Label name="lamp-exposure-value" text="2.5 stops" class="oasis-value" />
+      </ui:VisualElement>
+      <ui:Label text="Rendering" class="oasis-section" />
+      <ui:Toggle name="bloom-enabled" text="Bloom Enabled" class="oasis-toggle" />
+      <ui:VisualElement class="oasis-row">
+        <ui:Label text="Bloom Intensity" class="oasis-label" />
+        <ui:Slider name="bloom-intensity" low-value="0" high-value="10" direction="Horizontal" class="oasis-slider" />
+        <ui:Label name="bloom-intensity-value" text="0.8" class="oasis-value" />
+      </ui:VisualElement>
+      <ui:VisualElement class="oasis-buttons">
+        <ui:Button name="restore-defaults-button" text="Restore Defaults" />
+        <ui:Button name="cancel-button" text="Cancel" />
+        <ui:Button name="apply-button" text="Apply" />
+      </ui:VisualElement>
+    </ui:VisualElement>
+  </ui:VisualElement>
+</ui:UXML>

--- a/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml/GraphicsSettings.uxml.meta
+++ b/UnityProjects/OasisPlayer/Assets/Resources/UI/Uxml/GraphicsSettings.uxml.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d73e4bd7e4a7447f8cee12d6fdaf25e4

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceMaterialRegistry.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceMaterialRegistry.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using OasisPlayer.Settings;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public static class RuntimeFaceMaterialRegistry
+    {
+        private static readonly List<Material> Materials = new List<Material>();
+        private static PlayerGraphicsSettings _current = PlayerGraphicsSettings.Defaults();
+
+        public static void Register(Material material)
+        {
+            if (material == null || Materials.Contains(material)) return;
+            Materials.Add(material);
+            Apply(material, _current);
+        }
+
+        public static void Apply(PlayerGraphicsSettings settings)
+        {
+            _current = (settings ?? PlayerGraphicsSettings.Defaults()).Clone();
+            _current.Validate();
+            for (var i = Materials.Count - 1; i >= 0; i--)
+            {
+                var material = Materials[i];
+                if (material == null) { Materials.RemoveAt(i); continue; }
+                Apply(material, _current);
+            }
+        }
+
+        private static void Apply(Material material, PlayerGraphicsSettings settings)
+        {
+            if (material.HasProperty(RuntimeFaceShaderProperties.LampExposureStops))
+                material.SetFloat(RuntimeFaceShaderProperties.LampExposureStops, settings.LampExposureStops);
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceMaterialRegistry.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceMaterialRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47d6730e8aa94745864c86f25bec3baf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceRendering.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.Rendering;
+using OasisPlayer.Settings;
 
 namespace OasisPlayer.RuntimeBuild
 {
@@ -135,7 +136,7 @@ namespace OasisPlayer.RuntimeBuild
     {
         private const float DefaultStaticBrightness = 1f;
         private const float DefaultMaskStrength = 1f;
-        private const float DefaultLampExposureStops = 2.5f;
+        private static readonly float DefaultLampExposureStops = PlayerGraphicsSettings.Defaults().LampExposureStops;
         private const float DefaultBaseAmbientStrength = 1f;
         private const float DefaultBaseMainLightStrength = 1f;
         private const float DefaultBaseAdditionalLightStrength = 1f;
@@ -196,6 +197,7 @@ namespace OasisPlayer.RuntimeBuild
                 return false;
             }
             material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+            RuntimeFaceMaterialRegistry.Register(material);
             return true;
         }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a5ba892a9064cdcab8465839b267040
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: adf8f43a1807431e92f9cb7e5f94f647
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/GraphicsSettingsApplier.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/GraphicsSettingsApplier.cs
@@ -1,0 +1,55 @@
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace OasisPlayer.Settings
+{
+    public sealed class GraphicsSettingsApplier : MonoBehaviour
+    {
+        private PlayerSettingsService _settings;
+        private Bloom _bloom;
+
+        private void Awake()
+        {
+            _settings = PlayerSettingsService.EnsureGlobal();
+            _settings.GraphicsChanged += Apply;
+            EnsureBloomVolume();
+            Apply(_settings.Graphics);
+        }
+
+        private void OnDestroy()
+        {
+            if (_settings != null) _settings.GraphicsChanged -= Apply;
+        }
+
+        private void Apply(PlayerGraphicsSettings graphics)
+        {
+            RuntimeFaceMaterialRegistry.Apply(graphics);
+            if (_bloom == null) EnsureBloomVolume();
+            if (_bloom != null)
+            {
+                _bloom.active = graphics.BloomEnabled;
+                _bloom.intensity.overrideState = true;
+                _bloom.intensity.value = graphics.BloomIntensity;
+            }
+        }
+
+        private void EnsureBloomVolume()
+        {
+            foreach (var volume in FindObjectsByType<Volume>(FindObjectsInactive.Exclude, FindObjectsSortMode.None))
+            {
+                if (volume != null && volume.profile != null && volume.profile.TryGet(out _bloom)) return;
+            }
+
+            var go = new GameObject("Oasis Global Graphics Volume");
+            DontDestroyOnLoad(go);
+            var volumeComponent = go.AddComponent<Volume>();
+            volumeComponent.isGlobal = true;
+            volumeComponent.priority = 100f;
+            volumeComponent.profile = ScriptableObject.CreateInstance<VolumeProfile>();
+            volumeComponent.profile.name = "Oasis Runtime Graphics Volume";
+            _bloom = volumeComponent.profile.Add<Bloom>(true);
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/GraphicsSettingsApplier.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/GraphicsSettingsApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f971039ccd844549530e1d4391dffe7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef
@@ -1,8 +1,9 @@
 {
-    "name": "OasisPlayer.RuntimeBuild",
-    "rootNamespace": "OasisPlayer.RuntimeBuild",
+    "name": "OasisPlayer.Settings.Appliers",
+    "rootNamespace": "OasisPlayer.Settings.Appliers",
     "references": [
-        "OasisPlayer.Settings"
+        "OasisPlayer.Settings",
+        "OasisPlayer.RuntimeBuild"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef
@@ -3,7 +3,9 @@
     "rootNamespace": "OasisPlayer.Settings.Appliers",
     "references": [
         "OasisPlayer.Settings",
-        "OasisPlayer.RuntimeBuild"
+        "OasisPlayer.RuntimeBuild",
+        "Unity.RenderPipelines.Core.Runtime",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Appliers/OasisPlayer.Settings.Appliers.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c94abe75e3a34c17bf4018214a933766

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea2ca49ac4e44e40b41aa6f35d883e76
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerGraphicsSettings.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerGraphicsSettings.cs
@@ -1,0 +1,44 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.Settings
+{
+    [Serializable]
+    public sealed class PlayerGraphicsSettings
+    {
+        public const float MinLampExposureStops = 0f;
+        public const float MaxLampExposureStops = 8f;
+        public const float MinBloomIntensity = 0f;
+        public const float MaxBloomIntensity = 10f;
+
+        public float LampExposureStops = 2.5f;
+        public bool BloomEnabled = true;
+        public float BloomIntensity = 0.8f;
+
+        public static PlayerGraphicsSettings Defaults()
+        {
+            return new PlayerGraphicsSettings();
+        }
+
+        public PlayerGraphicsSettings Clone()
+        {
+            return new PlayerGraphicsSettings
+            {
+                LampExposureStops = LampExposureStops,
+                BloomEnabled = BloomEnabled,
+                BloomIntensity = BloomIntensity
+            };
+        }
+
+        public void Validate()
+        {
+            LampExposureStops = ClampFinite(LampExposureStops, MinLampExposureStops, MaxLampExposureStops, Defaults().LampExposureStops);
+            BloomIntensity = ClampFinite(BloomIntensity, MinBloomIntensity, MaxBloomIntensity, Defaults().BloomIntensity);
+        }
+
+        private static float ClampFinite(float value, float min, float max, float fallback)
+        {
+            return float.IsNaN(value) || float.IsInfinity(value) ? fallback : Mathf.Clamp(value, min, max);
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerGraphicsSettings.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerGraphicsSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 115089c4a22846a3913433de80246b05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerSettings.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerSettings.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace OasisPlayer.Settings
+{
+    [Serializable]
+    public sealed class PlayerSettings
+    {
+        public int Version = 1;
+        public PlayerGraphicsSettings Graphics = PlayerGraphicsSettings.Defaults();
+
+        public static PlayerSettings Defaults()
+        {
+            return new PlayerSettings();
+        }
+
+        public PlayerSettings Clone()
+        {
+            return new PlayerSettings
+            {
+                Version = Version,
+                Graphics = Graphics != null ? Graphics.Clone() : PlayerGraphicsSettings.Defaults()
+            };
+        }
+
+        public void Validate()
+        {
+            if (Version <= 0) Version = 1;
+            if (Graphics == null) Graphics = PlayerGraphicsSettings.Defaults();
+            Graphics.Validate();
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerSettings.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Models/PlayerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdedca6cd914fffaec5eb884ccd95b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/OasisPlayer.Settings.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/OasisPlayer.Settings.asmdef
@@ -1,0 +1,14 @@
+{
+  "name": "OasisPlayer.Settings",
+  "rootNamespace": "OasisPlayer.Settings",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/OasisPlayer.Settings.asmdef.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/OasisPlayer.Settings.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee858b79f2b54e7bbc2e608a6a78fced

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc96ab5b0ad24daabe3190cd71239e69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsService.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsService.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace OasisPlayer.Settings
+{
+    public sealed class PlayerSettingsService
+    {
+        public static PlayerSettingsService Instance { get; private set; }
+        private readonly PlayerSettingsStore _store;
+        private PlayerSettings _active;
+
+        public event Action<PlayerGraphicsSettings> GraphicsChanged;
+        public PlayerGraphicsSettings Graphics => _active.Graphics.Clone();
+
+        public PlayerSettingsService(PlayerSettingsStore store = null)
+        {
+            _store = store ?? new PlayerSettingsStore();
+            _active = _store.Load();
+            _active.Validate();
+        }
+
+        public static PlayerSettingsService EnsureGlobal(PlayerSettingsStore store = null)
+        {
+            return Instance ??= new PlayerSettingsService(store);
+        }
+
+        public void PreviewGraphics(PlayerGraphicsSettings graphics)
+        {
+            SetGraphics(graphics);
+        }
+
+        public bool ApplyGraphics(PlayerGraphicsSettings graphics)
+        {
+            SetGraphics(graphics);
+            return _store.Save(_active);
+        }
+
+        public PlayerGraphicsSettings DefaultsForGraphics()
+        {
+            return PlayerGraphicsSettings.Defaults();
+        }
+
+        private void SetGraphics(PlayerGraphicsSettings graphics)
+        {
+            _active.Graphics = (graphics ?? PlayerGraphicsSettings.Defaults()).Clone();
+            _active.Validate();
+            GraphicsChanged?.Invoke(_active.Graphics.Clone());
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsService.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64dffe6170ad4e1f9c44f0bd05e15162
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsStore.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsStore.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace OasisPlayer.Settings
+{
+    public sealed class PlayerSettingsStore
+    {
+        public string SettingsPath { get; }
+
+        public PlayerSettingsStore(string settingsPath = null)
+        {
+            SettingsPath = string.IsNullOrWhiteSpace(settingsPath)
+                ? Path.Combine(Application.persistentDataPath, "player-settings.json")
+                : settingsPath;
+        }
+
+        public PlayerSettings Load()
+        {
+            try
+            {
+                if (!File.Exists(SettingsPath)) return PlayerSettings.Defaults();
+                var json = File.ReadAllText(SettingsPath);
+                var settings = JsonUtility.FromJson<PlayerSettings>(json) ?? PlayerSettings.Defaults();
+                settings.Validate();
+                return settings;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"Oasis Player settings could not be loaded from '{SettingsPath}'; defaults will be used. {ex.Message}");
+                return PlayerSettings.Defaults();
+            }
+        }
+
+        public bool Save(PlayerSettings settings)
+        {
+            try
+            {
+                var copy = (settings ?? PlayerSettings.Defaults()).Clone();
+                copy.Validate();
+                Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath));
+                File.WriteAllText(SettingsPath, JsonUtility.ToJson(copy, true));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Oasis Player settings could not be saved to '{SettingsPath}'. {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsStore.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/Settings/Services/PlayerSettingsStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd20f7be8a664e8497a02c74168e1329
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/StartupController.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/StartupController.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using OasisPlayer.Loading;
 using OasisPlayer.RuntimeBuild;
+using OasisPlayer.Settings;
+using OasisPlayer.UI.Controllers;
 using OasisPlayer.Startup;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -16,6 +18,9 @@ public class StartupController : MonoBehaviour
     {
         if (_instance != null && _instance != this) { Destroy(gameObject); return; }
         _instance = this; DontDestroyOnLoad(gameObject); _errors = gameObject.GetComponent<FatalErrorOverlay>() ?? gameObject.AddComponent<FatalErrorOverlay>();
+        PlayerSettingsService.EnsureGlobal();
+        if (gameObject.GetComponent<GraphicsSettingsApplier>() == null) gameObject.AddComponent<GraphicsSettingsApplier>();
+        if (gameObject.GetComponent<PlayerUiRuntime>() == null) gameObject.AddComponent<PlayerUiRuntime>();
     }
 
     private async void Start()

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e70144a5bd21434da9e923576533e8f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d2192b67d52400e868cd5fa68c8e896
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/GraphicsSettingsController.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/GraphicsSettingsController.cs
@@ -1,0 +1,93 @@
+using System;
+using OasisPlayer.Settings;
+using UnityEngine.UIElements;
+
+namespace OasisPlayer.UI.Controllers
+{
+    public sealed class GraphicsSettingsController
+    {
+        private readonly PlayerSettingsService _settings;
+        private readonly Action _close;
+        private PlayerGraphicsSettings _baseline;
+        private PlayerGraphicsSettings _editable;
+        private Slider _lampExposure;
+        private Label _lampExposureValue;
+        private Toggle _bloomEnabled;
+        private Slider _bloomIntensity;
+        private Label _bloomIntensityValue;
+
+        public GraphicsSettingsController(PlayerSettingsService settings, Action close)
+        {
+            _settings = settings;
+            _close = close;
+        }
+
+        public void Bind(VisualElement root)
+        {
+            _baseline = _settings.Graphics;
+            _editable = _baseline.Clone();
+            _lampExposure = root.Q<Slider>("lamp-exposure");
+            _lampExposureValue = root.Q<Label>("lamp-exposure-value");
+            _bloomEnabled = root.Q<Toggle>("bloom-enabled");
+            _bloomIntensity = root.Q<Slider>("bloom-intensity");
+            _bloomIntensityValue = root.Q<Label>("bloom-intensity-value");
+
+            SetControls(_editable);
+            _lampExposure.RegisterValueChangedCallback(e => { _editable.LampExposureStops = e.newValue; Preview(); });
+            _bloomEnabled.RegisterValueChangedCallback(e => { _editable.BloomEnabled = e.newValue; Preview(); });
+            _bloomIntensity.RegisterValueChangedCallback(e => { _editable.BloomIntensity = e.newValue; Preview(); });
+            root.Q<Button>("restore-defaults-button").clicked += RestoreDefaults;
+            root.Q<Button>("cancel-button").clicked += Cancel;
+            root.Q<Button>("apply-button").clicked += Apply;
+            root.RegisterCallback<KeyDownEvent>(OnKeyDown);
+            _lampExposure.Focus();
+        }
+
+        public void Cancel()
+        {
+            _settings.PreviewGraphics(_baseline);
+            _close?.Invoke();
+        }
+
+        private void Apply()
+        {
+            if (_settings.ApplyGraphics(_editable)) _baseline = _editable.Clone();
+            _close?.Invoke();
+        }
+
+        private void RestoreDefaults()
+        {
+            _editable = _settings.DefaultsForGraphics();
+            SetControls(_editable);
+            Preview();
+        }
+
+        private void Preview()
+        {
+            _editable.Validate();
+            UpdateValueLabels();
+            _settings.PreviewGraphics(_editable);
+        }
+
+        private void SetControls(PlayerGraphicsSettings settings)
+        {
+            _lampExposure.SetValueWithoutNotify(settings.LampExposureStops);
+            _bloomEnabled.SetValueWithoutNotify(settings.BloomEnabled);
+            _bloomIntensity.SetValueWithoutNotify(settings.BloomIntensity);
+            UpdateValueLabels();
+        }
+
+        private void UpdateValueLabels()
+        {
+            _lampExposureValue.text = $"{_editable.LampExposureStops:0.0} stops";
+            _bloomIntensityValue.text = _editable.BloomIntensity.ToString("0.0");
+        }
+
+        private void OnKeyDown(KeyDownEvent evt)
+        {
+            if (evt.keyCode != UnityEngine.KeyCode.Escape) return;
+            evt.StopPropagation();
+            Cancel();
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/GraphicsSettingsController.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/GraphicsSettingsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2dc72e9cc8a9404784d82cae0298601e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs
@@ -1,0 +1,64 @@
+using OasisPlayer.Settings;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace OasisPlayer.UI.Controllers
+{
+    public sealed class PlayerUiRuntime : MonoBehaviour
+    {
+        private UIDocument _document;
+        private VisualTreeAsset _graphicsView;
+        private GraphicsSettingsController _controller;
+        private bool _open;
+        private bool _previousCursorVisible;
+        private CursorLockMode _previousLockMode;
+
+        private void Awake()
+        {
+            _graphicsView = Resources.Load<VisualTreeAsset>("UI/Uxml/GraphicsSettings");
+            _document = gameObject.AddComponent<UIDocument>();
+            _document.panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+            _document.panelSettings.name = "Oasis Runtime Panel Settings";
+            _document.enabled = false;
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                if (_open) _controller?.Cancel();
+                else OpenGraphicsSettings();
+            }
+        }
+
+        private void OpenGraphicsSettings()
+        {
+            if (_graphicsView == null)
+            {
+                Debug.LogError("Oasis Player UI could not load Resources/UI/Uxml/GraphicsSettings.uxml.");
+                return;
+            }
+
+            _previousCursorVisible = Cursor.visible;
+            _previousLockMode = Cursor.lockState;
+            Cursor.visible = true;
+            Cursor.lockState = CursorLockMode.None;
+            _document.visualTreeAsset = _graphicsView;
+            _document.enabled = true;
+            _open = true;
+            _controller = new GraphicsSettingsController(PlayerSettingsService.EnsureGlobal(), CloseGraphicsSettings);
+            _document.rootVisualElement.pickingMode = PickingMode.Position;
+            _controller.Bind(_document.rootVisualElement);
+        }
+
+        private void CloseGraphicsSettings()
+        {
+            _document.rootVisualElement.Clear();
+            _document.enabled = false;
+            _controller = null;
+            _open = false;
+            Cursor.visible = _previousCursorVisible;
+            Cursor.lockState = _previousLockMode;
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs
@@ -39,10 +39,10 @@ namespace OasisPlayer.UI.Controllers
                 return;
             }
 
-            _previousCursorVisible = Cursor.visible;
-            _previousLockMode = Cursor.lockState;
-            Cursor.visible = true;
-            Cursor.lockState = CursorLockMode.None;
+            _previousCursorVisible = UnityEngine.Cursor.visible;
+            _previousLockMode = UnityEngine.Cursor.lockState;
+            UnityEngine.Cursor.visible = true;
+            UnityEngine.Cursor.lockState = CursorLockMode.None;
             _document.visualTreeAsset = _graphicsView;
             _document.enabled = true;
             _open = true;
@@ -57,8 +57,8 @@ namespace OasisPlayer.UI.Controllers
             _document.enabled = false;
             _controller = null;
             _open = false;
-            Cursor.visible = _previousCursorVisible;
-            Cursor.lockState = _previousLockMode;
+            UnityEngine.Cursor.visible = _previousCursorVisible;
+            UnityEngine.Cursor.lockState = _previousLockMode;
         }
     }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/UI/Controllers/PlayerUiRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3235d6511ef94d5582c8e358adf56254
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/OasisPlayer.EditMode.Tests.asmdef
@@ -2,7 +2,8 @@
     "name": "OasisPlayer.EditMode.Tests",
     "rootNamespace": "OasisPlayer.Tests",
     "references": [
-        "OasisPlayer.RuntimeBuild"
+        "OasisPlayer.RuntimeBuild",
+        "OasisPlayer.Settings"
     ],
     "includePlatforms": [
         "Editor"

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/PlayerSettingsTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/PlayerSettingsTests.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using NUnit.Framework;
+using OasisPlayer.Settings;
+
+namespace OasisPlayer.Tests
+{
+    public sealed class PlayerSettingsTests
+    {
+        private string _path;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _path = Path.Combine(Path.GetTempPath(), $"oasis-player-settings-{System.Guid.NewGuid():N}.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_path)) File.Delete(_path);
+        }
+
+        [Test]
+        public void DefaultsAreValid()
+        {
+            var settings = PlayerSettings.Defaults();
+            settings.Validate();
+            Assert.That(settings.Graphics.LampExposureStops, Is.EqualTo(2.5f));
+            Assert.That(settings.Graphics.BloomEnabled, Is.True);
+        }
+
+        [Test]
+        public void MissingFileFallsBackToDefaults()
+        {
+            var loaded = new PlayerSettingsStore(_path).Load();
+            Assert.That(loaded.Graphics.LampExposureStops, Is.EqualTo(2.5f));
+        }
+
+        [Test]
+        public void ValidSettingsRoundTrip()
+        {
+            var store = new PlayerSettingsStore(_path);
+            var settings = PlayerSettings.Defaults();
+            settings.Graphics.LampExposureStops = 4.25f;
+            settings.Graphics.BloomEnabled = false;
+            settings.Graphics.BloomIntensity = 3.5f;
+            Assert.That(store.Save(settings), Is.True);
+
+            var loaded = store.Load();
+            Assert.That(loaded.Graphics.LampExposureStops, Is.EqualTo(4.25f));
+            Assert.That(loaded.Graphics.BloomEnabled, Is.False);
+            Assert.That(loaded.Graphics.BloomIntensity, Is.EqualTo(3.5f));
+        }
+
+        [Test]
+        public void InvalidValuesAreClamped()
+        {
+            File.WriteAllText(_path, "{\"Version\":1,\"Graphics\":{\"LampExposureStops\":99,\"BloomEnabled\":true,\"BloomIntensity\":-4}}");
+            var loaded = new PlayerSettingsStore(_path).Load();
+            Assert.That(loaded.Graphics.LampExposureStops, Is.EqualTo(PlayerGraphicsSettings.MaxLampExposureStops));
+            Assert.That(loaded.Graphics.BloomIntensity, Is.EqualTo(PlayerGraphicsSettings.MinBloomIntensity));
+        }
+
+        [Test]
+        public void CorruptFileFallsBackToDefaults()
+        {
+            File.WriteAllText(_path, "not json");
+            var loaded = new PlayerSettingsStore(_path).Load();
+            Assert.That(loaded.Graphics.LampExposureStops, Is.EqualTo(2.5f));
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/PlayerSettingsTests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/PlayerSettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc62d70785f446ed93dbd0b1e254a7a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Establish the long-term runtime Player UI foundation using Unity UI Toolkit and a clean separation between UI, settings ownership, persistence, and runtime rendering.
- Implement the first vertical slice: a Graphics Settings page that previews changes live, supports Apply/Cancel/Restore Defaults transactions, and updates rendering through centralised appliers instead of direct UI-to-material manipulation.

### Description
- Added typed settings models and persistence: `PlayerGraphicsSettings`, `PlayerSettings`, and `PlayerSettingsStore` which serialises to `player-settings.json` and validates/clamps values.
- Introduced a singleton `PlayerSettingsService` that owns active settings, exposes `Preview`/`Apply` semantics and broadcasts `GraphicsChanged` notifications to subscribers.
- Built UI Toolkit view and styling: `GraphicsSettings.uxml` and `OasisPlayerTheme.uss`, plus `GraphicsSettingsController` which implements baseline/editable transactions, immediate previewing, Restore Defaults, Apply and Cancel behaviour, and Escape-to-cancel handling.
- Added runtime wiring and appliers: `PlayerUiRuntime` (Escape-open/close, cursor state), `GraphicsSettingsApplier` (applies bloom via URP Volume and subscribes to the settings service), and `RuntimeFaceMaterialRegistry` plus small changes to `RuntimeFaceRendering` so newly-created runtime face materials are registered and receive active lamp exposure.
- Project/assembly updates: new asmdef for `OasisPlayer.Settings` and an appliers assembly, updated `OasisPlayer.RuntimeBuild` and test asmdef references, and startup wiring that ensures the settings service and applier are instantiated at launch.
- Added edit-mode tests `PlayerSettingsTests` covering defaults, missing-file fallback, persistence round-trip, invalid-value clamping, and corrupt-file fallback.

### Testing
- Ran `git diff --check` and fixed whitespace/format issues, which reported no problems.
- Validated modified asmdef JSON files with `python3 -m json.tool`, which succeeded for updated asmdef files.
- Added NUnit edit-mode tests (`PlayerSettingsTests`) for non-visual logic, but Unity Editor test execution was not run in this environment because no Unity editor executable is available on `PATH`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d1bb915648327b82de0e5b5895761)