### PR TITLE
Initial runtime placement of Face components on cabinet Face targets

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
@@ -92,14 +92,27 @@ namespace OasisPlayer.RuntimeBuild
         public RuntimeTextureAsset LampIds0 { get; private set; }
         public RuntimeTextureAsset LampWeights0 { get; private set; }
         public RuntimeFaceRenderBinding RenderBinding { get; private set; }
+        private readonly List<RuntimeReelRenderBinding> _reelRenderBindings = new List<RuntimeReelRenderBinding>();
+        public IReadOnlyList<RuntimeReelRenderBinding> ReelRenderBindings { get { return _reelRenderBindings; } }
 
         public void SetRenderBinding(RuntimeFaceRenderBinding renderBinding)
         {
             RenderBinding = renderBinding;
         }
 
+        public void AddReelRenderBinding(RuntimeReelRenderBinding binding)
+        {
+            if (binding != null) _reelRenderBindings.Add(binding);
+        }
+
         public void UnloadAssets()
         {
+            for (var i = 0; i < _reelRenderBindings.Count; i++)
+            {
+                _reelRenderBindings[i].Dispose();
+            }
+            _reelRenderBindings.Clear();
+
             if (RenderBinding != null)
             {
                 RenderBinding.Dispose();

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
@@ -76,13 +76,9 @@ namespace OasisPlayer.RuntimeBuild
 
             var bounds = usable.sharedMesh.bounds;
             var transform = usable.transform;
-            var horizontal = transform.TransformVector(new Vector3(bounds.size.x, 0f, 0f));
-            var vertical = transform.TransformVector(new Vector3(0f, bounds.size.y, 0f));
-            var physicalWidth = horizontal.magnitude;
-            var physicalHeight = vertical.magnitude;
-            if (physicalWidth <= 0.0001f || physicalHeight <= 0.0001f)
+            if (!TryResolveSurfaceAxes(bounds, transform, out var horizontal, out var vertical, out var physicalWidth, out var physicalHeight))
             {
-                warning = $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has degenerate surface dimensions.";
+                warning = $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has degenerate surface dimensions. Mesh bounds size is {bounds.size}.";
                 return false;
             }
 
@@ -108,6 +104,51 @@ namespace OasisPlayer.RuntimeBuild
                 return false;
             }
             return true;
+        }
+
+
+        private static bool TryResolveSurfaceAxes(Bounds bounds, Transform transform, out Vector3 horizontal, out Vector3 vertical, out float physicalWidth, out float physicalHeight)
+        {
+            horizontal = Vector3.zero;
+            vertical = Vector3.zero;
+            physicalWidth = 0f;
+            physicalHeight = 0f;
+            var size = bounds.size;
+            var horizontalAxis = SelectAxis(size, -1, 0, 2, 1);
+            if (horizontalAxis < 0) return false;
+            var verticalAxis = SelectAxis(size, horizontalAxis, 1, 2, 0);
+            if (verticalAxis < 0) return false;
+
+            horizontal = transform.TransformVector(AxisVector(horizontalAxis, AxisSize(size, horizontalAxis)));
+            vertical = transform.TransformVector(AxisVector(verticalAxis, AxisSize(size, verticalAxis)));
+            physicalWidth = horizontal.magnitude;
+            physicalHeight = vertical.magnitude;
+            return physicalWidth > 0.0001f && physicalHeight > 0.0001f;
+        }
+
+        private static int SelectAxis(Vector3 size, int excludedAxis, params int[] preferenceOrder)
+        {
+            const float epsilon = 0.000001f;
+            for (var i = 0; i < preferenceOrder.Length; i++)
+            {
+                var axis = preferenceOrder[i];
+                if (axis != excludedAxis && AxisSize(size, axis) > epsilon) return axis;
+            }
+            return -1;
+        }
+
+        private static float AxisSize(Vector3 size, int axis)
+        {
+            if (axis == 0) return size.x;
+            if (axis == 1) return size.y;
+            return size.z;
+        }
+
+        private static Vector3 AxisVector(int axis, float length)
+        {
+            if (axis == 0) return new Vector3(length, 0f, 0f);
+            if (axis == 1) return new Vector3(0f, length, 0f);
+            return new Vector3(0f, 0f, length);
         }
 
         public static bool ValidateComponent(RuntimeFace face, FaceRuntimeElementManifestEntry entry, out string warning)

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
@@ -1,0 +1,130 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public struct RuntimeFaceSurfaceGeometry
+    {
+        public Vector3 Center;
+        public Vector3 HorizontalTangent;
+        public Vector3 VerticalTangent;
+        public Vector3 VisibleNormal;
+        public float PhysicalWidth;
+        public float PhysicalHeight;
+
+        public Vector3 FacePointToWorld(float x, float y, int faceWidth, int faceHeight)
+        {
+            var u = x / faceWidth;
+            var v = y / faceHeight;
+            return Center
+                + HorizontalTangent * ((u - 0.5f) * PhysicalWidth)
+                + VerticalTangent * ((0.5f - v) * PhysicalHeight);
+        }
+
+        public Vector3 FaceRectCenterToWorld(FaceRuntimeElementManifestEntry entry, FaceRuntimeManifest manifest)
+        {
+            return FacePointToWorld(entry.x + (entry.width * 0.5f), entry.y + (entry.height * 0.5f), manifest.width, manifest.height);
+        }
+
+        public Quaternion AlignLocalReelAxesToSurface()
+        {
+            return Quaternion.LookRotation(VisibleNormal, VerticalTangent) * Quaternion.Euler(0f, 90f, 0f);
+        }
+    }
+
+    public static class RuntimeFacePlacement
+    {
+        public const float DefaultSurfaceClearanceMetres = 0.01f;
+
+        public static bool TryResolve(RuntimeFace face, out RuntimeFaceSurfaceGeometry geometry, out string warning)
+        {
+            geometry = new RuntimeFaceSurfaceGeometry();
+            warning = string.Empty;
+            var faceId = FaceId(face);
+            var targetId = TargetId(face);
+            if (face == null) { warning = "Runtime Face placement skipped because the Face was null."; return false; }
+            if (face.Manifest == null || face.Manifest.width <= 0 || face.Manifest.height <= 0)
+            {
+                warning = $"Runtime Face '{faceId}' has invalid manifest dimensions.";
+                return false;
+            }
+            if (face.CabinetTarget == null)
+            {
+                warning = $"Runtime Face '{faceId}' has no resolved cabinet target '{targetId}' for component placement.";
+                return false;
+            }
+
+            var filters = face.CabinetTarget.GetComponentsInChildren<MeshFilter>(true);
+            MeshFilter usable = null;
+            var usableCount = 0;
+            for (var i = 0; i < filters.Length; i++)
+            {
+                var filter = filters[i];
+                if (filter == null || filter.sharedMesh == null) continue;
+                if (filter.GetComponent<Renderer>() == null) continue;
+                usable = filter;
+                usableCount++;
+            }
+
+            if (usableCount != 1)
+            {
+                warning = usableCount == 0
+                    ? $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has no usable Face surface mesh."
+                    : $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has {usableCount} usable Face surface meshes; component placement skipped because the surface is ambiguous.";
+                return false;
+            }
+
+            var bounds = usable.sharedMesh.bounds;
+            var transform = usable.transform;
+            var horizontal = transform.TransformVector(new Vector3(bounds.size.x, 0f, 0f));
+            var vertical = transform.TransformVector(new Vector3(0f, bounds.size.y, 0f));
+            var physicalWidth = horizontal.magnitude;
+            var physicalHeight = vertical.magnitude;
+            if (physicalWidth <= 0.0001f || physicalHeight <= 0.0001f)
+            {
+                warning = $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has degenerate surface dimensions.";
+                return false;
+            }
+
+            var h = horizontal / physicalWidth;
+            var v = vertical / physicalHeight;
+            var meshNormal = Vector3.Cross(h, v).normalized;
+            if (!IsFinite(meshNormal) || meshNormal.sqrMagnitude <= 0.5f)
+            {
+                warning = $"Cabinet target '{targetId}' for Runtime Face '{faceId}' has degenerate surface normal.";
+                return false;
+            }
+
+            var frontSide = face.Reference != null ? RuntimeFaceFrontSideExtensions.Parse(face.Reference.frontSide) : RuntimeFaceFrontSide.Normal;
+            geometry.Center = transform.TransformPoint(bounds.center);
+            geometry.HorizontalTangent = h;
+            geometry.VerticalTangent = v;
+            geometry.VisibleNormal = frontSide == RuntimeFaceFrontSide.Inverted ? meshNormal : -meshNormal;
+            geometry.PhysicalWidth = physicalWidth;
+            geometry.PhysicalHeight = physicalHeight;
+            if (!IsFinite(geometry.Center))
+            {
+                warning = $"Cabinet target '{targetId}' for Runtime Face '{faceId}' produced a non-finite surface centre.";
+                return false;
+            }
+            return true;
+        }
+
+        public static bool ValidateComponent(RuntimeFace face, FaceRuntimeElementManifestEntry entry, out string warning)
+        {
+            warning = string.Empty;
+            if (entry == null) { warning = $"Runtime Face '{FaceId(face)}' has a null component entry."; return false; }
+            if (entry.width <= 0f || entry.height <= 0f || !IsFinite(new Vector3(entry.x, entry.y, entry.width)) || float.IsNaN(entry.height) || float.IsInfinity(entry.height))
+            {
+                warning = $"Runtime Face '{FaceId(face)}' component '{ComponentId(entry)}' has invalid Face-space bounds.";
+                return false;
+            }
+            return true;
+        }
+
+        public static string FaceId(RuntimeFace face) => face != null && face.Reference != null && !string.IsNullOrWhiteSpace(face.Reference.faceId) ? face.Reference.faceId.Trim() : "<unknown>";
+        public static string TargetId(RuntimeFace face) => face != null && face.Reference != null && !string.IsNullOrWhiteSpace(face.Reference.cabinetFaceTargetId) ? face.Reference.cabinetFaceTargetId.Trim() : "<unknown>";
+        public static string ComponentId(FaceRuntimeElementManifestEntry entry) => entry != null && !string.IsNullOrWhiteSpace(entry.objectId) ? entry.objectId.Trim() : "<unknown>";
+        private static bool IsFinite(Vector3 v) => !(float.IsNaN(v.x) || float.IsInfinity(v.x) || float.IsNaN(v.y) || float.IsInfinity(v.y) || float.IsNaN(v.z) || float.IsInfinity(v.z));
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
@@ -28,7 +28,7 @@ namespace OasisPlayer.RuntimeBuild
 
         public Quaternion AlignLocalReelAxesToSurface()
         {
-            return Quaternion.LookRotation(VisibleNormal, VerticalTangent) * Quaternion.Euler(0f, 90f, 0f);
+            return Quaternion.LookRotation(-VisibleNormal, VerticalTangent);
         }
     }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs
