### PR TITLE
Log full Fabric pump failures before cleanup

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -123,21 +123,104 @@ public sealed class FabricManagedBehaviorTests
     [Fact]
     public async Task Backend_PumpFailureIsRecordedAndCleanedUp()
     {
-        var session = new FakeSession { AdvanceFailure = new InvalidOperationException("advance failed") };
+        var failure = new FabricException(FabricResult.BackendError, "FabricSessionAdvance",
+            "production Amber adapter: Run returned an invalid result",
+            new InvalidOperationException("inner adapter failure"));
+        var session = new FakeSession { AdvanceFailure = failure };
         var runtime = new FakeRuntime(session);
-        var backend = new FabricEmulationBackend("runtime", "amber", _ => runtime, new FakeAudioSink(), new FakeClock());
+        var errors = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => runtime, new FakeAudioSink(), new FakeClock(), errors.Add);
         var request = new EmulationLaunchRequest(FruitMachinePlatformType.Impact, "machine", "", [], "", new System6NativeRomSettings());
 
         await backend.StartAsync(request, CancellationToken.None);
         await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await session.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForStateAsync(backend, EmulationBackendState.Failed);
 
-        Assert.IsType<InvalidOperationException>(backend.LastFailure);
+        Assert.Same(failure, backend.LastFailure);
+        var error = Assert.Single(errors);
+        Assert.Contains("Fabric emulation pump failed", error);
+        Assert.Contains("FabricSessionAdvance", error);
+        Assert.Contains("7 (BackendError)", error);
+        Assert.Contains("production Amber adapter", error);
+        Assert.Contains("inner adapter failure", error);
+        Assert.Contains(nameof(FabricException), error);
         Assert.Equal(EmulationBackendState.Failed, backend.State);
         Assert.Equal(1, session.ShutdownCount);
         Assert.Equal(1, session.DisposeCount);
         Assert.Equal(1, runtime.DisposeCount);
         await backend.StopAsync(CancellationToken.None);
+    }
+
+    [Theory]
+    [InlineData("snapshot")]
+    [InlineData("audio")]
+    public async Task Backend_PumpFailureLogIdentifiesSnapshotAndAudioOperations(string failingOperation)
+    {
+        var operation = failingOperation == "snapshot" ? "FabricSessionGetSnapshot" : "FabricSessionReadAudio";
+        var failure = new FabricException(FabricResult.InternalError, operation, "native last error");
+        var session = new FakeSession
+        {
+            SnapshotFailure = failingOperation == "snapshot" ? failure : null,
+            AudioFailure = failingOperation == "audio" ? failure : null
+        };
+        var errors = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
+            new FakeAudioSink(), new FakeClock(), errors.Add);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForStateAsync(backend, EmulationBackendState.Failed);
+
+        Assert.Same(failure, backend.LastFailure);
+        Assert.Contains(operation, Assert.Single(errors));
+        Assert.Equal(EmulationBackendState.Failed, backend.State);
+    }
+
+    [Fact]
+    public async Task Backend_CleanupFailureIsLoggedWithoutReplacingPumpFailure()
+    {
+        var pumpFailure = new InvalidOperationException("original pump failure");
+        var session = new FakeSession
+        {
+            AdvanceFailure = pumpFailure,
+            ShutdownFailure = new InvalidOperationException("cleanup shutdown failure"),
+            DisposeFailure = new InvalidOperationException("cleanup dispose failure")
+        };
+        var runtime = new FakeRuntime(session);
+        var errors = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => runtime,
+            new FakeAudioSink(), new FakeClock(), errors.Add);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitForStateAsync(backend, EmulationBackendState.Failed);
+
+        Assert.Same(pumpFailure, backend.LastFailure);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains("original pump failure", errors[0]);
+        Assert.Contains("cleanup after pump failure", errors[1]);
+        Assert.Contains("cleanup shutdown failure", errors[1]);
+        Assert.Contains("cleanup dispose failure", errors[1]);
+        Assert.Equal(1, runtime.DisposeCount);
+        Assert.Equal(EmulationBackendState.Failed, backend.State);
+    }
+
+    [Fact]
+    public async Task Backend_NormalStopCancellationDoesNotReportPumpFailure()
+    {
+        var session = new FakeSession();
+        var errors = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
+            new FakeAudioSink(), new FakeClock(), errors.Add);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Null(backend.LastFailure);
+        Assert.Empty(errors);
+        Assert.Equal(EmulationBackendState.Stopped, backend.State);
     }
 
     [Theory]
