### PR TITLE
Fix System 6 audio frame timing and buffer overflow handling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class NAudioEmulationAudioSinkTests
+{
+    [Theory]
+    [InlineData(800, 1000, 192, false)]
+    [InlineData(900, 1000, 192, true)]
+    [InlineData(1000, 1000, 1, true)]
+    public void IncomingBlockIsDroppedRatherThanRequiringBufferedAudioToBeCleared(
+        int bufferedBytes, int capacityBytes, int incomingBytes, bool expectedDrop)
+    {
+        Assert.Equal(expectedDrop,
+            NAudioEmulationAudioSink.ShouldDropIncomingBlock(bufferedBytes, capacityBytes, incomingBytes));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/System6NativeBackendTests.cs
@@ -106,6 +106,57 @@ public sealed class System6NativeBackendTests
         Assert.Contains((7u, false), fake.SwitchStates);
     }
 
+    [Fact]
+    public async Task PumpRequestsFramesAndPushesOnlyWrittenStereoSamples()
+    {
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge { AudioFramesWritten = 17 };
+        var sink = new FakeAudioSink();
+        var backend = new System6NativeBackend(files.Bridge, _ => fake, sink);
+
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        await fake.FirstAudioFill.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.All(fake.AudioFrameCapacities, capacity => Assert.Equal(48u, capacity));
+        Assert.Equal(48 * 2, fake.AudioSampleBufferLengths[0]);
+        Assert.Equal(17 * 2 * sizeof(short), sink.BlockLengths[0]);
+    }
+
+    [Fact]
+    public async Task FullPumpFillPushesNinetySixSamplesAsOneHundredNinetyTwoBytes()
+    {
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge { AudioFramesWritten = 48 };
+        var sink = new FakeAudioSink();
+        var backend = new System6NativeBackend(files.Bridge, _ => fake, sink);
+
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        await fake.FirstAudioFill.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(192, sink.BlockLengths[0]);
+    }
+
+    [Fact]
+    public void FramesPerPumpRequiresAnIntegralRelationship()
+    {
+        Assert.Equal(48, System6NativeBackend.CalculateFramesPerPump(48_000, 1_000));
+        Assert.Throws<NotSupportedException>(() => System6NativeBackend.CalculateFramesPerPump(44_100, 1_000));
+    }
+
+    [Fact]
+    public async Task CancellationDoesNotCauseUnboundedCatchUp()
+    {
+        using var files = NativeFiles.Create(2, 0);
+        var fake = new FakeAmberBridge { RunDelayMilliseconds = 8 };
+        var backend = new System6NativeBackend(files.Bridge, _ => fake);
+        await backend.StartAsync(Request(files), CancellationToken.None);
+        await Task.Delay(40);
+        await backend.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.InRange(fake.RunRequests.Count, 1, 10);
+    }
+
     private static EmulationLaunchRequest Request(NativeFiles files)
     {
         var settings = new System6NativeRomSettings
@@ -135,6 +186,11 @@ public sealed class System6NativeBackendTests
         public List<(uint Index, bool IsOn)> SwitchStates { get; } = [];
         public Exception? InitialiseException { get; init; }
         public int RunResult { get; init; } = 1;
+        public int RunDelayMilliseconds { get; init; }
+        public uint AudioFramesWritten { get; init; }
+        public List<uint> AudioFrameCapacities { get; } = [];
+        public List<int> AudioSampleBufferLengths { get; } = [];
+        public TaskCompletionSource FirstAudioFill { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public int ResetCount { get; private set; }
         public int ShutdownCount { get; private set; }
         public int DisposeCount { get; private set; }
@@ -147,11 +203,11 @@ public sealed class System6NativeBackendTests
             SoundRoms = soundRomPaths?.ToArray() ?? [];
         }
         public void Reset() { Calls.Add("Reset"); ResetCount++; }
-        public int Run(uint cycles) { lock (RunRequests) RunRequests.Add(cycles); return RunResult; }
+        public int Run(uint cycles) { lock (RunRequests) RunRequests.Add(cycles); if (RunDelayMilliseconds != 0) Thread.Sleep(RunDelayMilliseconds); return RunResult; }
         public void SetSwitchState(uint switchIndex, bool isOn) { lock (SwitchStates) SwitchStates.Add((switchIndex, isOn)); }
         public void GetOutputSnapshot(AmberOutputSnapshotBuffer destination) { }
         public AmberAudioFormat GetAudioFormat() => new(48000, 2, 1, 1);
-        public uint FillAudioFrames(Span<short> interleavedSamples, uint frameCapacity) => 0;
+        public uint FillAudioFrames(Span<short> interleavedSamples, uint frameCapacity) { lock (AudioFrameCapacities) { AudioFrameCapacities.Add(frameCapacity); AudioSampleBufferLengths.Add(interleavedSamples.Length); } FirstAudioFill.TrySetResult(); return AudioFramesWritten; }
         public void ConfigureReels(AmberReelConfiguration configuration) { }
         public void ConfigureCoins(AmberCoinConfiguration configuration) { }
         public void SetPercentageSwitch(uint rawValue) { }
@@ -160,6 +216,16 @@ public sealed class System6NativeBackendTests
     }
 
     private sealed class TestException : Exception;
+
+    private sealed class FakeAudioSink : IEmulationAudioSink
+    {
+        public List<int> BlockLengths { get; } = [];
+        public void Start(EmulationAudioFormat format) { }
+        public void PushPcm(ReadOnlySpan<byte> pcmBytes) { lock (BlockLengths) BlockLengths.Add(pcmBytes.Length); }
+        public void Stop() { }
+        public void Clear() { }
+        public void Dispose() { }
+    }
 
     private sealed class NativeFiles : IDisposable
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -10,6 +10,11 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     private BufferedWaveProvider? _buffer;
     private WasapiOut? _output;
     private EmulationAudioFormat? _format;
+    private long _droppedBlocks;
+    private long _droppedBytes;
+
+    internal long DroppedBlocks => Interlocked.Read(ref _droppedBlocks);
+    internal long DroppedBytes => Interlocked.Read(ref _droppedBytes);
 
     public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
     {
@@ -36,6 +41,8 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         _output.Init(_buffer);
         _output.Play();
         _format = format;
+        Interlocked.Exchange(ref _droppedBlocks, 0);
+        Interlocked.Exchange(ref _droppedBytes, 0);
     }
 
     public void PushPcm(ReadOnlySpan<byte> pcmBytes)
@@ -45,11 +52,14 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             return;
         }
 