@@ -95,7 +95,7 @@ namespace OasisPlayer.RuntimeBuild
             geometry.Center = transform.TransformPoint(bounds.center);
             geometry.HorizontalTangent = h;
             geometry.VerticalTangent = v;
-            geometry.VisibleNormal = frontSide == RuntimeFaceFrontSide.Inverted ? meshNormal : -meshNormal;
+            geometry.VisibleNormal = frontSide == RuntimeFaceFrontSide.Inverted ? -meshNormal : meshNormal;
             geometry.PhysicalWidth = physicalWidth;
             geometry.PhysicalHeight = physicalHeight;
             if (!IsFinite(geometry.Center))

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFacePlacement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f008f1649434933a6e63805d5c0c8c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
@@ -97,6 +97,34 @@ namespace OasisPlayer.RuntimeBuild
         }
     }
 
+    public sealed class RuntimeReelRenderBinding : IDisposable
+    {
+        public RuntimeReelRenderBinding(GameObject gameObject, Material material)
+        {
+            GameObject = gameObject;
+            Material = material;
+        }
+
+        public GameObject GameObject { get; private set; }
+        public Material Material { get; private set; }
+
+        public void Dispose()
+        {
+            if (GameObject != null)
+            {
+                if (Application.isPlaying) UnityEngine.Object.Destroy(GameObject);
+                else UnityEngine.Object.DestroyImmediate(GameObject);
+                GameObject = null;
+            }
+            if (Material != null)
+            {
+                if (Application.isPlaying) UnityEngine.Object.Destroy(Material);
+                else UnityEngine.Object.DestroyImmediate(Material);
+                Material = null;
+            }
+        }
+    }
+
     public sealed class RuntimeReelRenderer
     {
         private readonly RuntimeReelMeshFactory _meshFactory = new RuntimeReelMeshFactory();
@@ -104,24 +132,43 @@ namespace OasisPlayer.RuntimeBuild
         public void RenderReels(RuntimeMachine machine)
         {
             if (machine == null) throw new ArgumentNullException(nameof(machine));
-            var parent = machine.Cabinet != null ? machine.Cabinet.transform : null;
             foreach (var face in machine.Faces)
             {
                 var reels = face.Manifest != null && face.Manifest.reels != null ? face.Manifest.reels : Array.Empty<FaceRuntimeReelManifestEntry>();
+                if (reels.Length == 0) continue;
+                if (!RuntimeFacePlacement.TryResolve(face, out var surface, out var surfaceWarning))
+                {
+                    machine.AddWarning(surfaceWarning);
+                    continue;
+                }
+
                 foreach (var reel in reels)
                 {
                     if (reel == null) continue;
-                    if (!Validate(reel, out var warning)) { machine.AddWarning(warning); continue; }
-                    if (reel.BandTexture == null || reel.BandTexture.Texture == null) { machine.AddWarning($"Reel '{reel.objectId}' has no loaded reel-band texture."); continue; }
+                    if (!Validate(face, reel, out var warning)) { machine.AddWarning(warning); continue; }
+                    if (!RuntimeFacePlacement.ValidateComponent(face, reel, out warning)) { machine.AddWarning(warning); continue; }
+                    if (reel.BandTexture == null || reel.BandTexture.Texture == null) { machine.AddWarning($"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has no loaded reel-band texture."); continue; }
+
+                    var surfacePoint = surface.FaceRectCenterToWorld(reel, face.Manifest);
+                    var position = surfacePoint - (surface.VisibleNormal * (reel.physicalRadius + RuntimeFacePlacement.DefaultSurfaceClearanceMetres));
+                    if (float.IsNaN(position.x) || float.IsInfinity(position.x) || float.IsNaN(position.y) || float.IsInfinity(position.y) || float.IsNaN(position.z) || float.IsInfinity(position.z))
+                    {
+                        machine.AddWarning($"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' produced a non-finite placement position.");
+                        continue;
+                    }
+
                     var go = new GameObject("OasisRuntimeReel_" + reel.objectId);
-                    if (parent != null) go.transform.SetParent(parent, false);
-                    go.transform.localPosition = Vector3.zero;
-                    go.transform.localRotation = RuntimeReelPositionConverter.ToLocalRotation(0f, reel.isReversed, reel.bandOffset, RuntimeReelPositionConverter.DefaultBaselineDegrees, RuntimeReelPositionConverter.DefaultDirectionSign);
+                    go.transform.position = position;
+                    var baseRotation = surface.AlignLocalReelAxesToSurface();
+                    var positionRotation = RuntimeReelPositionConverter.ToLocalRotation(0f, reel.isReversed, reel.bandOffset, RuntimeReelPositionConverter.DefaultBaselineDegrees, RuntimeReelPositionConverter.DefaultDirectionSign);
+                    go.transform.rotation = baseRotation * positionRotation;
                     go.transform.localScale = Vector3.one;
                     var filter = go.AddComponent<MeshFilter>();
                     filter.sharedMesh = _meshFactory.Get(reel.physicalWidth, reel.physicalRadius, 96);
                     var renderer = go.AddComponent<MeshRenderer>();
-                    renderer.sharedMaterial = CreateMaterial(reel);
+                    var material = CreateMaterial(reel);
+                    renderer.sharedMaterial = material;
+                    face.AddReelRenderBinding(new RuntimeReelRenderBinding(go, material));
                 }
             }
         }
@@ -136,14 +183,14 @@ namespace OasisPlayer.RuntimeBuild
             return material;
         }
 
