### PR TITLE
Integrate Amber Bridge v0.1.1 with System 6 backend

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
@@ -62,3 +62,20 @@ valid through the complete `Initialise` call.
 
 v0.1.1 exposes no switch inputs, output snapshots, lamps, reels, displays, audio, reel configuration, coin
 configuration, percentage configuration, or persistence.
+
+## Oasis integration status
+
+`System6NativeBackend` now uses the managed `IAmberBridgeLibrary` lifecycle. The native-library preference passed
+to the backend is an absolute path to `AmberBridge.dll`, not to `AmberOasis.JPMSystem6.dll`. The core DLL must be
+colocated with the bridge; Amber Bridge selects and loads the `jpm-system6` core itself.
+
+Startup validates the Editor's existing two-required-program-ROM rule and file existence before creating the
+bridge. Non-empty program and sound ROM slots are supplied in their configured order; absent sound ROMs are an
+empty collection. Successful startup performs initialise followed by the single reset historically performed after
+ROM loading. The existing 1 kHz scheduler then calls bridge `Run`, while pause/resume gates that loop. Stop calls
+shutdown once and disposal releases the bridge (and therefore its instance and module).
+
+Bridge v0.1.1 cannot service the Editor's switch, output, audio, reel-configuration, coin-configuration, or
+percentage-configuration operations. Output and audio polling are disabled, and optional startup configuration is
+skipped rather than sent to the former JPM exports. An explicit switch request throws `NotSupportedException` with
+an Amber Bridge v0.1.1 diagnostic. These operations are deferred until a future bridge API exposes them.

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
@@ -13,11 +13,17 @@ load the core DLL. v0.1.1 exports exactly `AmberGetApi`, using `__cdecl`. The Sy
 
 ## ABI
 
+The semantic API version is **v1**, whose exact encoded ABI value is
+`AMBER_API_VERSION_1 = 0x00010000u` (65536 decimal). Oasis passes and validates `0x00010000`; decimal `1` is not a
+valid Amber API version value.
+
 The header does not specify an encoding for strings. The managed wrapper explicitly interprets all null-terminated
 `const char *` values as UTF-8, with no ANSI fallback. Handles (`AmberInstance_t *`) are opaque. Integer widths
 are explicit. Every callback and the sole export use `__cdecl`.
 
 ```c
+#define AMBER_API_VERSION_1 0x00010000u
+#define AMBER_API_VERSION_CURRENT AMBER_API_VERSION_1
 typedef struct AmberInstance_t* AmberHandle;
 typedef enum AmberResult {
   AMBER_OK=0, AMBER_INVALID_ARGUMENT=1, AMBER_UNSUPPORTED_VERSION=2,
@@ -43,7 +49,7 @@ typedef struct AmberApiV1 {
 AmberResult __cdecl AmberGetApi(uint32_t requested_version, uint32_t api_size, AmberApiV1* api);
 ```
 
-Oasis requests API version 1 and passes `sizeof(AmberApiV1)`. Success is **only** `AMBER_OK` (zero).
+Oasis requests API v1 by passing `AMBER_API_VERSION_1` (`0x00010000u`) and `sizeof(AmberApiV1)`. Success is **only** `AMBER_OK` (zero).
 `GetLastError` uses its `required` output and `AMBER_BUFFER_TOO_SMALL` to support a size query followed by retrieval.
 
 ## ROM and lifecycle rules

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-requirements.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-requirements.md
@@ -1,0 +1,12 @@
+# Amber Bridge missing-operation evidence
+
+This document records integration evidence only; it does not propose ABI signatures.
+
+| Requirement ID | Editor operation | Current direct JPM export | Amber Bridge v0.1.1 limitation | Observed impact | Temporary behaviour | Priority |
+|---|---|---|---|---|---|---|
+| AB2-INPUT | Set button/switch state | `TurnSwitchOn`, `TurnSwitchOff` | No input API | Interactive controls cannot reach the core | Explicit `NotSupportedException` | High |
+| AB2-OUTPUT | Poll lamps, reels and displays | `GetOutputSnapshotSize`, `GetOutputSnapshot` | No output snapshot API | Editor cannot publish visual state | Polling disabled | High |
+| AB2-AUDIO | Stream PCM audio | `GetAudioFormat`, `FillAudioFrames` | No audio API | Native System 6 audio is unavailable | Audio startup disabled | Medium |
+| AB2-REELS | Configure reel optos | `SetSteps`, `SetOptoStart`, `SetOptoEnd`, `SetOptoInvert` | No reel configuration API | Project reel settings cannot be applied | Optional startup configuration skipped | High |
+| AB2-COINS | Configure coin routing | `SetCoinEnable`, `SetCoinValue`, `SetLockoutVal`, `SetLockoutInvert`, `SetEnable`, `SetCounterIn`, `SetCounterOut`, `SetPortIndex`, `SetCoin`, `SetLevel`, `SetFullLevel` | No coin configuration API | Project coin settings cannot be applied | Optional startup configuration skipped | Medium |
+| AB2-PERCENT | Configure percentage switch | `SetPercent` | No percentage configuration API | Project percentage setting cannot be applied | Optional startup configuration skipped | Medium |

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AmberBridgeLibraryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AmberBridgeLibraryTests.cs
@@ -12,9 +12,10 @@ public sealed class AmberBridgeLibraryTests
         using var native = new FakeBridge();
         using var bridge = new AmberBridgeLibrary(native);
 
-        Assert.Equal(1u, native.RequestedVersion);
+        Assert.Equal(0x00010000u, native.RequestedVersion);
+        Assert.NotEqual(1u, native.RequestedVersion);
         Assert.Equal((uint)Marshal.SizeOf<AmberApiV1Native>(), native.RequestedSize);
-        Assert.Equal(new AmberBridgeDetails(1, "Amber", "0.1.1"), bridge.BridgeDetails);
+        Assert.Equal(new AmberBridgeDetails(AmberApiVersions.V1, "Amber", "0.1.1"), bridge.BridgeDetails);
         Assert.Contains("Create:jpm-system6", native.Calls);
     }
 
@@ -29,8 +30,8 @@ public sealed class AmberBridgeLibraryTests
     }
 
     [Theory]
-    [InlineData((int)AmberResult.UnsupportedVersion, 1)]
-    [InlineData((int)AmberResult.Ok, 2)]
+    [InlineData((int)AmberResult.UnsupportedVersion, 0x00010000u)]
+    [InlineData((int)AmberResult.Ok, 1u)]
     public void NegotiationFailuresUnloadTheModule(int resultCode, uint returnedVersion)
     {
         using var native = new FakeBridge
@@ -69,8 +70,8 @@ public sealed class AmberBridgeLibraryTests
     }
 
     [Theory]
-    [InlineData(0u, 1u)]
-    [InlineData(1u, 2u)]
+    [InlineData(0u, 0x00010000u)]
+    [InlineData(1u, 1u)]
     public void InvalidBridgeMetadataIsRejected(uint returnedSize, uint apiVersion)
     {
         using var native = new FakeBridge
@@ -439,11 +440,11 @@ internal sealed class FakeBridge : IAmberBridgeModule
 
     internal AmberGetApiDelegate GetApi { get; }
     internal AmberResult GetApiResult { get; set; } = AmberResult.Ok;
-    internal uint ReturnedVersion { get; set; } = 1;
+    internal uint ReturnedVersion { get; set; } = AmberApiVersions.V1;
     internal bool OmitRun { get; set; }
     internal AmberResult GetBridgeInfoResult { get; set; } = AmberResult.Ok;
     internal uint BridgeInfoSize { get; set; } = (uint)Marshal.SizeOf<AmberBridgeInfoNative>();
-    internal uint BridgeInfoApiVersion { get; set; } = 1;
+    internal uint BridgeInfoApiVersion { get; set; } = AmberApiVersions.V1;
     internal AmberResult EnumerateResult { get; set; } = AmberResult.Ok;
     internal uint CoreInfoSize { get; set; } = (uint)Marshal.SizeOf<AmberCoreInfoNative>();
     internal string? CoreId { get; set; } = AmberBridgeLibrary.System6CoreId;
@@ -471,6 +472,7 @@ internal sealed class FakeBridge : IAmberBridgeModule
         RequestedVersion = version;
         RequestedSize = size;
         if (GetApiResult != AmberResult.Ok) return GetApiResult;
+        if (version != 0x00010000u) return AmberResult.UnsupportedVersion;
 
         api.StructSize = (uint)Marshal.SizeOf<AmberApiV1Native>();
         api.ApiVersion = ReturnedVersion;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -8,7 +8,7 @@ public sealed class EmulationBackendFactoryTests
     [Fact]
     public void CreateBackend_ForNone_ReturnsNull()
     {
-        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/system6.dll");
+        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/AmberBridge.dll");
 
         Assert.Null(factory.CreateBackend(FruitMachinePlatformType.None));
     }
@@ -16,7 +16,7 @@ public sealed class EmulationBackendFactoryTests
     [Fact]
     public void CreateBackend_ForImpactWithSystem6Path_ReturnsSystem6Backend()
     {
-        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/system6.dll");
+        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "C:/cores/AmberBridge.dll", amberBridgeFactory: _ => throw new InvalidOperationException("created only on start"));
 
         Assert.IsType<System6NativeBackend>(factory.CreateBackend(FruitMachinePlatformType.Impact));
     }
