### PR TITLE
Add direct and Fabric Amber behavioural comparison diagnostics

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/amber-backend-comparison.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-backend-comparison.md
@@ -1,0 +1,82 @@
+# Amber backend comparison diagnostics
+
+## Executable paths inspected
+
+The direct path is `System6NativeBackend` (`Emulation/Native/System6NativeBackend.cs`) through
+`IAmberBridgeLibrary` and `AmberBridgeLibrary` (`Emulation/Native/AmberBridge`). Its loop is a
+fixed 1 kHz loop: one 8,000-cycle `Run`, input drain, snapshot, then audio fill. It clamps a stall
+by discarding catch-up beyond three pump ticks.
+
+The Fabric path is `FabricEmulationBackend` (`Emulation/Fabric/FabricEmulationBackend.cs`) through
+`FabricRuntimeLibrary` and `FabricMachineSession`. Its loop supplies monotonic variable elapsed
+nanoseconds to one `Advance`, then drains input, requests a snapshot, and reads audio. The elapsed
+converter retains fractional nanoseconds and the loop has no Oasis-side catch-up cap.
+
+`EmulationBackendFactory` selects Fabric when `UseFabricForAmber` is true and both Fabric paths are
+configured. Otherwise Impact uses `System6NativeBackend` when AmberBridge.dll is configured, then
+falls back to MAME. `MainWindowViewModel` creates the factory, starts/stops it through
+`EmulationSessionController`, routes input through `PlayViewInputRouter`, and applies backend output
+events to `MachineRuntimeState`. ROMs and System 6 reel/coin/percentage settings originate in
+`System6NativeRomSettings`; `FabricAmberConfiguration.FromSystem6` performs Fabric request mapping.
+Audio is negotiated and read in each backend and submitted through `IEmulationAudioSink` /
+`NAudioEmulationAudioSink`. Each backend owns cancellation, asserted-input release, audio stop,
+native shutdown, and disposal.
+
+## Preference and transcript
+
+`NativeEmulation.EnableAmberBackendComparisonLogging` is persisted by the existing JSON preference
+store and is exposed under **Native Emulation** as **Enable Amber backend comparison logging**. It
+defaults to false and is sampled whenever a backend starts, so neither Visual Studio nor Oasis needs
+restarting. Disabled sessions allocate only a small inert session object and emit no pump events.
+
+Both transports use `AmberComparisonSession` and the single-line schema:
+
+```text
+[AmberCompare] session=... backend=direct|fabric sequence=... elapsed_ns=... thread=... operation=... arguments=... result=... summary=...
+```
+
+Every start has a fresh eight-character id and explicit `ComparisonStart` / `ComparisonEnd` markers.
+The start includes selection, platform, machine, process and safe DLL filenames. ROM events include
+role, slot, configured index, basename and presence, never bytes. Configuration events preserve raw
+values. Bounds reset per session: 20 `Advance`, 8 `GetSnapshot`, 16 `ReadAudio`, and 32 queued input
+events. Lifecycle and shutdown events are not bounded. Fabric correctly reports
+`native_return:unavailable` because the public ABI exposes no native Amber Run result.
+
+## Earliest source-level disparity and A/B procedure
+
+No proprietary game, ROM set, Amber DLL, Windows audio device, or Windows WPF runtime is available
+in the Codex environment, so paired behavioural transcripts cannot honestly be manufactured. The
+earliest observable source-level difference is execution cadence:
+
+```text
+direct: Advance elapsed_ns:1000000 time_source:fixed requested_cycles:8000 native_run_calls:1 maximum_catch_up:3 clamping:true
+fabric: Advance elapsed_ns:<measured> time_source:monotonic_variable advance_calls:1 native_return:unavailable catch_up:false clamping:false
+```
+
+An earlier lifecycle difference is also intentionally exposed: direct calls `Initialise`, explicit
+startup `Reset`, audio negotiation, then configuration; Oasis passes Fabric ROM/configuration in
+`CreateSession`, calls `Initialise`, and does not issue a speculative second startup reset. Whether
+the production adapter resets or reapplies configuration inside those calls is not observable from
+the public Fabric ABI. Changing cadence or adding a reset without paired evidence could hide the
+actual first defect, so this change deliberately instruments rather than guesses.
+
+For validation, enable the preference, run Direct Amber for at least 20 iterations / 8 snapshots /
+16 audio reads, stop, change the existing Fabric checkbox, and repeat without restarting. Align the
+two session blocks first at lifecycle, then ROM/configuration, then `Advance`, snapshot and audio.
+
+## Conditional native follow-up specification
+
+If matched Oasis request metadata followed by the first Fabric `Advance` remains static while the
+direct `Run(8000)` changes output or produces audio, add a bounded diagnostic callback to the
+production Amber adapter in `AmberOasisBridge`: emit, for the first 20 Fabric advances, elapsed ns,
+cycle budget, number of Amber `Run` calls, each requested cycle count, each signed returned cycle
+count, accumulated remainder, and clamp/discard decision. Also emit adapter call order for create,
+ROM-slot marshal, initialise, reset, reel/coin/percentage application, snapshot and audio read.
+
+Tests in that separate repository must prove: (1) 1 ms advances have cadence equivalent to one
+direct `Run(8000)` or document the production core's required contract; (2) delayed advances follow
+the chosen cap/remainder policy; (3) program and sound resources retain sparse slot identity; (4)
+configuration survives the adapter's reset order; (5) advancing yields changing snapshots and
+nonzero audio with a deterministic fake production Amber DLL. Acceptance requires paired transcripts
+to match through the first native Run, or to show the exact native call/return that diverges. No file
+under `johnparker007/AmberOasisBridge` is changed by this work.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AmberComparisonDiagnosticsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AmberComparisonDiagnosticsTests.cs
@@ -1,0 +1,97 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class AmberComparisonDiagnosticsTests
+{
+    [Fact]
+    public void Preference_DefaultsToDisabled() =>
+        Assert.False(new EditorPreferences().NativeEmulation.EnableAmberBackendComparisonLogging);
+
+    [Fact]
+    public void DisabledSession_IsSilent()
+    {
+        var lines = new List<string>();
+        var session = new AmberComparisonSession(false, "direct", lines.Add, () => "test");
+        session.Write("Advance");
+        Assert.Empty(lines);
+    }
+
+    [Theory]
+    [InlineData("direct")]
+    [InlineData("fabric")]
+    public void BothBackends_UseSharedSchema(string backend)
+    {
+        var lines = new List<string>();
+        var session = new AmberComparisonSession(true, backend, lines.Add, () => "abcd1234");
+        session.Write("ComparisonStart", "selected_backend:test");
+        Assert.Contains("[AmberCompare] session=abcd1234", lines[0]);
+        Assert.Contains($"backend={backend}", lines[0]);
+        Assert.Contains("sequence=1", lines[0]);
+        Assert.Contains("elapsed_ns=", lines[0]);
+        Assert.Contains("thread=", lines[0]);
+        Assert.Contains("operation=ComparisonStart", lines[0]);
+        Assert.Contains("arguments=selected_backend:test", lines[0]);
+        Assert.Contains("result=success", lines[0]);
+        Assert.Contains("summary=none", lines[0]);
+    }
+
+    [Fact]
+    public void Sessions_HaveUniqueIdentifiers()
+    {
+        var first = new AmberComparisonSession(true, "direct", _ => { });
+        var second = new AmberComparisonSession(true, "direct", _ => { });
+        Assert.NotEqual(first.SessionId, second.SessionId);
+    }
+
+    [Fact]
+    public void HighFrequencyEvents_AreBoundedAndCountersArePerSession()
+    {
+        var firstLines = new List<string>();
+        var first = new AmberComparisonSession(true, "direct", firstLines.Add, () => "first");
+        for (var i = 0; i < 25; i++) first.WriteBounded("advance", 20, "Advance", $"elapsed_ns:{i}");
+        Assert.Equal(20, firstLines.Count);
+
+        var secondLines = new List<string>();
+        new AmberComparisonSession(true, "fabric", secondLines.Add, () => "second")
+            .WriteBounded("advance", 20, "Advance", "elapsed_ns:1");
+        Assert.Single(secondLines);
+    }
+
+    [Fact]
+    public void RomSummary_PreservesSparseSlotMetadataWithoutContents()
+    {
+        var summary = AmberComparisonSession.RomSummary("program", ["c:/roms/even.bin", "", "c:/roms/odd.bin"]);
+        Assert.Contains("slot:0|configured_index:0|filename:even.bin|present:true", summary);
+        Assert.Contains("slot:1|configured_index:1|filename:absent|present:false", summary);
+        Assert.Contains("slot:2|configured_index:2|filename:odd.bin|present:true", summary);
+        Assert.DoesNotContain("c:/roms", summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DiagnosticSinkFailures_DoNotEscape()
+    {
+        var session = new AmberComparisonSession(true, "direct", _ => throw new InvalidOperationException());
+        session.Write("Advance");
+    }
+
+    [Fact]
+    public void SnapshotTracking_DetectsChangesAndCountsStaticRuns()
+    {
+        var session = new AmberComparisonSession(true, "direct", _ => { });
+        Assert.Equal("snapshot_changed:yes|consecutive_static:0", session.TrackSnapshot("one"));
+        Assert.Equal("snapshot_changed:no|consecutive_static:1", session.TrackSnapshot("one"));
+        Assert.Equal("snapshot_changed:no|consecutive_static:2", session.TrackSnapshot("one"));
+        Assert.Equal("snapshot_changed:yes|consecutive_static:0", session.TrackSnapshot("two"));
+    }
+
+    [Fact]
+    public async Task Writes_AreThreadSafeAndSequenced()
+    {
+        var lines = new List<string>();
+        var session = new AmberComparisonSession(true, "fabric", lines.Add, () => "threaded");
+        await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => session.Write("SubmitInput"))));
+        Assert.Equal(32, lines.Count);
+        Assert.Equal(32, lines.Select(line => line.Split("sequence=")[1].Split(' ')[0]).Distinct().Count());
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EditorPreferencesSerializationTests.cs
@@ -6,6 +6,17 @@ namespace OasisEditor.Tests;
 public sealed class EditorPreferencesSerializationTests
 {
     [Fact]
+    public void AmberComparisonLogging_DefaultsFalseAndRoundTrips()
+    {
+        Assert.False(new EditorPreferences().NativeEmulation.EnableAmberBackendComparisonLogging);
+        var json = JsonSerializer.Serialize(new EditorPreferences
+        {
+            NativeEmulation = new NativeEmulationPreferences { EnableAmberBackendComparisonLogging = true }
+        });
+        Assert.True(JsonSerializer.Deserialize<EditorPreferences>(json)!.NativeEmulation.EnableAmberBackendComparisonLogging);
+    }
+
+    [Fact]
     public void MamePreferences_Defaults_AutoUpdateToTrue()
     {
         var preferences = new EditorPreferences();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -47,6 +47,7 @@ public sealed class NativeEmulationPreferences
     public bool UseFabricForAmber { get; init; }
     public string FabricRuntimeLibraryPath { get; init; } = string.Empty;
     public string FabricAmberApiV2LibraryPath { get; init; } = string.Empty;
+    public bool EnableAmberBackendComparisonLogging { get; init; }
     public int AudioBufferLengthMilliseconds { get; init; } = DefaultAudioBufferLengthMilliseconds;
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/AmberComparisonDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/AmberComparisonDiagnostics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 
 namespace OasisEditor;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/AmberComparisonDiagnostics.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/AmberComparisonDiagnostics.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace OasisEditor;
+
+/// <summary>Bounded, best-effort diagnostics shared by both Amber transports.</summary>
+internal sealed class AmberComparisonSession
+{
+    internal const int AdvanceLimit = 20;
+    internal const int SnapshotLimit = 8;
+    internal const int AudioLimit = 16;
+    internal const int InputLimit = 32;
+
+    private readonly Action<string>? _sink;
+    private readonly string _backend;
+    private readonly string _id;
+    private readonly long _started = Stopwatch.GetTimestamp();
+    private readonly object _gate = new();
+    private long _sequence;
+    private readonly Dictionary<string, int> _boundedCounts = [];
+    private string? _previousSnapshot;
+    private int _staticSnapshots;
+
+    internal AmberComparisonSession(bool enabled, string backend, Action<string>? sink,
+        Func<string>? idFactory = null)
+    {
+        _sink = enabled ? sink : null;
+        _backend = backend;
+        _id = (idFactory?.Invoke() ?? Guid.NewGuid().ToString("N")[..8]);
+    }
+
+    internal bool Enabled => _sink is not null;
+    internal string SessionId => _id;
+
+    internal void Write(string operation, string arguments = "", string result = "success", string summary = "")
+    {
+        if (_sink is null) return;
+        try
+        {
+            lock (_gate)
+            {
+                var sequence = ++_sequence;
+                var elapsed = (Stopwatch.GetTimestamp() - _started) * 1_000_000_000L / Stopwatch.Frequency;
+                _sink($"[AmberCompare] session={_id} backend={_backend} sequence={sequence} elapsed_ns={elapsed} thread={Environment.CurrentManagedThreadId} operation={Safe(operation)} arguments={Safe(arguments)} result={Safe(result)} summary={Safe(summary)}");
+            }
+        }
+        catch
+        {
+            // Diagnostics must never alter emulation behaviour.
+        }
+    }
+
+    internal void WriteBounded(string category, int limit, string operation, string arguments = "", string result = "success", string summary = "")
+    {
+        if (_sink is null) return;
+        lock (_gate)
+        {
+            _boundedCounts.TryGetValue(category, out var count);
+            if (count >= limit) return;
+            _boundedCounts[category] = count + 1;
+        }
+        Write(operation, arguments, result, summary);
+    }
+
+    internal static string RomSummary(string role, IReadOnlyList<string> paths) =>
+        string.Join(",", paths.Select((path, slot) =>
+            $"role:{role}|slot:{slot}|configured_index:{slot}|filename:{SafeFileName(path)}|present:{(!string.IsNullOrWhiteSpace(path)).ToString().ToLowerInvariant()}"));
+
+    internal string TrackSnapshot(string fingerprint)
+    {
+        lock (_gate)
+        {
+            var changed = _previousSnapshot is null || !string.Equals(_previousSnapshot, fingerprint, StringComparison.Ordinal);
+            _staticSnapshots = changed ? 0 : _staticSnapshots + 1;
+            _previousSnapshot = fingerprint;
+            return $"snapshot_changed:{(changed ? "yes" : "no")}|consecutive_static:{_staticSnapshots}";
+        }
+    }
+
+    internal static string SafeFileName(string? path) => string.IsNullOrWhiteSpace(path) ? "absent" : Safe(Path.GetFileName(path));
+    internal static string Number(long value) => value.ToString(CultureInfo.InvariantCulture);
+    private static string Safe(string? value) => string.IsNullOrEmpty(value) ? "none" : value.Replace('\r', ' ').Replace('\n', ' ').Replace(' ', '_');
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -13,6 +13,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     private readonly Func<int> _system6AudioBufferLengthMillisecondsProvider;
     private readonly Func<(bool Enabled,string? RuntimePath,string? AmberPath)> _fabricConfigurationProvider;
     private readonly Action<string>? _fabricErrorLogger;
+    private readonly Func<bool> _amberComparisonEnabledProvider;
+    private readonly Action<string>? _amberComparisonLogger;
 
     public EmulationBackendFactory(
         Func<IEmulationBackend> mameBackendFactory,
@@ -20,7 +22,9 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         Func<int>? system6AudioBufferLengthMillisecondsProvider = null,
         Func<string, IAmberBridgeLibrary>? amberBridgeFactory = null,
         Func<(bool Enabled,string? RuntimePath,string? AmberPath)>? fabricConfigurationProvider = null,
-        Action<string>? fabricErrorLogger = null)
+        Action<string>? fabricErrorLogger = null,
+        Func<bool>? amberComparisonEnabledProvider = null,
+        Action<string>? amberComparisonLogger = null)
     {
         _mameBackendFactory = mameBackendFactory ?? throw new ArgumentNullException(nameof(mameBackendFactory));
         _system6LibraryPathProvider = system6LibraryPathProvider ?? throw new ArgumentNullException(nameof(system6LibraryPathProvider));
@@ -28,6 +32,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         _amberBridgeFactory = amberBridgeFactory ?? (static path => new AmberBridgeLibrary(path));
         _fabricConfigurationProvider = fabricConfigurationProvider ?? (() => (false,null,null));
         _fabricErrorLogger = fabricErrorLogger;
+        _amberComparisonEnabledProvider = amberComparisonEnabledProvider ?? (() => false);
+        _amberComparisonLogger = amberComparisonLogger;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -49,12 +55,14 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             if (string.IsNullOrWhiteSpace(fabric.RuntimePath) || string.IsNullOrWhiteSpace(fabric.AmberPath))
                 throw new InvalidOperationException("Fabric emulation is enabled, but both the Fabric runtime DLL path and Amber API v2 DLL path must be configured.");
             return new FabricEmulationBackend(fabric.RuntimePath, fabric.AmberPath, path => new FabricRuntimeLibrary(path),
-                new NAudioEmulationAudioSink(), new StopwatchFabricClock(), _fabricErrorLogger);
+                new NAudioEmulationAudioSink(), new StopwatchFabricClock(), _fabricErrorLogger,
+                _amberComparisonEnabledProvider, _amberComparisonLogger);
         }
         var libraryPath = _system6LibraryPathProvider();
         return string.IsNullOrWhiteSpace(libraryPath)
             ? _mameBackendFactory()
-            : new System6NativeBackend(libraryPath, _amberBridgeFactory, new NAudioEmulationAudioSink(_system6AudioBufferLengthMillisecondsProvider()));
+            : new System6NativeBackend(libraryPath, _amberBridgeFactory, new NAudioEmulationAudioSink(_system6AudioBufferLengthMillisecondsProvider()),
+                _amberComparisonEnabledProvider, _amberComparisonLogger);
     }
 
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -17,6 +17,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly IFabricClock _clock;
     private readonly Action<string> _errorLogger;
     private readonly FabricElapsedTime _elapsedTime;
+    private readonly Func<bool> _comparisonEnabled;
+    private readonly Action<string>? _comparisonSink;
+    private AmberComparisonSession? _comparison;
+    private long _pumpIteration;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
     private readonly HashSet<int> _assertedInputs = [];
@@ -48,7 +52,9 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         IEmulationAudioSink audioSink,
         IFabricClock clock,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Func<bool>? comparisonEnabled = null,
+        Action<string>? comparisonSink = null)
     {
         _runtimePath = runtimePath;
         _amberPath = amberPath;
@@ -57,6 +63,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _clock = clock;
         _errorLogger = errorLogger ?? WriteDebugError;
         _elapsedTime = new FabricElapsedTime(clock.Frequency);
+        _comparisonEnabled = comparisonEnabled ?? (() => false);
+        _comparisonSink = comparisonSink;
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
@@ -80,21 +88,33 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             throw new InvalidOperationException($"Fabric backend cannot start while it is {State}.");
 
         SetState(EmulationBackendState.Starting);
+        var comparison = new AmberComparisonSession(_comparisonEnabled(), "fabric", _comparisonSink);
+        _comparison = comparison.Enabled ? comparison : null;
+        _pumpIteration = 0;
+        _comparison?.Write("ComparisonStart", $"selected_backend:Fabric_Amber|platform:{request.Platform}|machine:{request.MachineName}|process_id:{Environment.ProcessId}|fabric_runtime:{AmberComparisonSession.SafeFileName(_runtimePath)}|amber_dll:{AmberComparisonSession.SafeFileName(_amberPath)}");
+        _comparison?.Write("BackendCreate");
         try
         {
             var settings = request.System6NativeRoms
                 ?? throw new InvalidOperationException("Fabric System 6 requires native ROM settings.");
             var resources = BuildRomResources(settings);
+            _comparison?.Write("LoadProgramRoms", AmberComparisonSession.RomSummary("program", settings.ProgramRomPaths));
+            _comparison?.Write("LoadSoundRoms", AmberComparisonSession.RomSummary("sound", settings.SoundRomPaths));
+            WriteConfiguration(settings);
             cancellationToken.ThrowIfCancellationRequested();
             _runtime = _runtimeFactory(_runtimePath);
+            _comparison?.Write("LibraryLoad", $"filename:{AmberComparisonSession.SafeFileName(_runtimePath)}");
+            _comparison?.Write("RuntimeCreate");
             _session = _runtime.CreateSession(new FabricLaunchRequest(
                 "amber-api-v2", "jpm-system6", _amberPath, resources,
                 FabricAmberConfiguration.FromSystem6(settings)));
+            _comparison?.Write("SessionCreate");
 
             await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 _session.Initialise();
+                _comparison?.Write("Initialise");
                 ConfigureAudio(_session);
                 _elapsedTime.Reset(_clock.GetTimestamp());
             }
@@ -109,8 +129,9 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _pumpTask = Task.Run(() => PumpAsync(_pumpCancellation.Token), CancellationToken.None);
             SetState(EmulationBackendState.Running);
         }
