### PR TITLE
Correct reel lamp aperture geometry

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeBuildManifests.cs
@@ -138,7 +138,8 @@ namespace OasisPlayer.RuntimeBuild
         public string position = string.Empty;
         public int lampId = -1;
         public float localVerticalCenter;
-        public float radius;
+        // Zero/non-positive selects the stop-derived aperture radius; positive is an authored override.
+        public float radius = 0f;
         public float intensity;
     }
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceModels.cs
@@ -9,6 +9,10 @@ namespace OasisPlayer.RuntimeBuild
         private readonly List<string> _warnings = new List<string>();
         private RuntimeLampStateTexture _lampStateTexture;
         private RuntimeSegmentDisplayRenderer _segmentDisplayRenderer;
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        private RuntimeReelLampDiagnosticMode _reelLampDiagnosticMode = RuntimeReelLampDiagnosticMode.FollowLampState;
+        private float _reelLampDiagnosticMultiplier = 1f;
+#endif
 
         public RuntimeMachine(ResolvedRuntimeBuild build, GameObject cabinet)
         {
@@ -40,10 +44,25 @@ namespace OasisPlayer.RuntimeBuild
             if (_segmentDisplayRenderer != null) changed |= _segmentDisplayRenderer.ApplyDynamicState(this);
             foreach (var face in _faces)
             {
-                for (var i = 0; i < face.ReelRenderBindings.Count; i++) changed |= face.ReelRenderBindings[i].ApplyLampState(LampState);
+                for (var i = 0; i < face.ReelRenderBindings.Count; i++)
+                {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                    changed |= face.ReelRenderBindings[i].ApplyLampState(LampState, _reelLampDiagnosticMode, _reelLampDiagnosticMultiplier);
+#else
+                    changed |= face.ReelRenderBindings[i].ApplyLampState(LampState);
+#endif
+                }
             }
             return changed;
         }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        public void SetReelLampDiagnostics(RuntimeReelLampDiagnosticMode mode, float multiplier)
+        {
+            _reelLampDiagnosticMode = mode;
+            _reelLampDiagnosticMultiplier = Mathf.Clamp(multiplier, 1f, 20f);
+        }
+#endif
 
         public void SetSegmentDisplayRenderer(RuntimeSegmentDisplayRenderer renderer)
         {

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeFaceShaderProperties.cs
@@ -28,7 +28,10 @@ namespace OasisPlayer.RuntimeBuild
         public const string ReelLampIntensitiesName = "_OasisReelLampIntensities";
         public const string ReelTransmissionMaskTextureName = "_OasisReelTransmissionMaskTex";
         public const string ReelTransmissionMaskEnabledName = "_OasisReelTransmissionMaskEnabled";
-        public const string ReelWindowUvOffsetName = "_OasisReelWindowUvOffset";
+        public const string ReelApertureCenterWSName = "_OasisReelApertureCenterWS";
+        public const string ReelApertureRightWSName = "_OasisReelApertureRightWS";
+        public const string ReelApertureUpWSName = "_OasisReelApertureUpWS";
+        public const string ReelApertureSizeName = "_OasisReelApertureSize";
 
         public static readonly int ArtworkTexture = Shader.PropertyToID(ArtworkTextureName);
         public static readonly int MaskTexture = Shader.PropertyToID(MaskTextureName);
@@ -53,6 +56,9 @@ namespace OasisPlayer.RuntimeBuild
         public static readonly int ReelLampIntensities = Shader.PropertyToID(ReelLampIntensitiesName);
         public static readonly int ReelTransmissionMaskTexture = Shader.PropertyToID(ReelTransmissionMaskTextureName);
         public static readonly int ReelTransmissionMaskEnabled = Shader.PropertyToID(ReelTransmissionMaskEnabledName);
-        public static readonly int ReelWindowUvOffset = Shader.PropertyToID(ReelWindowUvOffsetName);
+        public static readonly int ReelApertureCenterWS = Shader.PropertyToID(ReelApertureCenterWSName);
+        public static readonly int ReelApertureRightWS = Shader.PropertyToID(ReelApertureRightWSName);
+        public static readonly int ReelApertureUpWS = Shader.PropertyToID(ReelApertureUpWSName);
+        public static readonly int ReelApertureSize = Shader.PropertyToID(ReelApertureSizeName);
     }
 }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeMachineLampUpdater.cs
@@ -234,6 +234,8 @@ namespace OasisPlayer.RuntimeBuild
         [SerializeField] private int allFlashCount = 2;
         [SerializeField] private bool repeat = true;
         [SerializeField] private int manualLampNumber = 1;
+        [SerializeField] private RuntimeReelLampDiagnosticMode reelLampDiagnosticMode = RuntimeReelLampDiagnosticMode.FollowLampState;
+        [SerializeField, Range(1f, 20f)] private float reelLampDiagnosticMultiplier = 1f;
         [SerializeField] private RuntimeLampDiagnosticStage currentStage;
         [SerializeField] private int currentLamp;
         [SerializeField] private bool running;
@@ -244,6 +246,7 @@ namespace OasisPlayer.RuntimeBuild
         public void Initialize(RuntimeMachine machine)
         {
             _machine = machine;
+            ApplyReelLampDiagnostics();
             _sequence = new RuntimeLampDiagnosticSequence(CreateSettings());
             RuntimeLampDiagnosticReporter.LogReady(machine);
             if (_sequence.Start(machine != null ? machine.LampState : null))
@@ -257,6 +260,7 @@ namespace OasisPlayer.RuntimeBuild
         private void Update()
         {
             if (_machine == null) return;
+            ApplyReelLampDiagnostics();
             if (_sequence == null) _sequence = new RuntimeLampDiagnosticSequence(CreateSettings());
 
             if (mode == RuntimeLampDiagnosticMode.Manual)
@@ -290,6 +294,11 @@ namespace OasisPlayer.RuntimeBuild
                 AllFlashCount = allFlashCount,
                 Repeat = repeat
             }.Clamped();
+        }
+
+        private void ApplyReelLampDiagnostics()
+        {
+            if (_machine != null) _machine.SetReelLampDiagnostics(reelLampDiagnosticMode, reelLampDiagnosticMultiplier);
         }
 
         private void RunManualControls()
@@ -352,6 +361,7 @@ namespace OasisPlayer.RuntimeBuild
 
         private void OnDisable()
         {
+            if (_machine != null) _machine.SetReelLampDiagnostics(RuntimeReelLampDiagnosticMode.FollowLampState, 1f);
             if (_machine != null) _machine.LampState.ClearAll();
         }
     }

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
@@ -108,24 +108,26 @@ namespace OasisPlayer.RuntimeBuild
     }
 
 