@@ -189,6 +272,14 @@ public sealed class FabricManagedBehaviorTests
     private static EmulationLaunchRequest CreateRequest() =>
         new(FruitMachinePlatformType.Impact, "machine", "", [], "", new System6NativeRomSettings());
 
+    private static async Task WaitForStateAsync(FabricEmulationBackend backend, EmulationBackendState state)
+    {
+        var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (backend.State != state && DateTime.UtcNow < timeout)
+            await Task.Delay(10);
+        Assert.Equal(state, backend.State);
+    }
+
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
@@ -211,6 +302,10 @@ public sealed class FabricManagedBehaviorTests
         public TaskCompletionSource FirstAudioRead { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource Disposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public Exception? AdvanceFailure { get; init; }
+        public Exception? SnapshotFailure { get; init; }
+        public Exception? AudioFailure { get; init; }
+        public Exception? ShutdownFailure { get; init; }
+        public Exception? DisposeFailure { get; init; }
         public FabricAudioFormat AudioFormat { get; init; } = new(48000, 2, 16, true, true, true);
         public int LastFrameCapacity { get; private set; }
         public int LastSampleCapacity { get; private set; }
@@ -223,7 +318,9 @@ public sealed class FabricManagedBehaviorTests
         public void Reset() => Invoke(() => ResetCount++);
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
         public void SubmitInput(FabricInput input) => Invoke(() => { });
-        public FabricMachineSnapshot GetSnapshot() => Invoke(() => new FabricMachineSnapshot(1, [], [], [], []));
+        public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
+            ? new FabricMachineSnapshot(1, [], [], [], [])
+            : throw SnapshotFailure);
         public FabricAudioFormat GetAudioFormat() => Invoke(() => AudioFormat);
         public int ReadAudio(Span<short> samples, int frameCapacity)
         {
@@ -233,11 +330,17 @@ public sealed class FabricManagedBehaviorTests
                 LastFrameCapacity = frameCapacity;
                 LastSampleCapacity = sampleCapacity;
                 FirstAudioRead.TrySetResult();
+                if (AudioFailure is not null) throw AudioFailure;
                 return 0;
             });
         }
-        public void Shutdown() => Invoke(() => ShutdownCount++);
-        public void Dispose() { DisposeCount++; Disposed.TrySetResult(); }
+        public void Shutdown() => Invoke(() => { ShutdownCount++; if (ShutdownFailure is not null) throw ShutdownFailure; });
+        public void Dispose()
+        {
+            DisposeCount++;
+            Disposed.TrySetResult();
+            if (DisposeFailure is not null) throw DisposeFailure;
+        }
         private void Invoke(Action action) => Invoke(() => { action(); return true; });
         private T Invoke<T>(Func<T> action)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -12,19 +12,22 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     private readonly Func<string, IAmberBridgeLibrary> _amberBridgeFactory;
     private readonly Func<int> _system6AudioBufferLengthMillisecondsProvider;
     private readonly Func<(bool Enabled,string? RuntimePath,string? AmberPath)> _fabricConfigurationProvider;
+    private readonly Action<string>? _fabricErrorLogger;
 
     public EmulationBackendFactory(
         Func<IEmulationBackend> mameBackendFactory,
         Func<string?> system6LibraryPathProvider,
         Func<int>? system6AudioBufferLengthMillisecondsProvider = null,
         Func<string, IAmberBridgeLibrary>? amberBridgeFactory = null,
-        Func<(bool Enabled,string? RuntimePath,string? AmberPath)>? fabricConfigurationProvider = null)
+        Func<(bool Enabled,string? RuntimePath,string? AmberPath)>? fabricConfigurationProvider = null,
+        Action<string>? fabricErrorLogger = null)
     {
         _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
         _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
         _system6AudioBufferLengthMillisecondsProvider = system6AudioBufferLengthMillisecondsProvider ?? (() => NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds);
         _amberBridgeFactory = amberBridgeFactory ?? (static path => new AmberBridgeLibrary(path));
         _fabricConfigurationProvider = fabricConfigurationProvider ?? (() => (false,null,null));
+        _fabricErrorLogger = fabricErrorLogger;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -45,7 +48,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         {
             if (string.IsNullOrWhiteSpace(fabric.RuntimePath) || string.IsNullOrWhiteSpace(fabric.AmberPath))
                 throw new InvalidOperationException("Fabric emulation is enabled, but both the Fabric runtime DLL path and Amber API v2 DLL path must be configured.");
-            return new FabricEmulationBackend(fabric.RuntimePath, fabric.AmberPath);
+            return new FabricEmulationBackend(fabric.RuntimePath, fabric.AmberPath, path => new FabricRuntimeLibrary(path),
+                new NAudioEmulationAudioSink(), new StopwatchFabricClock(), _fabricErrorLogger);
         }
         var libraryPath = _system6LibraryPathProvider();
         return string.IsNullOrWhiteSpace(libraryPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -38,7 +38,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
-            new NAudioEmulationAudioSink(), new StopwatchFabricClock(), Debug.WriteLine)
+            new NAudioEmulationAudioSink(), new StopwatchFabricClock(), WriteDebugError)
     {
     }
 