-        private static bool Validate(FaceRuntimeReelManifestEntry reel, out string warning)
+        private static bool Validate(RuntimeFace face, FaceRuntimeReelManifestEntry reel, out string warning)
         {
             warning = string.Empty;
-            if (string.IsNullOrWhiteSpace(reel.objectId)) warning = "Runtime reel entry has an empty objectId.";
-            else if (string.IsNullOrWhiteSpace(reel.machineReference)) warning = $"Runtime reel '{reel.objectId}' has an empty machineReference.";
-            else if (string.IsNullOrWhiteSpace(reel.reelBand)) warning = $"Runtime reel '{reel.objectId}' has an empty reelBand path.";
-            else if (reel.stops <= 0) warning = $"Runtime reel '{reel.objectId}' has invalid stop count '{reel.stops}'.";
-            else if (reel.physicalWidth <= 0f || reel.physicalRadius <= 0f) warning = $"Runtime reel '{reel.objectId}' has invalid physical dimensions.";
+            if (string.IsNullOrWhiteSpace(reel.objectId)) warning = $"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' has a reel entry with an empty objectId.";
+            else if (string.IsNullOrWhiteSpace(reel.machineReference)) warning = $"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has an empty machineReference.";
+            else if (string.IsNullOrWhiteSpace(reel.reelBand)) warning = $"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has an empty reelBand path.";
+            else if (reel.stops <= 0) warning = $"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has invalid stop count '{reel.stops}'.";
+            else if (reel.physicalWidth <= 0f || reel.physicalRadius <= 0f) warning = $"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has invalid physical dimensions.";
             return string.IsNullOrEmpty(warning);
         }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
