### PR TITLE
Resolve runtime reel dimensions from Cabinet specifications

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
@@ -34,6 +34,16 @@ namespace OasisPlayer.RuntimeBuild
         }
     }
 
+    public static class RuntimeReelUnits
+    {
+        public const float MillimetresPerMetre = 1000f;
+
+        public static float MillimetresToMetres(float millimetres)
+        {
+            return millimetres / MillimetresPerMetre;
+        }
+    }
+
     public sealed class RuntimeReelMeshFactory
     {
         private readonly Dictionary<string, Mesh> _cache = new Dictionary<string, Mesh>(StringComparer.Ordinal);
@@ -150,7 +160,9 @@ namespace OasisPlayer.RuntimeBuild
                     if (reel.BandTexture == null || reel.BandTexture.Texture == null) { machine.AddWarning($"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' has no loaded reel-band texture."); continue; }
 
                     var surfacePoint = surface.FaceRectCenterToWorld(reel, face.Manifest);
-                    var position = surfacePoint - (surface.VisibleNormal * (reel.physicalRadius + RuntimeFacePlacement.DefaultSurfaceClearanceMetres));
+                    var physicalWidthMetres = RuntimeReelUnits.MillimetresToMetres(reel.physicalWidth);
+                    var physicalRadiusMetres = RuntimeReelUnits.MillimetresToMetres(reel.physicalRadius);
+                    var position = surfacePoint - (surface.VisibleNormal * (physicalRadiusMetres + RuntimeFacePlacement.DefaultSurfaceClearanceMetres));
                     if (float.IsNaN(position.x) || float.IsInfinity(position.x) || float.IsNaN(position.y) || float.IsInfinity(position.y) || float.IsNaN(position.z) || float.IsInfinity(position.z))
                     {
                         machine.AddWarning($"Runtime Face '{RuntimeFacePlacement.FaceId(face)}' reel '{reel.objectId}' produced a non-finite placement position.");
@@ -164,7 +176,7 @@ namespace OasisPlayer.RuntimeBuild
                     go.transform.rotation = baseRotation * positionRotation;
                     go.transform.localScale = Vector3.one;
                     var filter = go.AddComponent<MeshFilter>();
-                    filter.sharedMesh = _meshFactory.Get(reel.physicalWidth, reel.physicalRadius, 96);
+                    filter.sharedMesh = _meshFactory.Get(physicalWidthMetres, physicalRadiusMetres, 96);
                     var renderer = go.AddComponent<MeshRenderer>();
                     var material = CreateMaterial(reel);
                     renderer.sharedMaterial = material;

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelMeshFactoryTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelMeshFactoryTests.cs
@@ -47,4 +47,44 @@ public sealed class RuntimeReelMeshFactoryTests
             Assert.Greater(Vector3.Dot(radial, faceNormal), 0f);
         }
     }
+    [Test]
+    public void MillimetresToMetres_ConvertsRuntimeManifestDimensionsOnce()
+    {
+        Assert.AreEqual(0.05f, RuntimeReelUnits.MillimetresToMetres(50f));
+        Assert.AreEqual(0.105f, RuntimeReelUnits.MillimetresToMetres(105f));
+    }
+
+    [Test]
+    public void GeneratedCylinder_UsesSpecifiedMetreDimensions()
+    {
+        var mesh = RuntimeReelMeshFactory.Create(RuntimeReelUnits.MillimetresToMetres(50f), RuntimeReelUnits.MillimetresToMetres(105f), 32);
+
+        Assert.AreEqual(new Vector3(0.05f, 0.21f, 0.21f), mesh.bounds.size);
+    }
+
+    [Test]
+    public void MeshCache_IncludesPhysicalDimensionsInKey()
+    {
+        var factory = new RuntimeReelMeshFactory();
+
+        var standard = factory.Get(0.05f, 0.105f, 32);
+        var standardAgain = factory.Get(0.05f, 0.105f, 32);
+        var wide = factory.Get(0.075f, 0.150f, 32);
+
+        Assert.AreSame(standard, standardAgain);
+        Assert.AreNotSame(standard, wide);
+        Assert.AreEqual(new Vector3(0.05f, 0.21f, 0.21f), standard.bounds.size);
+        Assert.AreEqual(new Vector3(0.075f, 0.3f, 0.3f), wide.bounds.size);
+    }
+
+    [Test]
+    public void FaceApertureDimensions_DoNotAffectGeneratedMeshDimensions()
+    {
+        var smallApertureMesh = RuntimeReelMeshFactory.Create(RuntimeReelUnits.MillimetresToMetres(50f), RuntimeReelUnits.MillimetresToMetres(105f), 32);
+        var largeApertureMesh = RuntimeReelMeshFactory.Create(RuntimeReelUnits.MillimetresToMetres(50f), RuntimeReelUnits.MillimetresToMetres(105f), 32);
+
+        Assert.AreEqual(smallApertureMesh.bounds.size, largeApertureMesh.bounds.size);
+        Assert.AreEqual(new Vector3(0.05f, 0.21f, 0.21f), largeApertureMesh.bounds.size);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using OasisEditor;
 using OasisEditor.Automation;
+using OasisEditor.Features.CabinetEditor.Models;
 using SkiaSharp;
 using Xunit;
 
@@ -75,6 +76,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var maskBefore = File.ReadAllBytes(authoredMaskPath);
 
         var document = CreateDocument("Assets/Faces/Stable Face/artwork.png", "Assets/Faces/Stable Face/mask.png", "Renamed In Inspector");
+        WriteDefaultCabinetAsset();
 
         var result = new FaceRuntimeExportService().Export(document, CreateProject(), GetFaceManifestPath("Stable Face"));
 
@@ -95,6 +97,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         WriteSolidPng(artworkPath, 4, 4, new SKColor(255, 0, 0, 128));
         WriteSolidPng(maskPath, 4, 4, SKColors.White);
         var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
+        WriteDefaultCabinetAsset();
         var project = CreateProject();
 
         var result = new FaceRuntimeExportService().Export(document, project, GetFaceManifestPath());
@@ -154,6 +157,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         WriteSolidPng(artworkPath, 4, 4, new SKColor(0, 255, 0, 192));
         WriteSolidPng(maskPath, 4, 4, SKColors.White);
         var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
+        WriteDefaultCabinetAsset();
         var current = new DocumentTabViewModel(
             EditorDocument.CreateFaceStub("Front Face").MarkDirty(),
             faceDocumentJson: FaceDocumentStorage.Serialize(document));
@@ -465,7 +469,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     {
         var document = CreateDocument("Assets/artwork.png", "Generated/source-mask.png");
 
-        var manifest = new FaceRuntimeExportService().CreateManifest(document, 4, 4);
+        var manifest = new FaceRuntimeExportService().CreateManifest(document, 4, 4, CreateCabinetContext(CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50))));
 
         Assert.Equal("trayId.png", manifest.TrayId);
         Assert.Equal("lampIds0.png", manifest.LampIds0);