-    public static class RuntimeReelShaderCoordinateHelper
+    public static class RuntimeReelLampGeometry
     {
-        public static float ToWindowUvOffset(float effectivePosition, bool isReversed, float bandOffset)
-        {
-            var adjusted = effectivePosition;
-            if (isReversed)
-            {
-                var wrappedInput = RuntimeReelPositionConverter.PositiveModulo(adjusted, RuntimeReelPositionConverter.PositionsPerRevolution);
-                adjusted = wrappedInput == 0f ? 0f : RuntimeReelPositionConverter.PositionsPerRevolution - wrappedInput;
-            }
+        public const float DefaultRadius = 0.15f;
 
-            adjusted += bandOffset * RuntimeReelPositionConverter.PositionsPerRevolution;
-            return RuntimeReelPositionConverter.PositiveModulo(adjusted, RuntimeReelPositionConverter.PositionsPerRevolution) / RuntimeReelPositionConverter.PositionsPerRevolution;
+        public static Vector4 DeriveVerticalCenters(int stops)
+        {
+            // Reel lamps are fixed in projected aperture space, not rotating band space.
+            // For N stops, adjacent visible symbols are at +/- one stop angle around the reel;
+            // projecting those positions onto the visible diameter gives 0.5 +/- 0.5*sin(2*pi/N).
+            var safeStops = Mathf.Max(1, stops);
+            var offset = 0.5f * Mathf.Sin((Mathf.PI * 2f) / safeStops);
+            return new Vector4(0.5f + offset, 0.5f, 0.5f - offset, 0f);
         }
 
-        public static Vector2 ToFixedWindowUv(Vector2 rotatingBandUv, float windowUvOffset)
+        public static float EvaluateField(Vector2 apertureUv, float verticalCenter, float radius, float physicalWidth, float physicalDiameter)
         {
-            return new Vector2(rotatingBandUv.x, RuntimeReelPositionConverter.PositiveModulo(rotatingBandUv.y - windowUvOffset, 1f));
+            var delta = apertureUv - new Vector2(0.5f, verticalCenter);
+            delta.x *= physicalWidth / Mathf.Max(physicalDiameter, 0.0001f);
+            var d = delta.magnitude;
+            return 1f - Mathf.SmoothStep(radius * 0.35f, Mathf.Max(radius, 0.0001f), d);
         }
     }
 
@@ -153,25 +155,35 @@ namespace OasisPlayer.RuntimeBuild
             var lampsEnabled = reel == null || reel.reelLampsEnabled;
             var lamps = reel != null && reel.reelLamps != null ? reel.reelLamps : Array.Empty<FaceRuntimeReelLampManifestEntry>();
             for (var i = 0; i < _lampIds.Length; i++) _lampIds[i] = -1;
-            var verticalCenters = new Vector4(1f / 6f, 0.5f, 5f / 6f, 0f);
-            var radii = new Vector4(0.42f, 0.42f, 0.42f, 0f);
+            var verticalCenters = RuntimeReelLampGeometry.DeriveVerticalCenters(reel != null ? reel.stops : 12);
+            var radii = new Vector4(RuntimeReelLampGeometry.DefaultRadius, RuntimeReelLampGeometry.DefaultRadius, RuntimeReelLampGeometry.DefaultRadius, 0f);
             var intensities = new Vector4(1f, 1f, 1f, 0f);
             for (var i = 0; i < lamps.Length && i < 3; i++)
             {
                 var lamp = lamps[i];
                 // RuntimeLampState is one-based (1..255), so both the -1 unassigned sentinel and manifest value 0 stay off.
                 _lampIds[i] = lampsEnabled && lamp != null && lamp.lampId > 0 ? lamp.lampId : -1;
-                if (i == 0) { verticalCenters.x = lamp.localVerticalCenter; radii.x = lamp.radius; intensities.x = lamp.intensity; }
-                else if (i == 1) { verticalCenters.y = lamp.localVerticalCenter; radii.y = lamp.radius; intensities.y = lamp.intensity; }
-                else { verticalCenters.z = lamp.localVerticalCenter; radii.z = lamp.radius; intensities.z = lamp.intensity; }
+                var radius = lamp != null && lamp.radius > 0f ? lamp.radius : RuntimeReelLampGeometry.DefaultRadius;
+                var intensity = lamp != null ? lamp.intensity : 1f;
+                if (i == 0) { radii.x = radius; intensities.x = intensity; }
+                else if (i == 1) { radii.y = radius; intensities.y = intensity; }
+                else { radii.z = radius; intensities.z = intensity; }
             }
             PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelLampVerticalCenters, verticalCenters);
             PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelLampRadii, radii);
             PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelLampIntensities, intensities);
             PropertyBlock.SetFloat(RuntimeFaceShaderProperties.ReelTransmissionMaskEnabled, reel != null && reel.TransmissionMaskTexture != null ? 1f : 0f);
-            PropertyBlock.SetFloat(RuntimeFaceShaderProperties.ReelWindowUvOffset, reel != null ? RuntimeReelShaderCoordinateHelper.ToWindowUvOffset(0f, reel.isReversed, reel.bandOffset) : 0f);
             if (reel != null && reel.TransmissionMaskTexture != null) PropertyBlock.SetTexture(RuntimeFaceShaderProperties.ReelTransmissionMaskTexture, reel.TransmissionMaskTexture.Texture);
             PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelLampBrightness, Vector4.zero);
+            if (Renderer != null) Renderer.SetPropertyBlock(PropertyBlock);
+        }
+
+        public void ConfigureAperture(Vector3 center, Vector3 right, Vector3 up, float physicalWidth, float physicalDiameter)
+        {
+            PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelApertureCenterWS, new Vector4(center.x, center.y, center.z, 0f));
+            PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelApertureRightWS, new Vector4(right.x, right.y, right.z, 0f));
+            PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelApertureUpWS, new Vector4(up.x, up.y, up.z, 0f));
+            PropertyBlock.SetVector(RuntimeFaceShaderProperties.ReelApertureSize, new Vector4(physicalWidth, physicalDiameter, 0f, 0f));
             if (Renderer != null) Renderer.SetPropertyBlock(PropertyBlock);
         }
 
@@ -260,6 +272,7 @@ namespace OasisPlayer.RuntimeBuild
                     }
                     renderer.sharedMaterial = material;
                     var binding = new RuntimeReelRenderBinding(go, material, renderer, reel);