@@ -1,0 +1,141 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using OasisPlayer.RuntimeBuild;
+
+public sealed class RuntimeFacePlacementTests
+{
+    private const float Epsilon = 0.0005f;
+
+    [Test]
+    public void CenterAndCornersMapFromImageCoordinatesToQuad()
+    {
+        var target = CreateQuad("face", Vector3.zero, Quaternion.identity, new Vector3(2f, 3f, 1f));
+        try
+        {
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 200, 300);
+            Assert.IsTrue(RuntimeFacePlacement.TryResolve(face, out var surface, out var warning), warning);
+            AssertVector(Vector3.zero, surface.FacePointToWorld(100, 150, 200, 300));
+            AssertVector(new Vector3(-1f, 1.5f, 0f), surface.FacePointToWorld(0, 0, 200, 300));
+            AssertVector(new Vector3(1f, -1.5f, 0f), surface.FacePointToWorld(200, 300, 200, 300));
+            AssertVector(Vector3.back, surface.VisibleNormal);
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
+    [Test]
+    public void RotatedTranslatedAndParentedTargetRespectsWorldTransformAndSize()
+    {
+        var parent = new GameObject("parent");
+        var target = CreateQuad("face", new Vector3(1f, 2f, 3f), Quaternion.Euler(0f, 90f, 0f), new Vector3(4f, 2f, 1f));
+        try
+        {
+            parent.transform.position = new Vector3(10f, 0f, 0f);
+            parent.transform.rotation = Quaternion.Euler(0f, 0f, 30f);
+            target.transform.SetParent(parent.transform, true);
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 400, 200);
+            Assert.IsTrue(RuntimeFacePlacement.TryResolve(face, out var surface, out var warning), warning);
+            Assert.AreEqual(4f, surface.PhysicalWidth, Epsilon);
+            Assert.AreEqual(2f, surface.PhysicalHeight, Epsilon);
+            AssertVector(target.transform.TransformPoint(Vector3.zero), surface.FacePointToWorld(200, 100, 400, 200));
+            AssertVector(-Vector3.Cross(target.transform.right, target.transform.up).normalized, surface.VisibleNormal);
+        }
+        finally { Object.DestroyImmediate(target); Object.DestroyImmediate(parent); }
+    }
+
+    [Test]
+    public void InvertedReversesVisibleNormal()
+    {
+        var target = CreateQuad("face", Vector3.zero, Quaternion.identity, Vector3.one);
+        try
+        {
+            Assert.IsTrue(RuntimeFacePlacement.TryResolve(CreateFace(target.transform, RuntimeFaceFrontSideExtensions.InvertedValue, 100, 100), out var surface, out var warning), warning);
+            AssertVector(Vector3.forward, surface.VisibleNormal);
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
+    [Test]
+    public void ReelRendererPlacesAxleBehindSurfaceAndAlignsAxle()
+    {
+        var target = CreateQuad("face", Vector3.zero, Quaternion.identity, new Vector3(2f, 2f, 1f));
+        try
+        {
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 200, 200, Reel("r1", 0.2f));
+            face.Manifest.reels[0].BandTexture = new RuntimeTextureAsset("band", new Texture2D(2, 2));
+            var machine = CreateMachine(face);
+            new RuntimeReelRenderer().RenderReels(machine);
+            Assert.AreEqual(1, face.ReelRenderBindings.Count);
+            var reel = face.ReelRenderBindings[0].GameObject.transform;
+            AssertVector(Vector3.right, reel.right);
+            Assert.AreEqual(0.21f, Vector3.Dot(Vector3.forward, reel.position), Epsilon);
+            Assert.AreEqual(0.01f, Vector3.Dot(Vector3.forward, reel.position) - 0.2f, Epsilon);
+            face.UnloadAssets();
+            Assert.IsTrue(face.ReelRenderBindings.Count == 0);
+            Assert.IsTrue(reel == null);
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
+    [Test]
+    public void DifferentReelRadiiKeepSameClearance()
+    {
+        var target = CreateQuad("face", Vector3.zero, Quaternion.identity, Vector3.one);
+        try
+        {
+            var r1 = Reel("r1", 0.1f); var r2 = Reel("r2", 0.3f); r1.x = 25; r2.x = 75;
+            r1.BandTexture = new RuntimeTextureAsset("b1", new Texture2D(2,2)); r2.BandTexture = new RuntimeTextureAsset("b2", new Texture2D(2,2));
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 100, 100, r1, r2);
+            new RuntimeReelRenderer().RenderReels(CreateMachine(face));
+            Assert.AreEqual(2, face.ReelRenderBindings.Count);
+            Assert.AreEqual(0.01f, face.ReelRenderBindings[0].GameObject.transform.position.z - 0.1f, Epsilon);
+            Assert.AreEqual(0.01f, face.ReelRenderBindings[1].GameObject.transform.position.z - 0.3f, Epsilon);
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
+    [Test]
+    public void MissingOrAmbiguousGeometryWarnsAndCreatesNoOriginFallback()
+    {
+        var target = new GameObject("empty");
+        try
+        {
+            var reel = Reel("r", 0.2f); reel.BandTexture = new RuntimeTextureAsset("b", new Texture2D(2,2));
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 100, 100, reel);
+            var machine = CreateMachine(face);
+            new RuntimeReelRenderer().RenderReels(machine);
+            Assert.AreEqual(0, face.ReelRenderBindings.Count);
+            Assert.That(machine.Warnings[0], Does.Contain("no usable Face surface mesh"));
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
+    private static GameObject CreateQuad(string name, Vector3 position, Quaternion rotation, Vector3 scale)
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        go.name = name;
+        go.transform.position = position;
+        go.transform.rotation = rotation;
+        go.transform.localScale = scale;
+        return go;
+    }
+
+    private static RuntimeFace CreateFace(Transform target, string frontSide, int width, int height, params FaceRuntimeReelManifestEntry[] reels) =>
+        new RuntimeFace(new MachineRuntimeFaceReference { faceId = "face", cabinetFaceTargetId = "target", frontSide = frontSide }, new FaceRuntimeManifest { faceId = "face", width = width, height = height, reels = reels }, target, new RuntimeTextureAsset("a", new Texture2D(2,2)), new RuntimeTextureAsset("m", new Texture2D(2,2)));
+
+    private static FaceRuntimeReelManifestEntry Reel(string id, float radius) => new FaceRuntimeReelManifestEntry { objectId = id, machineReference = id, reelBand = "band", stops = 20, x = 40, y = 40, width = 20, height = 20, physicalWidth = 0.2f, physicalRadius = radius };
+
+    private static RuntimeMachine CreateMachine(RuntimeFace face)
+    {
+        var machine = new RuntimeMachine(new ResolvedRuntimeBuild(string.Empty, new MachineRuntimeManifest(), string.Empty, new CabinetRuntimeManifest(), string.Empty, new MachineRuntimeFaceReference[0]), null);
+        machine.RegisterFace(face);
+        return machine;
+    }
+
+    private static void AssertVector(Vector3 expected, Vector3 actual)
+    {
+        Assert.AreEqual(expected.x, actual.x, Epsilon);
+        Assert.AreEqual(expected.y, actual.y, Epsilon);
+        Assert.AreEqual(expected.z, actual.z, Epsilon);
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
@@ -55,6 +55,23 @@ public sealed class RuntimeFacePlacementTests
         finally { Object.DestroyImmediate(target); }
     }
 
+
+    [Test]
+    public void LocalXzFaceTargetMeshUsesNonDegenerateSurfaceDimensions()
+    {
+        var target = CreateLocalXzQuad("xzFace", 2f, 3f);
+        try
+        {
+            var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 200, 300);
+            Assert.IsTrue(RuntimeFacePlacement.TryResolve(face, out var surface, out var warning), warning);
+            Assert.AreEqual(2f, surface.PhysicalWidth, Epsilon);
+            Assert.AreEqual(3f, surface.PhysicalHeight, Epsilon);
+            AssertVector(Vector3.zero, surface.FacePointToWorld(100, 150, 200, 300));
+            AssertVector(new Vector3(-1f, 0f, 1.5f), surface.FacePointToWorld(0, 0, 200, 300));
+        }
+        finally { Object.DestroyImmediate(target); }
+    }
+
     [Test]
     public void ReelRendererPlacesAxleBehindSurfaceAndAlignsAxle()
     {
@@ -117,6 +134,28 @@ public sealed class RuntimeFacePlacementTests
         go.transform.position = position;
         go.transform.rotation = rotation;
         go.transform.localScale = scale;
+        return go;
+    }
+
+
+    private static GameObject CreateLocalXzQuad(string name, float width, float height)
+    {
+        var go = new GameObject(name);
+        var mesh = new Mesh();
+        var halfWidth = width * 0.5f;
+        var halfHeight = height * 0.5f;
+        mesh.vertices = new[]
+        {
+            new Vector3(-halfWidth, 0f, -halfHeight),
+            new Vector3(halfWidth, 0f, -halfHeight),
+            new Vector3(-halfWidth, 0f, halfHeight),
+            new Vector3(halfWidth, 0f, halfHeight)
+        };
+        mesh.triangles = new[] { 0, 2, 1, 1, 2, 3 };
+        mesh.RecalculateBounds();
+        mesh.RecalculateNormals();
+        go.AddComponent<MeshFilter>().sharedMesh = mesh;
+        go.AddComponent<MeshRenderer>().sharedMaterial = new Material(Shader.Find("Standard"));
         return go;
     }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
@@ -85,6 +85,7 @@ public sealed class RuntimeFacePlacementTests
             Assert.AreEqual(1, face.ReelRenderBindings.Count);
             var reel = face.ReelRenderBindings[0].GameObject.transform;
             AssertVector(Vector3.right, reel.right);
+            AssertVector(Vector3.back, reel.forward);
             Assert.AreEqual(0.21f, Vector3.Dot(Vector3.forward, reel.position), Epsilon);
             Assert.AreEqual(0.01f, Vector3.Dot(Vector3.forward, reel.position) - 0.2f, Epsilon);
             face.UnloadAssets();

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs
@@ -18,7 +18,7 @@ public sealed class RuntimeFacePlacementTests
             AssertVector(Vector3.zero, surface.FacePointToWorld(100, 150, 200, 300));
             AssertVector(new Vector3(-1f, 1.5f, 0f), surface.FacePointToWorld(0, 0, 200, 300));
             AssertVector(new Vector3(1f, -1.5f, 0f), surface.FacePointToWorld(200, 300, 200, 300));
-            AssertVector(Vector3.back, surface.VisibleNormal);
+            AssertVector(Vector3.forward, surface.VisibleNormal);
         }
         finally { Object.DestroyImmediate(target); }
     }
@@ -38,7 +38,7 @@ public sealed class RuntimeFacePlacementTests
             Assert.AreEqual(4f, surface.PhysicalWidth, Epsilon);
             Assert.AreEqual(2f, surface.PhysicalHeight, Epsilon);
             AssertVector(target.transform.TransformPoint(Vector3.zero), surface.FacePointToWorld(200, 100, 400, 200));
-            AssertVector(-Vector3.Cross(target.transform.right, target.transform.up).normalized, surface.VisibleNormal);
+            AssertVector(Vector3.Cross(target.transform.right, target.transform.up).normalized, surface.VisibleNormal);
         }
         finally { Object.DestroyImmediate(target); Object.DestroyImmediate(parent); }
     }