@@ -479,6 +483,104 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         Assert.Equal("runtime-tray-lamp-24", tray.ObjectId);
         Assert.Equal("runtime-emitter-lamp-24", tray.LampEmitterObjectId);
         Assert.Equal(24, tray.LampId);
+    }
+
+
+    [Fact]
+    public void CreateManifest_ResolvesReelDimensionsFromCabinetSpecification()
+    {
+        var document = CreateReelDocument("standard", 10, 20, 300, 400);
+        var cabinet = CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50));
+
+        var manifest = new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(cabinet));
+
+        var reel = Assert.Single(manifest.Reels);
+        Assert.Equal(50, reel.PhysicalWidth);
+        Assert.Equal(105, reel.PhysicalRadius);
+    }
+
+    [Fact]
+    public void CreateManifest_UsesDifferentCabinetSpecificationsPerReel()
+    {
+        var document = CreateReelDocument("standard", 1, 1, 10, 10, "wide", 20, 20, 200, 40);
+        var cabinet = CreateCabinet(
+            new CabinetReelSpecification("standard", "Standard", 210, 50),
+            new CabinetReelSpecification("wide", "Wide", 300, 75));
+
+        var manifest = new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(cabinet));
+
+        Assert.Equal(2, manifest.Reels.Count);
+        Assert.Equal(50, manifest.Reels[0].PhysicalWidth);
+        Assert.Equal(105, manifest.Reels[0].PhysicalRadius);
+        Assert.Equal(75, manifest.Reels[1].PhysicalWidth);
+        Assert.Equal(150, manifest.Reels[1].PhysicalRadius);
+    }
+
+    [Fact]
+    public void CreateManifest_ReelDimensionsAreIndependentOfFaceRectangle()
+    {
+        var document = CreateReelDocument("standard", 1, 1, 10, 10, "standard", 50, 60, 700, 800);
+        var cabinet = CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50));
+
+        var manifest = new FaceRuntimeExportService().CreateManifest(document, 1000, 1000, CreateCabinetContext(cabinet));
+
+        Assert.All(manifest.Reels, reel =>
+        {
+            Assert.Equal(50, reel.PhysicalWidth);
+            Assert.Equal(105, reel.PhysicalRadius);
+        });
+    }
+
+    [Theory]
+    [InlineData("", "Face reel has no ReelSpecificationId")]
+    [InlineData("unknown", "does not exist")]
+    public void CreateManifest_WithUnresolvedReelSpecification_Throws(string specificationId, string expected)
+    {
+        var document = CreateReelDocument(specificationId, 1, 1, 1000, 1000);
+        var cabinet = CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(cabinet)));
+
+        Assert.Contains(expected, exception.Message);
+        Assert.Contains("Face asset", exception.Message);
+        Assert.Contains("Cabinet asset", exception.Message);
+        Assert.Contains(specificationId, exception.Message);
+    }
+
+    [Fact]
+    public void CreateManifest_WithMissingCabinet_Throws()
+    {
+        var document = CreateReelDocument("standard", 1, 1, 1000, 1000);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new FaceRuntimeExportService().CreateManifest(document, 100, 100));
+
+        Assert.Contains("Face has no assigned Cabinet", exception.Message);
+    }
+
+    [Fact]
+    public void CreateManifest_WithDuplicateSpecificationIds_Throws()
+    {
+        var document = CreateReelDocument("standard", 1, 1, 1000, 1000);
+        var cabinet = CreateCabinet(new CabinetReelSpecification("standard", "A", 210, 50), new CabinetReelSpecification("standard", "B", 220, 55));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(cabinet)));
+
+        Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0, 50, "diameter")]
+    [InlineData(double.NaN, 50, "diameter")]
+    [InlineData(210, 0, "width")]
+    [InlineData(210, double.PositiveInfinity, "width")]
+    public void CreateManifest_WithInvalidSpecificationDimensions_Throws(double diameterMm, double widthMm, string expected)
+    {
+        var document = CreateReelDocument("standard", 1, 1, 1000, 1000);
+        var cabinet = CreateCabinet(new CabinetReelSpecification("standard", "Standard", diameterMm, widthMm));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(cabinet)));
+
+        Assert.Contains(expected, exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
 
@@ -740,6 +842,13 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         };
     }
 