+                    binding.ConfigureAperture(surfacePoint, surface.HorizontalTangent, surface.VerticalTangent, physicalWidthMetres, physicalRadiusMetres * 2f);
                     binding.ApplyLampState(machine.LampState);
                     machine.AddWarning($"Reel lamp binding: reel={DisplayReelName(reel)}, enabled={reel.reelLampsEnabled.ToString().ToLowerInvariant()}, ids=[{FormatReelLampIds(reel)}], assigned={CountAssignedReelLamps(reel)}");
                     face.AddReelRenderBinding(binding);

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeReelRendering.cs
@@ -110,8 +110,6 @@ namespace OasisPlayer.RuntimeBuild
 
     public static class RuntimeReelLampGeometry
     {
-        public const float DefaultRadius = 0.15f;
-
         public static Vector4 DeriveVerticalCenters(int stops)
         {
             // Reel lamps are fixed in projected aperture space, not rotating band space.
@@ -122,6 +120,22 @@ namespace OasisPlayer.RuntimeBuild
             return new Vector4(0.5f + offset, 0.5f, 0.5f - offset, 0f);
         }
 
+        public static float DeriveAutomaticRadius(int stops)
+        {
+            // Radius is a fraction of projected reel diameter in aperture space, not band
+            // circumference or reel width. Aspect correction in the field calculation makes
+            // equal physical X/Y distances equal before this diameter-relative radius is used.
+            // For example, 16 stops gives ~0.1435, or ~0.0402m on a 0.28m diameter reel.
+            var safeStops = Mathf.Max(1, stops);
+            var projectedOffset = 0.5f * Mathf.Sin((Mathf.PI * 2f) / safeStops);
+            return Mathf.Max(0.0001f, projectedOffset * 0.75f);
+        }
+
+        public static float ResolveRadius(float authoredRadius, int stops)
+        {
+            return authoredRadius > 0f ? authoredRadius : DeriveAutomaticRadius(stops);
+        }
+
         public static float EvaluateField(Vector2 apertureUv, float verticalCenter, float radius, float physicalWidth, float physicalDiameter)
         {
             var delta = apertureUv - new Vector2(0.5f, verticalCenter);
@@ -130,6 +144,34 @@ namespace OasisPlayer.RuntimeBuild
             return 1f - Mathf.SmoothStep(radius * 0.35f, Mathf.Max(radius, 0.0001f), d);
         }
     }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    public enum RuntimeReelLampDiagnosticMode