-        var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
-        var configuredBufferBytes = format.SampleRate * format.Channels * (format.BitsPerSample / 8) * _bufferLengthMilliseconds / 1000;
-        if (_buffer.BufferedBytes > configuredBufferBytes)
+        _ = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
+        if (ShouldDropIncomingBlock(_buffer.BufferedBytes, _buffer.BufferLength, pcmBytes.Length))
         {
-            _buffer.ClearBuffer();
+            var droppedBlocks = Interlocked.Increment(ref _droppedBlocks);
+            Interlocked.Add(ref _droppedBytes, pcmBytes.Length);
+            if (droppedBlocks == 1 || (droppedBlocks & (droppedBlocks - 1)) == 0)
+                System.Diagnostics.Debug.WriteLine($"NAudio emulation buffer: dropped incoming audio block; blocks={droppedBlocks}, bytes={DroppedBytes}, buffered={_buffer.BufferedBytes}, capacity={_buffer.BufferLength}.");
+            return;
         }
 
         var bytes = pcmBytes.ToArray();
@@ -68,6 +78,9 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     }
 
     public void Dispose() => Stop();
+
+    internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes)
+        => incomingBytes > bufferCapacityBytes - bufferedBytes;
 
     private static void ValidateFormat(EmulationAudioFormat format)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -19,7 +19,10 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly AmberOutputSnapshotBuffer _snapshot = new();
     private readonly ConcurrentQueue<(uint Index, bool IsOn)> _switchCommands = new();
     private readonly HashSet<uint> _assertedSwitches = [];
-    private readonly short[] _audioSamples = new short[96 * 2];
+    private short[] _audioSamples = [];
+    private int _audioSampleRate;
+    private int _audioChannelCount;
+    private int _audioFramesPerPump;
     private AmberBridgeCapabilities? _amberCapabilities;
     private AmberLampState[] _lastLamps = [];
     private int[] _lastReels = [];
@@ -89,6 +92,10 @@ public sealed class System6NativeBackend : IEmulationBackend
             _bridge.Reset(); // Preserve the direct backend's post-ROM-load startup reset.
             var audioFormat = _bridge.GetAudioFormat();
             ValidateAudioFormat(audioFormat);
+            _audioSampleRate = checked((int)audioFormat.SampleRate);
+            _audioChannelCount = checked((int)audioFormat.Channels);
+            _audioFramesPerPump = CalculateFramesPerPump(_audioSampleRate, EmulationPumpHz);
+            _audioSamples = new short[checked(_audioFramesPerPump * _audioChannelCount)];
             _audioSink.Start(new((int)audioFormat.SampleRate, (int)audioFormat.Channels, 16));
             ApplyProjectConfiguration(roms);
             _shutdown = false;