+    private void WriteDefaultCabinetAsset()
+    {
+        var path = Path.Combine(_assetsDirectory, "Cabinets", "cabinet.asset");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, CabinetDocumentStorage.Serialize(CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50))));
+    }
+
     private string GetFaceManifestPath(string assetName = "Runtime Face") => Path.Combine(_assetsDirectory, "Faces", assetName, "asset.face");
 
     private static FaceDocumentModel CreateDocument(string artworkAssetPath, string maskAssetPath, string title = "Runtime Face")
@@ -748,6 +857,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         {
             Id = "face-runtime",
             Title = title,
+            AssignedCabinetAssetPath = "Assets/Cabinets/cabinet.asset",
             SourceRegion = new FaceSourceRegionModel
             {
                 X = 0,
@@ -793,13 +903,52 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
                     Y = 0,
                     Width = 1,
                     Height = 4,
-                    LinkedMachineObjectReference = MachineObjectReference.Reel(1)
+                    LinkedMachineObjectReference = MachineObjectReference.Reel(1),
+                    ReelSpecificationId = "standard",
+                    Stops = 20
                 }
             ]
         };
     }
 
+    private static CabinetDocument CreateCabinet(params CabinetReelSpecification[] specifications) => new(
+        2,
+        new CabinetModelReference("Assets/Cabinets/cabinet.glb", 1.0, "Y"),
+        [],
+        CabinetPreviewSettings.Default,
+        specifications,
+        specifications.FirstOrDefault()?.Id);
 
+    private static FaceCabinetContext CreateCabinetContext(CabinetDocument cabinet) => new(cabinet, null, "Assets/Cabinets/cabinet.asset", null, null);
+
+    private static FaceDocumentModel CreateReelDocument(params object[] reelData)
+    {
+        var elements = new List<FaceElementModel>();
+        for (var i = 0; i < reelData.Length; i += 5)
+        {
+            elements.Add(new FaceReelDisplayElement
+            {
+                ObjectId = $"reel-{i / 5 + 1}",
+                Name = $"Reel {i / 5 + 1}",
+                ReelSpecificationId = (string)reelData[i],
+                X = Convert.ToDouble(reelData[i + 1]),
+                Y = Convert.ToDouble(reelData[i + 2]),
+                Width = Convert.ToDouble(reelData[i + 3]),
+                Height = Convert.ToDouble(reelData[i + 4]),
+                Stops = 20,
+                LinkedMachineObjectReference = MachineObjectReference.Reel(i / 5 + 1)
+            });
+        }
+
+        return new FaceDocumentModel
+        {
+            Id = "face-runtime",
+            Title = "Runtime Face",
+            AssignedCabinetAssetPath = "Assets/Cabinets/cabinet.asset",
+            SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 1000, Height = 1000 },
+            Elements = elements
+        };
+    }
 
 
     private static FaceDocumentModel CreateDocumentWithLampWindows(params FaceLampWindowElement[] lampWindows)
@@ -915,6 +1064,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         WriteSolidPng(artworkPath, 4, 4, new SKColor(0, 0, 255, 128));
         WriteSolidPng(maskPath, 4, 4, SKColors.White);
         var document = CreateDocument("Assets/progress-artwork.png", "Generated/progress-mask.png");
+        WriteDefaultCabinetAsset();
         var project = CreateProject();
         var service = new FaceRuntimeExportService();
         var baseline = service.Export(document, project, GetFaceManifestPath());

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineRuntimeBuildServiceTests.cs
@@ -49,7 +49,7 @@ public sealed class MachineRuntimeBuildServiceTests
         var cabinetDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Cabinet3D", "Test Cabinet")).FullName;
         var sourceGlb = Path.Combine(cabinetDir, "source.glb");
         File.WriteAllBytes(sourceGlb, [1, 2, 3]);
-        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("source.glb").WithTargetOverride(new CabinetTargetOverride("target-front", " INVERTED ", 450, true))));
+        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("source.glb").WithTargetOverride(new CabinetTargetOverride("target-front", " INVERTED ", 450, true)).WithTargetOverride(new CabinetTargetOverride("target-back", CabinetTargetOverride.NormalFrontSide))));
         var faceDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Faces", "Front Face")).FullName;
         WriteSolidPng(Path.Combine(faceDir, "artwork.png"), 4, 4, SKColors.Red);
         WriteSolidPng(Path.Combine(faceDir, "mask.png"), 4, 4, SKColors.White);
@@ -87,7 +87,7 @@ public sealed class MachineRuntimeBuildServiceTests
         Assert.Equal(0, normalFace.GetProperty("faceRotation").GetInt32());
         Assert.False(normalFace.GetProperty("faceFlipHorizontal").GetBoolean());
 
-        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("source.glb").WithTargetOverride(new CabinetTargetOverride("target-front", CabinetTargetOverride.NormalFrontSide, 270, false))));
+        File.WriteAllText(Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName), CabinetDocumentStorage.Serialize(CabinetDocument.FromModelPath("source.glb").WithTargetOverride(new CabinetTargetOverride("target-front", CabinetTargetOverride.NormalFrontSide, 270, false)).WithTargetOverride(new CabinetTargetOverride("target-back", CabinetTargetOverride.NormalFrontSide))));
         var normalResult = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName));
         Assert.True(normalResult.Success, normalResult.ErrorMessage);
         using var normalMachine = JsonDocument.Parse(File.ReadAllText(Path.Combine(normalResult.BuildRoot!, "machine.runtime.json")));