-        catch
+        catch (Exception exception)
         {
+            _comparison?.Write("Failure", result: "failure", summary: exception.GetType().Name);
             await CleanupResourcesAsync().ConfigureAwait(false);
             SetState(EmulationBackendState.Failed);
             throw;
@@ -126,6 +147,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
         if (_pumpCancellation is not null)
             await _pumpCancellation.CancelAsync().ConfigureAwait(false);
+        _comparison?.Write("Cancellation", "expected:true|operation:pump");
         if (_pumpTask is not null && Task.CurrentId != _pumpTask.Id)
         {
             try
@@ -143,6 +165,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
         await CleanupResourcesAsync().ConfigureAwait(false);
         SetState(EmulationBackendState.Stopped);
+        _comparison?.Write("ComparisonEnd");
+        _comparison = null;
     }
 
     public Task PauseAsync(CancellationToken cancellationToken)
@@ -197,6 +221,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (!int.TryParse(inputDefinition.ButtonNumber, out var index))
             throw new InvalidOperationException($"Input '{inputDefinition.Id}' has no numeric switch mapping.");
         _inputCommands.Enqueue(new(index, isPressed));
+        _comparison?.WriteBounded("input", AmberComparisonSession.InputLimit, "SubmitInput", $"oasis_id:{inputDefinition.Id}|switch_index:{index}|active:{isPressed.ToString().ToLowerInvariant()}|duplicate_suppression:false|shutdown_release:false", "queued");
         return Task.CompletedTask;
     }
 