@@ -55,7 +55,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _runtimeFactory = runtimeFactory;
         _audioSink = audioSink;
         _clock = clock;
-        _errorLogger = errorLogger ?? Debug.WriteLine;
+        _errorLogger = errorLogger ?? WriteDebugError;
         _elapsedTime = new FabricElapsedTime(clock.Frequency);
     }
 
@@ -423,6 +423,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     private void LogException(string message, Exception exception) =>
         _errorLogger($"[Error] {message}{Environment.NewLine}{exception}");
+
+    private static void WriteDebugError(string message) => Debug.WriteLine(message);
 
     private void ReleaseAssertedInputs()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;
@@ -14,6 +15,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly Func<string, IFabricRuntimeLibrary> _runtimeFactory;
     private readonly IEmulationAudioSink _audioSink;
     private readonly IFabricClock _clock;
+    private readonly Action<string> _errorLogger;
     private readonly FabricElapsedTime _elapsedTime;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
@@ -36,7 +38,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
-            new NAudioEmulationAudioSink(), new StopwatchFabricClock())
+            new NAudioEmulationAudioSink(), new StopwatchFabricClock(), Debug.WriteLine)
     {
     }
 
@@ -45,13 +47,15 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         string amberPath,
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         IEmulationAudioSink audioSink,
-        IFabricClock clock)
+        IFabricClock clock,
+        Action<string>? errorLogger = null)
     {
         _runtimePath = runtimePath;
         _amberPath = amberPath;
         _runtimeFactory = runtimeFactory;
         _audioSink = audioSink;
         _clock = clock;
+        _errorLogger = errorLogger ?? Debug.WriteLine;
         _elapsedTime = new FabricElapsedTime(clock.Frequency);
     }
 
@@ -267,8 +271,16 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         catch (Exception exception)
         {
             LastFailure = exception;
+            LogException("Fabric emulation pump failed.", exception);
             _pumpCancellation?.Cancel();
-            await CleanupResourcesAsync().ConfigureAwait(false);
+            try
+            {
+                await CleanupResourcesAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupException)
+            {
+                LogException("Fabric cleanup after pump failure also failed.", cleanupException);
+            }
             SetState(EmulationBackendState.Failed);
         }
     }
@@ -367,25 +379,27 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private async Task CleanupResourcesAsync()
     {
         await _sessionGate.WaitAsync().ConfigureAwait(false);
+        List<Exception>? failures = null;
         try
         {
             if (_session is not null)
             {
-                try { ReleaseAssertedInputs(); } catch { }
+                TryCleanup(ReleaseAssertedInputs, ref failures);
                 if (!_shutdown)
                 {
-                    try { _session.Shutdown(); } catch { }
+                    TryCleanup(_session.Shutdown, ref failures);
                     _shutdown = true;
                 }
-                _session.Dispose();
+                TryCleanup(_session.Dispose, ref failures);
                 _session = null;
             }
             if (_audioStarted)
             {
-                _audioSink.Stop();
+                TryCleanup(_audioSink.Stop, ref failures);
                 _audioStarted = false;
             }
-            _runtime?.Dispose();
+            if (_runtime is not null)
+                TryCleanup(_runtime.Dispose, ref failures);
             _runtime = null;
             _audioFormat = null;
             _pumpCancellation?.Dispose();
@@ -397,7 +411,18 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             _sessionGate.Release();
         }
+        if (failures is { Count: > 0 })
+            throw failures.Count == 1 ? failures[0] : new AggregateException("Multiple Fabric cleanup operations failed.", failures);
     }