@@ -100,6 +100,56 @@ public sealed class MachineRuntimeBuildServiceTests
         Assert.Equal(2, faceManifest.RootElement.GetProperty("schemaVersion").GetInt32());
         Assert.Equal("artwork.png", faceManifest.RootElement.GetProperty("artwork").GetString());
         Assert.Equal("mask.png", faceManifest.RootElement.GetProperty("mask").GetString());
+    }
+
+
+    [Fact]
+    public void BuildFromCabinetDocument_ExportsReelDimensionsFromMachineCabinetWithoutFaceCabinetAssetPath()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var manifestPath = CreateCabinetAsset(project, "Runtime Cabinet", CreateCabinetWithSpec("source.glb", new CabinetTargetOverride("bottomGlass", CabinetTargetOverride.NormalFrontSide)));
+        CreateFaceAssetWithReel(project, "Bottom Face", "face-bottom", "bottomGlass", null, "standard");
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, manifestPath);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        using var faceManifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot!, "faces", "Bottom Face", "face.runtime.json")));
+        var reel = Assert.Single(faceManifest.RootElement.GetProperty("reels").EnumerateArray());
+        Assert.Equal(50, reel.GetProperty("physicalWidth").GetDouble());
+        Assert.Equal(105, reel.GetProperty("physicalRadius").GetDouble());
+    }
+
+    [Fact]
+    public void BuildFromCabinetDocument_ReelExportIgnoresUnrelatedOpenCabinetEquivalentData()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var manifestPath = CreateCabinetAsset(project, "Runtime Cabinet", CreateCabinetWithSpec("source.glb", new CabinetTargetOverride("bottomGlass", CabinetTargetOverride.NormalFrontSide)));
+        _ = CreateCabinetAsset(project, "Unrelated Cabinet", new CabinetDocument(2, new CabinetModelReference("source.glb", 1.0, "Y"), [new CabinetTargetOverride("bottomGlass", CabinetTargetOverride.NormalFrontSide)], CabinetPreviewSettings.Default, [new CabinetReelSpecification("standard", "Different", 500, 300)], "standard"));
+        CreateFaceAssetWithReel(project, "Bottom Face", "face-bottom", "bottomGlass", null, "standard");
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, manifestPath);
+
+        Assert.True(result.Success, result.ErrorMessage);
+        using var faceManifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(result.BuildRoot!, "faces", "Bottom Face", "face.runtime.json")));
+        var reel = Assert.Single(faceManifest.RootElement.GetProperty("reels").EnumerateArray());
+        Assert.Equal(50, reel.GetProperty("physicalWidth").GetDouble());
+        Assert.Equal(105, reel.GetProperty("physicalRadius").GetDouble());
+    }
+
+    [Fact]
+    public void BuildFromCabinetDocument_WithMissingMachineCabinet_ReturnsClearFailure()
+    {
+        var root = CreateTempRoot();
+        var project = CreateProject(root);
+        var missingManifest = Path.Combine(project.AssetsDirectory, "Cabinet3D", "Missing Cabinet", ProjectAssetPathService.Cabinet3DManifestFileName);
+
+        var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, missingManifest);
+
+        Assert.False(result.Success);
+        Assert.Contains("Cabinet3D manifest was not found", result.ErrorMessage);
+        Assert.DoesNotContain("open Cabinet documents", result.ErrorMessage);
     }
 
 
@@ -153,9 +203,10 @@ public sealed class MachineRuntimeBuildServiceTests
         var result = new MachineRuntimeBuildService().BuildFromCabinetDocument(project, manifestPath);
 
         Assert.False(result.Success);
-        Assert.Contains("no matching CabinetTargetOverride", result.ErrorMessage);
+        Assert.Contains("does not contain that target override", result.ErrorMessage);
         Assert.Contains("face-mismatch", result.ErrorMessage);
         Assert.Contains("OasisFace_Top-Glass 1", result.ErrorMessage);
+        Assert.Contains("Assets/Cabinet3D/Mismatch Cabinet/asset.cabinet3d", result.ErrorMessage);
         Assert.Contains("topGlass1", result.ErrorMessage);
     }
 
@@ -172,6 +223,47 @@ public sealed class MachineRuntimeBuildServiceTests
 
         Assert.False(result.Success);
         Assert.Contains("GLB model was not found", result.ErrorMessage);
