### PR TITLE
Refactor face lamp reconstruction into shared HLSL include

### DIFF
--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionBinding.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionBinding.cs
@@ -1,0 +1,40 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public static class RuntimeCabinetReflectionBinding
+    {
+        public static void Apply(Material material, RuntimeFace face, RuntimeLampStateTexture lampState, RuntimeCabinetReflectionPlane plane, float lampExposureStops = 2.5f, float maskStrength = 1f)
+        {
+            if (material == null) throw new ArgumentNullException(nameof(material));
+            if (face == null) throw new ArgumentNullException(nameof(face));
+            if (face.Artwork == null || face.Artwork.Texture == null || face.Mask == null || face.Mask.Texture == null)
+                throw new ArgumentException("Reflection source Face requires artwork and mask textures.", nameof(face));
+
+            SetTexture(material, RuntimeFaceShaderProperties.ArtworkTexture, face.Artwork.Texture);
+            SetTexture(material, RuntimeFaceShaderProperties.MaskTexture, face.Mask.Texture);
+            if (face.LampIds0 != null) SetTexture(material, RuntimeFaceShaderProperties.LampIds0Texture, face.LampIds0.Texture);
+            if (face.LampWeights0 != null) SetTexture(material, RuntimeFaceShaderProperties.LampWeights0Texture, face.LampWeights0.Texture);
+            if (lampState != null && lampState.Texture != null) SetTexture(material, RuntimeFaceShaderProperties.LampStateTexture, lampState.Texture);
+
+            var orientation = RuntimeFaceTextureOrientation.FromReference(face.Reference);
+            material.SetFloat(RuntimeFaceShaderProperties.LampExposureStops, Mathf.Max(0f, lampExposureStops));
+            material.SetFloat(RuntimeFaceShaderProperties.MaskStrength, Mathf.Max(0f, maskStrength));
+            material.SetFloat(RuntimeFaceShaderProperties.FaceRotationQuarterTurns, orientation.UnityUvQuarterTurns);
+            material.SetFloat(RuntimeFaceShaderProperties.FaceFlipHorizontal, orientation.FlipHorizontal ? 1f : 0f);
+            material.SetVector(RuntimeCabinetReflectionShaderProperties.FacePlaneOrigin, plane.Origin);
+            material.SetVector(RuntimeCabinetReflectionShaderProperties.FacePlaneRight, plane.Right);
+            material.SetVector(RuntimeCabinetReflectionShaderProperties.FacePlaneUp, plane.Up);
+            material.SetVector(RuntimeCabinetReflectionShaderProperties.FacePlaneNormal, plane.Normal);
+            material.SetVector(RuntimeCabinetReflectionShaderProperties.FacePlaneSize, new Vector4(plane.Width, plane.Height, 0f, 0f));
+        }
+
+        private static void SetTexture(Material material, int propertyId, Texture texture)
+        {
+            material.SetTexture(propertyId, texture);
+            material.SetTextureScale(propertyId, Vector2.one);
+            material.SetTextureOffset(propertyId, Vector2.zero);
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionBinding.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionBinding.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9047ae9211644bd8d5d2fed238021f8

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionMath.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionMath.cs
@@ -1,0 +1,58 @@
+using System;
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    /// <summary>
+    /// A single visible Face rectangle. Origin is untransformed UV (0,0); Right and Up point
+    /// toward increasing U and V, dimensions are measured before Face rotation/flip, and
+    /// cross(Right, Up) must point along the visible-side Normal.
+    /// </summary>
+    public readonly struct RuntimeCabinetReflectionPlane
+    {
+        public RuntimeCabinetReflectionPlane(Vector3 origin, Vector3 right, Vector3 up, Vector3 normal, float width, float height)
+        {
+            if (right.sqrMagnitude < 0.000001f || up.sqrMagnitude < 0.000001f || normal.sqrMagnitude < 0.000001f)
+                throw new ArgumentException("Face plane axes must be non-zero vectors.");
+            if (width <= 0f || height <= 0f) throw new ArgumentOutOfRangeException(nameof(width), "Face plane dimensions must be positive.");
+
+            Origin = origin;
+            Right = right.normalized;
+            Up = up.normalized;
+            Normal = normal.normalized;
+            if (Mathf.Abs(Vector3.Dot(Right, Up)) > 0.001f || Vector3.Dot(Vector3.Cross(Right, Up), Normal) < 0.999f)
+                throw new ArgumentException("Face plane right/up axes must be orthogonal and their cross product must match the visible-side normal.");
+            Width = width;
+            Height = height;
+        }
+
+        public Vector3 Origin { get; }
+        public Vector3 Right { get; }
+        public Vector3 Up { get; }
+        public Vector3 Normal { get; }
+        public float Width { get; }
+        public float Height { get; }
+    }
+
+    public static class RuntimeCabinetReflectionMath
+    {
+        public const float ParallelEpsilon = 0.00001f;
+
+        public static bool TryIntersectReflectedRay(Vector3 cameraPosition, Vector3 surfacePosition, Vector3 surfaceNormal, RuntimeCabinetReflectionPlane plane, out Vector2 uv, out float distance)
+        {
+            uv = Vector2.zero;
+            distance = 0f;
+            var incident = (surfacePosition - cameraPosition).normalized;
+            if (incident == Vector3.zero || surfaceNormal == Vector3.zero) return false;
+            var reflected = Vector3.Reflect(incident, surfaceNormal.normalized);
+            var denominator = Vector3.Dot(reflected, plane.Normal);
+            if (Mathf.Abs(denominator) < ParallelEpsilon) return false;
+            distance = Vector3.Dot(plane.Origin - surfacePosition, plane.Normal) / denominator;
+            if (distance <= 0f) return false;
+
+            var offset = surfacePosition + reflected * distance - plane.Origin;
+            uv = new Vector2(Vector3.Dot(offset, plane.Right) / plane.Width, Vector3.Dot(offset, plane.Up) / plane.Height);
+            return uv.x >= 0f && uv.x <= 1f && uv.y >= 0f && uv.y <= 1f;
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionMath.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionMath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d95620aab9844dd8d50d8ecf94cf99d

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionShaderProperties.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionShaderProperties.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace OasisPlayer.RuntimeBuild
+{
+    public static class RuntimeCabinetReflectionShaderProperties
+    {
+        public const string ShaderName = "Oasis/Cabinet Analytic Reflection";
+        public static readonly int ReflectionStrength = Shader.PropertyToID("_OasisReflectionStrength");
+        public static readonly int ReflectionVisibilityMask = Shader.PropertyToID("_OasisReflectionVisibilityMask");
+        public static readonly int FacePlaneOrigin = Shader.PropertyToID("_OasisFacePlaneOriginWS");
+        public static readonly int FacePlaneRight = Shader.PropertyToID("_OasisFacePlaneRightWS");
+        public static readonly int FacePlaneUp = Shader.PropertyToID("_OasisFacePlaneUpWS");
+        public static readonly int FacePlaneNormal = Shader.PropertyToID("_OasisFacePlaneNormalWS");
+        public static readonly int FacePlaneSize = Shader.PropertyToID("_OasisFacePlaneSize");
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionShaderProperties.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Scripts/RuntimeBuild/RuntimeCabinetReflectionShaderProperties.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6baeb57127584f0eb971f396655a9c72

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 93629293166e4f2f92eea2979b283a06
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes/OasisFaceLampCommon.hlsl
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes/OasisFaceLampCommon.hlsl
@@ -1,0 +1,79 @@
+#ifndef OASIS_FACE_LAMP_COMMON_INCLUDED
+#define OASIS_FACE_LAMP_COMMON_INCLUDED
+
+// Shared face-lamp reconstruction. Keep this independent of face lighting so it
+// can also be consumed by the future analytic cabinet-reflection shader.
+TEXTURE2D(_OasisMaskTex);
+SAMPLER(sampler_OasisMaskTex);
+TEXTURE2D(_OasisLampIds0Tex);
+SAMPLER(sampler_OasisLampIds0Tex);
+TEXTURE2D(_OasisLampWeights0Tex);
+SAMPLER(sampler_OasisLampWeights0Tex);
+TEXTURE2D(_OasisLampStateTex);
+SAMPLER(sampler_OasisLampStateTex);
+
+float2 TransformFaceUv(float2 uv)
+{
+    float turns = floor(_OasisFaceRotationQuarterTurns + 0.5);
+    float2 transformed = uv;
+    if (turns == 1.0)
+    {
+        transformed = float2(1.0 - uv.y, uv.x);
+    }
+    else if (turns == 2.0)
+    {
+        transformed = float2(1.0 - uv.x, 1.0 - uv.y);
+    }
+    else if (turns == 3.0)
+    {
+        transformed = float2(uv.y, 1.0 - uv.x);
+    }
+
+    if (_OasisFaceFlipHorizontal >= 0.5)
+    {
+        transformed.x = 1.0 - transformed.x;
+    }
+
+    return transformed;
+}
+
+float DecodeLampBrightness(float lampId)
+{
+    float decoded = floor(saturate(lampId) * 255.0 + 0.5);
+    if (decoded < 1.0 || decoded > 255.0) return 0.0;
+    float u = (decoded + 0.5) / 256.0;
+    return SAMPLE_TEXTURE2D(_OasisLampStateTex, sampler_OasisLampStateTex, float2(u, 0.5)).r;
+}
+
+float DecodeWeight(float weight)
+{
+    return floor(saturate(weight) * 255.0 + 0.5) / 255.0;
+}
+
+float DecodeMask(half4 mask)
+{
+    float grayscale = max(mask.r, max(mask.g, mask.b));
+    return saturate(grayscale * mask.a * _OasisMaskStrength);
+}
+
+float AccumulateLampAmount(float2 uv)
+{
+    half4 mask = SAMPLE_TEXTURE2D(_OasisMaskTex, sampler_OasisMaskTex, uv);
+    half4 lampIds = SAMPLE_TEXTURE2D(_OasisLampIds0Tex, sampler_OasisLampIds0Tex, uv);
+    half4 weights = SAMPLE_TEXTURE2D(_OasisLampWeights0Tex, sampler_OasisLampWeights0Tex, uv);
+
+    float visibleLight = 0.0;
+    visibleLight += DecodeLampBrightness(lampIds.r) * DecodeWeight(weights.r);
+    visibleLight += DecodeLampBrightness(lampIds.g) * DecodeWeight(weights.g);
+    visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
+    return DecodeMask(mask) * saturate(visibleLight);
+}
+
+float3 EvaluateLampExposure(float3 artworkRgb, float lampAmount)
+{
+    float exposureStops = max(_OasisLampExposureStops, 0.0) * saturate(lampAmount);
+    float exposureGain = exp2(exposureStops);
+    return artworkRgb * exposureGain;
+}
+
+#endif

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes/OasisFaceLampCommon.hlsl.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/Includes/OasisFaceLampCommon.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72bbac2d57fb4ef58e032632907d2060
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader
@@ -67,8 +67,7 @@ Shader "Oasis/Cabinet Analytic Reflection"
                 float4 shadowCoord : TEXCOORD4;
             };
 
-            TEXTURE2D(_BaseMap); SAMPLER(sampler_BaseMap);
-            TEXTURE2D(_BumpMap); SAMPLER(sampler_BumpMap);
+            // SurfaceInput.hlsl owns the conventional URP _BaseMap and _BumpMap declarations.
             TEXTURE2D(_OasisReflectionVisibilityMask); SAMPLER(sampler_OasisReflectionVisibilityMask);
             TEXTURE2D(_OasisArtworkTex); SAMPLER(sampler_OasisArtworkTex);
 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader
@@ -1,0 +1,166 @@
+Shader "Oasis/Cabinet Analytic Reflection"
+{
+    Properties
+    {
+        [MainTexture] _BaseMap ("Base Map", 2D) = "white" {}
+        [MainColor] _BaseColor ("Base Color", Color) = (1,1,1,1)
+        [Normal] _BumpMap ("Normal Map", 2D) = "bump" {}
+        _BumpScale ("Normal Scale", Range(0, 2)) = 1
+        _Smoothness ("Smoothness", Range(0, 1)) = 0.5
+        _Metallic ("Metallic", Range(0, 1)) = 0
+        _OasisReflectionVisibilityMask ("Reflection Visibility Mask", 2D) = "white" {}
+        _OasisReflectionStrength ("Reflection Strength", Range(0, 1)) = 0
+
+        _OasisArtworkTex ("Face Artwork", 2D) = "white" {}
+        _OasisMaskTex ("Face Mask", 2D) = "white" {}
+        _OasisLampIds0Tex ("Face Lamp IDs", 2D) = "black" {}
+        _OasisLampWeights0Tex ("Face Lamp Weights", 2D) = "black" {}
+        _OasisLampStateTex ("Lamp State", 2D) = "black" {}
+        _OasisLampExposureStops ("Lamp Exposure Stops", Range(0, 8)) = 2.5
+        _OasisMaskStrength ("Mask Strength", Range(0, 4)) = 1
+        _OasisFaceRotationQuarterTurns ("Face Rotation Quarter Turns", Float) = 0
+        _OasisFaceFlipHorizontal ("Face Flip Horizontal", Float) = 0
+
+        _OasisFacePlaneOriginWS ("Face Plane Origin WS", Vector) = (0,0,0,1)
+        _OasisFacePlaneRightWS ("Face Plane Right WS", Vector) = (1,0,0,0)
+        _OasisFacePlaneUpWS ("Face Plane Up WS", Vector) = (0,1,0,0)
+        _OasisFacePlaneNormalWS ("Face Plane Normal WS", Vector) = (0,0,1,0)
+        _OasisFacePlaneSize ("Face Plane Size", Vector) = (1,1,0,0)
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" "Queue"="Geometry" "RenderPipeline"="UniversalPipeline" }
+        Pass
+        {
+            Name "OasisCabinetAnalyticReflectionForwardLit"
+            Tags { "LightMode"="UniversalForward" }
+            Cull Back
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 3.5
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float3 normalOS : NORMAL;
+                float4 tangentOS : TANGENT;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionHCS : SV_POSITION;
+                float3 positionWS : TEXCOORD0;
+                half3 normalWS : TEXCOORD1;
+                half4 tangentWS : TEXCOORD2;
+                float2 uv : TEXCOORD3;
+                float4 shadowCoord : TEXCOORD4;
+            };
+
+            TEXTURE2D(_BaseMap); SAMPLER(sampler_BaseMap);
+            TEXTURE2D(_BumpMap); SAMPLER(sampler_BumpMap);
+            TEXTURE2D(_OasisReflectionVisibilityMask); SAMPLER(sampler_OasisReflectionVisibilityMask);
+            TEXTURE2D(_OasisArtworkTex); SAMPLER(sampler_OasisArtworkTex);
+
+            CBUFFER_START(UnityPerMaterial)
+                float4 _BaseMap_ST;
+                half4 _BaseColor;
+                float _BumpScale;
+                float _Smoothness;
+                float _Metallic;
+                float _OasisReflectionStrength;
+                float _OasisLampExposureStops;
+                float _OasisMaskStrength;
+                float _OasisFaceRotationQuarterTurns;
+                float _OasisFaceFlipHorizontal;
+                float4 _OasisFacePlaneOriginWS;
+                float4 _OasisFacePlaneRightWS;
+                float4 _OasisFacePlaneUpWS;
+                float4 _OasisFacePlaneNormalWS;
+                float4 _OasisFacePlaneSize;
+            CBUFFER_END
+
+            // Reuses the authoritative Face UV and live lamp reconstruction path from PR #579.
+            #include "Includes/OasisFaceLampCommon.hlsl"
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output;
+                VertexPositionInputs positions = GetVertexPositionInputs(input.positionOS.xyz);
+                VertexNormalInputs normals = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.positionHCS = positions.positionCS;
+                output.positionWS = positions.positionWS;
+                output.normalWS = normals.normalWS;
+                output.tangentWS = half4(normals.tangentWS, input.tangentOS.w * GetOddNegativeScale());
+                output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
+                output.shadowCoord = TransformWorldToShadowCoord(positions.positionWS);
+                return output;
+            }
+
+            bool TryResolveFaceUv(float3 positionWS, float3 normalWS, out float2 faceUv)
+            {
+                float3 incidentWS = normalize(positionWS - GetCameraPositionWS());
+                float3 reflectedWS = reflect(incidentWS, normalWS);
+                float3 faceNormalWS = normalize(_OasisFacePlaneNormalWS.xyz);
+                float denominator = dot(reflectedWS, faceNormalWS);
+                if (abs(denominator) < 1e-5) { faceUv = 0.0; return false; }
+
+                float t = dot(_OasisFacePlaneOriginWS.xyz - positionWS, faceNormalWS) / denominator;
+                float2 size = _OasisFacePlaneSize.xy;
+                if (t <= 0.0 || size.x <= 0.0 || size.y <= 0.0) { faceUv = 0.0; return false; }
+
+                float3 offset = positionWS + reflectedWS * t - _OasisFacePlaneOriginWS.xyz;
+                faceUv = float2(dot(offset, normalize(_OasisFacePlaneRightWS.xyz)) / size.x,
+                                dot(offset, normalize(_OasisFacePlaneUpWS.xyz)) / size.y);
+                return all(faceUv >= 0.0) && all(faceUv <= 1.0);
+            }
+
+            half4 frag(Varyings input) : SV_Target
+            {
+                half4 baseSample = SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, input.uv) * _BaseColor;
+                half3 bitangentWS = input.tangentWS.w * cross(input.normalWS, input.tangentWS.xyz);
+                half3 normalTS = UnpackNormalScale(SAMPLE_TEXTURE2D(_BumpMap, sampler_BumpMap, input.uv), _BumpScale);
+                half3 normalWS = NormalizeNormalPerPixel(TransformTangentToWorld(normalTS, half3x3(input.tangentWS.xyz, bitangentWS, input.normalWS)));
+
+                // Prototype cabinet lighting deliberately uses SH plus the shadowed main light;
+                // it is not a complete replacement for URP/Lit's additional-light/IBL features.
+                Light mainLight = GetMainLight(input.shadowCoord);
+                half ndotl = saturate(dot(normalWS, mainLight.direction));
+                half3 ambient = SampleSH(normalWS);
+                half3 diffuse = baseSample.rgb * (ambient + mainLight.color * ndotl * mainLight.distanceAttenuation * mainLight.shadowAttenuation);
+                half3 viewWS = GetWorldSpaceNormalizeViewDir(input.positionWS);
+                half3 halfDirection = SafeNormalize(mainLight.direction + viewWS);
+                half specularPower = exp2(10.0 * _Smoothness + 1.0);
+                half3 f0 = lerp(0.04.xxx, baseSample.rgb, _Metallic);
+                half3 ordinarySurface = diffuse * (1.0 - _Metallic) + f0 * pow(saturate(dot(normalWS, halfDirection)), specularPower) * mainLight.color;
+
+                float2 untransformedFaceUv;
+                if (_OasisReflectionStrength > 0.0 && TryResolveFaceUv(input.positionWS, normalWS, untransformedFaceUv))
+                {
+                    float2 faceUv = TransformFaceUv(untransformedFaceUv);
+                    half4 artwork = SAMPLE_TEXTURE2D(_OasisArtworkTex, sampler_OasisArtworkTex, faceUv);
+                    float lampAmount = AccumulateLampAmount(faceUv);
+                    half3 reflectedFace = EvaluateLampExposure(artwork.rgb, lampAmount);
+                    half visibility = SAMPLE_TEXTURE2D(_OasisReflectionVisibilityMask, sampler_OasisReflectionVisibilityMask, input.uv).r;
+                    half fresnel = pow(1.0 - saturate(dot(normalWS, viewWS)), 5.0);
+                    half blend = saturate(_OasisReflectionStrength * visibility * artwork.a * lerp(0.25, 1.0, fresnel));
+                    ordinarySurface = lerp(ordinarySurface, reflectedFace, blend);
+                }
+
+                return half4(ordinarySurface, baseSample.a);
+            }
+            ENDHLSL
+        }
+    }
+    FallBack Off
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisCabinetAnalyticReflection.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 78b29ec23b2d413b98349950c3d232a1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Shaders/OasisFace.shader
@@ -48,16 +48,8 @@ Shader "Oasis/Face"
 
         TEXTURE2D(_OasisArtworkTex);
         SAMPLER(sampler_OasisArtworkTex);
-        TEXTURE2D(_OasisMaskTex);
-        SAMPLER(sampler_OasisMaskTex);
         TEXTURE2D(_OasisTrayIdTex);
         SAMPLER(sampler_OasisTrayIdTex);
-        TEXTURE2D(_OasisLampIds0Tex);
-        SAMPLER(sampler_OasisLampIds0Tex);
-        TEXTURE2D(_OasisLampWeights0Tex);
-        SAMPLER(sampler_OasisLampWeights0Tex);
-        TEXTURE2D(_OasisLampStateTex);
-        SAMPLER(sampler_OasisLampStateTex);
 
         CBUFFER_START(UnityPerMaterial)
             float4 _OasisArtworkTex_ST;
@@ -72,30 +64,8 @@ Shader "Oasis/Face"
             float _OasisFaceFlipHorizontal;
         CBUFFER_END
 
-        float2 TransformFaceUv(float2 uv)
-        {
-            float turns = floor(_OasisFaceRotationQuarterTurns + 0.5);
-            float2 transformed = uv;
-            if (turns == 1.0)
-            {
-                transformed = float2(1.0 - uv.y, uv.x);
-            }
-            else if (turns == 2.0)
-            {
-                transformed = float2(1.0 - uv.x, 1.0 - uv.y);
-            }
-            else if (turns == 3.0)
-            {
-                transformed = float2(uv.y, 1.0 - uv.x);
-            }
-
-            if (_OasisFaceFlipHorizontal >= 0.5)
-            {
-                transformed.x = 1.0 - transformed.x;
-            }
-
-            return transformed;
-        }
+        // Shared with the face shader now and intended for analytic cabinet reflections later.
+        #include "Includes/OasisFaceLampCommon.hlsl"
 
         Varyings vert(Attributes input)
         {
@@ -109,38 +79,6 @@ Shader "Oasis/Face"
             output.shadowCoord = TransformWorldToShadowCoord(positionInputs.positionWS);
             output.screenPos = ComputeScreenPos(positionInputs.positionCS);
             return output;
-        }
-
-        float DecodeLampBrightness(float lampId)
-        {
-            float decoded = floor(saturate(lampId) * 255.0 + 0.5);
-            if (decoded < 1.0 || decoded > 255.0) return 0.0;
-            float u = (decoded + 0.5) / 256.0;
-            return SAMPLE_TEXTURE2D(_OasisLampStateTex, sampler_OasisLampStateTex, float2(u, 0.5)).r;
-        }
-
-        float DecodeWeight(float weight)
-        {
-            return floor(saturate(weight) * 255.0 + 0.5) / 255.0;
-        }
-
-        float DecodeMask(half4 mask)
-        {
-            float grayscale = max(mask.r, max(mask.g, mask.b));
-            return saturate(grayscale * mask.a * _OasisMaskStrength);
-        }
-
-        float AccumulateLampAmount(float2 uv)
-        {
-            half4 mask = SAMPLE_TEXTURE2D(_OasisMaskTex, sampler_OasisMaskTex, uv);
-            half4 lampIds = SAMPLE_TEXTURE2D(_OasisLampIds0Tex, sampler_OasisLampIds0Tex, uv);
-            half4 weights = SAMPLE_TEXTURE2D(_OasisLampWeights0Tex, sampler_OasisLampWeights0Tex, uv);
-
-            float visibleLight = 0.0;
-            visibleLight += DecodeLampBrightness(lampIds.r) * DecodeWeight(weights.r);
-            visibleLight += DecodeLampBrightness(lampIds.g) * DecodeWeight(weights.g);
-            visibleLight += DecodeLampBrightness(lampIds.b) * DecodeWeight(weights.b);
-            return DecodeMask(mask) * saturate(visibleLight);
         }
 
         float3 EvaluateDiffuseLight(Light light, half3 normalWS, float strength)
@@ -173,12 +111,6 @@ Shader "Oasis/Face"
             return max(lighting, 0.0);
         }
 
-        float3 EvaluateLampExposure(float3 artworkRgb, float lampAmount)
-        {
-            float exposureStops = max(_OasisLampExposureStops, 0.0) * saturate(lampAmount);
-            float exposureGain = exp2(exposureStops);
-            return artworkRgb * exposureGain;
-        }
         ENDHLSL
 
         Pass

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeCabinetReflectionTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeCabinetReflectionTests.cs
@@ -1,0 +1,68 @@
+using System;
+using NUnit.Framework;
+using OasisPlayer.RuntimeBuild;
+using UnityEngine;
+
+namespace OasisPlayer.Tests
+{
+    public sealed class RuntimeCabinetReflectionTests
+    {
+        private static readonly RuntimeCabinetReflectionPlane FacePlane = new RuntimeCabinetReflectionPlane(
+            new Vector3(-1f, -1f, 0f), Vector3.right, Vector3.up, Vector3.forward, 2f, 2f);
+
+        [Test]
+        public void ReflectedRayHitsFacePlaneAndReturnsUntransformedUv()
+        {
+            Assert.True(RuntimeCabinetReflectionMath.TryIntersectReflectedRay(
+                new Vector3(0f, 0f, -2f), new Vector3(0f, 0f, -1f), Vector3.right, FacePlane, out var uv, out var distance));
+
+            Assert.AreEqual(new Vector2(0.5f, 0.5f), uv);
+            Assert.AreEqual(1f, distance, 0.0001f);
+        }
+
+        [Test]
+        public void ReflectedRayRejectsParallelBehindAndOutsideHits()
+        {
+            Assert.False(RuntimeCabinetReflectionMath.TryIntersectReflectedRay(
+                new Vector3(-2f, 0f, 0f), Vector3.zero, Vector3.up, FacePlane, out _, out _));
+            Assert.False(RuntimeCabinetReflectionMath.TryIntersectReflectedRay(
+                new Vector3(0f, 0f, -2f), new Vector3(0f, 0f, -1f), Vector3.forward, FacePlane, out _, out _));
+            Assert.False(RuntimeCabinetReflectionMath.TryIntersectReflectedRay(
+                new Vector3(4f, 0f, -2f), new Vector3(4f, 0f, -1f), Vector3.right, FacePlane, out _, out _));
+        }
+
+        [Test]
+        public void FacePlaneRequiresPositiveDimensionsAndConsistentBasis()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RuntimeCabinetReflectionPlane(Vector3.zero, Vector3.right, Vector3.up, Vector3.forward, 0f, 1f));
+            Assert.Throws<ArgumentException>(() => new RuntimeCabinetReflectionPlane(Vector3.zero, Vector3.right, Vector3.right, Vector3.forward, 1f, 1f));
+            Assert.Throws<ArgumentException>(() => new RuntimeCabinetReflectionPlane(Vector3.zero, Vector3.right, Vector3.up, Vector3.back, 1f, 1f));
+        }
+
+        [Test]
+        public void CabinetShaderExposesFaceSourceAndPlaneProperties()
+        {
+            var shader = Shader.Find(RuntimeCabinetReflectionShaderProperties.ShaderName);
+            Assert.NotNull(shader);
+            var material = new Material(shader);
+            try
+            {
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.ArtworkTexture));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.MaskTexture));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.LampIds0Texture));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.LampWeights0Texture));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.LampStateTexture));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.LampExposureStops));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.MaskStrength));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.FaceRotationQuarterTurns));
+                Assert.True(material.HasProperty(RuntimeFaceShaderProperties.FaceFlipHorizontal));
+                Assert.True(material.HasProperty(RuntimeCabinetReflectionShaderProperties.FacePlaneOrigin));
+                Assert.True(material.HasProperty(RuntimeCabinetReflectionShaderProperties.FacePlaneSize));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(material);
+            }
+        }
+    }
+}

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeCabinetReflectionTests.cs.meta
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeCabinetReflectionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26e92d23fd564c408ecad682d6497f39

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
@@ -7,6 +7,36 @@ namespace OasisPlayer.Tests
     public sealed class RuntimeFaceRendererTests
     {
         [Test]
+        public void OasisFaceShaderContainsEveryRuntimeFaceProperty()
+        {
+            var shader = Shader.Find(RuntimeFaceShaderProperties.ShaderName);
+            Assert.NotNull(shader);
+
+            var propertyNames = new[]
+            {
+                RuntimeFaceShaderProperties.ArtworkTextureName,
+                RuntimeFaceShaderProperties.MaskTextureName,
+                RuntimeFaceShaderProperties.TrayIdTextureName,
+                RuntimeFaceShaderProperties.LampIds0TextureName,
+                RuntimeFaceShaderProperties.LampWeights0TextureName,
+                RuntimeFaceShaderProperties.LampStateTextureName,
+                RuntimeFaceShaderProperties.LampExposureStopsName,
+                RuntimeFaceShaderProperties.StaticBrightnessName,
+                RuntimeFaceShaderProperties.BaseAmbientStrengthName,
+                RuntimeFaceShaderProperties.BaseMainLightStrengthName,
+                RuntimeFaceShaderProperties.BaseAdditionalLightStrengthName,
+                RuntimeFaceShaderProperties.MaskStrengthName,
+                RuntimeFaceShaderProperties.NormalSignName,
+                RuntimeFaceShaderProperties.CullModeName,
+                RuntimeFaceShaderProperties.FaceRotationQuarterTurnsName,
+                RuntimeFaceShaderProperties.FaceFlipHorizontalName
+            };
+
+            foreach (var propertyName in propertyNames)
+                Assert.True(shader.HasProperty(propertyName), "Oasis face shader is missing " + propertyName);
+        }
+
+        [Test]
         public void ValidRuntimeFaceProducesBindingAndDoesNotMutateSharedMaterial()
         {
             var target = new GameObject("OasisFace_Front");

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeFaceRendererTests.cs
@@ -11,29 +11,36 @@ namespace OasisPlayer.Tests
         {
             var shader = Shader.Find(RuntimeFaceShaderProperties.ShaderName);
             Assert.NotNull(shader);
-
-            var propertyNames = new[]
+            var material = new Material(shader);
+            try
             {
-                RuntimeFaceShaderProperties.ArtworkTextureName,
-                RuntimeFaceShaderProperties.MaskTextureName,
-                RuntimeFaceShaderProperties.TrayIdTextureName,
-                RuntimeFaceShaderProperties.LampIds0TextureName,
-                RuntimeFaceShaderProperties.LampWeights0TextureName,
-                RuntimeFaceShaderProperties.LampStateTextureName,
-                RuntimeFaceShaderProperties.LampExposureStopsName,
-                RuntimeFaceShaderProperties.StaticBrightnessName,
-                RuntimeFaceShaderProperties.BaseAmbientStrengthName,
-                RuntimeFaceShaderProperties.BaseMainLightStrengthName,
-                RuntimeFaceShaderProperties.BaseAdditionalLightStrengthName,
-                RuntimeFaceShaderProperties.MaskStrengthName,
-                RuntimeFaceShaderProperties.NormalSignName,
-                RuntimeFaceShaderProperties.CullModeName,
-                RuntimeFaceShaderProperties.FaceRotationQuarterTurnsName,
-                RuntimeFaceShaderProperties.FaceFlipHorizontalName
-            };
+                var propertyNames = new[]
+                {
+                    RuntimeFaceShaderProperties.ArtworkTextureName,
+                    RuntimeFaceShaderProperties.MaskTextureName,
+                    RuntimeFaceShaderProperties.TrayIdTextureName,
+                    RuntimeFaceShaderProperties.LampIds0TextureName,
+                    RuntimeFaceShaderProperties.LampWeights0TextureName,
+                    RuntimeFaceShaderProperties.LampStateTextureName,
+                    RuntimeFaceShaderProperties.LampExposureStopsName,
+                    RuntimeFaceShaderProperties.StaticBrightnessName,
+                    RuntimeFaceShaderProperties.BaseAmbientStrengthName,
+                    RuntimeFaceShaderProperties.BaseMainLightStrengthName,
+                    RuntimeFaceShaderProperties.BaseAdditionalLightStrengthName,
+                    RuntimeFaceShaderProperties.MaskStrengthName,
+                    RuntimeFaceShaderProperties.NormalSignName,
+                    RuntimeFaceShaderProperties.CullModeName,
+                    RuntimeFaceShaderProperties.FaceRotationQuarterTurnsName,
+                    RuntimeFaceShaderProperties.FaceFlipHorizontalName
+                };
 
-            foreach (var propertyName in propertyNames)
-                Assert.True(shader.HasProperty(propertyName), "Oasis face shader is missing " + propertyName);
+                foreach (var propertyName in propertyNames)
+                    Assert.True(material.HasProperty(propertyName), "Oasis face shader is missing " + propertyName);
+            }
+            finally
+            {
+                Object.DestroyImmediate(material);
+            }
         }
 
         [Test]

--- a/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
+++ b/UnityProjects/OasisPlayer/Assets/_Project/Tests/EditMode/RuntimeLampStateTests.cs
@@ -62,6 +62,20 @@ namespace OasisPlayer.Tests
         }
 
         [Test]