+
+    private static void TryCleanup(Action action, ref List<Exception>? failures)
+    {
+        try { action(); }
+        catch (Exception exception) { (failures ??= []).Add(exception); }
+    }
+
+    private void LogException(string message, Exception exception) =>
+        _errorLogger($"[Error] {message}{Environment.NewLine}{exception}");
 
     private void ReleaseAssertedInputs()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
@@ -31,6 +31,11 @@ public enum FabricResult { Ok, InvalidArgument, UnsupportedVersion, NotFound, In
 public sealed class FabricException : Exception
 {
     public FabricException(FabricResult result, string operation, string? detail = null, Exception? inner = null)
-        : base($"{operation} failed with Fabric result {(int)result} ({result}){(string.IsNullOrEmpty(detail) ? string.Empty : $": {detail}")}", inner) { Result = result; }
+        : base($"{operation} failed with Fabric result {(int)result} ({result}){(string.IsNullOrEmpty(detail) ? string.Empty : $":{Environment.NewLine}{detail}")}", inner)
+    {
+        Result = result;
+        Operation = operation;
+    }
     public FabricResult Result { get; }
+    public string Operation { get; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -385,7 +385,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 input => LoadedProject?.InputDefinitions.FirstOrDefault(definition => string.Equals(definition.Id, input.Id, StringComparison.OrdinalIgnoreCase))),
             () => System6NativeLibraryPath,
             () => System6AudioBufferLengthMilliseconds,
-            fabricConfigurationProvider: () => (UseFabricForAmber, FabricRuntimeLibraryPath, FabricAmberApiV2LibraryPath));
+            fabricConfigurationProvider: () => (UseFabricForAmber, FabricRuntimeLibraryPath, FabricAmberApiV2LibraryPath),
+            fabricErrorLogger: message => AddOutputEntry(message, OutputLogStatus.Error));
 
         _mameEmulationService.StateChanged += (_, state) =>
         {


### PR DESCRIPTION
### Motivation

- Improve diagnostics when the asynchronous Fabric pump throws after startup so the full exception (type, message, inner chain, stack) and Fabric-specific context are visible in the Editor Output before any native/managed cleanup destroys native error context.
- Preserve the original pump failure during best-effort cleanup and avoid emitting error logs for expected cancellation.

### Description

- At the top-level pump boundary in `FabricEmulationBackend.PumpAsync`, capture and store the exception to `LastFailure`, log the full exception text before cancelling and before cleanup, then perform best-effort cleanup and finally transition to `Failed` (preserving ordering: capture -> log -> cancel -> cleanup -> set state).
- Make cleanup best-effort by collecting exceptions from `ReleaseAssertedInputs`, session `Shutdown`/`Dispose`, audio stop, and runtime `Dispose` using `TryCleanup`, and log any cleanup exceptions separately without replacing the original pump exception.
- Route the Fabric error diagnostics into the existing Oasis Editor Output log by allowing an injected `Action<string>` error logger; wire it through `EmulationBackendFactory` and `MainWindowViewModel` so the UI `AddOutputEntry` receives pump/cleanup diagnostics when the Editor constructs the Fabric backend.
- Extend `FabricException` so the managed message includes the operation and native detail on separate lines and expose the operation via an `Operation` property so operation/result/native-error context is preserved in the thrown exception.
- Add and update managed tests in `FabricManagedBehaviorTests` to verify that pump failures for `Advance`, `GetSnapshot`, and `ReadAudio` are recorded, that inner/native details appear in the captured log, that cleanup failures are logged without replacing the original pump failure, that expected cancellation does not produce an error, and that only one top-level error entry is emitted for one pump failure.
- Files changed: `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs`, `WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs`, and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs`.

### Testing

- Ran `git diff --check` and committed the changes as the patch verification performed in this environment succeeded. 
- Added and updated unit tests in `FabricManagedBehaviorTests` covering: `FabricSessionAdvance`, `FabricSessionGetSnapshot`, `FabricSessionReadAudio`, inner exceptions, cleanup-failure preservation, expected cancellation, and single top-level error logging, but the managed test suite was not executed here because `WindowsNetProjects/OasisEditor/AGENTS.md` prohibits running the Windows/.NET/WPF toolchain in this environment.
- Full `dotnet test` and manual Editor Output verification with the native Fabric/Amber runtime must be run in a Windows development environment; instructions and the focused test cases are included in the modified `FabricManagedBehaviorTests` for local validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6a67fed63483279c59515b2b62f8f4)