@@ -34,7 +34,7 @@ public sealed class EmulationBackendFactoryTests
     public void CreateBackend_ForMpu4_ReturnsMameBackend()
     {
         var mameBackend = new FakeBackend();
-        var factory = new EmulationBackendFactory(() => mameBackend, () => "C:/cores/system6.dll");
+        var factory = new EmulationBackendFactory(() => mameBackend, () => "C:/cores/AmberBridge.dll");
 
         Assert.Same(mameBackend, factory.CreateBackend(FruitMachinePlatformType.MPU4));
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -12,972 +5,166 @@ namespace OasisEditor.Tests;
 public sealed class System6NativeBackendTests
 {
     [Fact]
-    public async Task StartAsyncInitialisesLoadsRomsResetsAndStopShutsDown()
+    public async Task StartUsesBridgePathAndPassesOrderedRomsThenResets()
     {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest(rom1, rom2);
+        using var files = NativeFiles.Create(programCount: 2, soundCount: 2);
+        var fake = new FakeAmberBridge();
+        string? requestedPath = null;
+        var backend = new System6NativeBackend(files.Bridge, path => { requestedPath = path; fake.Calls.Add("Create"); return fake; });
 
-        await backend.StartAsync(request, CancellationToken.None);
+        await backend.StartAsync(Request(files), CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
 
-        Assert.True(library.InitialiseCalled);
-        Assert.Equal(new[] { rom1, rom2, string.Empty, string.Empty }, library.LoadedRoms);
-        Assert.True(library.ResetCalled);
-        Assert.Equal(8 * 4 + 1, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
-        Assert.Contains("SetPercent:0", library.Calls);
-        Assert.True(library.Calls.IndexOf("Reset") < library.Calls.IndexOf("SetSteps:0:96"));
-        Assert.True(library.ShutdownCalled);
-        Assert.True(library.DisposeCalled);
-        Assert.Equal(EmulationBackendState.Stopped, backend.State);
+        Assert.Equal(files.Bridge, requestedPath);
+        Assert.EndsWith("AmberBridge.dll", requestedPath, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("AmberOasis.JPMSystem6.dll", requestedPath, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(files.Programs, fake.ProgramRoms);
+        Assert.Equal(files.Sounds, fake.SoundRoms);
+        Assert.Equal(new[] { "Create", "Initialise", "Reset" }, fake.Calls.Take(3));
+        Assert.Equal(1, fake.ShutdownCount);
+        Assert.True(fake.Disposed);
     }
 
-
-
     [Fact]
-    public async Task StartAsyncStartsAudioSinkWithNativeFormatAndStreamsPcm()
+    public async Task MissingSoundRomsArePassedAsEmptyCollection()
     {
-        var library = new FakeSystem6NativeLibrary { AudioAvailable = true };
-        var sink = new FakeAudioSink();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        var observedAudio = SpinWait.SpinUntil(() => sink.PushedBytes.Count > 0, TimeSpan.FromSeconds(1));
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge();
+        var backend = new System6NativeBackend(files.Bridge, _ => fake);
+        await backend.StartAsync(Request(files), CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
-
-        Assert.True(observedAudio, "Expected the emulation pump to pull native audio and push PCM bytes.");
-        Assert.Equal(new EmulationAudioFormat(48000, 2, 16), sink.StartedFormats.Single());
-        Assert.Contains((short)100, sink.PushedSamples);
-        Assert.Contains((short)-100, sink.PushedSamples);
+        Assert.Empty(fake.SoundRoms);
     }
 
     [Fact]
-    public async Task PauseResetAndStopClearAudioPlayback()
+    public async Task MissingRequiredProgramRomFailsBeforeBridgeCreation()
     {
-        var library = new FakeSystem6NativeLibrary { AudioAvailable = true };
-        var sink = new FakeAudioSink();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        await backend.PauseAsync(CancellationToken.None);
-        await backend.ResumeAsync(CancellationToken.None);
-        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.True(sink.ClearCount >= 3);
-        Assert.True(sink.StopCount >= 2);
-        Assert.True(sink.DisposeCalled);
-    }
-
-    [Fact]
-    public async Task StartAsyncContinuesWithoutAudioSinkWhenNativeAudioUnavailable()
-    {
-        var library = new FakeSystem6NativeLibrary { AudioAvailable = false };
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => throw new InvalidOperationException("Audio sink should not be created."));
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.DoesNotContain("GetAudioFormat", library.Calls);
-    }
-
-    [Fact]
-    public async Task StartAsyncFailsCleanlyForMalformedNativeAudioFormat()
-    {
-        var library = new FakeSystem6NativeLibrary
-        {
-            AudioAvailable = true,
-            AudioFormat = new System6NativeAudioFormat
-            {
-                SizeBytes = (uint)Marshal.SizeOf<System6NativeAudioFormat>(),
-                Version = System6NativeAudioFormat.VersionValue,
-                SampleRate = 0,
-                Channels = 2,
-                BitsPerSample = 16,
-                Format = System6NativeAudioFormat.PcmS16FormatValue
-            }
-        };
-        var sink = new FakeAudioSink();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library, 60, () => sink);
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None));
-
-        Assert.Contains("audio format", exception.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.True(library.DisposeCalled);
-        Assert.Empty(sink.StartedFormats);
-    }
-
-    [Fact]
-    public async Task StartAsyncWithOutputPollingDisabledRunsCoreWithoutPollingOutputs()
-    {
-        var previousPolling = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING");
-        var previousPump = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", "0");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", null);
-        try
-        {
-            var library = new FakeSystem6NativeLibrary();
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            var observedRun = SpinWait.SpinUntil(() => Volatile.Read(ref library.RunCallCount) > 0, TimeSpan.FromSeconds(1));
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.True(observedRun, "Expected the emulation pump to call Run while output polling was disabled.");
-            Assert.Contains("Run:8000", library.Calls);
-            Assert.DoesNotContain("LampsUpdate", library.Calls);
-            Assert.DoesNotContain("GetOutputSnapshot", library.Calls);
-            
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_OUTPUT_POLLING", previousPolling);
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_EMULATION_PUMP_HZ", previousPump);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncSendsZeroBasedNativeReelOptoIndicesForDisplayedReelsOneAndEight()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.Contains("SetSteps:0:96", library.Calls);
-        Assert.Contains("SetOptoStart:0:5", library.Calls);
-        Assert.Contains("SetOptoEnd:0:7", library.Calls);
-        Assert.Contains("SetOptoInvert:0:0", library.Calls);
-        Assert.Contains("SetSteps:7:96", library.Calls);
-        Assert.Contains("SetOptoStart:7:5", library.Calls);
-        Assert.Contains("SetOptoEnd:7:7", library.Calls);
-        Assert.Contains("SetOptoInvert:7:0", library.Calls);
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetSteps:8:", StringComparison.Ordinal));
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:8:", StringComparison.Ordinal));
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoEnd:8:", StringComparison.Ordinal));
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoInvert:8:", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void System6ReelOptoViewModelDisplaysOneBasedReelNumbersFromZeroBasedStoredIndices()
-    {
-        var firstReel = new System6ReelOptoSettingsViewModel(System6ReelOptoSettings.CreateDefault(0), () => { });
-        var eighthReel = new System6ReelOptoSettingsViewModel(System6ReelOptoSettings.CreateDefault(7), () => { });
-
-        Assert.Equal(0, firstReel.ReelIndex);
-        Assert.Equal(1, firstReel.ReelNumber);
-        Assert.Equal(7, eighthReel.ReelIndex);
-        Assert.Equal(8, eighthReel.ReelNumber);
-        Assert.Equal(0, firstReel.ToModel().ReelIndex);
-        Assert.Equal(7, eighthReel.ToModel().ReelIndex);
-    }
-
-
-    [Fact]
-    public async Task StartAsyncAppliesOnlyEnabledNativeCoinRows()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest(rom1, rom2);
-        request.System6NativeRoms!.Coins[0].Enabled = true;
-        request.System6NativeRoms.Coins[0].Name = "10p";
-        request.System6NativeRoms.Coins[0].Num = 2;
-        request.System6NativeRoms.Coins[0].Coin = 3;
-        request.System6NativeRoms.Coins[0].CoinValue = 10;
-        request.System6NativeRoms.Coins[0].CoinEnable = 1;
-        request.System6NativeRoms.Coins[0].LockoutValue = 4;
-        request.System6NativeRoms.Coins[0].LockoutInvert = 5;
-        request.System6NativeRoms.Coins[0].CounterIn = 6;
-        request.System6NativeRoms.Coins[0].CounterOut = 7;
-        request.System6NativeRoms.Coins[0].PortIndex = 8;
-        request.System6NativeRoms.Coins[0].Level = 9;
-        request.System6NativeRoms.Coins[0].FullLevel = 10;
-        request.System6NativeRoms.Coins[1].Enabled = false;
-        request.System6NativeRoms.Coins[1].Num = 9;
-
-        await backend.StartAsync(request, CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.Contains("SetCoinEnable:3:1", library.Calls);
-        Assert.Contains("SetCoinValue:3:10", library.Calls);
-        Assert.Contains("SetLockoutVal:3:4", library.Calls);
-        Assert.Contains("SetLockoutInvert:3:5", library.Calls);
-        Assert.Contains("SetEnable:2:1", library.Calls);
-        Assert.Contains("SetCounterIn:2:6", library.Calls);
-        Assert.Contains("SetCounterOut:2:7", library.Calls);
-        Assert.Contains("SetPortIndex:2:8", library.Calls);
-        Assert.Contains("SetCoin:2:3", library.Calls);
-        Assert.Contains("SetLevel:2:9", library.Calls);
-        Assert.Contains("SetFullLevel:2:10", library.Calls);
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetCoinEnable:9:", StringComparison.Ordinal));
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetEnable:9:", StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task SetInputStateAsyncMapsButtonNumberToNativeSwitchCalls()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        var input = new InputDefinitionModel { Id = "btn-1", Kind = InputDefinitionKind.Button, ButtonNumber = "12" };
-
-        await backend.SetInputStateAsync(input, true, CancellationToken.None);
-        await backend.SetInputStateAsync(input, false, CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.Equal(new[] { 12 }, library.SwitchesTurnedOn);
-        Assert.Equal(new[] { 12 }, library.SwitchesTurnedOff);
-    }
-
-
-    [Fact]
-    public async Task SetInputStateAsyncIgnoresCoinInputs()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var input = new InputDefinitionModel { Id = "coin-1", Kind = InputDefinitionKind.Coin, CoinInput = true, ButtonNumber = "1" };
-
-        await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-        await backend.SetInputStateAsync(input, true, CancellationToken.None);
-        await backend.StopAsync(CancellationToken.None);
-
-        Assert.Empty(library.SwitchesTurnedOn);
-        Assert.Empty(library.SwitchesTurnedOff);
-    }
-
-    [Fact]
-    public async Task StartAsyncWithoutRomPathsFailsBeforeLoadingRoms()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, _, _) = CreateNativeFiles(0);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest();
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
-
-        Assert.True(library.InitialiseCalled);
-        Assert.Empty(library.LoadedRoms);
-        Assert.False(library.ResetCalled);
+        using var files = NativeFiles.Create(1, 0);
+        var created = false;
+        var backend = new System6NativeBackend(files.Bridge, _ => { created = true; return new FakeAmberBridge(); });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(Request(files), CancellationToken.None));
+        Assert.False(created);
         Assert.Equal(EmulationBackendState.Failed, backend.State);
     }
 
     [Fact]
-    public async Task StartAsyncInvalidReelOptosFailsBeforeResetAndRun()
+    public async Task InitialiseFailureDisposesBridgeAndPreventsRun()
     {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest(rom1, rom2);
-        request.System6NativeRoms!.ReelOptos[0].Steps = 0;
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => backend.StartAsync(request, CancellationToken.None));
-
-        Assert.Contains("steps must be between 1 and 255", ex.Message);
-        Assert.False(library.ResetCalled);
-        Assert.Empty(library.Calls.Where(call => call.StartsWith("Run", StringComparison.Ordinal)));
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge { InitialiseException = new TestException() };
+        var backend = new System6NativeBackend(files.Bridge, _ => fake);
+        await Assert.ThrowsAsync<TestException>(() => backend.StartAsync(Request(files), CancellationToken.None));
+        Assert.True(fake.Disposed);
+        Assert.Empty(fake.RunRequests);
+        Assert.Throws<InvalidOperationException>(() => backend.RunCycles(1));
     }
 
     [Fact]
-    public async Task StartAsyncSkipsDisabledReelOptos()
+    public async Task RunMapsUnsignedRequestAndPreservesSignedResult()
     {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest(rom1, rom2);
-        request.System6NativeRoms!.ReelOptos[1].Enabled = false;
-        request.System6NativeRoms.ReelOptos[1].Steps = 0;
-
-        await backend.StartAsync(request, CancellationToken.None);
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge { RunResult = -17 };
+        var backend = new System6NativeBackend(files.Bridge, _ => fake);
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        Assert.Equal(-17, backend.RunCycles(123));
+        Assert.Equal(-17, backend.LastCyclesRun);
+        Assert.Contains(123u, fake.RunRequests);
+        Assert.Throws<ArgumentOutOfRangeException>(() => backend.RunCycles(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => backend.RunCycles((long)uint.MaxValue + 1));
         await backend.StopAsync(CancellationToken.None);
-
-        Assert.DoesNotContain("SetSteps:1:0", library.Calls);
-        Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:1:", StringComparison.Ordinal));
-        Assert.Equal(7 * 4 + 1, library.Calls.Count(call => call.StartsWith("Set", StringComparison.Ordinal)));
-        Assert.True(library.ResetCalled);
     }
 
     [Fact]
-    public async Task StartAsyncOneRunOnlyAppliesReelOptosAfterResetAndBeforeFirstRun()
+    public async Task ResetShutdownAndDisposalAreMappedExactlyOnce()
     {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary();
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            AssertOrdered(
-                library.Calls,
-                "Initialise",
-                "LoadRom",
-                "Reset",
-                "SetSteps:0:96",
-                "SetOptoStart:0:5",
-                "SetOptoEnd:0:7",
-                "SetOptoInvert:0:0",
-                "SetPercent:0",
-                "Run:8000");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyUpdatesLampsBeforePollingAndUsesOneBasedReelOutputEvents()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary();
-            library.GetLampsOnValues[0] = true;
-            library.PositionOutputs[0] = 10;
-            library.PositionOutputs[1] = 20;
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var lampEvents = new List<MachineLampChangedEventArgs>();
-            var reelEvents = new List<MachineReelChangedEventArgs>();
-            backend.LampChanged += (_, e) => lampEvents.Add(e);
-            backend.ReelChanged += (_, e) => reelEvents.Add(e);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-            Assert.Contains(lampEvents, e => e.LampId == 0 && e.Value == 255);
-            Assert.Contains(reelEvents, e => e.ReelId == 1 && e.Position == 86);
-            Assert.Contains(reelEvents, e => e.ReelId == 2 && e.Position == 76);
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-            
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyPollsOnlyEnabledReelOptos()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary();
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var request = CreateLaunchRequest(rom1, rom2);
-            foreach (var reel in request.System6NativeRoms!.ReelOptos)
-            {
-                reel.Enabled = reel.ReelIndex is 0 or 2 or 4;
-            }
-
-            await backend.StartAsync(request, CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.Contains("SetSteps:0:96", library.Calls);
-            Assert.Contains("SetSteps:2:96", library.Calls);
-            Assert.Contains("SetSteps:4:96", library.Calls);
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetSteps:1:", StringComparison.Ordinal));
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoStart:3:", StringComparison.Ordinal));
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoEnd:5:", StringComparison.Ordinal));
-            Assert.DoesNotContain(library.Calls, call => call.StartsWith("SetOptoInvert:7:", StringComparison.Ordinal));
-
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyPollsOnlyConfiguredLampIdsIncludingHighLamp()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary();
-            library.GetLampsOnValues[5] = true;
-            library.GetLampsOnValues[255] = true;
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var lampEvents = new List<MachineLampChangedEventArgs>();
-            backend.LampChanged += (_, e) => lampEvents.Add(e);
-
-            await backend.StartAsync(CreateLaunchRequest([5, 255], rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-            Assert.Contains(lampEvents, e => e.LampId == 5 && e.Value == 255);
-            Assert.Contains(lampEvents, e => e.LampId == 255 && e.Value == 255);
-            
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-
-    [Theory]
-    [InlineData(0, 96, 0)]
-    [InlineData(1, 96, 95)]
-    [InlineData(95, 96, 1)]
-    [InlineData(10, 0, 10)]
-    [InlineData(10, -1, 10)]
-    public void NormalizeNativeSystem6ReelPosition_ReversesDirectionWhenStepsAreKnown(int rawPosition, int steps, int expected)
-    {
-        Assert.Equal(expected, System6NativeBackend.NormalizeNativeSystem6ReelPosition(rawPosition, steps));
-    }
-
-
-    [Fact]
-    public void FormatAlphaSegments_FormatsHexAndDecimalValues()
-    {
-        var raw = System6NativeBackend.FormatAlphaSegments(new[] { 0, 17615, -1 });
-
-        Assert.Equal("[0]=0x0000/0 [1]=0x44CF/17615 [2]=0xFFFF/-1", raw);
-    }
-
-
-    [Fact]
-    public void System6AlphaSegmentMapper_MapsKnownRawMaskToOasisMask()
-    {
-        Assert.Equal(0x2003, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0x8003));
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyPollsAlphaSegmentsAndPublishesNativeAlphaSegmentMasks()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary { AlphaSegmentPollingAvailable = true };
-            library.AlphaSegments[0] = 0x0001;
-            library.AlphaSegments[1] = 0x8002;
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var segmentEvents = new List<MachineSegmentChangedEventArgs>();
-            backend.SegmentChanged += (_, e) => segmentEvents.Add(e);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            var nativeAlphaEvents = segmentEvents
-                .Where(e => e.OutputType == MameSegmentOutputType.NativeAlpha)
-                .OrderBy(e => e.CellId)
-                .ToArray();
-
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-            Assert.Equal(16, nativeAlphaEvents.Length);
-            Assert.Equal(Enumerable.Range(0, 16).ToArray(), nativeAlphaEvents.Select(e => e.CellId).ToArray());
-            Assert.Contains(nativeAlphaEvents, e => e.CellId == 0 && e.SegmentMask == 0x0001);
-            Assert.Contains(nativeAlphaEvents, e => e.CellId == 1 && e.SegmentMask == 0x2002);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyPollsConfiguredSevenSegmentsAndPublishesDigitMasks()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary { SevenSegmentPollingAvailable = true };
-            for (ushort index = 32; index <= 37; index++)
-            {
-                library.SevenSegmentCells[index] = true;
-            }
-
-            library.SevenSegmentCells[80 + 1] = true;
-            library.SevenSegmentCells[80 + 2] = true;
-            library.SevenSegmentCells[80 + 7] = true;
-            library.SevenSegmentBrightness[32] = 7;
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var segmentEvents = new List<MachineSegmentChangedEventArgs>();
-            backend.SegmentChanged += (_, e) => segmentEvents.Add(e);
-            var request = CreateLaunchRequest(rom1, rom2) with { ConfiguredSevenSegmentDisplayIds = [2, 5] };
-
-            await backend.StartAsync(request, CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-            Assert.Contains(segmentEvents, e => e.CellId == 2 && e.SegmentMask == 0x3F && e.OutputType == MameSegmentOutputType.Digit);
-            Assert.Contains(segmentEvents, e => e.CellId == 5 && e.SegmentMask == 0x86 && e.OutputType == MameSegmentOutputType.Digit);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyDoesNotPublishAlphaSegmentsWhenExportMissing()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary { AlphaSegmentPollingAvailable = false };
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var segmentEvents = new List<MachineSegmentChangedEventArgs>();
-            backend.SegmentChanged += (_, e) => segmentEvents.Add(e);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            Assert.Empty(library.AlphaSegmentIndices);
-            Assert.Empty(segmentEvents);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-
-    [Theory]
-    [InlineData(0, 0d)]
-    [InlineData(1, 1d / 31d)]
-    [InlineData(15, 15d / 31d)]
-    [InlineData(31, 1d)]
-    [InlineData(32, 1d)]
-    public void NormalizeSystem6AlphaBrightness_MapsNativeByteToMameBrightnessRange(int rawBrightness, double expected)
-    {
-        Assert.Equal(expected, System6NativeBackend.NormalizeSystem6AlphaBrightness((byte)rawBrightness), precision: 6);
-    }
-
-    [Fact]
-    public async Task StartAsyncOneRunOnlyPollsAlphaBrightnessAndPublishesVfdBrightness()
-    {
-        var previousStage = Environment.GetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE");
-        Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", "OneRunOnly");
-        try
-        {
-            var library = new FakeSystem6NativeLibrary
-            {
-                AlphaSegmentPollingAvailable = true,
-                AlphaBrightnessPollingAvailable = true,
-                AlphaBrightness = 15
-            };
-            var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-            var backend = new System6NativeBackend(dllPath, _ => library);
-            var brightnessEvents = new List<MachineVfdBrightnessChangedEventArgs>();
-            backend.VfdBrightnessChanged += (_, e) => brightnessEvents.Add(e);
-
-            await backend.StartAsync(CreateLaunchRequest(rom1, rom2), CancellationToken.None);
-            await backend.StopAsync(CancellationToken.None);
-
-            var brightnessEvent = Assert.Single(brightnessEvents);
-            Assert.Equal(0, brightnessEvent.CellId);
-            Assert.Equal(15d / 31d, brightnessEvent.NormalizedBrightness, precision: 6);
-            Assert.Contains("GetOutputSnapshot", library.Calls);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("OASIS_SYSTEM6_STARTUP_STAGE", previousStage);
-        }
-    }
-
-    [Fact]
-    public async Task StartAsyncAppliesConfiguredPercentSwitchValue()
-    {
-        var library = new FakeSystem6NativeLibrary();
-        var (dllPath, rom1, rom2) = CreateNativeFiles(2);
-        var backend = new System6NativeBackend(dllPath, _ => library);
-        var request = CreateLaunchRequest(rom1, rom2);
-        request.System6NativeRoms!.PercentSwitchValue = 15;
-
-        await backend.StartAsync(request, CancellationToken.None);
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge();
+        var backend = new System6NativeBackend(files.Bridge, _ => fake);
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        await backend.ResetAsync(EmulationResetKind.Hard, CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
-
-        Assert.Contains("SetPercent:15", library.Calls);
+        await backend.StopAsync(CancellationToken.None);
+        await backend.DisposeAsync();
+        await backend.DisposeAsync();
+        Assert.Equal(2, fake.ResetCount); // startup plus explicit reset
+        Assert.Equal(1, fake.ShutdownCount);
+        Assert.Equal(1, fake.DisposeCount);
+        Assert.Throws<ObjectDisposedException>(() => backend.RunCycles(1));
     }
 
-    private static void AssertOrdered(IReadOnlyList<string> calls, params string[] expectedCalls)
+    [Fact]
+    public async Task SwitchInputIsExplicitlyUnsupported()
     {
-        var previousIndex = -1;
-        foreach (var expectedCall in expectedCalls)
+        using var files = NativeFiles.Create(2, 0);
+        var backend = new System6NativeBackend(files.Bridge, _ => new FakeAmberBridge());
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => backend.SetInputStateAsync(new InputDefinitionModel { Id = "button" }, true, CancellationToken.None));
+        Assert.Contains("Amber Bridge v0.1.1", ex.Message);
+        await backend.StopAsync(CancellationToken.None);
+    }
+
+    private static EmulationLaunchRequest Request(NativeFiles files)
+    {
+        var settings = new System6NativeRomSettings
         {
-            var index = FindCallIndex(calls, expectedCall);
-            Assert.True(index >= 0, $"Expected call '{expectedCall}' was not found. Calls: {string.Join(", ", calls)}");
-            Assert.True(index > previousIndex, $"Expected call '{expectedCall}' after index {previousIndex}. Calls: {string.Join(", ", calls)}");
-            previousIndex = index;
-        }
-    }
-
-    private static int FindCallIndex(IReadOnlyList<string> calls, string expectedCall)
-    {
-        for (var index = 0; index < calls.Count; index++)
-        {
-            if (string.Equals(calls[index], expectedCall, StringComparison.Ordinal))
-            {
-                return index;
-            }
-        }
-
-        return -1;
-    }
-
-    private static EmulationLaunchRequest CreateLaunchRequest(params string[] romPaths)
-    {
-        return CreateLaunchRequest(null, romPaths);
-    }
-
-    private static EmulationLaunchRequest CreateLaunchRequest(IReadOnlyList<int>? configuredLampIds, params string[] romPaths)
-    {
-        return new EmulationLaunchRequest(
-            FruitMachinePlatformType.None,
-            "test-machine",
-            "C:/roms",
-            [],
-            string.Empty,
-            new System6NativeRomSettings
-            {
-                ProgramRom1Path = romPaths.Length > 0 ? romPaths[0] : string.Empty,
-                ProgramRom2Path = romPaths.Length > 1 ? romPaths[1] : string.Empty
-            },
-            configuredLampIds,
-            null);
-    }
-
-    private static (string DllPath, string Rom1, string Rom2) CreateNativeFiles(int romCount)
-    {
-        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(directory);
-        var dllPath = Path.Combine(directory, "system6.dll");
-        File.WriteAllBytes(dllPath, []);
-        var rom1 = Path.Combine(directory, "a.rom");
-        var rom2 = Path.Combine(directory, "b.rom");
-        if (romCount >= 1) File.WriteAllBytes(rom1, []);
-        if (romCount >= 2) File.WriteAllBytes(rom2, []);
-        return (dllPath, rom1, rom2);
-    }
-
-    private sealed class FakeAudioSink : IEmulationAudioSink
-    {
-        public List<EmulationAudioFormat> StartedFormats { get; } = new();
-        public List<byte[]> PushedBytes { get; } = new();
-        public List<short> PushedSamples { get; } = new();
-        public int ClearCount { get; private set; }
-        public int StopCount { get; private set; }
-        public bool DisposeCalled { get; private set; }
-
-        public void Start(EmulationAudioFormat format) => StartedFormats.Add(format);
-
-        public void PushPcm(ReadOnlySpan<byte> pcmBytes)
-        {
-            var copy = pcmBytes.ToArray();
-            PushedBytes.Add(copy);
-            for (var i = 0; i + 1 < copy.Length; i += 2)
-            {
-                PushedSamples.Add(BitConverter.ToInt16(copy, i));
-            }
-        }
-
-        public void Stop() => StopCount++;
-        public void Clear() => ClearCount++;
-        public void Dispose() => DisposeCalled = true;
-    }
-
-    private sealed class FakeSystem6NativeLibrary : ISystem6NativeLibrary
-    {
-        public string LibraryPath => "C:/cores/system6.dll";
-
-        public Architecture ProcessArchitecture => Architecture.X64;
-
-        public bool IsLoaded => !DisposeCalled;
-
-        public bool InitialiseCalled { get; private set; }
-
-        public bool ResetCalled { get; private set; }
-
-        public bool ShutdownCalled { get; private set; }
-
-        public bool DisposeCalled { get; private set; }
-
-        public List<string> LoadedRoms { get; } = new();
-
-        public List<int> SwitchesTurnedOn { get; } = new();
-
-        public List<int> SwitchesTurnedOff { get; } = new();
-
-        public List<string> Calls { get; } = new();
-
-        public int RunCallCount;
-
-        public Dictionary<ushort, bool> GetLampsOnValues { get; } = new();
-
-        public Dictionary<sbyte, short> PositionOutputs { get; } = new();
-
-        public Dictionary<byte, int> AlphaSegments { get; } = new();
-
-        public List<int> AlphaSegmentIndices { get; } = new();
-
-        public bool AlphaSegmentPollingAvailable { get; set; }
-
-        public bool AlphaBrightnessPollingAvailable { get; set; }
-
-        public byte AlphaBrightness { get; set; } = 255;
-
-        public bool SevenSegmentPollingAvailable { get; set; }
-
-        public bool AudioAvailable { get; set; }
-
-        public System6NativeAudioFormat AudioFormat { get; set; } = new()
-        {
-            SizeBytes = (uint)Marshal.SizeOf<System6NativeAudioFormat>(),
-            Version = System6NativeAudioFormat.VersionValue,
-            SampleRate = 48000,
-            Channels = 2,
-            BitsPerSample = 16,
-            Format = System6NativeAudioFormat.PcmS16FormatValue
+            ProgramRom1Path = files.Programs.ElementAtOrDefault(0) ?? "",
+            ProgramRom2Path = files.Programs.ElementAtOrDefault(1) ?? "",
+            ProgramRom3Path = files.Programs.ElementAtOrDefault(2) ?? "",
+            ProgramRom4Path = files.Programs.ElementAtOrDefault(3) ?? "",
+            SoundRom1Path = files.Sounds.ElementAtOrDefault(0) ?? "",
+            SoundRom2Path = files.Sounds.ElementAtOrDefault(1) ?? "",
+            SoundRom3Path = files.Sounds.ElementAtOrDefault(2) ?? "",
+            SoundRom4Path = files.Sounds.ElementAtOrDefault(3) ?? ""
         };
+        return new(FruitMachinePlatformType.Impact, "test", files.Directory, [], "", settings);
+    }
 
-        public short[] AudioSamples { get; set; } = [100, -100, 200, -200];
-
-        public Dictionary<ushort, bool> SevenSegmentCells { get; } = new();
-
-        public Dictionary<ushort, byte> SevenSegmentBrightness { get; } = new();
-
-        public uint GetOutputSnapshotSize() => (uint)Marshal.SizeOf<System6NativeOutputSnapshot>();
-
-        public System6NativeOutputSnapshot GetOutputSnapshot()
-        {
-            Calls.Add("GetOutputSnapshot");
-            var snapshot = new System6NativeOutputSnapshot
-            {
-                SizeBytes = (uint)Marshal.SizeOf<System6NativeOutputSnapshot>(),
-                Version = System6NativeOutputSnapshot.VersionValue,
-                MatrixLampCount = System6NativeOutputSnapshot.MatrixLampCapacity,
-                ReelCount = System6NativeOutputSnapshot.ReelCapacity,
-                AlphaSegmentedDisplayCount = AlphaSegmentPollingAvailable || AlphaBrightnessPollingAvailable ? 1u : 0u,
-                LedDisplayCount = SevenSegmentPollingAvailable ? System6NativeOutputSnapshot.LedDisplayCapacity : 0u
-            };
-
-            foreach (var (index, isOn) in GetLampsOnValues)
-            {
-                snapshot.SetMatrixLamp(index, new System6NativeLampState { OnOff = isOn ? (byte)1 : (byte)0, Brightness = isOn ? 1f : 0f });
-            }
-
-            foreach (var (index, position) in PositionOutputs)
-            {
-                snapshot.SetReelPosition(index, position);
-            }
-
-            if (AlphaSegmentPollingAvailable || AlphaBrightnessPollingAvailable)
-            {
-                var alpha = new System6NativeAlphaSegmentedState { Brightness = AlphaBrightnessPollingAvailable ? (float)System6NativeBackend.NormalizeSystem6AlphaBrightness(AlphaBrightness) : 1f };
-                unsafe
-                {
-                    foreach (var (index, segments) in AlphaSegments)
-                    {
-                        alpha.Segments[index] = (ushort)segments;
-                        AlphaSegmentIndices.Add(index);
-                    }
-                }
-                snapshot.SetAlphaSegmented(0, alpha);
-            }
-
-            foreach (var group in SevenSegmentCells.GroupBy(cell => cell.Key / 16))
-            {
-                uint mask = 0;
-                foreach (var cell in group.Where(cell => cell.Value))
-                {
-                    mask |= 1u << (cell.Key % 16);
-                }
-                snapshot.SetLedDisplay(group.Key, new System6NativeLedDisplayState { OnOff = mask, Brightness = 1f });
-            }
-
-            return snapshot;
-        }
-
-        public byte Initialise()
+    private sealed class FakeAmberBridge : IAmberBridgeLibrary
+    {
+        public AmberBridgeDetails BridgeDetails { get; } = new(1, "Test Amber Bridge", "0.1.1");
+        public List<string> Calls { get; } = [];
+        public IReadOnlyList<string> ProgramRoms { get; private set; } = [];
+        public IReadOnlyList<string> SoundRoms { get; private set; } = [];
+        public List<uint> RunRequests { get; } = [];
+        public Exception? InitialiseException { get; init; }
+        public int RunResult { get; init; } = 1;
+        public int ResetCount { get; private set; }
+        public int ShutdownCount { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool Disposed => DisposeCount != 0;
+        public void Initialise(IReadOnlyList<string> programRomPaths, IReadOnlyList<string>? soundRomPaths = null)
         {
             Calls.Add("Initialise");
-            InitialiseCalled = true;
-            return 1;
+            if (InitialiseException is not null) throw InitialiseException;
+            ProgramRoms = programRomPaths.ToArray();
+            SoundRoms = soundRomPaths?.ToArray() ?? [];
         }
+        public void Reset() { Calls.Add("Reset"); ResetCount++; }
+        public int Run(uint cycles) { lock (RunRequests) RunRequests.Add(cycles); return RunResult; }
+        public void Shutdown() { Calls.Add("Shutdown"); ShutdownCount++; }
+        public void Dispose() { Calls.Add("Dispose"); DisposeCount++; }
+    }
 
-        public int LoadRom(IReadOnlyList<string> programRomPaths, bool flashSwitch)
+    private sealed class TestException : Exception;
+
+    private sealed class NativeFiles : IDisposable
+    {
+        private NativeFiles(string directory, string bridge, string[] programs, string[] sounds)
+            => (Directory, Bridge, Programs, Sounds) = (directory, bridge, programs, sounds);
+        public string Directory { get; }
+        public string Bridge { get; }
+        public string[] Programs { get; }
+        public string[] Sounds { get; }
+        public static NativeFiles Create(int programCount, int soundCount)
         {
-            Calls.Add("LoadRom");
-            LoadedRoms.AddRange(programRomPaths);
-            return 1;
+            var directory = Path.Combine(Path.GetTempPath(), "oasis-amber-tests", Guid.NewGuid().ToString("N"));
+            System.IO.Directory.CreateDirectory(directory);
+            var bridge = Touch(directory, "AmberBridge.dll");
+            var programs = Enumerable.Range(1, programCount).Select(i => Touch(directory, $"program{i}.rom")).ToArray();
+            var sounds = Enumerable.Range(1, soundCount).Select(i => Touch(directory, $"sound{i}.rom")).ToArray();
+            return new(directory, bridge, programs, sounds);
         }
-
-        public int LoadSoundRom(IReadOnlyList<string> soundRomPaths)
-        {
-            return 1;
-        }
-
-        public void SetSteps(byte reelNum, byte steps) => Calls.Add($"SetSteps:{reelNum}:{steps}");
-
-        public void SetOptoStart(byte reelNum, byte start) => Calls.Add($"SetOptoStart:{reelNum}:{start}");
-
-        public void SetOptoEnd(byte reelNum, byte end) => Calls.Add($"SetOptoEnd:{reelNum}:{end}");
-
-        public void SetOptoInvert(byte reelNum, byte state) => Calls.Add($"SetOptoInvert:{reelNum}:{state}");
-
-        public bool IsSetPercentAvailable => true;
-
-        public bool IsSevenSegmentPollingAvailable => SevenSegmentPollingAvailable;
-
-        public void UpdateSegs() => Calls.Add("UpdateSegs");
-
-        public int GetSegsOn(ushort index)
-        {
-            Calls.Add($"GetSegsOn:{index}");
-            return SevenSegmentCells.TryGetValue(index, out var isOn) && isOn ? 1 : 0;
-        }
-
-        public byte GetSegsBright(ushort index)
-        {
-            Calls.Add($"GetSegsBright:{index}");
-            return SevenSegmentBrightness.TryGetValue(index, out var brightness) ? brightness : (byte)0;
-        }
-
-        public void SetPercent(byte percent) => Calls.Add($"SetPercent:{percent}");
-
-        public void SetCoinEnable(byte coin, byte coinEnable) => Calls.Add($"SetCoinEnable:{coin}:{coinEnable}");
-
-        public void SetCoinValue(byte coin, byte coinValue) => Calls.Add($"SetCoinValue:{coin}:{coinValue}");
-
-        public void SetLockoutVal(byte coin, byte lockoutValue) => Calls.Add($"SetLockoutVal:{coin}:{lockoutValue}");
-
-        public void SetLockoutInvert(byte coin, byte lockoutInvert) => Calls.Add($"SetLockoutInvert:{coin}:{lockoutInvert}");
-
-        public void SetEnable(byte num, byte enable) => Calls.Add($"SetEnable:{num}:{enable}");
-
-        public void SetCounterIn(byte num, byte counterIn) => Calls.Add($"SetCounterIn:{num}:{counterIn}");
-
-        public void SetCounterOut(byte num, byte counterOut) => Calls.Add($"SetCounterOut:{num}:{counterOut}");
-
-        public void SetPortIndex(byte num, byte portIndex) => Calls.Add($"SetPortIndex:{num}:{portIndex}");
-
-        public void SetCoin(byte num, byte coin) => Calls.Add($"SetCoin:{num}:{coin}");
-
-        public void SetLevel(byte num, byte level) => Calls.Add($"SetLevel:{num}:{level}");
-
-        public void SetFullLevel(byte num, byte fullLevel) => Calls.Add($"SetFullLevel:{num}:{fullLevel}");
-
-        public void Reset()
-        {
-            Calls.Add("Reset");
-            ResetCalled = true;
-        }
-
-        public int Run(int cycles)
-        {
-            Calls.Add($"Run:{cycles}");
-            Interlocked.Increment(ref RunCallCount);
-            return 1;
-        }
-
-        public byte Shutdown()
-        {
-            ShutdownCalled = true;
-            return 1;
-        }
-
-        public bool IsLampsUpdateAvailable => true;
-
-        public string? LampsUpdateExportName => "SYSTEM6UpdateLamps";
-
-        public void LampsUpdate() => Calls.Add("LampsUpdate");
-
-        public bool GetLampsOn(ushort lampIndex)
-        {
-            Calls.Add($"GetLampsOn:{lampIndex}");
-            return GetLampsOnValues.TryGetValue(lampIndex, out var isOn) && isOn;
-        }
-
-        public float GetLampBrightness(ushort lampIndex) => 0f;
-
-        public short GetPosOut(sbyte positionIndex)
-        {
-            Calls.Add($"GetPosOut:{positionIndex}");
-            return PositionOutputs.TryGetValue(positionIndex, out var position) ? position : (short)0;
-        }
-
-        public bool IsAlphaSegmentPollingAvailable => AlphaSegmentPollingAvailable;
-
-        public int GetAlphaSegments(byte index)
-        {
-            Calls.Add($"GetAlphaSegments:{index}");
-            AlphaSegmentIndices.Add(index);
-            return AlphaSegments.TryGetValue(index, out var segments) ? segments : 0;
-        }
-
-        public bool IsAlphaBrightnessPollingAvailable => AlphaBrightnessPollingAvailable;
-
-        public byte GetAlphaBrightness()
-        {
-            Calls.Add("GetAlphaBrightness");
-            return AlphaBrightness;
-        }
-
-        public void TurnSwitchOn(int switchIndex)
-        {
-            SwitchesTurnedOn.Add(switchIndex);
-        }
-
-        public void TurnSwitchOff(int switchIndex)
-        {
-            SwitchesTurnedOff.Add(switchIndex);
-        }
-
-        public bool IsAudioAvailable => AudioAvailable;
-
-        public System6NativeAudioFormat GetAudioFormat()
-        {
-            Calls.Add("GetAudioFormat");
-            return AudioFormat;
-        }
-
-        public uint FillAudioFrames(Span<short> interleavedStereoFrames, uint framesRequired)
-        {
-            Calls.Add($"FillAudioFrames:{framesRequired}");
-            if (!AudioAvailable || AudioSamples.Length == 0)
-            {
-                return 0;
-            }
-
-            var framesToWrite = Math.Min((int)framesRequired, AudioSamples.Length / 2);
-            AudioSamples.AsSpan(0, framesToWrite * 2).CopyTo(interleavedStereoFrames);
-            return (uint)framesToWrite;
-        }
-
-        public void Dispose()
-        {
-            DisposeCalled = true;
-        }
+        private static string Touch(string directory, string name) { var path = Path.Combine(directory, name); File.WriteAllBytes(path, []); return path; }
+        public void Dispose() => System.IO.Directory.Delete(Directory, true);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -121,7 +121,7 @@ public sealed class System6NativeBackendTests
 
     private sealed class FakeAmberBridge : IAmberBridgeLibrary
     {
-        public AmberBridgeDetails BridgeDetails { get; } = new(1, "Test Amber Bridge", "0.1.1");
+        public AmberBridgeDetails BridgeDetails { get; } = new(AmberApiVersions.V1, "Test Amber Bridge", "0.1.1");
         public List<string> Calls { get; } = [];
         public IReadOnlyList<string> ProgramRoms { get; private set; } = [];
         public IReadOnlyList<string> SoundRoms { get; private set; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -9,16 +9,18 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
 {
     private readonly Func<IEmulationBackend> _mameBackendFactory;
     private readonly Func<string?> _system6LibraryPathProvider;
-    private readonly Func<int> _system6AudioBufferLengthMillisecondsProvider;
+    private readonly Func<string, IAmberBridgeLibrary> _amberBridgeFactory;
 
     public EmulationBackendFactory(
         Func<IEmulationBackend> mameBackendFactory,
         Func<string?> system6LibraryPathProvider,
-        Func<int>? system6AudioBufferLengthMillisecondsProvider = null)
+        Func<int>? system6AudioBufferLengthMillisecondsProvider = null,
+        Func<string, IAmberBridgeLibrary>? amberBridgeFactory = null)
     {
         _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
         _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
-        _system6AudioBufferLengthMillisecondsProvider = system6AudioBufferLengthMillisecondsProvider ?? (() => NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds);
+        _ = system6AudioBufferLengthMillisecondsProvider; // Retained in the public constructor pending preferences UI cleanup.
+        _amberBridgeFactory = amberBridgeFactory ?? (static path => new AmberBridgeLibrary(path));
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -37,13 +39,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         var libraryPath = _system6LibraryPathProvider();
         return string.IsNullOrWhiteSpace(libraryPath)
             ? _mameBackendFactory()
-            : new System6NativeBackend(
-                libraryPath,
-                static path => new System6NativeLibrary(path),
-                60,
-                () => new NAudioEmulationAudioSink(NormalizeSystem6AudioBufferLengthMilliseconds(_system6AudioBufferLengthMillisecondsProvider())));
+            : new System6NativeBackend(libraryPath, _amberBridgeFactory);
     }
 
-    private static int NormalizeSystem6AudioBufferLengthMilliseconds(int value)
-        => Math.Clamp(value, 10, 1000);
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/AmberBridge/AmberBridgeLibrary.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/AmberBridge/AmberBridgeLibrary.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;
@@ -30,7 +31,9 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
         {
             api = NegotiateApi(module);
             BridgeDetails = ReadBridgeDetails(api);
+            Debug.WriteLine($"Amber Bridge: Bridge information read ({BridgeDetails.Name} {BridgeDetails.BridgeVersion}, {AmberApiVersions.Format(BridgeDetails.ApiVersion)}).");
             VerifyCore(api);
+            Debug.WriteLine($"Amber Bridge: {System6CoreId} core found.");
 
             using var core = new Utf8Allocation(System6CoreId, _allocator);
             var createResult = api.Create(core.Pointer, out handle);
@@ -42,6 +45,7 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
 
             _api = api;
             _handle = handle;
+            Debug.WriteLine("Amber Bridge: Instance created.");
         }
         catch
         {
@@ -75,8 +79,10 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
 
             using var paths = new RomPathAllocations(programRomPaths, soundRomPaths, _allocator);
             var parameters = paths.Parameters;
+            Debug.WriteLine("Amber Bridge: Initialise starting.");
             ThrowForResult(_api, "Initialise", _api.Initialise(_handle, ref parameters), _handle);
             _initialised = true;
+            Debug.WriteLine("Amber Bridge: Initialise completed.");
         }
     }
 
@@ -86,6 +92,7 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
         {
             RequireRunning();
             ThrowForResult(_api, "Reset", _api.Reset(_handle), _handle);
+            Debug.WriteLine("Amber Bridge: Reset completed.");
         }
     }
 
@@ -147,12 +154,14 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
     private static NativeApi NegotiateApi(IAmberBridgeModule module)
     {
         var table = new AmberApiV1Native { StructSize = SizeOf<AmberApiV1Native>() };
-        var result = module.BindAmberGetApi()(1, table.StructSize, ref table);
+        Debug.WriteLine($"Amber Bridge: Calling AmberGetApi with {AmberApiVersions.Format(AmberApiVersions.V1)}.");
+        var result = module.BindAmberGetApi()(AmberApiVersions.V1, table.StructSize, ref table);
         if (result != AmberResult.Ok)
         {
             throw new AmberBridgeException("AmberGetApi", result);
         }
-        if (table.StructSize < SizeOf<AmberApiV1Native>() || table.ApiVersion != 1)
+        Debug.WriteLine("Amber Bridge: AmberGetApi succeeded.");
+        if (table.StructSize < SizeOf<AmberApiV1Native>() || table.ApiVersion != AmberApiVersions.V1)
         {
             throw new AmberBridgeException("AmberGetApi validation", AmberResult.UnsupportedVersion);
         }
@@ -165,7 +174,7 @@ public sealed class AmberBridgeLibrary : IAmberBridgeLibrary
     {
         var info = new AmberBridgeInfoNative { StructSize = SizeOf<AmberBridgeInfoNative>() };
         ThrowForResult(api, "GetBridgeInfo", api.GetBridgeInfo(ref info), IntPtr.Zero);
-        if (info.StructSize < SizeOf<AmberBridgeInfoNative>() || info.ApiVersion != 1)
+        if (info.StructSize < SizeOf<AmberBridgeInfoNative>() || info.ApiVersion != AmberApiVersions.V1)
         {
             throw new AmberBridgeException("GetBridgeInfo validation", AmberResult.UnsupportedVersion);
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/AmberBridge/AmberBridgeNativeTypes.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/AmberBridge/AmberBridgeNativeTypes.cs
@@ -1,7 +1,17 @@
 using System.IO;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;
+
+internal static class AmberApiVersions
+{
+    internal const uint V1 = 0x00010000u;
+
+    internal static string Format(uint version) => version == V1
+        ? $"API v1 (0x{version:X8})"
+        : $"API version 0x{version:X8}";
+}
 
 internal enum AmberResult : int
 {
@@ -50,6 +60,7 @@ internal sealed class AmberBridgeModule : IAmberBridgeModule
     internal AmberBridgeModule(string path)
     {
         if (!Path.IsPathFullyQualified(path)) throw new ArgumentException("Amber Bridge path must be absolute.", nameof(path));
+        Debug.WriteLine("Amber Bridge: Loading AmberBridge.dll.");
         _loader = new NativeLibraryLoader(path);
     }
     public AmberGetApiDelegate BindAmberGetApi() => _loader.BindExport<AmberGetApiDelegate>("AmberGetApi");

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -73,9 +73,10 @@ public sealed class System6NativeBackend : IEmulationBackend
             _bridge.Reset(); // Preserve the direct backend's post-ROM-load startup reset.
             _shutdown = false;
             var details = _bridge.BridgeDetails;
-            Debug.WriteLine($"System6 Amber Bridge startup: {details.Name} {details.BridgeVersion}; API {details.ApiVersion}; core jpm-system6; program ROMs={programs.Count}; sound ROMs={sounds.Count}.");
+            Debug.WriteLine($"System6 Amber Bridge startup: {details.Name} {details.BridgeVersion}; {AmberApiVersions.Format(details.ApiVersion)}; core jpm-system6; program ROMs={programs.Count}; sound ROMs={sounds.Count}.");
 
             _runCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            Debug.WriteLine("System6 Amber Bridge startup: Run loop starting.");
             _runTask = Task.Run(() => RunLoopAsync(_runCancellation.Token), CancellationToken.None);
             SetState(EmulationBackendState.Running);
             return Task.CompletedTask;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,302 +1,87 @@
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
+/// <summary>The active System 6 backend. Native ABI ownership is delegated to Amber Bridge.</summary>
 public sealed class System6NativeBackend : IEmulationBackend
 {
-    private const int DefaultOutputPollsPerSecond = 60;
-    private const int DefaultEmulationPumpHz = 1000;
-    private const int System6ClockHz = 8000000;
-    private const int FallbackLampCount = 32;
-    private const int MaximumLampId = byte.MaxValue;
-    private const int ReelCount = 16;
-    private const int DiagnosticChangedLampSampleCount = 8;
-    private const int DiagnosticMappingSampleCount = 8;
-    private const int AlphaCellCount = 16;
-    private const int SevenSegmentMaskBits = 8;
-    private const int NativeSevenSegmentCellStride = 16;
-    private const int SupportedReelOptoCount = 8;
-    private const string DiagnosticStageEnvironmentVariable = "OASIS_SYSTEM6_STARTUP_STAGE";
-    private const string TimingDiagnosticsEnvironmentVariable = "OASIS_SYSTEM6_TIMING_DIAGNOSTICS";
-    private const string OutputPollingEnabledEnvironmentVariable = "OASIS_SYSTEM6_OUTPUT_POLLING";
-    private const string OutputPollingRateEnvironmentVariable = "OASIS_SYSTEM6_OUTPUT_POLL_HZ";
-    private const string EmulationPumpRateEnvironmentVariable = "OASIS_SYSTEM6_EMULATION_PUMP_HZ";
-    private const int MaxCatchUpSlicesPerLoop = 4;
-    private const double SlowRunWarningMilliseconds = 8.0d;
-    private const double SlowPollOutputsWarningMilliseconds = 8.0d;
-    private static readonly TimeSpan RunWarningThrottleInterval = TimeSpan.FromSeconds(10);
+    private const int EmulationPumpHz = 1000;
+    private const int System6ClockHz = 8_000_000;
+    private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1000d / EmulationPumpHz);
+    private static readonly EmulationBackendCapabilities BackendCapabilities = new(true, true, true, true, false, false, false, false);
 
-    private static readonly EmulationBackendCapabilities System6Capabilities = new(
-        SupportsPause: true,
-        SupportsResume: true,
-        SupportsSoftReset: true,
-        SupportsHardReset: true,
-        SupportsSaveState: false,
-        SupportsLoadState: false,
-        SupportsThrottle: false,
-        SupportsDebugger: false);
-
-    private readonly string _libraryPath;
-    private readonly Func<string, ISystem6NativeLibrary> _libraryFactory;
-    private readonly Func<IEmulationAudioSink?> _audioSinkFactory;
-    private readonly TimeSpan _emulationInterval;
-    private readonly TimeSpan _pollInterval;
-    private readonly int _emulationPumpHz;
-    private readonly int _outputPollsPerSecond;
-    private readonly bool _outputPollingEnabled;
-    private readonly long _emulationIntervalTimestampTicks;
-    private readonly long _pollIntervalTimestampTicks;
-    private readonly bool _timingDiagnosticsEnabled;
+    private readonly string _bridgePath;
+    private readonly Func<string, IAmberBridgeLibrary> _bridgeFactory;
     private readonly object _stateGate = new();
-    private readonly int[] _lastLampValues = Enumerable.Repeat(-1, MaximumLampId + 1).ToArray();
-    private readonly int[] _lastLampRawValues = Enumerable.Repeat(-1, MaximumLampId + 1).ToArray();
-    private readonly int[] _lastReelPositions = Enumerable.Repeat(int.MinValue, ReelCount).ToArray();
-    private readonly int[] _reelStepCounts = new int[ReelCount];
-    private int[]? _lastAlphaSegments;
-    private readonly Dictionary<int, int> _lastSevenSegmentMasks = new();
-    private bool _hasLoggedSevenSegmentUnavailable;
-    private IReadOnlyList<int>? _configuredSevenSegmentDisplayIds;
-    private double? _lastAlphaBrightness;
-    private bool _hasLoggedAlphaUnavailable;
-    private bool _hasLoggedLampPollingConfiguration;
-    private bool _hasLoggedReelPollingMapping;
-    private int[]? _configuredLampPollingIds;
-    private int[] _enabledReelPollingIndices = [];
-
-    private ISystem6NativeLibrary? _library;
-    private CancellationTokenSource? _runLoopCancellation;
-    private Task? _runLoopTask;
-    private Task? _pollLoopTask;
+    private IAmberBridgeLibrary? _bridge;
+    private CancellationTokenSource? _runCancellation;
+    private Task? _runTask;
     private EmulationBackendState _state = EmulationBackendState.Stopped;
-    private DateTime _lastRunWarningUtc = DateTime.MinValue;
-    private IEmulationAudioSink? _audioSink;
-    private EmulationAudioFormat? _audioFormat;
-    private short[] _audioFrameBuffer = [];
+    private bool _shutdown;
+    private bool _disposed;
 
-    public System6NativeBackend(string libraryPath)
-        : this(libraryPath, static path => new System6NativeLibrary(path), DefaultOutputPollsPerSecond, static () => new NAudioEmulationAudioSink())
+    public System6NativeBackend(string bridgePath)
+        : this(bridgePath, static path => new AmberBridgeLibrary(path)) { }
+
+    internal System6NativeBackend(string bridgePath, Func<string, IAmberBridgeLibrary> bridgeFactory)
     {
-    }
-
-    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory)
-        : this(libraryPath, libraryFactory, DefaultOutputPollsPerSecond)
-    {
-    }
-
-    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory, int framesPerSecond)
-        : this(libraryPath, libraryFactory, framesPerSecond, static () => null)
-    {
-    }
-
-    public System6NativeBackend(string libraryPath, Func<string, ISystem6NativeLibrary> libraryFactory, int framesPerSecond, Func<IEmulationAudioSink?> audioSinkFactory)
-    {
-        if (string.IsNullOrWhiteSpace(libraryPath))
-        {
-            throw new ArgumentException("System6 native core library path must not be empty.", nameof(libraryPath));
-        }
-
-        if (framesPerSecond <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(framesPerSecond), framesPerSecond, "System6 polling rate must be greater than zero.");
-        }
-
-        _libraryPath = libraryPath;
-        _libraryFactory = libraryFactory ?? throw new ArgumentNullException(nameof(libraryFactory));
-        _audioSinkFactory = audioSinkFactory ?? throw new ArgumentNullException(nameof(audioSinkFactory));
-        _timingDiagnosticsEnabled = IsTimingDiagnosticsEnabled();
-        _outputPollingEnabled = ResolveOutputPollingEnabled();
-        _outputPollsPerSecond = ResolveOutputPollingRate(framesPerSecond);
-        _emulationPumpHz = ResolveEmulationPumpRate();
-        _emulationInterval = TimeSpan.FromMilliseconds(1000.0 / _emulationPumpHz);
-        _pollInterval = TimeSpan.FromMilliseconds(1000.0 / _outputPollsPerSecond);
-        _emulationIntervalTimestampTicks = Math.Max(1L, (long)Math.Round((double)Stopwatch.Frequency / _emulationPumpHz));
-        _pollIntervalTimestampTicks = Math.Max(1L, (long)Math.Round((double)Stopwatch.Frequency / _outputPollsPerSecond));
+        if (string.IsNullOrWhiteSpace(bridgePath))
+            throw new ArgumentException("Amber Bridge DLL path must not be empty.", nameof(bridgePath));
+        _bridgePath = bridgePath;
+        _bridgeFactory = bridgeFactory ?? throw new ArgumentNullException(nameof(bridgeFactory));
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
-
-    public EmulationBackendState State
-    {
-        get
-        {
-            lock (_stateGate)
-            {
-                return _state;
-            }
-        }
-    }
-
-    public EmulationBackendCapabilities Capabilities => System6Capabilities;
+    public EmulationBackendCapabilities Capabilities => BackendCapabilities;
+    public EmulationBackendState State { get { lock (_stateGate) return _state; } }
+    internal int LastCyclesRun { get; private set; }
 
     public event EventHandler<EmulationBackendState>? StateChanged;
-
-    public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
-    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged;
-    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged;
-
-    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged;
-
-    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged
-    {
-        add { }
-        remove { }
-    }
+    // Output polling is intentionally disabled until Amber Bridge exposes snapshots.
+    public event EventHandler<MachineLampChangedEventArgs>? LampChanged { add { } remove { } }
+    public event EventHandler<MachineReelChangedEventArgs>? ReelChanged { add { } remove { } }
+    public event EventHandler<MachineSegmentChangedEventArgs>? SegmentChanged { add { } remove { } }
+    public event EventHandler<MachineVfdBrightnessChangedEventArgs>? VfdBrightnessChanged { add { } remove { } }
+    public event EventHandler<MachineDotMatrixChangedEventArgs>? DotMatrixChanged { add { } remove { } }
 
     public Task StartAsync(EmulationLaunchRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
-
-        if (State is not EmulationBackendState.Stopped)
-        {
+        ThrowIfDisposed();
+        if (State != EmulationBackendState.Stopped)
             throw new InvalidOperationException($"System6 native backend cannot start while it is {State}.");
-        }
 
         SetState(EmulationBackendState.Starting);
-
         try
         {
-            if (string.IsNullOrWhiteSpace(_libraryPath) || !File.Exists(_libraryPath))
-            {
-                throw new InvalidOperationException($"System6 native backend DLL path is missing or does not exist: '{_libraryPath}'.");
-            }
+            if (!Path.IsPathFullyQualified(_bridgePath))
+                throw new InvalidOperationException($"Amber Bridge path must be absolute: '{_bridgePath}'.");
+            if (!string.Equals(Path.GetFileName(_bridgePath), "AmberBridge.dll", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("System6 native backend must be configured with AmberBridge.dll, not the JPM core DLL.");
+            if (!File.Exists(_bridgePath))
+                throw new FileNotFoundException("AmberBridge.dll was not found.", _bridgePath);
 
-            var startupStage = ResolveStartupStage();
-            LogStartupStage($"startup diagnostic stage = {startupStage}");
+            var roms = request.System6NativeRoms
+                ?? throw new InvalidOperationException("System6 native backend requires native ROM settings.");
+            var programs = ValidateRomPaths(roms.ProgramRomPaths, requireTwoProgramRoms: true, "program");
+            var sounds = ValidateRomPaths(roms.SoundRomPaths, requireTwoProgramRoms: false, "sound");
 
-            _library = _libraryFactory(_libraryPath);
-            LogStartupStage("native DLL loaded and exports bound");
-            LogStartupStage($"GetOutputSnapshot size={_library.GetOutputSnapshotSize()} bytes");
-            LogStartupStage($"SetPercent export {(_library.IsSetPercentAvailable ? "available" : "missing")}");
-            if (startupStage is System6StartupStage.LoadBindOnly)
-            {
-                return CompleteStagedStartup();
-            }
+            _bridge = _bridgeFactory(_bridgePath);
+            _bridge.Initialise(programs, sounds);
+            _bridge.Reset(); // Preserve the direct backend's post-ROM-load startup reset.
+            _shutdown = false;
+            var details = _bridge.BridgeDetails;
+            Debug.WriteLine($"System6 Amber Bridge startup: {details.Name} {details.BridgeVersion}; API {details.ApiVersion}; core jpm-system6; program ROMs={programs.Count}; sound ROMs={sounds.Count}.");
 
-            try
-            {
-                var initialiseResult = _library.Initialise();
-                LogStartupStage($"Initialise returned {initialiseResult}");
-                if (initialiseResult == 0)
-                {
-                    throw new InvalidOperationException("Initialise returned failure.");
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"System6 native backend failed to initialise core '{_libraryPath}'.", ex);
-            }
-            if (startupStage is System6StartupStage.InitialiseOnly)
-            {
-                return CompleteStagedStartup();
-            }
-
-            var nativeRoms = request.System6NativeRoms
-                ?? throw new InvalidOperationException("System6 native backend requires native DLL ROM settings.");
-            var programRomPaths = ValidateNativeRomPaths(nativeRoms.ProgramRomPaths, true, "program");
-            var soundRomPaths = ValidateNativeRomPaths(nativeRoms.SoundRomPaths, false, "sound");
-            var reelOptos = ValidateReelOptos(nativeRoms.ReelOptos);
-            var coins = ValidateCoins(nativeRoms.Coins);
-            var percentSwitchValue = ValidatePercentSwitchValue(nativeRoms.PercentSwitchValue);
-            ConfigureLampPolling(request.ConfiguredLampIds);
-            ConfigureSevenSegmentPolling(request.ConfiguredSevenSegmentDisplayIds);
-
-            cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                var loadRomResult = _library.LoadRom(programRomPaths, nativeRoms.FlashSwitch);
-                LogStartupStage($"LoadROM returned {loadRomResult}");
-                if (loadRomResult == 0)
-                {
-                    throw new InvalidOperationException("LoadROM returned failure.");
-                }
-
-                if (soundRomPaths.Any(path => !string.IsNullOrWhiteSpace(path)))
-                {
-                    var loadSoundRomResult = _library.LoadSoundRom(soundRomPaths);
-                    LogStartupStage($"LoadSoundROM returned {loadSoundRomResult}");
-                    if (loadSoundRomResult == 0)
-                    {
-                        throw new InvalidOperationException("LoadSoundROM returned failure.");
-                    }
-                }
-                else
-                {
-                    LogStartupStage("LoadSoundROM skipped");
-                }
-
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"System6 native backend failed to load native ROMs with core '{_libraryPath}'.", ex);
-            }
-            if (startupStage is System6StartupStage.LoadRomOnly)
-            {
-                return CompleteStagedStartup();
-            }
-
-            try
-            {
-                LogStartupStage("Reset starting");
-                _library.Reset();
-                LogStartupStage("Reset completed");
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"System6 native backend failed to reset core '{_libraryPath}' during startup.", ex);
-            }
-            ResetCachedOutputState();
-            ResetConfiguredReelStepCounts();
-            ResetEnabledReelPollingIndices();
-            StartAudioIfAvailable(_library);
-
-            try
-            {
-                LogStartupStage("Apply reel optos starting after Reset");
-                ApplyReelOptos(_library, reelOptos);
-                LogStartupStage("Apply reel optos completed before first Run");
-                LogStartupStage("Apply coins starting before first Run");
-                ApplyCoins(_library, coins);
-                LogStartupStage("Apply coins completed before first Run");
-                ApplyPercent(_library, percentSwitchValue);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"System6 native backend failed to apply reel optos with core '{_libraryPath}'.", ex);
-            }
-            if (startupStage is System6StartupStage.ResetOnly)
-            {
-                LogStartupStage("first Run skipped / pending");
-                return CompleteStagedStartup();
-            }
-
-            if (startupStage is System6StartupStage.OneRunOnly)
-            {
-                var cycles = CalculateCyclesForSlice(0);
-                var runResult = _library.Run(cycles);
-                LogStartupStage($"first Run({cycles}) returned {runResult}");
-                PollOutputs(_library);
-                return CompleteStagedStartup();
-            }
-
-            LogStartupStage("first Run skipped / pending");
-            Debug.WriteLine($"System6 native backend timing config: emulationPumpHz={_emulationPumpHz}; slice={_emulationInterval.TotalMilliseconds:0.###} ms; outputPollingEnabled={_outputPollingEnabled}; outputPollHz={_outputPollsPerSecond}.");
-            _runLoopCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _runLoopTask = Task.Run(() => RunLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
-            if (_outputPollingEnabled)
-            {
-                _pollLoopTask = Task.Run(() => PollLoopAsync(_runLoopCancellation.Token), CancellationToken.None);
-            }
-            _audioSink?.Clear();
+            _runCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _runTask = Task.Run(() => RunLoopAsync(_runCancellation.Token), CancellationToken.None);
             SetState(EmulationBackendState.Running);
             return Task.CompletedTask;
         }
         catch
         {
-            CleanupLibraryAfterFailedStart();
+            DisposeBridgeAfterFailure();
             SetState(EmulationBackendState.Failed);
             throw;
         }
@@ -304,99 +89,50 @@ public sealed class System6NativeBackend : IEmulationBackend
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (State is EmulationBackendState.Stopped)
-        {
-            return;
-        }
-
+        if (_disposed || State == EmulationBackendState.Stopped) return;
         SetState(EmulationBackendState.Stopping);
-
-        var runLoopCancellation = _runLoopCancellation;
-        if (runLoopCancellation is not null)
+        if (_runCancellation is not null) await _runCancellation.CancelAsync().ConfigureAwait(false);
+        if (_runTask is not null)
         {
-            await runLoopCancellation.CancelAsync().ConfigureAwait(false);
+            try { await _runTask.WaitAsync(cancellationToken).ConfigureAwait(false); }
+            catch (OperationCanceledException) when (_runCancellation?.IsCancellationRequested == true) { }
+            catch { /* Cleanup must still run after a failed run loop. */ }
         }
-
-        if (_runLoopTask is not null)
+        try { ShutdownBridgeOnce(); }
+        finally
         {
-            try
-            {
-                await _runLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (runLoopCancellation?.IsCancellationRequested == true)
-            {
-            }
-            catch
-            {
-                // The run loop moves the backend to Failed before faulting. Stop should still
-                // release the native core and return the backend to a clean stopped state.
-            }
+            _bridge?.Dispose();
+            _bridge = null;
         }
-
-        if (_pollLoopTask is not null)
-        {
-            try
-            {
-                await _pollLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (runLoopCancellation?.IsCancellationRequested == true)
-            {
-            }
-            catch
-            {
-            }
-        }
-
-        StopAndDisposeAudio();
-        ShutdownAndDisposeLibrary();
-        _runLoopCancellation?.Dispose();
-        _runLoopCancellation = null;
-        _runLoopTask = null;
-        _pollLoopTask = null;
+        _runCancellation?.Dispose();
+        _runCancellation = null;
+        _runTask = null;
         SetState(EmulationBackendState.Stopped);
     }
 
     public Task PauseAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (State is EmulationBackendState.Running)
-        {
-            SetState(EmulationBackendState.Paused);
-            _audioSink?.Clear();
-            _audioSink?.Stop();
-        }
-
+        ThrowIfDisposed();
+        if (State == EmulationBackendState.Running) SetState(EmulationBackendState.Paused);
         return Task.CompletedTask;
     }
 
     public Task ResumeAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        if (State is EmulationBackendState.Paused)
-        {
-            _audioSink?.Clear();
-            if (_audioSink is not null && _audioFormat is { } audioFormat)
-            {
-                _audioSink.Start(audioFormat);
-            }
-            SetState(EmulationBackendState.Running);
-        }
-
+        ThrowIfDisposed();
+        if (State == EmulationBackendState.Paused) SetState(EmulationBackendState.Running);
         return Task.CompletedTask;
     }
 
     public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
         if (resetKind is not EmulationResetKind.Soft and not EmulationResetKind.Hard)
-        {
             throw new ArgumentOutOfRangeException(nameof(resetKind), resetKind, null);
-        }
-
-        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot reset before it has started.");
-        library.Reset();
-        _audioSink?.Clear();
-        ResetCachedOutputState();
+        RequireActiveBridge().Reset();
         return Task.CompletedTask;
     }
 
@@ -404,181 +140,43 @@ public sealed class System6NativeBackend : IEmulationBackend
     {
         ArgumentNullException.ThrowIfNull(inputDefinition);
         cancellationToken.ThrowIfCancellationRequested();
-
-        if (inputDefinition.Kind is not InputDefinitionKind.Button || inputDefinition.CoinInput)
-        {
-            return Task.CompletedTask;
-        }
-
-        var library = _library ?? throw new InvalidOperationException("System6 native backend cannot set input state before it has started.");
-        if (!int.TryParse(inputDefinition.ButtonNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out var switchIndex))
-        {
-            throw new InvalidOperationException($"System6 native backend input '{inputDefinition.Id}' button number '{inputDefinition.ButtonNumber}' is not a numeric switch index.");
-        }
-
-        if (switchIndex is < byte.MinValue or > byte.MaxValue)
-        {
-            throw new InvalidOperationException($"System6 native backend input '{inputDefinition.Id}' switch index {switchIndex} is outside the supported range 0-255.");
-        }
-
-        if (isPressed)
-        {
-            library.TurnSwitchOn(switchIndex);
-        }
-        else
-        {
-            library.TurnSwitchOff(switchIndex);
-        }
-
-        return Task.CompletedTask;
+        ThrowIfDisposed();
+        throw new NotSupportedException("Switch input is not supported by Amber Bridge v0.1.1; it is deferred to a future bridge API.");
     }
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed) return;
         await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _disposed = true;
     }
 
-    private Task CompleteStagedStartup()
+    internal int RunCycles(long cycles)
     {
-        LogStartupStage("staged startup complete; run loop not started");
-        SetState(EmulationBackendState.Running);
-        return Task.CompletedTask;
-    }
-
-    private static bool IsTimingDiagnosticsEnabled()
-    {
-        var raw = Environment.GetEnvironmentVariable(TimingDiagnosticsEnvironmentVariable);
-        return bool.TryParse(raw, out var enabled)
-            ? enabled
-            : string.Equals(raw, "1", StringComparison.Ordinal);
-    }
-
-
-    private static bool ResolveOutputPollingEnabled()
-    {
-        var raw = Environment.GetEnvironmentVariable(OutputPollingEnabledEnvironmentVariable);
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            return true;
-        }
-
-        return bool.TryParse(raw, out var enabled)
-            ? enabled
-            : !string.Equals(raw, "0", StringComparison.Ordinal);
-    }
-
-    private static int ResolveOutputPollingRate(int constructorDefault)
-    {
-        var raw = Environment.GetEnvironmentVariable(OutputPollingRateEnvironmentVariable);
-        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rate))
-        {
-            rate = constructorDefault;
-        }
-
-        return rate switch
-        {
-            10 or 30 or 60 => rate,
-            _ => DefaultOutputPollsPerSecond
-        };
-    }
-
-    private static int ResolveEmulationPumpRate()
-    {
-        var raw = Environment.GetEnvironmentVariable(EmulationPumpRateEnvironmentVariable);
-        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rate))
-        {
-            return DefaultEmulationPumpHz;
-        }
-
-        return Math.Clamp(rate, 500, 2000);
-    }
-
-    private static System6StartupStage ResolveStartupStage()
-    {
-        var raw = Environment.GetEnvironmentVariable(DiagnosticStageEnvironmentVariable);
-        return Enum.TryParse<System6StartupStage>(raw, ignoreCase: true, out var stage)
-            ? stage
-            : System6StartupStage.FullRunLoop;
-    }
-
-
-    internal static string FormatAlphaSegments(IReadOnlyList<int> segments)
-    {
-        ArgumentNullException.ThrowIfNull(segments);
-        return string.Join(" ", segments.Select((value, index) => $"[{index}]=0x{(value & 0xFFFF):X4}/{value.ToString(CultureInfo.InvariantCulture)}"));
-    }
-
-    private static string FormatOptionalExportStatus(bool isAvailable, string? exportName)
-    {
-        return isAvailable && !string.IsNullOrWhiteSpace(exportName)
-            ? $"available ({exportName})"
-            : "missing";
-    }
-
-    private static void LogStartupStage(string message)
-    {
-        Debug.WriteLine($"System6 native startup: {message}");
+        if (cycles < 0 || cycles > uint.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(cycles), cycles, "Amber Bridge cycle requests must be between 0 and UInt32.MaxValue.");
+        var result = RequireActiveBridge().Run(checked((uint)cycles));
+        LastCyclesRun = result; // Deliberately signed: negative bridge diagnostics must not wrap.
+        return result;
     }
 
     private async Task RunLoopAsync(CancellationToken cancellationToken)
     {
-        var nextSliceTimestamp = Stopwatch.GetTimestamp();
-        var sliceIndex = 0L;
-        var diagnosticsStartedAt = Stopwatch.GetTimestamp();
-        var diagnosticsCycles = 0L;
-
         try
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                if (State is not EmulationBackendState.Running || _library is not { } library)
+                if (State != EmulationBackendState.Running)
                 {
-                    nextSliceTimestamp = Stopwatch.GetTimestamp() + _emulationIntervalTimestampTicks;
-                    await Task.Delay(_emulationInterval, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
                     continue;
                 }
-
-                var slicesRunThisLoop = 0;
-                do
-                {
-                    var cycles = CalculateCyclesForSlice(sliceIndex++);
-                    var runStartTimestamp = Stopwatch.GetTimestamp();
-                    var runResult = library.Run(cycles);
-                    var runElapsed = TimestampTicksToTimeSpan(Stopwatch.GetTimestamp() - runStartTimestamp);
-                    diagnosticsCycles += cycles;
-                    if (runResult == 0)
-                    {
-                        Debug.WriteLine($"System6 native backend Run({cycles}) returned 0.");
-                    }
-
-                    PullAudioFrames(library);
-                    WarnIfEmulationTimingIsSlow(cycles, runElapsed, Stopwatch.GetTimestamp() - diagnosticsStartedAt, diagnosticsCycles, 0);
-                    nextSliceTimestamp += _emulationIntervalTimestampTicks;
-                    slicesRunThisLoop++;
-                }
-                while (!cancellationToken.IsCancellationRequested
-                    && State is EmulationBackendState.Running
-                    && slicesRunThisLoop < MaxCatchUpSlicesPerLoop
-                    && Stopwatch.GetTimestamp() >= nextSliceTimestamp);
-
-                var now = Stopwatch.GetTimestamp();
-                if (now >= nextSliceTimestamp)
-                {
-                    WarnIfEmulationTimingIsSlow(0, TimeSpan.Zero, now - diagnosticsStartedAt, diagnosticsCycles, slicesRunThisLoop);
-                    if (slicesRunThisLoop >= MaxCatchUpSlicesPerLoop)
-                    {
-                        nextSliceTimestamp = now + _emulationIntervalTimestampTicks;
-                    }
-
-                    continue;
-                }
-
-                await Task.Delay(TimestampTicksToTimeSpan(nextSliceTimestamp - now), cancellationToken).ConfigureAwait(false);
+                RunCycles(System6ClockHz / EmulationPumpHz);
+                // A zero result still yields to the existing cadence, avoiding a busy loop.
+                await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
         catch
         {
             SetState(EmulationBackendState.Failed);
@@ -586,649 +184,55 @@ public sealed class System6NativeBackend : IEmulationBackend
         }
     }
 
-    private async Task PollLoopAsync(CancellationToken cancellationToken)
+    private static IReadOnlyList<string> ValidateRomPaths(IReadOnlyList<string> paths, bool requireTwoProgramRoms, string kind)
     {
-        var nextPollTimestamp = Stopwatch.GetTimestamp() + _pollIntervalTimestampTicks;
-        var skippedPolls = 0L;
-
-        try
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                if (State is not EmulationBackendState.Running || _library is not { } library)
-                {
-                    nextPollTimestamp = Stopwatch.GetTimestamp() + _pollIntervalTimestampTicks;
-                    await Task.Delay(_pollInterval, cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                var now = Stopwatch.GetTimestamp();
-                if (now < nextPollTimestamp)
-                {
-                    await Task.Delay(TimestampTicksToTimeSpan(nextPollTimestamp - now), cancellationToken).ConfigureAwait(false);
-                    continue;
-                }
-
-                var pollStartTimestamp = Stopwatch.GetTimestamp();
-                var pollInvokeCount = PollOutputs(library);
-                var pollElapsed = TimestampTicksToTimeSpan(Stopwatch.GetTimestamp() - pollStartTimestamp);
-                nextPollTimestamp += _pollIntervalTimestampTicks;
-
-                now = Stopwatch.GetTimestamp();
-                while (now >= nextPollTimestamp)
-                {
-                    skippedPolls++;
-                    nextPollTimestamp += _pollIntervalTimestampTicks;
-                }
-
-                WarnIfPollTimingIsSlow(pollElapsed, skippedPolls, pollInvokeCount);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
-        catch
-        {
-            SetState(EmulationBackendState.Failed);
-            throw;
-        }
-    }
-
-    private int CalculateCyclesForSlice(long sliceIndex)
-    {
-        var completedCycles = Math.DivRem((sliceIndex + 1) * (long)System6ClockHz, _emulationPumpHz, out _);
-        var previousCycles = Math.DivRem(sliceIndex * (long)System6ClockHz, _emulationPumpHz, out _);
-        return checked((int)(completedCycles - previousCycles));
-    }
-
-    private static IReadOnlyList<System6ReelOptoSettings> ValidateReelOptos(IReadOnlyList<System6ReelOptoSettings>? reelOptos)
-    {
-        var settings = reelOptos is { Count: > 0 } ? reelOptos : System6NativeRomSettings.CreateDefaultReelOptos();
-        foreach (var reel in settings)
-        {
-            if (reel.ReelIndex is < 0 or >= SupportedReelOptoCount)
-            {
-                throw new InvalidOperationException($"System6 reel opto setting has invalid reel index {reel.ReelIndex}; supported range is 0-{SupportedReelOptoCount - 1}.");
-            }
-            if (!reel.Enabled)
-            {
-                continue;
-            }
-            if (reel.Steps is < 1 or > byte.MaxValue)
-            {
-                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto steps must be between 1 and 255.");
-            }
-            if (reel.OptoStart is < 0 or > byte.MaxValue)
-            {
-                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto start must be between 0 and 255.");
-            }
-            if (reel.OptoEnd is < 0 or > byte.MaxValue)
-            {
-                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto end must be between 0 and 255.");
-            }
-            if (reel.OptoStart >= reel.OptoEnd)
-            {
-                throw new InvalidOperationException($"System6 reel {reel.ReelIndex + 1} opto start must be less than opto end.");
-            }
-        }
-
-        return settings;
-    }
-
-    private static IReadOnlyList<System6CoinSettings> ValidateCoins(IReadOnlyList<System6CoinSettings>? coins)
-    {
-        var defaults = System6NativeRomSettings.CreateDefaultCoins();
-        if (coins is null || coins.Count == 0)
-        {
-            return defaults;
-        }
-
-        var settings = new List<System6CoinSettings>(System6NativeRomSettings.DefaultCoinSlotCount);
-        for (var index = 0; index < System6NativeRomSettings.DefaultCoinSlotCount; index++)
-        {
-            settings.Add(index < coins.Count ? coins[index] : defaults[index]);
-        }
-
-        foreach (var coin in settings.Where(coin => coin.Enabled))
-        {
-            ValidateCoinByte(coin.Num, nameof(coin.Num));
-            ValidateCoinByte(coin.Coin, nameof(coin.Coin));
-            ValidateCoinByte(coin.CoinValue, nameof(coin.CoinValue));
-            ValidateCoinByte(coin.CoinEnable, nameof(coin.CoinEnable));
-            ValidateCoinByte(coin.LockoutValue, nameof(coin.LockoutValue));
-            ValidateCoinByte(coin.LockoutInvert, nameof(coin.LockoutInvert));
-            ValidateCoinByte(coin.CounterIn, nameof(coin.CounterIn));
-            ValidateCoinByte(coin.CounterOut, nameof(coin.CounterOut));
-            ValidateCoinByte(coin.PortIndex, nameof(coin.PortIndex));
-            ValidateCoinByte(coin.Level, nameof(coin.Level));
-            ValidateCoinByte(coin.FullLevel, nameof(coin.FullLevel));
-        }
-
-        return settings;
-    }
-
-    private static void ValidateCoinByte(int value, string propertyName)
-    {
-        if (value is < 0 or > byte.MaxValue)
-        {
-            throw new InvalidOperationException($"System6 coin {propertyName} must be between 0 and 255.");
-        }
-    }
-
-    private static int ValidatePercentSwitchValue(int percentSwitchValue)
-    {
-        if (percentSwitchValue is < 0 or > 15)
-        {
-            throw new InvalidOperationException("System6 percent switch value must be between 0 and 15.");
-        }
-
-        return percentSwitchValue;
-    }
-
-    private void ApplyReelOptos(ISystem6NativeLibrary library, IReadOnlyList<System6ReelOptoSettings> reelOptos)
-    {
-        var enabledReelIndices = new List<int>();
-        foreach (var reel in reelOptos.Where(reel => reel.Enabled))
-        {
-            var nativeReelIndex = checked((byte)reel.ReelIndex);
-            var displayReelNumber = reel.ReelIndex + 1;
-            library.SetSteps(nativeReelIndex, checked((byte)reel.Steps));
-            enabledReelIndices.Add(reel.ReelIndex);
-            _reelStepCounts[reel.ReelIndex] = reel.Steps;
-            library.SetOptoStart(nativeReelIndex, checked((byte)reel.OptoStart));
-            library.SetOptoEnd(nativeReelIndex, checked((byte)reel.OptoEnd));
-            library.SetOptoInvert(nativeReelIndex, reel.OptoInvert ? (byte)1 : (byte)0);
-            LogStartupStage($"System6 reel {displayReelNumber} -> native index {nativeReelIndex}: steps={reel.Steps} start={reel.OptoStart} end={reel.OptoEnd} inverted={reel.OptoInvert.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}");
-        }
-
-        _enabledReelPollingIndices = enabledReelIndices.Distinct().OrderBy(index => index).ToArray();
-    }
-
-    private static void ApplyCoins(ISystem6NativeLibrary library, IReadOnlyList<System6CoinSettings> coins)
-    {
-        foreach (var coin in coins.Where(coin => coin.Enabled))
-        {
-            var num = checked((byte)coin.Num);
-            var channel = checked((byte)coin.Coin);
-            library.SetCoinEnable(channel, checked((byte)coin.CoinEnable));
-            library.SetCoinValue(channel, checked((byte)coin.CoinValue));
-            library.SetLockoutVal(channel, checked((byte)coin.LockoutValue));
-            library.SetLockoutInvert(channel, checked((byte)coin.LockoutInvert));
-            library.SetEnable(num, 1);
-            library.SetCounterIn(num, checked((byte)coin.CounterIn));
-            library.SetCounterOut(num, checked((byte)coin.CounterOut));
-            library.SetPortIndex(num, checked((byte)coin.PortIndex));
-            library.SetCoin(num, channel);
-            library.SetLevel(num, checked((byte)coin.Level));
-            library.SetFullLevel(num, checked((byte)coin.FullLevel));
-            LogStartupStage($"System6 coin '{coin.Name}' -> num={coin.Num} coin={coin.Coin} value={coin.CoinValue} enabled={coin.CoinEnable}");
-        }
-    }
-
-    private static void ApplyPercent(ISystem6NativeLibrary library, int percentSwitchValue)
-    {
-        LogStartupStage($"SetPercent export {(library.IsSetPercentAvailable ? "available" : "missing")}");
-        LogStartupStage($"configured percent switch value = {percentSwitchValue}");
-        if (!library.IsSetPercentAvailable)
-        {
-            return;
-        }
-
-        var nativeValue = checked((byte)percentSwitchValue);
-        library.SetPercent(nativeValue);
-        LogStartupStage($"SetPercent passed value {nativeValue} (0x{nativeValue:X2}) to DLL");
-    }
-
-    private static IReadOnlyList<string> ValidateNativeRomPaths(IReadOnlyList<string> romPaths, bool requireFirst, string romKind)
-    {
-        if (requireFirst && (romPaths.Count < 2 || string.IsNullOrWhiteSpace(romPaths[0]) || string.IsNullOrWhiteSpace(romPaths[1])))
-        {
+        ArgumentNullException.ThrowIfNull(paths);
+        if (paths.Count > 4) throw new InvalidOperationException($"Amber Bridge supports at most four {kind} ROM paths; none will be truncated.");
+        if (requireTwoProgramRoms && (paths.Count < 2 || string.IsNullOrWhiteSpace(paths[0]) || string.IsNullOrWhiteSpace(paths[1])))
             throw new InvalidOperationException("System6 native backend requires Program ROM 1 and Program ROM 2 before starting.");
-        }
 
-        var validated = new[] { string.Empty, string.Empty, string.Empty, string.Empty };
-        for (var i = 0; i < Math.Min(validated.Length, romPaths.Count); i++)
+        var result = new List<string>(paths.Count);
+        var sawEmptySlot = false;
+        for (var index = 0; index < paths.Count; index++)
         {
-            var path = romPaths[i];
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                continue;
-            }
-
-            if (!File.Exists(path))
-            {
-                throw new FileNotFoundException($"System6 native {romKind} ROM {i + 1} was not found.", path);
-            }
-
-            validated[i] = path;
+            var path = paths[index];
+            if (string.IsNullOrWhiteSpace(path)) { sawEmptySlot = true; continue; }
+            if (sawEmptySlot)
+                throw new InvalidOperationException($"System6 native {kind} ROM paths must occupy consecutive slots so their ordering is preserved.");
+            if (!File.Exists(path)) throw new FileNotFoundException($"System6 native {kind} ROM {index + 1} was not found.", path);
+            result.Add(path);
         }
-
-        return validated;
+        return result;
     }
 
-    private static TimeSpan TimestampTicksToTimeSpan(long timestampTicks)
+    private IAmberBridgeLibrary RequireActiveBridge()
     {
-        if (timestampTicks <= 0)
-        {
-            return TimeSpan.Zero;
-        }
-
-        return TimeSpan.FromSeconds((double)timestampTicks / Stopwatch.Frequency);
+        ThrowIfDisposed();
+        if (_shutdown || _bridge is null || State is EmulationBackendState.Stopped or EmulationBackendState.Stopping or EmulationBackendState.Failed)
+            throw new InvalidOperationException("System6 Amber Bridge backend is not active.");
+        return _bridge;
     }
 
-    private void WarnIfEmulationTimingIsSlow(int cycles, TimeSpan runElapsed, long diagnosticsElapsedTicks, long diagnosticsCycles, int skippedSlices)
+    private void ShutdownBridgeOnce()
     {
-        var elapsed = TimestampTicksToTimeSpan(diagnosticsElapsedTicks);
-        var achievedCyclesPerSecond = elapsed.TotalSeconds > 0 ? diagnosticsCycles / elapsed.TotalSeconds : 0d;
-        var shouldLog = _timingDiagnosticsEnabled
-            || runElapsed.TotalMilliseconds > SlowRunWarningMilliseconds
-            || skippedSlices > 0;
-        if (!shouldLog || DateTime.UtcNow - _lastRunWarningUtc < RunWarningThrottleInterval)
-        {
-            return;
-        }
-
-        _lastRunWarningUtc = DateTime.UtcNow;
-        Debug.WriteLine($"System6 native backend emulation timing: slice={_emulationInterval.TotalMilliseconds:0.###} ms; Run({cycles})={runElapsed.TotalMilliseconds:0.00} ms; achievedHz={achievedCyclesPerSecond:0}; targetHz={System6ClockHz}; skippedEmulationSlices={skippedSlices}.");
+        if (_bridge is null || _shutdown) return;
+        _shutdown = true;
+        _bridge.Shutdown();
     }
 
-    private void WarnIfPollTimingIsSlow(TimeSpan pollElapsed, long skippedPolls, int nativeInvokeCount)
+    private void DisposeBridgeAfterFailure()
     {
-        var shouldLog = _timingDiagnosticsEnabled
-            || pollElapsed.TotalMilliseconds > SlowPollOutputsWarningMilliseconds
-            || skippedPolls > 0;
-        if (!shouldLog || DateTime.UtcNow - _lastRunWarningUtc < RunWarningThrottleInterval)
-        {
-            return;
-        }
-
-        _lastRunWarningUtc = DateTime.UtcNow;
-        Debug.WriteLine($"System6 native backend output timing: pollHz={_outputPollsPerSecond}; PollOutputs={pollElapsed.TotalMilliseconds:0.00} ms; skippedVisualPolls={skippedPolls}; nativeCalls={nativeInvokeCount}.");
+        try { _bridge?.Dispose(); } finally { _bridge = null; _runCancellation?.Dispose(); _runCancellation = null; _runTask = null; }
     }
 
-    private unsafe int PollOutputs(ISystem6NativeLibrary library)
+    private void ThrowIfDisposed()
     {
-        var snapshot = library.GetOutputSnapshot();
-        var nativeInvokeCount = 1;
-        nativeInvokeCount += PollLampOutputs(snapshot);
-        nativeInvokeCount += PollReelOutputs(snapshot);
-        nativeInvokeCount += PollAlphaOutputs(snapshot);
-        nativeInvokeCount += PollSevenSegmentOutputs(snapshot);
-        return nativeInvokeCount;
-    }
-
-    private unsafe int PollSevenSegmentOutputs(System6NativeOutputSnapshot snapshot)
-    {
-        var displayIds = _configuredSevenSegmentDisplayIds;
-        if (displayIds is null || displayIds.Count == 0)
-        {
-            return 0;
-        }
-
-        foreach (var displayId in displayIds)
-        {
-            if (displayId >= snapshot.LedDisplayCount || displayId >= System6NativeOutputSnapshot.LedDisplayCapacity)
-            {
-                continue;
-            }
-
-            var ledDisplay = snapshot.GetLedDisplay(displayId);
-            var mask = unchecked((int)ledDisplay.OnOff);
-            if (!_lastSevenSegmentMasks.TryGetValue(displayId, out var previous) || previous != mask)
-            {
-                _lastSevenSegmentMasks[displayId] = mask;
-                SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(displayId, mask, MameSegmentOutputType.Digit));
-            }
-        }
-
-        return 0;
-    }
-
-    internal static int GetNativeSevenSegmentBaseIndex(int displayId) => displayId;
-
-    private int PollLampOutputs(System6NativeOutputSnapshot snapshot)
-    {
-        var changedDiagnostics = new List<string>();
-        var lampCount = (int)Math.Min(snapshot.MatrixLampCount, (uint)System6NativeOutputSnapshot.MatrixLampCapacity);
-        foreach (var lampIndex in GetLampPollingIds().Where(id => id < lampCount))
-        {
-            var lamp = snapshot.GetMatrixLamp(lampIndex);
-            var rawValue = lamp.OnOff != 0 ? 1 : 0;
-            var value = NormalizeLampBrightness(lamp);
-            var diagnosticChanged = _lastLampRawValues[lampIndex] != rawValue;
-            if (diagnosticChanged)
-            {
-                _lastLampRawValues[lampIndex] = rawValue;
-            }
-            if (_lastLampValues[lampIndex] != value)
-            {
-                _lastLampValues[lampIndex] = value;
-                LampChanged?.Invoke(this, new MachineLampChangedEventArgs(lampIndex, value));
-            }
-
-            if (diagnosticChanged && changedDiagnostics.Count < DiagnosticChangedLampSampleCount)
-            {
-                changedDiagnostics.Add(FormatLampChangeDiagnostic((ushort)lampIndex, lampIndex, rawValue, value > 0, value));
-            }
-        }
-
-        if (_timingDiagnosticsEnabled && changedDiagnostics.Count > 0)
-        {
-            Debug.WriteLine($"[System6 Lamps] changed: {string.Join("; ", changedDiagnostics)}");
-        }
-
-        return 0;
-    }
-
-    private static int NormalizeLampBrightness(System6NativeLampState lamp)
-    {
-        if (lamp.Brightness > 0f)
-        {
-            return Math.Clamp((int)Math.Round(lamp.Brightness * 255f), 0, 255);
-        }
-
-        return lamp.OnOff != 0 ? 255 : 0;
-    }
-
-    private static string FormatLampChangeDiagnostic(ushort nativeLampIndex, int lampIndex, int rawValue, bool isOn, int value)
-    {
-        return $"native {nativeLampIndex} -> lamp:{lampIndex} raw={rawValue.ToString(CultureInfo.InvariantCulture)} on={isOn.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()} value={value}";
-    }
-
-    private int PollReelOutputs(System6NativeOutputSnapshot snapshot)
-    {
-        LogReelPollingMapping();
-        var reelCount = (int)Math.Min(snapshot.ReelCount, (uint)System6NativeOutputSnapshot.ReelCapacity);
-        foreach (var reelIndex in _enabledReelPollingIndices.Where(index => index < reelCount))
-        {
-            var reelId = reelIndex + 1;
-            var rawPosition = snapshot.GetReelPosition(reelIndex);
-            var position = NormalizeConfiguredNativeSystem6ReelPosition(reelIndex, rawPosition);
-            if (_lastReelPositions[reelIndex] != position)
-            {
-                _lastReelPositions[reelIndex] = position;
-                ReelChanged?.Invoke(this, new MachineReelChangedEventArgs(reelId, position));
-            }
-        }
-
-        return 0;
-    }
-
-    private unsafe int PollAlphaOutputs(System6NativeOutputSnapshot snapshot)
-    {
-        if (snapshot.AlphaSegmentedDisplayCount == 0)
-        {
-            return 0;
-        }
-
-        var alpha = snapshot.GetAlphaSegmented(0);
-        var normalizedBrightness = Math.Clamp(alpha.Brightness, 0d, 1d);
-        if (!_lastAlphaBrightness.HasValue || Math.Abs(_lastAlphaBrightness.Value - normalizedBrightness) >= 0.000001d)
-        {
-            _lastAlphaBrightness = normalizedBrightness;
-            VfdBrightnessChanged?.Invoke(this, new MachineVfdBrightnessChangedEventArgs(0, normalizedBrightness));
-        }
-
-        var segments = new int[AlphaCellCount];
-        var mappedSegments = new int[AlphaCellCount];
-        for (var index = 0; index < segments.Length; index++)
-        {
-            segments[index] = alpha.Segments[index];
-            mappedSegments[index] = System6AlphaSegmentMapper.MapNativeMaskToOasisMask(segments[index]);
-        }
-
-        if (_lastAlphaSegments is not null && segments.SequenceEqual(_lastAlphaSegments))
-        {
-            return 0;
-        }
-
-        _lastAlphaSegments = segments;
-        for (var index = 0; index < segments.Length; index++)
-        {
-            SegmentChanged?.Invoke(this, new MachineSegmentChangedEventArgs(index, mappedSegments[index], MameSegmentOutputType.NativeAlpha));
-        }
-
-        return 0;
-    }
-
-    private void ResetConfiguredReelStepCounts()
-    {
-        Array.Clear(_reelStepCounts);
-    }
-
-    private void ResetEnabledReelPollingIndices()
-    {
-        _enabledReelPollingIndices = [];
-    }
-
-    private void ConfigureLampPolling(IReadOnlyList<int>? configuredLampIds)
-    {
-        _configuredLampPollingIds = configuredLampIds?
-            .Where(lampId => lampId is >= 0 and <= MaximumLampId)
-            .Distinct()
-            .OrderBy(lampId => lampId)
-            .ToArray();
-        if (_configuredLampPollingIds is { Length: 0 })
-        {
-            _configuredLampPollingIds = null;
-        }
-    }
-
-    private void ConfigureSevenSegmentPolling(IReadOnlyList<int>? configuredSevenSegmentDisplayIds)
-    {
-        _configuredSevenSegmentDisplayIds = configuredSevenSegmentDisplayIds?
-            .Where(displayId => displayId is >= 0 and <= (ushort.MaxValue / NativeSevenSegmentCellStride))
-            .Distinct()
-            .OrderBy(displayId => displayId)
-            .ToArray();
-        if (_configuredSevenSegmentDisplayIds is { Count: 0 })
-        {
-            _configuredSevenSegmentDisplayIds = null;
-        }
-    }
-
-    private IReadOnlyList<int> GetLampPollingIds()
-    {
-        return _configuredLampPollingIds ?? Enumerable.Range(0, FallbackLampCount).ToArray();
-    }
-
-    private int NormalizeConfiguredNativeSystem6ReelPosition(int reelIndex, int rawPosition)
-    {
-        var steps = reelIndex >= 0 && reelIndex < _reelStepCounts.Length
-            ? _reelStepCounts[reelIndex]
-            : 0;
-
-        return NormalizeNativeSystem6ReelPosition(rawPosition, steps);
-    }
-
-    internal static int NormalizeNativeSystem6ReelPosition(int rawPosition, int steps)
-    {
-        if (steps <= 0)
-        {
-            return rawPosition;
-        }
-
-        // Native System 6 internals expose reel motion in the opposite direction
-        // to the MAME/Oasis convention. Normalize at the backend boundary so
-        // rendering can treat both emulation backends identically.
-        var positionWithinReel = rawPosition % steps;
-        if (positionWithinReel < 0)
-        {
-            positionWithinReel += steps;
-        }
-
-        return (steps - positionWithinReel) % steps;
-    }
-
-    private void LogReelPollingMapping()
-    {
-        if (_hasLoggedReelPollingMapping)
-        {
-            return;
-        }
-
-        _hasLoggedReelPollingMapping = true;
-        var mappings = _enabledReelPollingIndices.Take(DiagnosticMappingSampleCount)
-            .Select(index => $"native {index} -> reel:{index + 1} (GetPosOut selector {index})");
-        Debug.WriteLine($"[System6 Reels] mapping sample: {string.Join("; ", mappings)}");
-    }
-
-    internal static double NormalizeSystem6AlphaBrightness(byte rawBrightness)
-    {
-        const double maxSystem6AlphaDuty = 31d;
-        return Math.Clamp(rawBrightness / maxSystem6AlphaDuty, 0d, 1d);
-    }
-
-    private void ResetCachedOutputState()
-    {
-        Array.Fill(_lastLampValues, -1);
-        Array.Fill(_lastLampRawValues, -1);
-        Array.Fill(_lastReelPositions, int.MinValue);
-        _lastAlphaSegments = null;
-        _lastSevenSegmentMasks.Clear();
-        _lastAlphaBrightness = null;
-        _hasLoggedAlphaUnavailable = false;
-        _hasLoggedLampPollingConfiguration = false;
-        _hasLoggedReelPollingMapping = false;
-        _hasLoggedSevenSegmentUnavailable = false;
-    }
-
-
-    private void StartAudioIfAvailable(ISystem6NativeLibrary library)
-    {
-        if (!library.IsAudioAvailable)
-        {
-            LogStartupStage("audio exports missing; playback disabled");
-            return;
-        }
-
-        var nativeFormat = library.GetAudioFormat();
-        var format = ValidateNativeAudioFormat(nativeFormat);
-        _audioSink = _audioSinkFactory();
-        if (_audioSink is null)
-        {
-            LogStartupStage("audio sink unavailable; playback disabled");
-            return;
-        }
-
-        _audioFormat = format;
-        _audioFrameBuffer = new short[Math.Max(1, (int)Math.Ceiling((double)format.SampleRate / _emulationPumpHz)) * format.Channels];
-        _audioSink.Start(format);
-        _audioSink.Clear();
-        LogStartupStage($"audio enabled: {format.SampleRate} Hz, {format.Channels} channels, {format.BitsPerSample}-bit PCM");
-    }
-
-    private static EmulationAudioFormat ValidateNativeAudioFormat(System6NativeAudioFormat nativeFormat)
-    {
-        if (nativeFormat.SampleRate is 0 || nativeFormat.Channels is 0 || nativeFormat.BitsPerSample is 0)
-        {
-            throw new InvalidOperationException($"OasisEmulator reported an invalid audio format: sampleRate={nativeFormat.SampleRate}, channels={nativeFormat.Channels}, bits={nativeFormat.BitsPerSample}.");
-        }
-
-        if (nativeFormat.Format != System6NativeAudioFormat.PcmS16FormatValue || nativeFormat.BitsPerSample != 16)
-        {
-            throw new NotSupportedException($"OasisEmulator reported unsupported audio format {nativeFormat.Format} with {nativeFormat.BitsPerSample} bits per sample; only PCM signed 16-bit is supported.");
-        }
-
-        if (nativeFormat.Channels > 8 || nativeFormat.SampleRate > 384000)
-        {
-            throw new InvalidOperationException($"OasisEmulator reported an unreasonable audio format: sampleRate={nativeFormat.SampleRate}, channels={nativeFormat.Channels}.");
-        }
-
-        return new EmulationAudioFormat(checked((int)nativeFormat.SampleRate), checked((int)nativeFormat.Channels), checked((int)nativeFormat.BitsPerSample));
-    }
-
-    private void PullAudioFrames(ISystem6NativeLibrary library)
-    {
-        if (_audioSink is null || _audioFormat is not { } format || _audioFrameBuffer.Length == 0)
-        {
-            return;
-        }
-
-        var framesRequested = checked((uint)(_audioFrameBuffer.Length / format.Channels));
-        var framesWritten = library.FillAudioFrames(_audioFrameBuffer, framesRequested);
-        if (framesWritten == 0)
-        {
-            return;
-        }
-
-        var clampedFrames = Math.Min(framesWritten, framesRequested);
-        var bytesWritten = checked((int)clampedFrames * format.Channels * (format.BitsPerSample / 8));
-        _audioSink.PushPcm(MemoryMarshal.AsBytes(_audioFrameBuffer.AsSpan(0, bytesWritten / sizeof(short))));
-    }
-
-    private void StopAndDisposeAudio()
-    {
-        var sink = _audioSink;
-        _audioSink = null;
-        _audioFormat = null;
-        _audioFrameBuffer = [];
-        if (sink is null)
-        {
-            return;
-        }
-
-        sink.Clear();
-        sink.Stop();
-        sink.Dispose();
-    }
-
-    private void CleanupLibraryAfterFailedStart()
-    {
-        StopAndDisposeAudio();
-        ShutdownAndDisposeLibrary();
-        _runLoopCancellation?.Dispose();
-        _runLoopCancellation = null;
-        _runLoopTask = null;
-        _pollLoopTask = null;
-    }
-
-    private void ShutdownAndDisposeLibrary()
-    {
-        var library = _library;
-        _library = null;
-        if (library is null)
-        {
-            return;
-        }
-
-        try
-        {
-            var shutdownResult = library.Shutdown();
-            LogStartupStage($"Shutdown returned {shutdownResult}");
-        }
-        finally
-        {
-            library.Dispose();
-        }
+        if (_disposed) throw new ObjectDisposedException(nameof(System6NativeBackend));
     }
 
     private void SetState(EmulationBackendState state)
     {
-        var changed = false;
-        lock (_stateGate)
-        {
-            if (_state != state)
-            {
-                _state = state;
-                changed = true;
-            }
-        }
-
-        if (changed)
-        {
-            StateChanged?.Invoke(this, state);
-        }
+        lock (_stateGate) _state = state;
+        StateChanged?.Invoke(this, state);
     }
-}
-
-
-internal enum System6StartupStage
-{
-    LoadBindOnly,
-    InitialiseOnly,
-    LoadRomOnly,
-    ResetOnly,
-    OneRunOnly,
-    FullRunLoop
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 
 namespace OasisEditor;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -175,7 +175,7 @@
                     </Style>
                 </StackPanel.Style>
                 <TextBlock FontSize="18" FontWeight="SemiBold" Text="Native Emulation" />
-                <TextBlock Margin="0,16,0,4" Text="System6 native core DLL path" Foreground="{DynamicResource TextSecondaryBrush}" />
+                <TextBlock Margin="0,16,0,4" Text="System6 AmberBridge.dll path" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding System6NativeLibraryPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                 <TextBlock Margin="0,16,0,4" Text="Audio Buffer Length (ms)" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Width="120"


### PR DESCRIPTION
### Motivation

- Replace the active System 6 direct-JPM native runtime path with the managed Amber Bridge wrapper so the backend lifecycle is driven by `IAmberBridgeLibrary` and `AmberBridge.dll` rather than binding JPM exports directly.
- Preserve existing backend and scheduler contracts (start/reset/run/stop/pause/resume/dispose) and the Editor ROM validation model while explicitly handling Amber Bridge v0.1.1 limitations.

### Description

- `System6NativeBackend` now constructs or accepts an `IAmberBridgeLibrary` factory and uses `AmberBridge.dll` via `IAmberBridgeLibrary` for `Initialise`, `Reset`, `Run`, `Shutdown`, and `Dispose`, preserving the previous post-ROM `Reset` and 1 kHz run cadence; invalid cycle requests are range-checked and bridge-returned signed `cycles_run` is preserved. (`WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs`)
- Enforced that the configured path be an absolute path to `AmberBridge.dll` (not `AmberOasis.JPMSystem6.dll`), validated program/sound ROM ordering and existence before creating the bridge, reject non-consecutive ROM slots, and pass missing sound ROMs as an empty managed collection. (`System6NativeBackend.cs`, `EditorProject.cs` usage retained)
- Updated `EmulationBackendFactory` to construct the Amber-bridge-backed `System6NativeBackend` via an injectable bridge factory so tests can provide a fake `IAmberBridgeLibrary` without loading native code. Production defaults to `new AmberBridgeLibrary(path)`. (`WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs`)
- Explicitly disabled or mapped unsupported v0.1.1 features: switch input now throws `NotSupportedException` with a clear Amber Bridge v0.1.1 message, output/audio polling and event publishing are disabled (no-op event accessors), and optional reel/coin/percent configuration is skipped rather than calling obsolete JPM exports; added integration-status text and a short evidence file documenting missing operations. (docs: `Docs/amber-bridge-v0.1.1-integration.md`, `Docs/amber-bridge-v0.2-requirements.md`)
- Tests: replaced/added focused backend tests that use a `FakeAmberBridge` (fake `IAmberBridgeLibrary`) to assert path selection, ROM ordering, initialise/reset/run/shutdown/dispose ordering and failure cleanup, cycle mapping and range validation, and unsupported-operation behaviour. (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs`, `EmulationBackendFactoryTests.cs` updated)

### Testing

- Repository checks: `git diff --check` (whitespace / trivial-diff checks) passed in this environment.
- Added focused unit tests using a `FakeAmberBridge` to exercise lifecycle, ROM forwarding and error handling, but `dotnet build` / `dotnet test` were not run here because `WindowsNetProjects/OasisEditor/AGENTS.md` prohibits attempting the Windows/.NET/WPF toolchain in this environment.
- No real-DLL or Editor smoke tests were executed because the execution environment lacks Windows native/DLL support; maintainers should run the normal `dotnet build` and `dotnet test` locally and perform the smoke checks described in `Docs/amber-bridge-v0.1.1-integration.md` (configure absolute `AmberBridge.dll` with colocated `AmberOasis.JPMSystem6.dll`, verify ordered ROMs, start/reset/stop and confirm unsupported operations behaviour).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68e4b904ec83279240797966433367)