+    {
+        FollowLampState,
+        ForceTop,
+        ForceMiddle,
+        ForceBottom,
+        ForceAll
+    }
+
+    public static class RuntimeReelLampDiagnostics
+    {
+        public static Vector4 SelectBrightness(Vector4 lampStateBrightness, RuntimeReelLampDiagnosticMode mode, float multiplier)
+        {
+            Vector4 selected;
+            switch (mode)
+            {
+                case RuntimeReelLampDiagnosticMode.ForceTop: selected = new Vector4(1f, 0f, 0f, 0f); break;
+                case RuntimeReelLampDiagnosticMode.ForceMiddle: selected = new Vector4(0f, 1f, 0f, 0f); break;
+                case RuntimeReelLampDiagnosticMode.ForceBottom: selected = new Vector4(0f, 0f, 1f, 0f); break;
+                case RuntimeReelLampDiagnosticMode.ForceAll: selected = new Vector4(1f, 1f, 1f, 0f); break;
+                default: selected = lampStateBrightness; break;
+            }
+            return selected * Mathf.Clamp(multiplier, 1f, 20f);
+        }
+    }
+#endif
 
     public sealed class RuntimeReelRenderBinding : IDisposable
     {
@@ -156,14 +198,15 @@ namespace OasisPlayer.RuntimeBuild
             var lamps = reel != null && reel.reelLamps != null ? reel.reelLamps : Array.Empty<FaceRuntimeReelLampManifestEntry>();
             for (var i = 0; i < _lampIds.Length; i++) _lampIds[i] = -1;
             var verticalCenters = RuntimeReelLampGeometry.DeriveVerticalCenters(reel != null ? reel.stops : 12);
-            var radii = new Vector4(RuntimeReelLampGeometry.DefaultRadius, RuntimeReelLampGeometry.DefaultRadius, RuntimeReelLampGeometry.DefaultRadius, 0f);
+            var automaticRadius = RuntimeReelLampGeometry.DeriveAutomaticRadius(reel != null ? reel.stops : 12);
+            var radii = new Vector4(automaticRadius, automaticRadius, automaticRadius, 0f);
             var intensities = new Vector4(1f, 1f, 1f, 0f);
             for (var i = 0; i < lamps.Length && i < 3; i++)
             {
                 var lamp = lamps[i];
                 // RuntimeLampState is one-based (1..255), so both the -1 unassigned sentinel and manifest value 0 stay off.
                 _lampIds[i] = lampsEnabled && lamp != null && lamp.lampId > 0 ? lamp.lampId : -1;
-                var radius = lamp != null && lamp.radius > 0f ? lamp.radius : RuntimeReelLampGeometry.DefaultRadius;
+                var radius = RuntimeReelLampGeometry.ResolveRadius(lamp != null ? lamp.radius : 0f, reel != null ? reel.stops : 12);
                 var intensity = lamp != null ? lamp.intensity : 1f;
                 if (i == 0) { radii.x = radius; intensities.x = intensity; }
                 else if (i == 1) { radii.y = radius; intensities.y = intensity; }
@@ -189,12 +232,36 @@ namespace OasisPlayer.RuntimeBuild
 
         public bool ApplyLampState(RuntimeLampState lampState)
         {
-            if (lampState == null || lampState.Version == _lampStateVersion) return false;
+            return ApplyLampStateInternal(lampState, false, Vector4.zero);
+        }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+        public bool ApplyLampState(RuntimeLampState lampState, RuntimeReelLampDiagnosticMode diagnosticMode, float diagnosticMultiplier)
+        {
+            var normal = ReadBrightness(lampState);
+            var selected = RuntimeReelLampDiagnostics.SelectBrightness(normal, diagnosticMode, diagnosticMultiplier);
+            return ApplyLampStateInternal(lampState, true, selected);
+        }
+#endif
+
+        private Vector4 ReadBrightness(RuntimeLampState lampState)
+        {
+            return new Vector4(
+                _lampIds[0] > 0 ? lampState.GetBrightness(_lampIds[0]) : 0f,
+                _lampIds[1] > 0 ? lampState.GetBrightness(_lampIds[1]) : 0f,
+                _lampIds[2] > 0 ? lampState.GetBrightness(_lampIds[2]) : 0f,
+                0f);
+        }
+
+        private bool ApplyLampStateInternal(RuntimeLampState lampState, bool hasSelectedBrightness, Vector4 selectedBrightness)
+        {
+            if (lampState == null || (!hasSelectedBrightness && lampState.Version == _lampStateVersion)) return false;
             _lampStateVersion = lampState.Version;
+            var selected = hasSelectedBrightness ? selectedBrightness : ReadBrightness(lampState);
             var changed = false;
             for (var i = 0; i < _brightness.Length; i++)
             {
-                var next = _lampIds[i] > 0 ? lampState.GetBrightness(_lampIds[i]) : 0f;
+                var next = selected[i];
                 if (Mathf.Abs(_brightness[i] - next) > 0.0001f) { _brightness[i] = next; changed = true; }
             }
             if (!changed) return false;

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisReelLamp.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisReelLamp.shader
@@ -7,7 +7,7 @@ Shader "Oasis/ReelLamp"
         _OasisReelTransmissionMaskEnabled ("Transmission Mask Enabled", Float) = 0
         _OasisReelLampBrightness ("Lamp Brightness", Vector) = (0,0,0,0)
         _OasisReelLampVerticalCenters ("Lamp Vertical Centers", Vector) = (0.75,0.5,0.25,0)
-        _OasisReelLampRadii ("Lamp Radii", Vector) = (0.15,0.15,0.15,0)
+        _OasisReelLampRadii ("Lamp Radii", Vector) = (0,0,0,0)
         _OasisReelLampIntensities ("Lamp Intensities", Vector) = (1,1,1,0)
         _OasisReelLampColor ("Lamp Color", Color) = (1.0,0.82,0.55,1)
         _OasisReelApertureCenterWS ("Aperture Center WS", Vector) = (0,0,0,0)

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisReelLamp.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisReelLamp.shader
@@ -6,11 +6,14 @@ Shader "Oasis/ReelLamp"
         _OasisReelTransmissionMaskTex ("Transmission Mask", 2D) = "white" {}
         _OasisReelTransmissionMaskEnabled ("Transmission Mask Enabled", Float) = 0
         _OasisReelLampBrightness ("Lamp Brightness", Vector) = (0,0,0,0)
-        _OasisReelLampVerticalCenters ("Lamp Vertical Centers", Vector) = (0.1667,0.5,0.8333,0)
-        _OasisReelLampRadii ("Lamp Radii", Vector) = (0.42,0.42,0.42,0)
+        _OasisReelLampVerticalCenters ("Lamp Vertical Centers", Vector) = (0.75,0.5,0.25,0)
+        _OasisReelLampRadii ("Lamp Radii", Vector) = (0.15,0.15,0.15,0)
         _OasisReelLampIntensities ("Lamp Intensities", Vector) = (1,1,1,0)
         _OasisReelLampColor ("Lamp Color", Color) = (1.0,0.82,0.55,1)
-        _OasisReelWindowUvOffset ("Window UV Offset", Float) = 0
+        _OasisReelApertureCenterWS ("Aperture Center WS", Vector) = (0,0,0,0)
+        _OasisReelApertureRightWS ("Aperture Right WS", Vector) = (1,0,0,0)
+        _OasisReelApertureUpWS ("Aperture Up WS", Vector) = (0,1,0,0)
+        _OasisReelApertureSize ("Aperture Size", Vector) = (1,1,0,0)
     }
 
     SubShader
@@ -51,7 +54,10 @@ Shader "Oasis/ReelLamp"
             float4 _OasisReelLampRadii;
             float4 _OasisReelLampIntensities;
             float4 _OasisReelLampColor;
-            float _OasisReelWindowUvOffset;
+            float4 _OasisReelApertureCenterWS;
+            float4 _OasisReelApertureRightWS;
+            float4 _OasisReelApertureUpWS;
+            float4 _OasisReelApertureSize;
         CBUFFER_END
 
         Varyings vert(Attributes input)
@@ -96,19 +102,24 @@ Shader "Oasis/ReelLamp"
             return max(lighting, 0.0);
         }
 
-        float SmoothField(float2 windowUv, float verticalCenter, float radius)
+        float2 ApertureUv(float3 positionWS)
         {
-            float2 center = float2(0.5, verticalCenter);
-            float d = distance(windowUv, center);
-            return 1.0 - smoothstep(radius * 0.35, max(radius, 0.0001), d);
+            // Aperture UV is the fixed projected reel window: X is physical reel width,
+            // Y is physical reel diameter.  The rotating band UV remains separate for artwork
+            // and transmission-mask sampling.
+            float2 size = max(_OasisReelApertureSize.xy, float2(0.0001, 0.0001));
+            float3 delta = positionWS - _OasisReelApertureCenterWS.xyz;
+            return float2(0.5 + dot(delta, normalize(_OasisReelApertureRightWS.xyz)) / size.x,
+                          0.5 + dot(delta, normalize(_OasisReelApertureUpWS.xyz)) / size.y);
         }
 
-        float2 FixedWindowUv(float2 bandUv)
+        float SmoothField(float2 apertureUv, float verticalCenter, float radius)
         {
-            // The reel-band UV is attached to the generated cylinder and therefore rotates with the symbols.
-            // The renderer supplies the current band offset separately, letting the shader derive aperture UVs
-            // that stay fixed relative to the reel window instead of cabinet world-space translation/rotation.
-            return float2(bandUv.x, frac(bandUv.y - _OasisReelWindowUvOffset + 1.0));
+            float2 center = float2(0.5, verticalCenter);
+            float2 delta = apertureUv - center;
+            delta.x *= _OasisReelApertureSize.x / max(_OasisReelApertureSize.y, 0.0001);
+            float d = length(delta);
+            return 1.0 - smoothstep(radius * 0.35, max(radius, 0.0001), d);
         }
         ENDHLSL
 
@@ -132,16 +143,16 @@ Shader "Oasis/ReelLamp"
             half4 frag(Varyings input) : SV_Target
             {
                 half4 band = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.bandUv);
-                float2 windowUv = FixedWindowUv(input.bandUv);
+                float2 apertureUv = ApertureUv(input.positionWS);
                 float mask = lerp(1.0, SAMPLE_TEXTURE2D(_OasisReelTransmissionMaskTex, sampler_OasisReelTransmissionMaskTex, input.bandUv).r, saturate(_OasisReelTransmissionMaskEnabled));
 
                 float lamp = 0.0;
-                lamp += SmoothField(windowUv, _OasisReelLampVerticalCenters.x, _OasisReelLampRadii.x) * _OasisReelLampBrightness.x * _OasisReelLampIntensities.x;
-                lamp += SmoothField(windowUv, _OasisReelLampVerticalCenters.y, _OasisReelLampRadii.y) * _OasisReelLampBrightness.y * _OasisReelLampIntensities.y;
-                lamp += SmoothField(windowUv, _OasisReelLampVerticalCenters.z, _OasisReelLampRadii.z) * _OasisReelLampBrightness.z * _OasisReelLampIntensities.z;
+                lamp += SmoothField(apertureUv, _OasisReelLampVerticalCenters.x, _OasisReelLampRadii.x) * _OasisReelLampBrightness.x * _OasisReelLampIntensities.x;
+                lamp += SmoothField(apertureUv, _OasisReelLampVerticalCenters.y, _OasisReelLampRadii.y) * _OasisReelLampBrightness.y * _OasisReelLampIntensities.y;
+                lamp += SmoothField(apertureUv, _OasisReelLampVerticalCenters.z, _OasisReelLampRadii.z) * _OasisReelLampBrightness.z * _OasisReelLampIntensities.z;
 
                 float3 lit = band.rgb * EvaluateBaseLighting(input);
-                float3 emission = band.rgb * _OasisReelLampColor.rgb * saturate(lamp) * mask;
+                float3 emission = band.rgb * _OasisReelLampColor.rgb * max(lamp, 0.0) * mask;
                 return half4(lit + emission, band.a);
             }
             ENDHLSL

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelRenderingTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelRenderingTests.cs
@@ -56,6 +56,10 @@ public sealed class RuntimeReelRenderingTests
             Assert.AreEqual(0.6545f, centers.x, 0.0001f);
             Assert.AreEqual(0.5f, centers.y, 0.0001f);
             Assert.AreEqual(0.3455f, centers.z, 0.0001f);