@@ -50,7 +50,7 @@ public sealed class RuntimeFacePlacementTests
         try
         {
             Assert.IsTrue(RuntimeFacePlacement.TryResolve(CreateFace(target.transform, RuntimeFaceFrontSideExtensions.InvertedValue, 100, 100), out var surface, out var warning), warning);
-            AssertVector(Vector3.forward, surface.VisibleNormal);
+            AssertVector(Vector3.back, surface.VisibleNormal);
         }
         finally { Object.DestroyImmediate(target); }
     }
@@ -85,9 +85,9 @@ public sealed class RuntimeFacePlacementTests
             Assert.AreEqual(1, face.ReelRenderBindings.Count);
             var reel = face.ReelRenderBindings[0].GameObject.transform;
             AssertVector(Vector3.right, reel.right);
-            AssertVector(Vector3.back, reel.forward);
-            Assert.AreEqual(0.21f, Vector3.Dot(Vector3.forward, reel.position), Epsilon);
-            Assert.AreEqual(0.01f, Vector3.Dot(Vector3.forward, reel.position) - 0.2f, Epsilon);
+            AssertVector(Vector3.forward, reel.forward);
+            Assert.AreEqual(-0.21f, Vector3.Dot(Vector3.forward, reel.position), Epsilon);
+            Assert.AreEqual(0.01f, -Vector3.Dot(Vector3.forward, reel.position) - 0.2f, Epsilon);
             face.UnloadAssets();
             Assert.IsTrue(face.ReelRenderBindings.Count == 0);
             Assert.IsTrue(reel == null);