@@ -253,7 +278,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 try
                 {
                     var session = RequireSession();
-                    session.Advance(_elapsedTime.AdvanceTo(_clock.GetTimestamp()));
+                    var iteration = ++_pumpIteration;
+                    var elapsed = _elapsedTime.AdvanceTo(_clock.GetTimestamp());
+                    var started = Stopwatch.GetTimestamp();
+                    session.Advance(elapsed);
+                    var durationNs = (Stopwatch.GetTimestamp() - started) * 1_000_000_000L / Stopwatch.Frequency;
+                    _comparison?.WriteBounded("advance", AmberComparisonSession.AdvanceLimit, "Advance", $"iteration:{iteration}|elapsed_ns:{elapsed}|time_source:monotonic_variable|advance_calls:1|native_return:unavailable|catch_up:false|clamping:false|duration_ns:{durationNs}");
                     ProcessInputs(session);
                     PublishSnapshot(session.GetSnapshot());
                     ReadAudio(session);
@@ -290,6 +320,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (!session.Capabilities.Has(FabricCapability.Audio))
             return;
         var format = session.GetAudioFormat();
+        _comparison?.Write("GetAudioFormat", $"sample_rate:{format.SampleRate}|channels:{format.ChannelCount}|bits_per_sample:{format.BitsPerSample}|encoding:pcm_signed|interleaving:{format.Interleaved}");
         if (format.SampleRate == 0 || format.ChannelCount == 0 || format is not
             { BitsPerSample: 16, Interleaved: true, SignedSamples: true, LittleEndian: true })
             throw new NotSupportedException($"Unsupported Fabric audio format: {format}.");
@@ -301,6 +332,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             checked((int)format.ChannelCount),
             checked((int)format.BitsPerSample)));
         _audioStarted = true;