+            var radii = block.GetVector(RuntimeFaceShaderProperties.ReelLampRadii);
+            Assert.AreEqual(0.2f, radii.x, 0.0001f);
+            Assert.AreEqual(0.3f, radii.y, 0.0001f);
+            Assert.AreEqual(0.4f, radii.z, 0.0001f);
             Assert.AreEqual(1f, block.GetFloat(RuntimeFaceShaderProperties.ReelTransmissionMaskEnabled), 0.0001f);
             Assert.AreSame(mask, block.GetTexture(RuntimeFaceShaderProperties.ReelTransmissionMaskTexture));
             binding.Dispose();
@@ -179,8 +183,8 @@ public sealed class RuntimeReelRenderingTests
     [Test]
     public void AspectCorrection_EqualPhysicalDistancesHaveEqualFieldStrength()
     {
-        var fieldA = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f + 10f / 70f, 0.5f), 0.5f, 0.15f, 70f, 190f);
-        var fieldB = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, 0.5f + 10f / 190f), 0.5f, 0.15f, 70f, 190f);
+        var fieldA = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f + 0.6f, 0.5f), 0.5f, 0.2f, 70f, 280f);
+        var fieldB = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, 0.5f + 0.15f), 0.5f, 0.2f, 70f, 280f);
         Assert.AreEqual(fieldA, fieldB, 0.0001f);
 
         var squareA = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.6f, 0.5f), 0.5f, 0.15f, 100f, 100f);
@@ -189,14 +193,95 @@ public sealed class RuntimeReelRenderingTests
     }
 
     [Test]
-    public void DefaultRadius_PrimarilyIlluminatesOneSymbol()
+    public void AutomaticRadius_IsStopDerivedAndPrimarilyIlluminatesOneSymbol()
     {
         var centers = RuntimeReelLampGeometry.DeriveVerticalCenters(12);
-        var own = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.x), centers.x, RuntimeReelLampGeometry.DefaultRadius, 70f, 190f);
-        var middle = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.y), centers.x, RuntimeReelLampGeometry.DefaultRadius, 70f, 190f);
+        var radius = RuntimeReelLampGeometry.DeriveAutomaticRadius(12);
+        var own = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.x), centers.x, radius, 70f, 190f);
+        var middle = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.y), centers.x, radius, 70f, 190f);
         Assert.Greater(own, 0.95f);
         Assert.Less(middle, 0.05f);
     }