+    }
+
+    private static string CreateCabinetAsset(EditorProject project, string assetName, CabinetDocument cabinetDocument)
+    {
+        var cabinetDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Cabinet3D", assetName)).FullName;
+        File.WriteAllBytes(Path.Combine(cabinetDir, "source.glb"), [1, 2, 3]);
+        var manifestPath = Path.Combine(cabinetDir, ProjectAssetPathService.Cabinet3DManifestFileName);
+        File.WriteAllText(manifestPath, CabinetDocumentStorage.Serialize(cabinetDocument));
+        return manifestPath;
+    }
+
+    private static CabinetDocument CreateCabinetWithSpec(string modelPath, CabinetTargetOverride targetOverride) => new(
+        2,
+        new CabinetModelReference(modelPath, 1.0, "Y"),
+        [targetOverride],
+        CabinetPreviewSettings.Default,
+        [new CabinetReelSpecification("standard", "Standard", 210, 50)],
+        "standard");
+
+    private static void CreateFaceAssetWithReel(EditorProject project, string assetName, string faceId, string targetId, string? cabinetAssetPath, string reelSpecificationId)
+    {
+        var faceDir = Directory.CreateDirectory(Path.Combine(project.AssetsDirectory, "Faces", assetName)).FullName;
+        var artworkPath = Path.Combine(faceDir, "artwork.png");
+        var maskPath = Path.Combine(faceDir, "mask.png");
+        WriteSolidPng(artworkPath, 4, 4, SKColors.Red);
+        WriteSolidPng(maskPath, 4, 4, SKColors.White);
+        var document = new FaceDocumentModel
+        {
+            Id = faceId,
+            Title = assetName,
+            AssignedCabinetFaceTargetId = targetId,
+            AssignedCabinetAssetPath = cabinetAssetPath,
+            SourceRegion = new FaceSourceRegionModel { X = 0, Y = 0, Width = 4, Height = 4 },
+            MaskLayer = new FaceMaskLayerModel { AssetPath = ProjectAssetPathService.NormalizeProjectRelativePath(Path.GetRelativePath(project.ProjectDirectory, maskPath)), Width = 4, Height = 4 },
+            Elements =
+            [
+                new FaceArtworkElement { ObjectId = "artwork", Name = "Artwork", X = 0, Y = 0, Width = 4, Height = 4, IsVisible = true, AssetPath = ProjectAssetPathService.NormalizeProjectRelativePath(Path.GetRelativePath(project.ProjectDirectory, artworkPath)) },
+                new FaceReelDisplayElement { ObjectId = "reel-1", Name = "Reel 1", X = 1, Y = 1, Width = 100, Height = 200, Stops = 20, ReelSpecificationId = reelSpecificationId, LinkedMachineObjectReference = MachineObjectReference.Reel(1) }
+            ]
+        };
+        File.WriteAllText(Path.Combine(faceDir, ProjectAssetPathService.FaceManifestFileName), FaceDocumentStorage.Serialize(document));
     }
 
     private static FaceDocumentModel CreateFaceDocument(string faceId, string targetId, string artworkPath, string maskPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -33,8 +33,15 @@ public sealed class FaceRuntimeExportService
 
     public FaceRuntimeExportResult Export(FaceDocumentModel faceDocument, EditorProject project, string? documentPath = null, IEditorProgressReporter? progress = null)
     {
+        var cabinetContext = ResolveStandaloneCabinetContext(faceDocument, project);
+        return Export(faceDocument, project, cabinetContext, documentPath, progress);
+    }
+
+    public FaceRuntimeExportResult Export(FaceDocumentModel faceDocument, EditorProject project, FaceCabinetContext cabinetContext, string? documentPath = null, IEditorProgressReporter? progress = null)
+    {
         ArgumentNullException.ThrowIfNull(faceDocument);
         ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(cabinetContext);
         progress ??= NoOpEditorProgressReporter.Instance;
         progress.Report(0.0, "Resolving dimensions/output directory...");
 
@@ -65,7 +72,6 @@ public sealed class FaceRuntimeExportService
 
         var generatedUtc = DateTime.UtcNow;
         progress.Report(0.8, "Writing manifest...");
-        var cabinetContext = new FaceCabinetContextResolver().ResolveForFace(project, Array.Empty<DocumentTabViewModel>(), faceDocument);
         var manifest = CreateManifest(faceDocument, width, height, textureResult.Plan, cabinetContext);
         var manifestPath = Path.Combine(outputDirectory, ManifestFileName);
         File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest, s_manifestJsonOptions));
@@ -97,7 +103,7 @@ public sealed class FaceRuntimeExportService
             SourcePanel2DDocumentPath = faceDocument.SourcePanel2DDocumentPath,
             SourceFaceShapeId = faceDocument.SourceFaceShapeId,
             AssignedCabinetFaceTargetId = faceDocument.AssignedCabinetFaceTargetId,
-                AssignedCabinetAssetPath = faceDocument.AssignedCabinetAssetPath,
+            AssignedCabinetAssetPath = faceDocument.AssignedCabinetAssetPath,
             SourceRegion = faceDocument.SourceRegion,
             LastRegeneratedAtUtc = faceDocument.LastRegeneratedAtUtc,
             GenerationSettings = faceDocument.GenerationSettings,
@@ -111,6 +117,36 @@ public sealed class FaceRuntimeExportService
 
         progress.Report(1.0, "Runtime export complete.");
         return new FaceRuntimeExportResult(updatedDocument, manifest, outputDirectory, manifestPath, artworkPath, maskPath);