+        public void LookupDecoderRejectsZeroAndResolvesBoundaryLampIds()
+        {
+            var brightness = new float[256];
+            brightness[0] = 1f;
+            brightness[1] = 0.25f;
+            brightness[255] = 0.75f;
+
+            Assert.AreEqual(0f, RuntimeFaceLampLookupDecoder.Accumulate(brightness, new[] { 0, 0, 0 }, new[] { 255, 255, 255 }));
+            Assert.AreEqual(1f, RuntimeFaceLampLookupDecoder.Accumulate(brightness, new[] { 1, 255, 0 }, new[] { 255, 255, 255 }));
+            Assert.AreEqual(1, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(0, 1));
+            Assert.AreEqual(255, RuntimeFaceLampLookupDecoder.ResolveLampStateIndex(0, 255));
+        }
+
+        [Test]
         public void SetAllBrightnessSetsValidLampsAndLeavesSentinelZeroWithoutRedirtyingUnchangedState()
         {
             var state = new RuntimeLampState();


### PR DESCRIPTION
### Motivation

- Extract reusable face UV and lamp reconstruction logic so multiple shaders (face and future analytic cabinet reflections) can share identical semantics.
- Preserve the existing face rendering behavior, material property names, and URP-compatible lighting while removing duplicate implementations.

### Description

- Add `Assets/_Project/Shaders/Includes/OasisFaceLampCommon.hlsl` which declares shared textures/samplers and implements `TransformFaceUv`, `DecodeLampBrightness`, `DecodeWeight`, `DecodeMask`, `AccumulateLampAmount`, and `EvaluateLampExposure` with comments noting future cabinet-reflection use.
- Move the mask/ID/weight/state texture lookups and lamp accumulation/exposure math into the include and keep texel-centre sampling, one-based lamp IDs (`0` invalid), byte decoding, RGB-only accumulation, clamping, and `exp2(exposureStops * lampAmount)` exactly as before.
- Update `Assets/_Project/Shaders/OasisFace.shader` to `#include

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a661788deac8327bbefe7e7be08e411)