+
+    [Test]
+    public void AutomaticRadius_MatchesStopCountsAndDecreasesWithMoreStops()
+    {
+        var twelve = RuntimeReelLampGeometry.DeriveAutomaticRadius(12);
+        var sixteen = RuntimeReelLampGeometry.DeriveAutomaticRadius(16);
+        var twentyFive = RuntimeReelLampGeometry.DeriveAutomaticRadius(25);
+        Assert.AreEqual(0.1875f, twelve, 0.000001f);
+        Assert.AreEqual(0.143506f, sixteen, 0.000001f);
+        Assert.AreEqual(0.093259f, twentyFive, 0.000001f);
+        Assert.Greater(twelve, sixteen);
+        Assert.Greater(sixteen, twentyFive);
+    }
+
+    [Test]
+    public void ResolveRadius_NonPositiveIsAutomaticAndPositiveIsExactOverride()
+    {
+        var automatic = RuntimeReelLampGeometry.DeriveAutomaticRadius(16);
+        Assert.AreEqual(automatic, RuntimeReelLampGeometry.ResolveRadius(0f, 16));
+        Assert.AreEqual(automatic, RuntimeReelLampGeometry.ResolveRadius(-1f, 16));
+        Assert.AreEqual(0.234f, RuntimeReelLampGeometry.ResolveRadius(0.234f, 16));
+    }
+
+    [Test]
+    public void Configure_ZeroAndNegativeRadiiUseAutomaticWhilePositiveOverrides()
+    {
+        var reel = Reel();
+        reel.stops = 16;
+        reel.reelLamps = new[]
+        {
+            new FaceRuntimeReelLampManifestEntry { radius = 0f, intensity = 1f },
+            new FaceRuntimeReelLampManifestEntry { radius = -0.5f, intensity = 1f },
+            new FaceRuntimeReelLampManifestEntry { radius = 0.2f, intensity = 1f }
+        };
+        var go = new GameObject("reel");
+        var renderer = go.AddComponent<MeshRenderer>();
+        var material = new Material(Shader.Find("Oasis/ReelLamp"));
+        try
+        {
+            var binding = new RuntimeReelRenderBinding(go, material, renderer, reel);
+            var block = new MaterialPropertyBlock();
+            renderer.GetPropertyBlock(block);
+            var radii = block.GetVector(RuntimeFaceShaderProperties.ReelLampRadii);
+            Assert.AreEqual(0.143506f, radii.x, 0.000001f);
+            Assert.AreEqual(0.143506f, radii.y, 0.000001f);
+            Assert.AreEqual(0.2f, radii.z, 0.000001f);
+            binding.Dispose();
+        }
+        finally
+        {
+            if (go != null) Object.DestroyImmediate(go);
+            if (material != null) Object.DestroyImmediate(material);
+            reel.BandTexture.Unload();
+        }
+    }
+
+    [Test]
+    public void ChangingStopCountChangesCentersAndAutomaticRadius()
+    {
+        Assert.AreNotEqual(RuntimeReelLampGeometry.DeriveVerticalCenters(12), RuntimeReelLampGeometry.DeriveVerticalCenters(25));
+        Assert.AreNotEqual(RuntimeReelLampGeometry.DeriveAutomaticRadius(12), RuntimeReelLampGeometry.DeriveAutomaticRadius(25));
+    }
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+    [TestCase(RuntimeReelLampDiagnosticMode.ForceTop, 8f, 8f, 0f, 0f)]
+    [TestCase(RuntimeReelLampDiagnosticMode.ForceMiddle, 8f, 0f, 8f, 0f)]
+    [TestCase(RuntimeReelLampDiagnosticMode.ForceBottom, 8f, 0f, 0f, 8f)]
+    public void ReelLampDiagnostics_ForcedModesSelectChannelAndApplyMultiplier(RuntimeReelLampDiagnosticMode mode, float multiplier, float top, float middle, float bottom)
+    {
+        var result = RuntimeReelLampDiagnostics.SelectBrightness(new Vector4(0.2f, 0.3f, 0.4f, 0f), mode, multiplier);
+        Assert.AreEqual(new Vector4(top, middle, bottom, 0f), result);
+    }
+
+    [Test]
+    public void ReelLampDiagnostics_FollowStateDefaultsToUnmodifiedBrightness()
+    {
+        var brightness = new Vector4(0.2f, 0.3f, 0.4f, 0f);
+        Assert.AreEqual(brightness, RuntimeReelLampDiagnostics.SelectBrightness(brightness, RuntimeReelLampDiagnosticMode.FollowLampState, 1f));
+    }
+#endif
 
     [Test]
     public void ApertureProperties_DoNotUseBandOffset()

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelRenderingTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelRenderingTests.cs
@@ -33,7 +33,7 @@ public sealed class RuntimeReelRenderingTests
     }
 
     [Test]
-    public void Configure_WritesAllThreeImportedVerticalCentersAndMaskProperties()
+    public void Configure_DerivesVerticalCentersFromStopCountAndMaskProperties()
     {
         var reel = Reel();
         var mask = new Texture2D(2, 2);
@@ -53,9 +53,9 @@ public sealed class RuntimeReelRenderingTests
             var block = new MaterialPropertyBlock();
             renderer.GetPropertyBlock(block);
             var centers = block.GetVector(RuntimeFaceShaderProperties.ReelLampVerticalCenters);
-            Assert.AreEqual(0.12f, centers.x, 0.0001f);
-            Assert.AreEqual(0.47f, centers.y, 0.0001f);
-            Assert.AreEqual(0.91f, centers.z, 0.0001f);
+            Assert.AreEqual(0.6545f, centers.x, 0.0001f);
+            Assert.AreEqual(0.5f, centers.y, 0.0001f);
+            Assert.AreEqual(0.3455f, centers.z, 0.0001f);
             Assert.AreEqual(1f, block.GetFloat(RuntimeFaceShaderProperties.ReelTransmissionMaskEnabled), 0.0001f);
             Assert.AreSame(mask, block.GetTexture(RuntimeFaceShaderProperties.ReelTransmissionMaskTexture));
             binding.Dispose();
@@ -169,15 +169,67 @@ public sealed class RuntimeReelRenderingTests
     }
 
     [Test]
-    public void FixedWindowUv_IsIndependentOfWorldTransforms()
+    public void DerivedVerticalCenters_MatchProjectedStopCounts()
     {
-        var bandUv = new Vector2(0.25f, 0.75f);
-        var offset = RuntimeReelShaderCoordinateHelper.ToWindowUvOffset(24f, false, 0f);
-        var a = RuntimeReelShaderCoordinateHelper.ToFixedWindowUv(bandUv, offset);
-        var b = RuntimeReelShaderCoordinateHelper.ToFixedWindowUv(bandUv, offset);
-        Assert.AreEqual(a, b);
-        Assert.AreEqual(0.25f, a.x, 0.0001f);
-        Assert.AreEqual(0.5f, a.y, 0.0001f);
+        AssertCenters(12, 0.75f, 0.5f, 0.25f);
+        AssertCenters(16, 0.6913f, 0.5f, 0.3087f);
+        AssertCenters(25, 0.6243f, 0.5f, 0.3757f);
+    }
+
+    [Test]
+    public void AspectCorrection_EqualPhysicalDistancesHaveEqualFieldStrength()
+    {
+        var fieldA = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f + 10f / 70f, 0.5f), 0.5f, 0.15f, 70f, 190f);
+        var fieldB = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, 0.5f + 10f / 190f), 0.5f, 0.15f, 70f, 190f);
+        Assert.AreEqual(fieldA, fieldB, 0.0001f);
+
+        var squareA = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.6f, 0.5f), 0.5f, 0.15f, 100f, 100f);
+        var squareB = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, 0.6f), 0.5f, 0.15f, 100f, 100f);
+        Assert.AreEqual(squareA, squareB, 0.0001f);
+    }
+
+    [Test]
+    public void DefaultRadius_PrimarilyIlluminatesOneSymbol()
+    {
+        var centers = RuntimeReelLampGeometry.DeriveVerticalCenters(12);
+        var own = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.x), centers.x, RuntimeReelLampGeometry.DefaultRadius, 70f, 190f);
+        var middle = RuntimeReelLampGeometry.EvaluateField(new Vector2(0.5f, centers.y), centers.x, RuntimeReelLampGeometry.DefaultRadius, 70f, 190f);
+        Assert.Greater(own, 0.95f);
+        Assert.Less(middle, 0.05f);
+    }
+
+    [Test]
+    public void ApertureProperties_DoNotUseBandOffset()
+    {
+        var reel = Reel();
+        reel.bandOffset = 0.25f;
+        var go = new GameObject("reel");
+        var renderer = go.AddComponent<MeshRenderer>();
+        var material = new Material(Shader.Find("Oasis/ReelLamp"));
+        try
+        {
+            var binding = new RuntimeReelRenderBinding(go, material, renderer, reel);
+            binding.ConfigureAperture(new Vector3(1f, 2f, 3f), Vector3.right, Vector3.up, 0.07f, 0.19f);
+            var block = new MaterialPropertyBlock();
+            renderer.GetPropertyBlock(block);
+            Assert.AreEqual(new Vector4(1f, 2f, 3f, 0f), block.GetVector(RuntimeFaceShaderProperties.ReelApertureCenterWS));
+            Assert.AreEqual(new Vector4(0.07f, 0.19f, 0f, 0f), block.GetVector(RuntimeFaceShaderProperties.ReelApertureSize));
+            binding.Dispose();
+        }
+        finally
+        {
+            if (go != null) Object.DestroyImmediate(go);
+            if (material != null) Object.DestroyImmediate(material);
+            reel.BandTexture.Unload();
+        }
+    }
+
+    private static void AssertCenters(int stops, float top, float middle, float bottom)
+    {
+        var centers = RuntimeReelLampGeometry.DeriveVerticalCenters(stops);
+        Assert.AreEqual(top, centers.x, 0.001f);
+        Assert.AreEqual(middle, centers.y, 0.0001f);
+        Assert.AreEqual(bottom, centers.z, 0.001f);
     }
 
     private static FaceRuntimeReelManifestEntry Reel()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceDocumentRoundTripTests.cs