+    }
+
+    private static FaceCabinetContext ResolveStandaloneCabinetContext(FaceDocumentModel faceDocument, EditorProject project)
+    {
+        ArgumentNullException.ThrowIfNull(faceDocument);
+        ArgumentNullException.ThrowIfNull(project);
+        var cabinetAssetPath = string.IsNullOrWhiteSpace(faceDocument.AssignedCabinetAssetPath)
+            ? null
+            : ProjectAssetPathService.NormalizeProjectRelativePath(faceDocument.AssignedCabinetAssetPath);
+        if (string.IsNullOrWhiteSpace(cabinetAssetPath))
+        {
+            return new FaceCabinetContext(null, null, null, "Face.Cabinet.ContextUnavailable", "Standalone Face runtime export has no Cabinet context. Assign a Cabinet asset to the Face or export it through a Machine build that supplies the Cabinet context.");
+        }
+
+        if (string.IsNullOrWhiteSpace(project.ProjectDirectory))
+        {
+            return new FaceCabinetContext(null, null, cabinetAssetPath, "Face.Cabinet.ProjectUnavailable", $"Assigned Cabinet asset '{cabinetAssetPath}' cannot be resolved because no project is loaded.");
+        }
+
+        var fullPath = Path.IsPathRooted(cabinetAssetPath)
+            ? cabinetAssetPath
+            : Path.Combine(project.ProjectDirectory, cabinetAssetPath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(fullPath))
+        {
+            return new FaceCabinetContext(null, null, cabinetAssetPath, "Face.Cabinet.AssetMissing", $"Assigned Cabinet asset '{cabinetAssetPath}' could not be found.");
+        }
+
+        return CabinetDocumentStorage.TryRead(File.ReadAllText(fullPath), out var cabinetDocument)
+            ? new FaceCabinetContext(cabinetDocument, null, cabinetAssetPath, null, null)
+            : new FaceCabinetContext(null, null, cabinetAssetPath, "Face.Cabinet.AssetInvalid", $"Assigned Cabinet asset '{cabinetAssetPath}' could not be read.");
     }
 
     public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height, FaceCabinetContext? cabinetContext = null)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SkiaSharp;
+using OasisEditor.Features.CabinetEditor.Models;
 using OasisEditor.Progress;
 
 namespace OasisEditor;
@@ -64,7 +65,8 @@ public sealed class FaceRuntimeExportService
 
         var generatedUtc = DateTime.UtcNow;
         progress.Report(0.8, "Writing manifest...");
-        var manifest = CreateManifest(faceDocument, width, height, textureResult.Plan);
+        var cabinetContext = new FaceCabinetContextResolver().ResolveForFace(project, Array.Empty<DocumentTabViewModel>(), faceDocument);
+        var manifest = CreateManifest(faceDocument, width, height, textureResult.Plan, cabinetContext);
         var manifestPath = Path.Combine(outputDirectory, ManifestFileName);
         File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest, s_manifestJsonOptions));
 
@@ -111,14 +113,14 @@ public sealed class FaceRuntimeExportService
         return new FaceRuntimeExportResult(updatedDocument, manifest, outputDirectory, manifestPath, artworkPath, maskPath);
     }
 
-    public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height)
+    public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height, FaceCabinetContext? cabinetContext = null)
     {
         ArgumentNullException.ThrowIfNull(faceDocument);
         var texturePlan = _runtimeTextureGenerator.CreatePlan(faceDocument, width, height);
-        return CreateManifest(faceDocument, width, height, texturePlan);
+        return CreateManifest(faceDocument, width, height, texturePlan, cabinetContext);
     }
 
-    public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height, FaceRuntimeTextureGenerationPlan texturePlan)
+    public FaceRuntimeManifest CreateManifest(FaceDocumentModel faceDocument, int width, int height, FaceRuntimeTextureGenerationPlan texturePlan, FaceCabinetContext? cabinetContext = null)
     {
         ArgumentNullException.ThrowIfNull(faceDocument);
         ArgumentNullException.ThrowIfNull(texturePlan);
@@ -149,7 +151,7 @@ public sealed class FaceRuntimeExportService
             LampWeightsDebug = FaceRuntimeTextureGenerator.LampWeightsDebugFileName,
             Lamps = texturePlan.Emitters.Select(CreateLampManifestEntry).ToArray(),
             Trays = texturePlan.Trays.Select(CreateTrayManifestEntry).ToArray(),
-            Reels = faceDocument.Elements.OfType<FaceReelDisplayElement>().Select(CreateReelManifestEntry).ToArray(),
+            Reels = faceDocument.Elements.OfType<FaceReelDisplayElement>().Select(reel => CreateReelManifestEntry(faceDocument, reel, cabinetContext)).ToArray(),
             SevenSegmentDisplays = faceDocument.Elements.OfType<FaceSevenSegmentDisplayElement>().Select(CreateDisplayManifestEntry).ToArray(),
             AlphaDisplays = faceDocument.Elements.OfType<FaceAlphaDisplayElement>().Select(CreateDisplayManifestEntry).ToArray(),
             Buttons = faceDocument.Elements.OfType<FaceButtonElement>().Select(CreateButtonManifestEntry).ToArray()
@@ -341,8 +343,9 @@ public sealed class FaceRuntimeExportService
     }
 
 
-    private static FaceRuntimeReelManifestEntry CreateReelManifestEntry(FaceReelDisplayElement element)
+    private static FaceRuntimeReelManifestEntry CreateReelManifestEntry(FaceDocumentModel faceDocument, FaceReelDisplayElement element, FaceCabinetContext? cabinetContext)
     {
+        var dimensions = ResolveReelPhysicalDimensions(faceDocument, element, cabinetContext);
         return new FaceRuntimeReelManifestEntry
         {
             ObjectId = element.ObjectId,
@@ -353,14 +356,63 @@ public sealed class FaceRuntimeExportService
             Stops = element.Stops.GetValueOrDefault(0),
             IsReversed = element.IsReversed,
             BandOffset = element.BandOffset.GetValueOrDefault(0d),
-            PhysicalWidth = Math.Max(0.01d, element.Width / 1000d),
-            PhysicalRadius = Math.Max(0.01d, element.Height / 2000d),
+            PhysicalWidth = dimensions.WidthMm,
+            PhysicalRadius = dimensions.RadiusMm,
             X = element.X,
             Y = element.Y,
             Width = element.Width,
             Height = element.Height
         };
     }