@@ -198,18 +205,36 @@ public sealed class System6NativeBackend : IEmulationBackend
     {
         try
         {
+            var pumpTicks = Math.Max(1L, Stopwatch.Frequency / EmulationPumpHz);
+            var nextDeadline = Stopwatch.GetTimestamp();
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (State != EmulationBackendState.Running)
                 {
                     await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    nextDeadline = Stopwatch.GetTimestamp();
                     continue;
                 }
                 RunCycles(System6ClockHz / EmulationPumpHz);
                 ProcessSwitchCommands();
                 PollOutputsAndAudio();
-                // A zero result still yields to the existing cadence, avoiding a busy loop.
-                await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+
+                nextDeadline += pumpTicks;
+                var now = Stopwatch.GetTimestamp();
+                // Never run an unbounded sequence of immediate catch-up slices after a stall.
+                if (now - nextDeadline > pumpTicks * 3)
+                    nextDeadline = now + pumpTicks;
+
+                var remainingTicks = nextDeadline - Stopwatch.GetTimestamp();
+                if (remainingTicks > 0)
+                {
+                    var remaining = TimeSpan.FromSeconds((double)remainingTicks / Stopwatch.Frequency);
+                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await Task.Yield();
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
@@ -236,9 +261,11 @@ public sealed class System6NativeBackend : IEmulationBackend
         bridge.GetOutputSnapshot(_snapshot);
         if (!_firstSnapshot) { _firstSnapshot = true; Debug.WriteLine($"Amber Bridge: First output snapshot received; lamps={_snapshot.MatrixLampCount}, reels={_snapshot.ReelCount}, alpha={_snapshot.AlphaDisplayCount}, sevenSegment={_snapshot.SevenSegmentDisplayCount}."); }
         TranslateSnapshot();
-        var frames = bridge.FillAudioFrames(_audioSamples, 96);
-        if (frames != 0) _audioSink.PushPcm(MemoryMarshal.AsBytes(_audioSamples.AsSpan(0, checked((int)frames * 2))));
-        if (!_firstAudio) { _firstAudio = true; Debug.WriteLine($"Amber Bridge: First audio fill completed; requested=96, written={frames}."); }
+        var writtenFrames = bridge.FillAudioFrames(_audioSamples, checked((uint)_audioFramesPerPump));
+        var writtenSamples = checked((int)writtenFrames * _audioChannelCount);
+        var bytes = MemoryMarshal.AsBytes(_audioSamples.AsSpan(0, writtenSamples));
+        if (!bytes.IsEmpty) _audioSink.PushPcm(bytes);
+        if (!_firstAudio) { _firstAudio = true; Debug.WriteLine($"Amber Bridge: First audio fill completed; sampleRate={_audioSampleRate} Hz, pumpRate={EmulationPumpHz} Hz, framesRequested={_audioFramesPerPump}, framesWritten={writtenFrames}, samplesWritten={writtenSamples}, bytesSubmitted={bytes.Length}."); }
     }
 
     private void TranslateSnapshot()
@@ -262,7 +289,15 @@ public sealed class System6NativeBackend : IEmulationBackend
     }
 
     private static void ValidateRequiredCapabilities(AmberBridgeCapabilities c) { var missing = new List<string>(); if (!c.SupportsSwitchInput) missing.Add("switch input"); if (!c.SupportsOutputSnapshots) missing.Add("output snapshots"); if (!c.SupportsAudio) missing.Add("audio"); if (missing.Count != 0) throw new InvalidOperationException($"Amber Bridge API v2 core jpm-system6 is missing required capabilities: {string.Join(", ", missing)}. Raw mask=0x{c.RawFeatureBits:X16}."); }
-    private static void ValidateAudioFormat(AmberAudioFormat f) { if (f is not { SampleRate: 48000, Channels: 2, SampleFormat: 1, Interleaving: 1 }) throw new NotSupportedException($"Unsupported Amber audio format: rate={f.SampleRate}, channels={f.Channels}, sampleFormat={f.SampleFormat}, interleaving={f.Interleaving}."); Debug.WriteLine("Amber Bridge: Audio format 48000 Hz, 2 channels, signed PCM16, interleaved."); }
+    private static void ValidateAudioFormat(AmberAudioFormat f) { if (f is not { SampleRate: 48000, Channels: 2, SampleFormat: 1, Interleaving: 1 }) throw new NotSupportedException($"Unsupported Amber audio format: rate={f.SampleRate}, channels={f.Channels}, sampleFormat={f.SampleFormat}, interleaving={f.Interleaving}."); CalculateFramesPerPump(checked((int)f.SampleRate), EmulationPumpHz); Debug.WriteLine("Amber Bridge: Audio format 48000 Hz, 2 channels, signed PCM16, interleaved."); }
+    internal static int CalculateFramesPerPump(int sampleRate, int pumpRate)
+    {
+        if (sampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        if (pumpRate <= 0) throw new ArgumentOutOfRangeException(nameof(pumpRate));
+        if (sampleRate % pumpRate != 0)
+            throw new NotSupportedException($"Audio sample rate {sampleRate} Hz is not evenly divisible by the {pumpRate} Hz emulation pump.");
+        return sampleRate / pumpRate;
+    }
     private void ReleaseAssertedSwitches() { if (_bridge is not null) foreach (var index in _assertedSwitches) _bridge.SetSwitchState(index, false); _assertedSwitches.Clear(); while (_switchCommands.TryDequeue(out _)) { } }
     private void ClearOutputCaches() { _lastLamps = []; _lastReels = []; _lastAlpha = []; _lastSevenSegments = []; }
 


### PR DESCRIPTION
### Motivation
- The System 6 backend was requesting a hard-coded 96-frame capacity per 1 ms pump which produced ~2× the expected audio rate, buffer overflows, and audible distortion.
- The run loop used a fixed post-work `Task.Delay` which accumulated processing time into each 1 ms slice, introducing timing drift and jitter.
- Clearing the entire NAudio buffer on overflow created audible discontinuities and was too destructive for normal overflow conditions.

### Description
- Derive frames-per-pump from the negotiated audio format via `CalculateFramesPerPump(sampleRate, EmulationPumpHz)` and allocate the managed sample buffer from `framesPerPump * channelCount`, yielding `48` frames per pump for `48000 Hz / 1000 Hz`, `96` PCM16 samples, and `192` bytes per full fill; pass frames (not samples/bytes) to `FillAudioFrames`. 
- Submit only the samples actually written by the bridge by computing `writtenSamples = writtenFrames * channelCount` and pushing `MemoryMarshal.AsBytes(_audioSamples.AsSpan(0, writtenSamples))` to the audio sink, and expand the first-fill diagnostic to include `sampleRate`, `pumpRate`, `framesRequested`, `framesWritten`, `samplesWritten`, and `bytesSubmitted`.
- Replace the fixed post-work `Task.Delay(PumpInterval)` with a monotonic `Stopwatch` deadline loop that advances an accumulated `nextDeadline` by one pump interval (`pumpTicks`), delays only for remaining time, bounds catch-up after stalls, preserves cancellation/pause behavior, and avoids unbounded immediate catch-up.
- Change `NAudioEmulationAudioSink` overflow handling to drop an incoming block when it cannot safely fit rather than clearing existing buffered audio, keep `DiscardOnBufferOverflow = true`, add `DroppedBlocks`/`DroppedBytes` counters, and emit low-volume debug diagnostics on throttled intervals.
- Tests added and existing tests updated to assert correct frame accounting, partial-fill behavior, full-fill byte counts, integral sample-rate/pump-rate validation, bounded run-loop behaviour, and the incoming-block drop policy; modified/added files: `System6NativeBackend.cs`, `NAudioEmulationAudioSink.cs`, `System6NativeBackendTests.cs`, and `NAudioEmulationAudioSinkTests.cs`.

### Testing
- Added unit tests: `PumpRequestsFramesAndPushesOnlyWrittenStereoSamples`, `FullPumpFillPushesNinetySixSamplesAsOneHundredNinetyTwoBytes`, `FramesPerPumpRequiresAnIntegralRelationship`, `CancellationDoesNotCauseUnboundedCatchUp`, and `NAudioEmulationAudioSinkTests.ShouldDropIncomingBlock` which validate frame calculation, partial/full fill accounting, integral division rejection, bounded catch-up, and drop policy.
- Repository checks (`git diff --check`, status) were performed locally in this environment and passed, but automated `dotnet test` was not executed here because the workspace lacks the required Windows/.NET/WPF toolchain as documented in `AGENTS.md`.
- Windows runtime validation to run locally: execute the OasisEditor tests on Windows and verify sustained System 6 playback at 48 kHz shows `framesRequested=48`, up to `96` samples and `192` bytes per full fill, no doubled-rate distortion, and only occasional low-volume drop diagnostics under heavy load.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69126ab0408327ac9054d747f62c71)