@@ -106,8 +106,8 @@ public sealed class RuntimeFacePlacementTests
             var face = CreateFace(target.transform, RuntimeFaceFrontSideExtensions.NormalValue, 100, 100, r1, r2);
             new RuntimeReelRenderer().RenderReels(CreateMachine(face));
             Assert.AreEqual(2, face.ReelRenderBindings.Count);
-            Assert.AreEqual(0.01f, face.ReelRenderBindings[0].GameObject.transform.position.z - 0.1f, Epsilon);
-            Assert.AreEqual(0.01f, face.ReelRenderBindings[1].GameObject.transform.position.z - 0.3f, Epsilon);
+            Assert.AreEqual(0.01f, -face.ReelRenderBindings[0].GameObject.transform.position.z - 0.1f, Epsilon);
+            Assert.AreEqual(0.01f, -face.ReelRenderBindings[1].GameObject.transform.position.z - 0.3f, Epsilon);
         }
         finally { Object.DestroyImmediate(target); }
     }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFacePlacementTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26bed2da5d3f4aa1a3cc8d17e60f4bbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Motivation
- Provide an initial Player-side 3D placement for Face components (reels, segments, alpha displays) by combining face-space layout from `face.runtime.json` with the resolved cabinet Face target geometry and the Face `frontSide` flag. 
- Ensure mechanical reels sit behind the cabinet glass with a configurable clearance and that reel axles align with the physical Face tangent rather than defaulting to the cabinet origin. 
- Centralize surface conventions (horizontal/vertical tangents, visible normal, physical width/height, image→world mapping) to avoid duplicated coordinate-sign handling across renderers. 
- Emit clear non-fatal warnings and skip placement for ambiguous or missing Face target geometry rather than silently placing objects at the origin. 