@@ -294,4 +294,31 @@ public sealed class FaceDocumentRoundTripTests
         Assert.True(alpha.IsReversed);
     }
 
+    [Fact]
+    public void Serialize_AndRead_RoundTripsAutomaticAndOverrideReelLampRadii()
+    {
+        var source = new FaceDocumentModel
+        {
+            Id = "face-reel-lamps",
+            Title = "Reel Lamps",
+            Elements =
+            [
+                new FaceReelDisplayElement
+                {
+                    ObjectId = "reel-1", Name = "Reel", Width = 70, Height = 280, Stops = 16,
+                    ReelLamps =
+                    [
+                        new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = 1, Radius = 0d, Intensity = 1d },
+                        new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LampNumber = 2, Radius = 0.2d, Intensity = 1d }
+                    ]
+                }
+            ]
+        };
+
+        var json = FaceDocumentStorage.Serialize(source);
+        Assert.True(FaceDocumentStorage.TryReadValidated(json, out var file, out var error), error);
+        var reel = Assert.IsType<FaceReelDisplayElement>(Assert.Single(FaceDocumentStorage.ToModel(file).Elements));
+        Assert.Equal([0d, 0.2d], reel.ReelLamps.Select(lamp => lamp.Radius).ToArray());
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeExportServiceTests.cs
@@ -894,7 +894,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     [Fact]
     public void CreateManifest_UnassignedReelLamp_UsesNegativeSentinel()
     {
-        var document = CreateReelDocumentWithLamps([new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = null, LocalVerticalCenter = 1d / 6d, Radius = 0.42d, Intensity = 1d }]);
+        var document = CreateReelDocumentWithLamps([new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = null, LocalVerticalCenter = 1d / 6d, Radius = 0d, Intensity = 1d }]);
         var manifest = new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50))));
         Assert.Equal(-1, Assert.Single(Assert.Single(manifest.Reels).ReelLamps).LampId);
     }
@@ -905,9 +905,9 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
     {
         var document = CreateReelDocumentWithLamps(
         [
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = 5, LocalVerticalCenter = 1d / 6d, Radius = 0.42d, Intensity = 1d },
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LampNumber = 4, LocalVerticalCenter = 0.5d, Radius = 0.42d, Intensity = 1d },
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LampNumber = 3, LocalVerticalCenter = 5d / 6d, Radius = 0.42d, Intensity = 1d }
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = 5, LocalVerticalCenter = 1d / 6d, Radius = 0d, Intensity = 1d },
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LampNumber = 4, LocalVerticalCenter = 0.5d, Radius = 0d, Intensity = 1d },
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LampNumber = 3, LocalVerticalCenter = 5d / 6d, Radius = 0d, Intensity = 1d }
         ], reelLampsEnabled: false);
 
         var manifest = new FaceRuntimeExportService().CreateManifest(document, 100, 100, CreateCabinetContext(CreateCabinet(new CabinetReelSpecification("standard", "Standard", 210, 50))));
@@ -915,6 +915,7 @@ public sealed class FaceRuntimeExportServiceTests : IDisposable
         var reel = Assert.Single(manifest.Reels);
         Assert.False(reel.ReelLampsEnabled);
         Assert.Equal([5, 4, 3], reel.ReelLamps.Select(lamp => lamp.LampId).ToArray());
+        Assert.All(reel.ReelLamps, lamp => Assert.Equal(0d, lamp.Radius));
     }
 
     private EditorProject CreateProject()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -455,6 +455,7 @@ public sealed class FmlReelLampImportTests
         Assert.Equal(PanelElementKind.Reel, element.Kind);
         Assert.True(element.ReelLampsEnabled);
         Assert.Equal([5, 4, 3], element.ReelLamps.Select(lamp => lamp.LampNumber).ToArray());
+        Assert.All(element.ReelLamps, lamp => Assert.Equal(0d, lamp.Radius));
         Assert.DoesNotContain(result.Warnings, warning => warning.Code == "fml.import.reel.lamps.common3");
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportPanelElementsCommandTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ImportPanelElementsCommandTests.cs
@@ -122,6 +122,7 @@ public sealed class ImportPanelElementsCommandTests
         var element = Panel2DDocumentStorage.ToModel(parsed).Elements.Single();
         Assert.True(element.ReelLampsEnabled);
         Assert.Equal([5, 4, 3], element.ReelLamps.Select(lamp => lamp.LampNumber).ToArray());
+        Assert.All(element.ReelLamps, lamp => Assert.Equal(0d, lamp.Radius));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceDocumentStorage.cs
@@ -912,7 +912,7 @@ public sealed record FaceReelLampFile
     public string Position { get; init; } = "middle";
     public int? LampNumber { get; init; }
     public double LocalVerticalCenter { get; init; }