+        _comparison?.Write("AudioSink", "state:started");
     }
 
     private void ProcessInputs(IFabricMachineSession session)
@@ -325,10 +357,26 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
         if (!bytes.IsEmpty)
             _audioSink.PushPcm(bytes);
+        if (_comparison is not null)
+        {
+            var samples = _audioBuffer.AsSpan(0, sampleCount);
+            var nonzero = 0; var peak = 0;
+            foreach (var sample in samples) { if (sample != 0) nonzero++; peak = Math.Max(peak, Math.Abs((int)sample)); }
+            _comparison.WriteBounded("audio", AmberComparisonSession.AudioLimit, "ReadAudio", $"requested_frames:{frameCapacity}|returned_frames:{framesWritten}|nonzero_samples:{nonzero}|peak_absolute_sample:{peak}|submitted_frames:{framesWritten}");
+        }
     }
 
     private void PublishSnapshot(FabricMachineSnapshot snapshot)
     {
+        if (_comparison?.Enabled == true)
+        {
+            var fingerprint = string.Join(',', snapshot.Lamps.Select(x => $"{x.NumericalIndex}:{x.LogicalState}:{x.Brightness}")) + ";" +
+                string.Join(',', snapshot.Reels.Select(x => $"{x.NumericalIndex}:{x.Position}")) + ";" +
+                string.Join(',', snapshot.CharacterDisplays.SelectMany(x => x.Characters)) + ";" +
+                string.Join(',', snapshot.SegmentDisplays.SelectMany(x => x.SegmentMasks));
+            var change = _comparison.TrackSnapshot(fingerprint);
+            _comparison.WriteBounded("snapshot", AmberComparisonSession.SnapshotLimit, "GetSnapshot", $"sequence:{snapshot.Sequence}|lamp_count:{snapshot.Lamps.Count}|reel_count:{snapshot.Reels.Count}|reel_positions:{string.Join(',', snapshot.Reels.Select(x => x.Position))}|character_display_count:{snapshot.CharacterDisplays.Count}|segment_display_count:{snapshot.SegmentDisplays.Count}|{change}");
+        }
         foreach (var lamp in snapshot.Lamps)
         {
             var value = (lamp.LogicalState, lamp.Brightness);
@@ -376,6 +424,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
+    private void WriteConfiguration(System6NativeRomSettings settings)
+    {
+        _comparison?.Write("ConfigureReels", string.Join(",", settings.ReelOptos.Select(r => $"index:{r.ReelIndex}|enabled:{r.Enabled}|steps:{r.Steps}|opto_start:{r.OptoStart}|opto_end:{r.OptoEnd}|opto_invert:{r.OptoInvert}|apply:true")));
+        _comparison?.Write("ConfigureCoins", string.Join(",", settings.Coins.Select(c => $"index:{c.Num}|enabled:{c.Enabled}|value:{c.CoinValue}|lockout_invert:{c.LockoutInvert}|port_index:{c.PortIndex}|coin_code:{c.Coin}|level:{c.Level}|full_level:{c.FullLevel}")));
+        _comparison?.Write("ConfigurePercentage", $"raw_value:{settings.PercentSwitchValue}");
+    }
+
     private async Task CleanupResourcesAsync()
     {
         await _sessionGate.WaitAsync().ConfigureAwait(false);
@@ -384,22 +439,30 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             if (_session is not null)
             {
+                var releasedCount = _assertedInputs.Count;
                 TryCleanup(ReleaseAssertedInputs, ref failures);
+                _comparison?.Write("SubmitInput", "shutdown_release:true", "success", $"released_count:{releasedCount}");
                 if (!_shutdown)
                 {
                     TryCleanup(_session.Shutdown, ref failures);
+                    _comparison?.Write("Shutdown");
                     _shutdown = true;
                 }
                 TryCleanup(_session.Dispose, ref failures);
+                _comparison?.Write("Destroy", "resource:session");
                 _session = null;
             }
             if (_audioStarted)
             {
                 TryCleanup(_audioSink.Stop, ref failures);
+                _comparison?.Write("AudioSink", "state:stopped");
                 _audioStarted = false;
             }
             if (_runtime is not null)
+            {
                 TryCleanup(_runtime.Dispose, ref failures);
+                _comparison?.Write("Destroy", "resource:runtime");
+            }
             _runtime = null;
             _audioFormat = null;
             _pumpCancellation?.Dispose();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -16,6 +16,10 @@ public sealed class System6NativeBackend : IEmulationBackend
     private readonly string _bridgePath;
     private readonly Func<string, IAmberBridgeLibrary> _bridgeFactory;
     private readonly IEmulationAudioSink _audioSink;
+    private readonly Func<bool> _comparisonEnabled;
+    private readonly Action<string>? _comparisonSink;
+    private AmberComparisonSession? _comparison;
+    private long _pumpIteration;
     private readonly AmberOutputSnapshotBuffer _snapshot = new();
     private readonly ConcurrentQueue<(uint Index, bool IsOn)> _switchCommands = new();
     private readonly HashSet<uint> _assertedSwitches = [];
@@ -40,13 +44,16 @@ public sealed class System6NativeBackend : IEmulationBackend
     public System6NativeBackend(string bridgePath)
         : this(bridgePath, static path => new AmberBridgeLibrary(path), new NAudioEmulationAudioSink()) { }
 
-    internal System6NativeBackend(string bridgePath, Func<string, IAmberBridgeLibrary> bridgeFactory, IEmulationAudioSink? audioSink = null)
+    internal System6NativeBackend(string bridgePath, Func<string, IAmberBridgeLibrary> bridgeFactory, IEmulationAudioSink? audioSink = null,
+        Func<bool>? comparisonEnabled = null, Action<string>? comparisonSink = null)
     {
         if (string.IsNullOrWhiteSpace(bridgePath))
             throw new ArgumentException("Amber Bridge DLL path must not be empty.", nameof(bridgePath));
         _bridgePath = bridgePath;
         _bridgeFactory = bridgeFactory ?? throw new ArgumentNullException(nameof(bridgeFactory));
         _audioSink = audioSink ?? new NullAudioSink();
+        _comparisonEnabled = comparisonEnabled ?? (() => false);
+        _comparisonSink = comparisonSink;
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
@@ -70,6 +77,11 @@ public sealed class System6NativeBackend : IEmulationBackend
             throw new InvalidOperationException($"System6 native backend cannot start while it is {State}.");
 
         SetState(EmulationBackendState.Starting);
+        var comparison = new AmberComparisonSession(_comparisonEnabled(), "direct", _comparisonSink);
+        _comparison = comparison.Enabled ? comparison : null;
+        _pumpIteration = 0;
+        _comparison?.Write("ComparisonStart", $"selected_backend:Direct_Amber|platform:{request.Platform}|machine:{request.MachineName}|process_id:{Environment.ProcessId}|amber_dll:{AmberComparisonSession.SafeFileName(_bridgePath)}");
+        _comparison?.Write("BackendCreate");
         try
         {
             if (!Path.IsPathFullyQualified(_bridgePath))
@@ -84,19 +96,27 @@ public sealed class System6NativeBackend : IEmulationBackend
             var programs = ValidateRomPaths(roms.ProgramRomPaths, requireTwoProgramRoms: true, "program");
             var sounds = ValidateRomPaths(roms.SoundRomPaths, requireTwoProgramRoms: false, "sound");
 
+            _comparison?.Write("LoadProgramRoms", AmberComparisonSession.RomSummary("program", roms.ProgramRomPaths));
+            _comparison?.Write("LoadSoundRoms", AmberComparisonSession.RomSummary("sound", roms.SoundRomPaths));
+
             _bridge = _bridgeFactory(_bridgePath);
+            _comparison?.Write("LibraryLoad", $"filename:{AmberComparisonSession.SafeFileName(_bridgePath)}");
             _amberCapabilities = _bridge.GetCapabilities();
             ValidateRequiredCapabilities(_amberCapabilities);
             Debug.WriteLine($"Amber Bridge: Capabilities read; mask 0x{_amberCapabilities.RawFeatureBits:X16}; maximum switches {_amberCapabilities.MaximumSwitches}.");
             _bridge.Initialise(programs, sounds);
+            _comparison?.Write("Initialise");
             _bridge.Reset(); // Preserve the direct backend's post-ROM-load startup reset.
+            _comparison?.Write("Reset", "startup:true");
             var audioFormat = _bridge.GetAudioFormat();
+            _comparison?.Write("GetAudioFormat", $"sample_rate:{audioFormat.SampleRate}|channels:{audioFormat.Channels}|bits_per_sample:16|encoding:pcm_signed|interleaving:{audioFormat.Interleaving}");
             ValidateAudioFormat(audioFormat);
             _audioSampleRate = checked((int)audioFormat.SampleRate);
             _audioChannelCount = checked((int)audioFormat.Channels);
             _audioFramesPerPump = CalculateFramesPerPump(_audioSampleRate, EmulationPumpHz);
             _audioSamples = new short[checked(_audioFramesPerPump * _audioChannelCount)];
             _audioSink.Start(new((int)audioFormat.SampleRate, (int)audioFormat.Channels, 16));
+            _comparison?.Write("AudioSink", "state:started");
             ApplyProjectConfiguration(roms);
             _shutdown = false;
             var details = _bridge.BridgeDetails;
@@ -109,8 +129,9 @@ public sealed class System6NativeBackend : IEmulationBackend
             SetState(EmulationBackendState.Running);
             return Task.CompletedTask;
         }
-        catch
+        catch (Exception exception)
         {
+            _comparison?.Write("Failure", result: "failure", summary: exception.GetType().Name);
             DisposeBridgeAfterFailure();
             SetState(EmulationBackendState.Failed);
             throw;
@@ -122,6 +143,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         if (_disposed || State == EmulationBackendState.Stopped) return;
         SetState(EmulationBackendState.Stopping);
         if (_runCancellation is not null) await _runCancellation.CancelAsync().ConfigureAwait(false);
+        _comparison?.Write("Cancellation", "expected:true|operation:pump");
         if (_runTask is not null)
         {
             try { await _runTask.WaitAsync(cancellationToken).ConfigureAwait(false); }
@@ -131,14 +153,19 @@ public sealed class System6NativeBackend : IEmulationBackend
         try { ShutdownBridgeOnce(); }
         finally
         {
+            _comparison?.Write("Shutdown");
             _audioSink.Stop();
+            _comparison?.Write("AudioSink", "state:stopped");
             _bridge?.Dispose();
+            _comparison?.Write("Destroy");
             _bridge = null;
         }
         _runCancellation?.Dispose();
         _runCancellation = null;
         _runTask = null;
         SetState(EmulationBackendState.Stopped);
+        _comparison?.Write("ComparisonEnd");
+        _comparison = null;
     }
 
     public Task PauseAsync(CancellationToken cancellationToken)
@@ -181,6 +208,7 @@ public sealed class System6NativeBackend : IEmulationBackend
         if (_amberCapabilities is null || switchIndex >= _amberCapabilities.MaximumSwitches)
             throw new ArgumentOutOfRangeException(nameof(inputDefinition), $"Switch {switchIndex} exceeds the bridge capability limit.");
         _switchCommands.Enqueue((switchIndex, isPressed));
+        _comparison?.WriteBounded("input", AmberComparisonSession.InputLimit, "SubmitInput", $"oasis_id:{inputDefinition.Id}|switch_index:{switchIndex}|active:{isPressed.ToString().ToLowerInvariant()}|duplicate_suppression:false|shutdown_release:false", "queued");
         return Task.CompletedTask;
     }
 
@@ -215,7 +243,11 @@ public sealed class System6NativeBackend : IEmulationBackend
                     nextDeadline = Stopwatch.GetTimestamp();
                     continue;
                 }
-                RunCycles(System6ClockHz / EmulationPumpHz);
+                var iteration = ++_pumpIteration;
+                var advanceStarted = Stopwatch.GetTimestamp();
+                var cyclesRun = RunCycles(System6ClockHz / EmulationPumpHz);
+                var durationNs = (Stopwatch.GetTimestamp() - advanceStarted) * 1_000_000_000L / Stopwatch.Frequency;
+                _comparison?.WriteBounded("advance", AmberComparisonSession.AdvanceLimit, "Advance", $"iteration:{iteration}|elapsed_ns:1000000|time_source:fixed|requested_cycles:8000|native_run_calls:1|native_return:{cyclesRun}|maximum_catch_up:3|clamping:true|accumulated_remainder:false|duration_ns:{durationNs}");
                 ProcessSwitchCommands();
                 PollOutputsAndAudio();
 
@@ -259,12 +291,27 @@ public sealed class System6NativeBackend : IEmulationBackend
     {
         var bridge = RequireActiveBridge();
         bridge.GetOutputSnapshot(_snapshot);
+        if (_comparison?.Enabled == true)
+        {
+            var fingerprint = string.Join(',', Enumerable.Range(0, (int)_snapshot.MatrixLampCount).Select(i => _snapshot.GetLamp(i))) + ";" +
+                string.Join(',', Enumerable.Range(0, (int)_snapshot.ReelCount).Select(i => _snapshot.GetReelPosition(i))) + ";" +
+                string.Join(',', Enumerable.Range(0, (int)_snapshot.SevenSegmentDisplayCount).Select(i => _snapshot.GetSevenSegmentDisplay(i).SegmentMask));
+            var change = _comparison.TrackSnapshot(fingerprint);
+            _comparison.WriteBounded("snapshot", AmberComparisonSession.SnapshotLimit, "GetSnapshot", $"lamp_count:{_snapshot.MatrixLampCount}|reel_count:{_snapshot.ReelCount}|reel_positions:{string.Join(',', Enumerable.Range(0, (int)_snapshot.ReelCount).Select(i => _snapshot.GetReelPosition(i)))}|character_display_count:{_snapshot.AlphaDisplayCount}|segment_display_count:{_snapshot.SevenSegmentDisplayCount}|{change}");
+        }
         if (!_firstSnapshot) { _firstSnapshot = true; Debug.WriteLine($"Amber Bridge: First output snapshot received; lamps={_snapshot.MatrixLampCount}, reels={_snapshot.ReelCount}, alpha={_snapshot.AlphaDisplayCount}, sevenSegment={_snapshot.SevenSegmentDisplayCount}."); }
         TranslateSnapshot();
         var writtenFrames = bridge.FillAudioFrames(_audioSamples, checked((uint)_audioFramesPerPump));
         var writtenSamples = checked((int)writtenFrames * _audioChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioSamples.AsSpan(0, writtenSamples));
         if (!bytes.IsEmpty) _audioSink.PushPcm(bytes);
+        if (_comparison is not null)
+        {
+            var samples = _audioSamples.AsSpan(0, writtenSamples);
+            var nonzero = 0; var peak = 0;
+            foreach (var sample in samples) { if (sample != 0) nonzero++; peak = Math.Max(peak, Math.Abs((int)sample)); }
+            _comparison.WriteBounded("audio", AmberComparisonSession.AudioLimit, "ReadAudio", $"requested_frames:{_audioFramesPerPump}|returned_frames:{writtenFrames}|nonzero_samples:{nonzero}|peak_absolute_sample:{peak}|submitted_frames:{writtenFrames}");
+        }
         if (!_firstAudio) { _firstAudio = true; Debug.WriteLine($"Amber Bridge: First audio fill completed; sampleRate={_audioSampleRate} Hz, pumpRate={EmulationPumpHz} Hz, framesRequested={_audioFramesPerPump}, framesWritten={writtenFrames}, samplesWritten={writtenSamples}, bytesSubmitted={bytes.Length}."); }
     }
 
@@ -283,6 +330,9 @@ public sealed class System6NativeBackend : IEmulationBackend
     private void ApplyProjectConfiguration(System6NativeRomSettings settings)
     {
         var bridge = RequireActiveBridge(); var caps = _amberCapabilities!;
+        _comparison?.Write("ConfigureReels", string.Join(",", settings.ReelOptos.Select(r => $"index:{r.ReelIndex}|enabled:{r.Enabled}|steps:{r.Steps}|opto_start:{r.OptoStart}|opto_end:{r.OptoEnd}|opto_invert:{r.OptoInvert}|apply:true")));
+        _comparison?.Write("ConfigureCoins", string.Join(",", settings.Coins.Select(c => $"index:{c.Num}|enabled:{c.Enabled}|value:{c.CoinValue}|lockout_invert:{c.LockoutInvert}|port_index:{c.PortIndex}|coin_code:{c.Coin}|level:{c.Level}|full_level:{c.FullLevel}")));
+        _comparison?.Write("ConfigurePercentage", $"raw_value:{settings.PercentSwitchValue}");
         if (settings.ReelOptos.Count != 0) { if (!caps.SupportsReelConfiguration) throw new InvalidOperationException("Project contains reel configuration but the bridge does not support it."); var reels = settings.ReelOptos.Select(r => new AmberReelConfigurationEntry((uint)r.ReelIndex, r.Enabled, (uint)r.Steps, (uint)r.OptoStart, (uint)r.OptoEnd, r.OptoInvert)).ToArray(); bridge.ConfigureReels(new(reels.Aggregate(0u, (m, r) => m | 1u << (int)r.Index), reels)); }
         if (settings.Coins.Any(c => c.Enabled)) { if (!caps.SupportsCoinConfiguration) throw new InvalidOperationException("Project contains coin configuration but the bridge does not support it."); var channels = settings.Coins.Where(c => c.Enabled).Select(c => new AmberCoinChannelConfiguration((uint)c.Num, c.CoinEnable != 0, (uint)c.CoinValue, c.LockoutInvert != 0)).ToArray(); var routes = settings.Coins.Where(c => c.Enabled).Select(c => new AmberCoinRouteConfiguration((uint)c.Num, c.Enabled, (uint)c.CounterIn, (uint)c.CounterOut, (uint)c.PortIndex, (uint)c.Coin, (uint)c.Level, (uint)c.FullLevel)).ToArray(); bridge.ConfigureCoins(new(channels.Aggregate(0u, (m, c) => m | 1u << (int)c.Index), routes.Aggregate(0u, (m, r) => m | 1u << (int)r.Index), channels, routes)); }
         if (caps.SupportsPercentageSwitch) bridge.SetPercentageSwitch(checked((uint)settings.PercentSwitchValue));
@@ -333,7 +383,9 @@ public sealed class System6NativeBackend : IEmulationBackend
     private void ShutdownBridgeOnce()
     {
         if (_bridge is null || _shutdown) return;
+        var releasedCount = _assertedSwitches.Count;
         ReleaseAssertedSwitches();
+        _comparison?.Write("SubmitInput", "shutdown_release:true", "success", $"released_count:{releasedCount}");
         _shutdown = true;
         _bridge.Shutdown();
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -43,6 +43,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _mameCommandLineOverrides = string.Empty;
     private string _system6NativeLibraryPath = string.Empty;
     private bool _useFabricForAmber;
+    private bool _enableAmberBackendComparisonLogging;
     private string _fabricRuntimeLibraryPath = string.Empty;
     private string _fabricAmberApiV2LibraryPath = string.Empty;
     private int _system6AudioBufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds;
@@ -284,6 +285,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             _mameCommandLineOverrides = preferences.Mame.CommandLineOverrides;
             _system6NativeLibraryPath = preferences.NativeEmulation.System6LibraryPath;
             _useFabricForAmber = preferences.NativeEmulation.UseFabricForAmber;
+            _enableAmberBackendComparisonLogging = preferences.NativeEmulation.EnableAmberBackendComparisonLogging;
             _fabricRuntimeLibraryPath = preferences.NativeEmulation.FabricRuntimeLibraryPath;
             _fabricAmberApiV2LibraryPath = preferences.NativeEmulation.FabricAmberApiV2LibraryPath;
             _system6AudioBufferLengthMilliseconds = NormalizeSystem6AudioBufferLengthMilliseconds(preferences.NativeEmulation.AudioBufferLengthMilliseconds);
@@ -386,7 +388,9 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => System6NativeLibraryPath,
             () => System6AudioBufferLengthMilliseconds,
             fabricConfigurationProvider: () => (UseFabricForAmber, FabricRuntimeLibraryPath, FabricAmberApiV2LibraryPath),
-            fabricErrorLogger: message => AddOutputEntry(message, OutputLogStatus.Error));
+            fabricErrorLogger: message => AddOutputEntry(message, OutputLogStatus.Error),
+            amberComparisonEnabledProvider: () => EnableAmberBackendComparisonLogging,
+            amberComparisonLogger: message => AddOutputEntry(message, OutputLogStatus.Info));
 
         _mameEmulationService.StateChanged += (_, state) =>
         {
@@ -672,6 +676,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public string MameCommandLineOverrides { get => _mameCommandLineOverrides; set { if (SetProperty(ref _mameCommandLineOverrides, value)) SavePreferences(); } }
     public string System6NativeLibraryPath { get => _system6NativeLibraryPath; set { if (SetProperty(ref _system6NativeLibraryPath, value)) SavePreferences(); } }
     public bool UseFabricForAmber { get => _useFabricForAmber; set { if (SetProperty(ref _useFabricForAmber, value)) SavePreferences(); } }
+    public bool EnableAmberBackendComparisonLogging { get => _enableAmberBackendComparisonLogging; set { if (SetProperty(ref _enableAmberBackendComparisonLogging, value)) SavePreferences(); } }
     public string FabricRuntimeLibraryPath { get => _fabricRuntimeLibraryPath; set { if (SetProperty(ref _fabricRuntimeLibraryPath, value)) SavePreferences(); } }
     public string FabricAmberApiV2LibraryPath { get => _fabricAmberApiV2LibraryPath; set { if (SetProperty(ref _fabricAmberApiV2LibraryPath, value)) SavePreferences(); } }
     public int System6AudioBufferLengthMilliseconds
@@ -2554,6 +2559,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             {
                 System6LibraryPath = System6NativeLibraryPath,
                 UseFabricForAmber = UseFabricForAmber,
+                EnableAmberBackendComparisonLogging = EnableAmberBackendComparisonLogging,
                 FabricRuntimeLibraryPath = FabricRuntimeLibraryPath,
                 FabricAmberApiV2LibraryPath = FabricAmberApiV2LibraryPath,
                 AudioBufferLengthMilliseconds = System6AudioBufferLengthMilliseconds

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/PreferencesView.xaml
@@ -178,6 +178,7 @@
                 <TextBlock Margin="0,16,0,4" Text="System6 AmberBridge.dll path" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding System6NativeLibraryPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                 <CheckBox Margin="0,16,0,4" Content="Use Fabric for Amber emulation" IsChecked="{Binding UseFabricForAmber}" />
+                <CheckBox Margin="0,8,0,4" Content="Enable Amber backend comparison logging" IsChecked="{Binding EnableAmberBackendComparisonLogging}" />
                 <TextBlock Margin="0,8,0,4" Text="FabricRuntime.dll path" Foreground="{DynamicResource TextSecondaryBrush}" />
                 <TextBox Text="{Binding FabricRuntimeLibraryPath, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
                 <TextBlock Margin="0,8,0,4" Text="Amber API v2 DLL path for JPM System 6 / Impact" Foreground="{DynamicResource TextSecondaryBrush}" />


### PR DESCRIPTION
### Motivation

- There is an observable behavioural gap between the original direct Amber backend and the new Fabric-backed path that requires deterministic, side-by-side evidence before any runtime changes are attempted.
- Provide an opt-in, low-overhead A/B diagnostic system so Oasis can capture comparable lifecycle, ROM, timing, snapshot, audio, input and shutdown data from both transports without logging ROM or audio contents.
- Keep instrumentation purely managed and non-speculative so the first divergence can be proven to be either an Oasis-side ordering/timing issue or a native Fabric/adapter defect to be fixed separately.

### Description

- Added a persisted opt-in preference `NativeEmulation.EnableAmberBackendComparisonLogging` (default: `false`) and exposed it in the existing Native Emulation preferences UI so logs apply on the next backend start without restarting the editor. (files: `EditorPreferences.cs`, `PreferencesView.xaml`, `MainWindowViewModel.cs`).
- Implemented a single shared, thread-safe comparison event model `AmberComparisonSession` that emits bounded structured lines to the existing editor output sink and provides per-session ids, monotonic elapsed timestamps, sequence numbers, thread ids, safe ROM filename metadata, and fault-isolated sinks (file: `Emulation/AmberComparisonDiagnostics.cs`).
- Instrumented both backends with the shared schema: `System6NativeBackend` (direct Amber) and `FabricEmulationBackend` (Fabric-backed) now log lifecycle markers, ROM/resource summaries, Initialise/Reset/order points, per-pump Advance events (bounded), snapshot summaries (with static-snapshot detection), audio summaries, input queueing/releases, cancellation and shutdown events; high-frequency logs are bounded (20 Advance, 8 snapshots, 16 audio reads, 32 inputs). (files: `Emulation/Native/System6NativeBackend.cs`, `Emulation/Fabric/FabricEmulationBackend.cs`).
- Wired the factory/UI to propagate the opt-in and logger into backend creation, added snapshot fingerprint tracking and audio/sample summaries (without raw dumps), and documented the inspected paths and A/B procedure in `Docs/amber-backend-comparison.md`; added deterministic managed tests for the diagnostics helper and preference round-trip. (files: `Emulation/EmulationBackendFactory.cs`, `MainWindowViewModel.cs`, `Docs/amber-backend-comparison.md`, `OasisEditor.Tests/AmberComparisonDiagnosticsTests.cs`).

### Testing

- Ran repository static checks before committing with `git diff --check`, which passed.
- Added managed unit tests validating preference default/round-trip, disabled-silence behaviour, shared schema shape, per-session ids and bounded counters, rom-summary safety and snapshot-change counters (file: `OasisEditor.Tests/AmberComparisonDiagnosticsTests.cs`), but automated test execution was not performed in this environment.
- No builds or runtime Direct/Fabric manual runs were executed here because the workspace lacks the required Windows/.NET/WPF toolchain, Fabric runtime and production Amber DLLs; local validation steps are documented in `Docs/amber-backend-comparison.md` and should be executed in a Windows dev environment (run unit tests, Debug/Release builds, then paired Direct vs Fabric runs with the same ROM set and preference enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b589237948327a41b069879f27729)