### Description
- Add `RuntimeFacePlacement` / `RuntimeFaceSurfaceGeometry` implementing a surface coordinate frame with `Center`, `HorizontalTangent`, `VerticalTangent`, `VisibleNormal`, `PhysicalWidth`, `PhysicalHeight`, a `FacePointToWorld` converter, and `AlignLocalReelAxesToSurface`; default clearance is `DefaultSurfaceClearanceMetres = 0.01f`.
- Update `RuntimeReelRenderer` to resolve the owning `RuntimeFace` surface, convert each reel's Face-space rectangle centre to world position, align the reel axle to the Face horizontal tangent, compose the existing reel-position rotation around the axle, and place the axle centre at `physicalRadius + 0.01m` behind the visible Face surface.
- Introduce `RuntimeReelRenderBinding` and track per-face `ReelRenderBindings` on `RuntimeFace` so generated reel `GameObject` and `Material` instances are owned and disposed by `RuntimeFace.UnloadAssets()`.
- Add focused placement validation and diagnostics for invalid manifest dimensions, missing/ambiguous mesh, degenerate dimensions/normals, invalid component bounds, and non-finite transforms; the code skips placement and records warnings when detection fails.
- Add Unity EditMode tests `RuntimeFacePlacementTests` that cover center/corner mapping, UV Y-orientation, transformed/parented targets, `frontSide` normal inversion, reel axle alignment and clearance for different radii, no-origin fallback for missing/ambiguous geometry, and cleanup on unload.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues; the check passed.
- Attempted `dotnet test --no-restore` but it could not run in this environment because `dotnet` is not installed (test execution was therefore not performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5e7bf9cc04832781f8508373f72c14)