### PR TITLE
Fix Fabric negotiated audio format handling

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -140,6 +140,55 @@ public sealed class FabricManagedBehaviorTests
         await backend.StopAsync(CancellationToken.None);
     }
 
+    [Theory]
+    [InlineData(44100, 2)]
+    [InlineData(48000, 2)]
+    [InlineData(32000, 1)]
+    public async Task Backend_AcceptsPositivePcm16FormatsAndPassesFormatToSink(uint sampleRate, ushort channels)
+    {
+        var session = new FakeSession { AudioFormat = new(sampleRate, channels, 16, true, true, true) };
+        var audio = new FakeAudioSink();
+        var backend = CreateBackend(session, audio);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.FirstAudioRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(new EmulationAudioFormat(checked((int)sampleRate), channels, 16), audio.StartedFormat);
+        Assert.Equal(Math.Max(1, checked((int)sampleRate / 500)), session.LastFrameCapacity);
+        Assert.Equal(0, session.LastSampleCapacity % channels);
+    }
+
+    [Theory]
+    [InlineData(48000, 2, 16, false, true, true)]
+    [InlineData(48000, 2, 16, true, false, true)]
+    [InlineData(48000, 2, 16, true, true, false)]
+    [InlineData(48000, 2, 8, true, true, true)]
+    [InlineData(0, 2, 16, true, true, true)]
+    [InlineData(48000, 0, 16, true, true, true)]
+    public async Task Backend_RejectsUnsupportedAudioFormats(
+        uint sampleRate, ushort channels, ushort bitsPerSample,
+        bool interleaved, bool signedSamples, bool littleEndian)
+    {
+        var session = new FakeSession
+        {
+            AudioFormat = new(sampleRate, channels, bitsPerSample, interleaved, signedSamples, littleEndian)
+        };
+        var audio = new FakeAudioSink();
+        var backend = CreateBackend(session, audio);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            backend.StartAsync(CreateRequest(), CancellationToken.None));
+
+        Assert.Null(audio.StartedFormat);
+    }
+
+    private static FabricEmulationBackend CreateBackend(FakeSession session, FakeAudioSink audio) =>
+        new("runtime", "amber", _ => new FakeRuntime(session), audio, new FakeClock());
+
+    private static EmulationLaunchRequest CreateRequest() =>
+        new(FruitMachinePlatformType.Impact, "machine", "", [], "", new System6NativeRomSettings());
+
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
@@ -159,8 +208,12 @@ public sealed class FabricManagedBehaviorTests
     {
         private int _activeCalls;
         public TaskCompletionSource FirstAdvance { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource FirstAudioRead { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource Disposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public Exception? AdvanceFailure { get; init; }
+        public FabricAudioFormat AudioFormat { get; init; } = new(48000, 2, 16, true, true, true);
+        public int LastFrameCapacity { get; private set; }
+        public int LastSampleCapacity { get; private set; }
         public int MaximumConcurrentCalls { get; private set; }
         public int ResetCount { get; private set; }
         public int ShutdownCount { get; private set; }
@@ -171,8 +224,18 @@ public sealed class FabricManagedBehaviorTests
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
         public void SubmitInput(FabricInput input) => Invoke(() => { });
         public FabricMachineSnapshot GetSnapshot() => Invoke(() => new FabricMachineSnapshot(1, [], [], [], []));
-        public FabricAudioFormat GetAudioFormat() => Invoke(() => new FabricAudioFormat(48000, 2, 16, true, true, true));
-        public int ReadAudio(Span<short> samples, int frameCapacity) => Invoke(() => 0);
+        public FabricAudioFormat GetAudioFormat() => Invoke(() => AudioFormat);
+        public int ReadAudio(Span<short> samples, int frameCapacity)
+        {
+            var sampleCapacity = samples.Length;
+            return Invoke(() =>
+            {
+                LastFrameCapacity = frameCapacity;
+                LastSampleCapacity = sampleCapacity;
+                FirstAudioRead.TrySetResult();
+                return 0;
+            });
+        }
         public void Shutdown() => Invoke(() => ShutdownCount++);
         public void Dispose() { DisposeCount++; Disposed.TrySetResult(); }
         private void Invoke(Action action) => Invoke(() => { action(); return true; });
@@ -189,7 +252,8 @@ public sealed class FabricManagedBehaviorTests
     {
         public int StartCount { get; private set; }
         public int StopCount { get; private set; }
-        public void Start(EmulationAudioFormat format) => StartCount++;
+        public EmulationAudioFormat? StartedFormat { get; private set; }
+        public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
         public void PushPcm(ReadOnlySpan<byte> pcmBytes) { }
         public void Stop() => StopCount++;
         public void Clear() { }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -278,12 +278,16 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (!session.Capabilities.Has(FabricCapability.Audio))
             return;
         var format = session.GetAudioFormat();
-        if (format is not { SampleRate: 48000, ChannelCount: 2, BitsPerSample: 16,
-            Interleaved: true, SignedSamples: true, LittleEndian: true })
+        if (format.SampleRate == 0 || format.ChannelCount == 0 || format is not
+            { BitsPerSample: 16, Interleaved: true, SignedSamples: true, LittleEndian: true })
             throw new NotSupportedException($"Unsupported Fabric audio format: {format}.");
         _audioFormat = format;
-        _audioBuffer = new short[96];
-        _audioSink.Start(new(48000, 2, 16));
+        var frameCapacity = Math.Max(1, checked((int)format.SampleRate / 500));
+        _audioBuffer = new short[checked(frameCapacity * (int)format.ChannelCount)];
+        _audioSink.Start(new(
+            checked((int)format.SampleRate),
+            checked((int)format.ChannelCount),
+            checked((int)format.BitsPerSample)));
         _audioStarted = true;
     }
 


### PR DESCRIPTION
### Motivation

- Fabric clients may report sample rates and channel counts other than 48 kHz stereo, causing a runtime `NotSupportedException` and preventing audio from working with the fake Amber runtime.
- The existing backend assumed exactly 48,000 Hz stereo PCM16 and started the sink with hard-coded values and a fixed buffer sized for 48 kHz, which is incorrect for negotiated formats.

### Description

- Relaxed Fabric audio validation in `FabricEmulationBackend.ConfigureAudio` to accept any positive `SampleRate` and `ChannelCount` while preserving checks that the audio is 16-bit PCM, interleaved, signed, and little-endian. (`ConfigureAudio` now rejects zero rates or channels but no longer requires 48000 Hz.)
- Start the audio sink with the negotiated format reported by Fabric using checked casts to the managed types: `SampleRate`, `ChannelCount`, and `BitsPerSample` are passed into the sink constructor instead of using hard-coded 48 kHz/2/16.
- Size the internal `_audioBuffer` based on a small frame capacity (~2 ms): `frameCapacity = Math.Max(1, checked((int)format.SampleRate / 500))`, and allocate `short[frameCapacity * ChannelCount]` so buffer capacity remains frame-aligned.
- Preserve existing validation for `Interleaved`, `SignedSamples`, `LittleEndian`, and `BitsPerSample == 16`.
- Added managed unit tests in `FabricManagedBehaviorTests` to cover acceptance of 44,100 Hz and 48,000 Hz stereo PCM16 and another positive rate, propagation of the negotiated format to the sink, frame-aligned buffer sizing, and rejection cases for non-interleaved, unsigned, big-endian, non-16-bit, zero-sample-rate, and zero-channel formats.
- Extended test doubles to expose negotiated `FabricAudioFormat`, record the frame/sample capacities observed during `ReadAudio`, and capture the `EmulationAudioFormat` passed to the audio sink.

### Testing

- Ran repository static checks with `git diff --check`, which reported no issues.
- Added comprehensive managed unit tests (new and updated `FabricManagedBehaviorTests`) but did not execute `dotnet test` in this environment because the repository's `AGENTS.md` states the execution environment lacks the required Windows/.NET/WPF toolchain and instructs agents not to run builds or tests here.
- Local validation to run after pulling these changes: run the Oasis Editor managed test suite (`dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests`) and verify the new audio-related tests pass and that the editor no longer throws for 44,100 Hz stereo PCM16 from the fake Amber runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6a5bcdce988327b96ff53430bcfa46)