+
+    private static ResolvedReelPhysicalDimensions ResolveReelPhysicalDimensions(FaceDocumentModel faceDocument, FaceReelDisplayElement reel, FaceCabinetContext? cabinetContext)
+    {
+        var faceAsset = string.IsNullOrWhiteSpace(faceDocument.Title) ? faceDocument.Id : faceDocument.Title;
+        var reelName = DisplayName(reel);
+        var requestedId = string.IsNullOrWhiteSpace(reel.ReelSpecificationId) ? string.Empty : reel.ReelSpecificationId.Trim();
+        var cabinetAsset = cabinetContext?.CabinetAssetPath ?? faceDocument.AssignedCabinetAssetPath ?? string.Empty;
+
+        InvalidOperationException Fail(string reason) => new($"Unable to resolve physical reel dimensions. Face asset '{faceAsset}', reel '{reelName}' (objectId '{reel.ObjectId}'), Cabinet asset '{cabinetAsset}', requested specification ID '{requestedId}': {reason}");
+
+        if (cabinetContext is null || cabinetContext.CabinetDocument is null)
+        {
+            var reason = cabinetContext?.DiagnosticMessage ?? "Face has no assigned Cabinet.";
+            throw Fail(reason);
+        }
+
+        if (string.IsNullOrWhiteSpace(requestedId))
+        {
+            throw Fail("Face reel has no ReelSpecificationId.");
+        }
+
+        var matches = (cabinetContext.CabinetDocument.ReelSpecifications ?? [])
+            .Where(specification => string.Equals(specification.Id?.Trim(), requestedId, StringComparison.Ordinal))
+            .ToArray();
+        if (matches.Length == 0)
+        {
+            throw Fail("Referenced Cabinet reel specification does not exist.");
+        }
+
+        if (matches.Length > 1)
+        {
+            throw Fail("Cabinet contains duplicate matching reel specification IDs.");
+        }
+
+        var specification = matches[0];
+        if (!PanelElementValidation.IsFinite(specification.DiameterMm) || specification.DiameterMm <= 0d)
+        {
+            throw Fail($"Cabinet reel specification diameter '{specification.DiameterMm}' is not a positive finite millimetre value.");
+        }
+
+        if (!PanelElementValidation.IsFinite(specification.WidthMm) || specification.WidthMm <= 0d)
+        {
+            throw Fail($"Cabinet reel specification width '{specification.WidthMm}' is not a positive finite millimetre value.");
+        }
+
+        return new ResolvedReelPhysicalDimensions(specification.WidthMm, specification.DiameterMm / 2d);
+    }
+
+    private readonly record struct ResolvedReelPhysicalDimensions(double WidthMm, double RadiusMm);
 
     private static string ResolveCabinetReelTargetId(FaceReelDisplayElement element)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeBuildService.cs
@@ -65,7 +65,8 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
             var cabinetRoot = Path.Combine(stagingRoot, CabinetDirectoryName);
             Directory.CreateDirectory(cabinetRoot);
             File.Copy(sourceGlb, Path.Combine(cabinetRoot, CabinetGlbFileName), overwrite: true);
-            var faceReferences = ExportReferencedFaces(project, stagingRoot, cabinetDocument);
+            var cabinetAssetPath = ToProjectRelativePath(project, cabinetManifestPath);
+            var faceReferences = ExportReferencedFaces(project, stagingRoot, cabinetDocument, cabinetAssetPath);
             var cabinetManifest = new CabinetRuntimeManifest(CabinetSchema, CabinetSchemaVersion, cabinetAssetName, CabinetGlbFileName, cabinetDocument.Model.Scale, cabinetDocument.Model.UpAxis);
             File.WriteAllText(Path.Combine(cabinetRoot, CabinetManifestFileName), JsonSerializer.Serialize(cabinetManifest, JsonOptions));
             var machineManifest = new MachineRuntimeManifest(MachineSchema, MachineSchemaVersion, project.Name, project.Name, ProjectAssetPathService.NormalizeProjectRelativePath(Path.Combine(CabinetDirectoryName, CabinetManifestFileName)), faceReferences);
@@ -83,7 +84,7 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
         }
     }
 
-    private IReadOnlyList<MachineRuntimeFaceReference> ExportReferencedFaces(EditorProject project, string stagingRoot, CabinetDocument cabinetDocument)
+    private IReadOnlyList<MachineRuntimeFaceReference> ExportReferencedFaces(EditorProject project, string stagingRoot, CabinetDocument cabinetDocument, string cabinetAssetPath)
     {
         var faceRoot = _pathService.GetAssetTypeDirectory(project, EditorAssetType.Face);
         if (!Directory.Exists(faceRoot)) return Array.Empty<MachineRuntimeFaceReference>();
@@ -106,13 +107,15 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
                 throw new InvalidOperationException($"Face manifests must be stored as Assets/Faces/<AssetName>/{ProjectAssetPathService.FaceManifestFileName}: {manifestPath}");
             }
 