-    public double Radius { get; init; }
+    public double Radius { get; init; } = 0d;
     public double Intensity { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeExportService.cs
@@ -732,7 +732,7 @@ public sealed class FaceRuntimeReelLampManifestEntry
     public string Position { get; init; } = string.Empty;
     public int LampId { get; init; }
     public double LocalVerticalCenter { get; init; }
-    public double Radius { get; init; }
+    public double Radius { get; init; } = 0d;
     public double Intensity { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -142,9 +142,9 @@ internal sealed class FmlToOasisMapper
 
         return
         [
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = bySlot.GetValueOrDefault(2), LocalVerticalCenter = 1d / 6d, Radius = 0.42d, Intensity = 1d },
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LampNumber = bySlot.GetValueOrDefault(3), LocalVerticalCenter = 0.5d, Radius = 0.42d, Intensity = 1d },
-            new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LampNumber = bySlot.GetValueOrDefault(4), LocalVerticalCenter = 5d / 6d, Radius = 0.42d, Intensity = 1d }
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LampNumber = bySlot.GetValueOrDefault(2), LocalVerticalCenter = 1d / 6d, Radius = 0d, Intensity = 1d },
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LampNumber = bySlot.GetValueOrDefault(3), LocalVerticalCenter = 0.5d, Radius = 0d, Intensity = 1d },
+            new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LampNumber = bySlot.GetValueOrDefault(4), LocalVerticalCenter = 5d / 6d, Radius = 0d, Intensity = 1d }
         ];
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -87,7 +87,9 @@ public sealed class ReelLampSlotModel
     public ReelLampSlotPosition Position { get; init; }
     public int? LampNumber { get; init; }
     public double LocalVerticalCenter { get; init; }
-    public double Radius { get; init; }
+    // Fraction of projected reel diameter. Zero means derive from stop count at runtime;
+    // a positive value is an explicit authored override.
+    public double Radius { get; init; } = 0d;
     public double Intensity { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentStorage.cs
@@ -877,7 +877,7 @@ internal static class Panel2DDocumentStorage
             Position = position,
             LampNumber = lamp.LampNumber is >= 0 ? lamp.LampNumber : null,
             LocalVerticalCenter = IsFinite(lamp.LocalVerticalCenter) ? Math.Clamp(lamp.LocalVerticalCenter, 0d, 1d) : DefaultReelLampCenter(position),
-            Radius = IsFinite(lamp.Radius) && lamp.Radius > 0d ? lamp.Radius : 0.42d,
+            Radius = IsFinite(lamp.Radius) && lamp.Radius > 0d ? lamp.Radius : 0d,
             Intensity = IsFinite(lamp.Intensity) && lamp.Intensity >= 0d ? lamp.Intensity : 1d
         };
     }
@@ -984,7 +984,7 @@ internal sealed record PanelElementReelLampFile
     public string Position { get; init; } = "middle";
     public int? LampNumber { get; init; }
     public double LocalVerticalCenter { get; init; }
-    public double Radius { get; init; }
+    public double Radius { get; init; } = 0d;
     public double Intensity { get; init; }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/InspectorViewModel.cs
@@ -1649,9 +1649,9 @@ public sealed class InspectorViewModel : INotifyPropertyChanged
         var source = lamps ?? [];
         return
         [
-            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Top) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LocalVerticalCenter = 1d / 6d, Radius = 0.42d, Intensity = 1d },
-            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Middle) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LocalVerticalCenter = 0.5d, Radius = 0.42d, Intensity = 1d },
-            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Bottom) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LocalVerticalCenter = 5d / 6d, Radius = 0.42d, Intensity = 1d }
+            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Top) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Top, LocalVerticalCenter = 1d / 6d, Radius = 0d, Intensity = 1d },
+            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Middle) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Middle, LocalVerticalCenter = 0.5d, Radius = 0d, Intensity = 1d },
+            source.FirstOrDefault(lamp => lamp.Position == ReelLampSlotPosition.Bottom) ?? new ReelLampSlotModel { Position = ReelLampSlotPosition.Bottom, LocalVerticalCenter = 5d / 6d, Radius = 0d, Intensity = 1d }
         ];
     }
 


### PR DESCRIPTION
### Motivation
- The reel lamp illumination was being sampled from the rotating band UVs which produced vertically stretched, elliptical and mis-positioned lamp fields that rotated with the reel artwork.
- The goal was to treat reel lamps as fixed physical lights behind a static visible aperture and derive sensible default lamp centres at runtime from reel stop count.
- The implementation must keep transmission-mask and artwork sampling on the band UV while evaluating lamp fields in a fixed projected aperture coordinate system that accounts for physical aspect ratio.

### Description
- Replace band-derived `FixedWindowUv` logic in `OasisReelLamp.shader` with a world-space projected aperture coordinate `ApertureUv` and add aperture material properties `_OasisReelApertureCenterWS`, `_OasisReelApertureRightWS`, `_OasisReelApertureUpWS` and `_OasisReelApertureSize`.
- Compute circular light fields in aperture space with physical aspect correction (scale X by `physicalWidth/physicalDiameter`) and replace `saturate(lamp)` with `max(lamp, 0.0)` to allow HDR emission.
- Add `RuntimeReelLampGeometry` to `RuntimeReelRendering.cs` with `DeriveVerticalCenters(int stops)` (stop-count-derived top/middle/bottom centres) and `EvaluateField(...)`, set a new default radius `0.15f`, and wire `ConfigureAperture(...)` to push aperture properties via the `MaterialPropertyBlock` at binding time.
- Remove the obsolete `_OasisReelWindowUvOffset` plumbing and `RuntimeReelShaderCoordinateHelper` window-UV helpers and update `RuntimeFaceShaderProperties` constants and the runtime binding to no longer supply a band-derived window offset.
- Update edit-mode unit tests in `RuntimeReelRenderingTests.cs` to assert stop-count-derived centres for 12/16/25 stops, aspect correction equality, default-radius behaviour, and aperture property binding.

### Testing
- Ran `git diff --check` with no issues reported.
- Searched the runtime shader/property helpers with `rg "ReelWindowUvOffset|FixedWindowUv|RuntimeReelShaderCoordinateHelper|_OasisReelWindowUvOffset|saturate(lamp)"` and observed no remaining matches for the removed legacy plumbing.
- Updated Unity edit-mode tests under `UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeReelRenderingTests.cs`, but the Unity test runner was not executed in this environment so these tests must be run locally (expected to validate stop-count centres, aspect correction, radius behaviour, mask sampling, and aperture independence from band offset).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a63d5fc3be48327a42e2f8bb5163d88)