-            var exportResult = _faceRuntimeExportService.Export(faceDocument, project, manifestPath);
-            var buildFaceDirectory = Path.Combine(stagingRoot, "faces", _pathService.SanitizePathSegment(faceAssetName));
-            CopyDirectory(exportResult.OutputDirectory, buildFaceDirectory);
             if (!TryResolveTargetOverride(cabinetDocument, targetId, out var targetOverride))
             {
-                throw new InvalidOperationException(BuildMissingTargetOverrideMessage(faceDocument.Id, faceAssetName, targetId, cabinetDocument.TargetOverrides));
+                throw new InvalidOperationException(BuildMissingTargetOverrideMessage(faceDocument.Id, faceAssetName, targetId, cabinetAssetPath, cabinetDocument.TargetOverrides));
             }
+
+            var cabinetContext = new FaceCabinetContext(cabinetDocument, null, cabinetAssetPath, null, null);
+            var exportResult = _faceRuntimeExportService.Export(faceDocument, project, cabinetContext, manifestPath);
+            var buildFaceDirectory = Path.Combine(stagingRoot, "faces", _pathService.SanitizePathSegment(faceAssetName));
+            CopyDirectory(exportResult.OutputDirectory, buildFaceDirectory);
             references.Add(new MachineRuntimeFaceReference(
                 faceDocument.Id,
                 faceAssetName,
@@ -163,15 +166,21 @@ public sealed class MachineRuntimeBuildService : IMachineRuntimeBuildService
         return false;
     }
 
-    private static string BuildMissingTargetOverrideMessage(string faceId, string faceAssetName, string targetId, IReadOnlyList<CabinetTargetOverride> targetOverrides)
+    private static string BuildMissingTargetOverrideMessage(string faceId, string faceAssetName, string targetId, string cabinetAssetPath, IReadOnlyList<CabinetTargetOverride> targetOverrides)
     {
         var availableIds = targetOverrides.Count == 0
             ? "<none>"
             : string.Join(", ", targetOverrides.Select(targetOverride => $"'{targetOverride.TargetId}'"));
-        return $"Face '{faceId}' ({faceAssetName}) is assigned to cabinet target '{targetId}', but no matching CabinetTargetOverride was found. Available target override IDs: {availableIds}.";
+        return $"Face '{faceId}' ({faceAssetName}) is assigned to cabinet target '{targetId}', but Cabinet asset '{cabinetAssetPath}' does not contain that target override. Available target override IDs: {availableIds}.";
     }
 
     private static string? NormalizeOptional(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string ToProjectRelativePath(EditorProject project, string path)
+    {
+        if (string.IsNullOrWhiteSpace(project.ProjectDirectory)) return ProjectAssetPathService.NormalizeProjectRelativePath(path);
+        return ProjectAssetPathService.NormalizeProjectRelativePath(Path.GetRelativePath(project.ProjectDirectory, path));
+    }
 
     public string GetBuildRoot(EditorProject project, string machineName) => Path.Combine(project.GeneratedDirectory, "Builds", _pathService.SanitizePathSegment(machineName));
     private static string ResolveCabinetModelPath(string manifestPath, string modelPath) => Path.IsPathFullyQualified(modelPath) ? Path.GetFullPath(modelPath) : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(manifestPath) ?? string.Empty, modelPath));


### PR DESCRIPTION
### Motivation
- Previously the exported reel physical sizes were derived from the Face rectangle (e.g. `physicalWidth = element.Width / 1000`, `physicalRadius = element.Height / 2000`), which conflated aperture/layout with mechanical dimensions and produced incorrect runtime geometry.
- The goal is to export reel physical dimensions from authored Cabinet reel specifications and ensure Oasis Player constructs meshes using those physical values rather than any Face rectangle inference.

### Description
- Editor export: `FaceRuntimeExportService` now resolves a `FaceCabinetContext` and passes it into manifest creation, and `CreateReelManifestEntry` uses a new `ResolveReelPhysicalDimensions` helper to produce `PhysicalWidth` and `PhysicalRadius` from the matched `CabinetReelSpecification` (`WidthMm` and `DiameterMm / 2`).
- Export validation: explicit export-time errors are thrown for missing Cabinet context, missing/empty `ReelSpecificationId`, unknown or duplicate specification IDs, and non-finite or non-positive `DiameterMm`/`WidthMm`, with diagnostics including Face asset, reel object, Cabinet asset, requested specification ID, and reason.
- Player changes: added `RuntimeReelUnits` and a single conversion point in `RuntimeReelRenderer` where manifest millimetres are converted to Unity metres via `metres = millimetres / 1000` immediately before placement and mesh creation, and the mesh factory is called with metre values.
- Tests and fixtures: added Editor export tests (`FaceRuntimeExportServiceTests`) to assert exact resolution, multiple-spec differentiation, rectangle-independence, and failure cases, and added Unity EditMode tests (`RuntimeReelMeshFactoryTests`) to assert the conversion and mesh sizing/caching behavior; no runtime schema shape was changed so schema versions were left unchanged.

### Testing
- Added and committed unit tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests` and EditMode tests in `UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode`; these test files were created in the PR but the test suites were not executed in this environment per project constraints.
- Per repository guidance I ran static checks including `git diff --check` and repository greps to confirm old rectangle-derived expressions were removed and replaced with specification resolution, and these checks passed.
- Manual Unity/Editor verification remains required locally: export a face with two different Cabinet reel specifications, confirm the generated `face.runtime.json` contains `physicalWidth` (mm) and `physicalRadius` (mm) derived from the Cabinet specs, and confirm Oasis Player produces two distinct meshes after the single mm→m conversion in `RuntimeReelRenderer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a623b915ad48327a107f865f6361a0f)