### PR TITLE
Fix Fabric audio scheduling and buffering parity

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -48,6 +48,28 @@ public sealed class EmulationBackendFactoryTests
         Assert.IsType<FabricEmulationBackend>(factory.CreateBackend(FruitMachinePlatformType.Impact));
     }
 
+    [Theory]
+    [InlineData(false, 73)]
+    [InlineData(true, 73)]
+    [InlineData(false, NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)]
+    [InlineData(true, NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)]
+    public void AmberBackends_UseTheSameConfiguredAudioBuffer(bool fabricEnabled, int configuredMilliseconds)
+    {
+        var factory = new EmulationBackendFactory(() => new FakeBackend(), () => "legacy.dll",
+            () => configuredMilliseconds,
+            fabricConfigurationProvider: () => (fabricEnabled, "runtime.dll", "amber.dll"));
+
+        var backend = factory.CreateBackend(FruitMachinePlatformType.Impact);
+        var sink = backend switch
+        {
+            FabricEmulationBackend fabric => fabric.AudioSink,
+            System6NativeBackend direct => direct.AudioSink,
+            _ => throw new Xunit.Sdk.XunitException("Expected an Amber backend.")
+        };
+
+        Assert.Equal(configuredMilliseconds, Assert.IsType<NAudioEmulationAudioSink>(sink).BufferLengthMilliseconds);
+    }
+
     [Fact]
     public void CreateBackend_WithIncompleteEnabledFabricFeature_ThrowsActionableError()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -316,8 +316,6 @@ public sealed class FabricManagedBehaviorTests
     {
         public FabricLaunchRequest? Request { get; private set; }
         public int DisposeCount { get; private set; }
-        public int FramesToWrite { get; init; }
-        public List<ulong> Advances { get; } = [];
         public IFabricMachineSession CreateSession(FabricLaunchRequest request) { Request = request; return session; }
         public void Dispose() => DisposeCount++;
     }
@@ -340,6 +338,8 @@ public sealed class FabricManagedBehaviorTests
         public int ResetCount { get; private set; }
         public int ShutdownCount { get; private set; }
         public int DisposeCount { get; private set; }
+        public int FramesToWrite { get; init; }
+        public List<ulong> Advances { get; } = [];
         public FabricCapabilities Capabilities => new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
         public void Initialise() => Invoke(() => { });
         public void Reset() => Invoke(() => ResetCount++);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -238,8 +238,33 @@ public sealed class FabricManagedBehaviorTests
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Equal(new EmulationAudioFormat(checked((int)sampleRate), channels, 16), audio.StartedFormat);
-        Assert.Equal(Math.Max(1, checked((int)sampleRate / 500)), session.LastFrameCapacity);
+        Assert.Equal((checked((int)sampleRate) + 999) / 1000, session.LastFrameCapacity);
         Assert.Equal(0, session.LastSampleCapacity % channels);
+    }
+
+    [Theory]
+    [InlineData(48000, 48)]
+    [InlineData(44100, 45)]
+    [InlineData(1, 1)]
+    public void AudioCapacity_HoldsMaximumSingleTickEntitlement(int sampleRate, int expectedFrames)
+    {
+        Assert.Equal(expectedFrames, FabricEmulationBackend.CalculateAudioFramesPerTick(sampleRate));
+    }
+
+    [Fact]
+    public async Task Backend_UsesFixedOneMillisecondAdvancesAndSubmitsFramesExactlyOnce()
+    {
+        var session = new FakeSession { FramesToWrite = 48 };
+        var audio = new FakeAudioSink();
+        var backend = CreateBackend(session, audio);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.FirstAudioRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.All(session.Advances, value => Assert.Equal(1_000_000UL, value));
+        Assert.Equal(48, session.LastFrameCapacity);
+        Assert.Equal(48 * 2 * sizeof(short), audio.LastPcmBytes);
     }
 
     [Theory]
@@ -283,7 +308,7 @@ public sealed class FabricManagedBehaviorTests
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
-        public long Frequency => 1_000;
+        public long Frequency => 10_000;
         public long GetTimestamp() => Interlocked.Increment(ref _timestamp);
     }
 
@@ -291,6 +316,8 @@ public sealed class FabricManagedBehaviorTests
     {
         public FabricLaunchRequest? Request { get; private set; }
         public int DisposeCount { get; private set; }
+        public int FramesToWrite { get; init; }
+        public List<ulong> Advances { get; } = [];
         public IFabricMachineSession CreateSession(FabricLaunchRequest request) { Request = request; return session; }
         public void Dispose() => DisposeCount++;
     }
@@ -316,7 +343,7 @@ public sealed class FabricManagedBehaviorTests
         public FabricCapabilities Capabilities => new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
         public void Initialise() => Invoke(() => { });
         public void Reset() => Invoke(() => ResetCount++);
-        public void Advance(ulong elapsedNanoseconds) => Invoke(() => { FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
+        public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
         public void SubmitInput(FabricInput input) => Invoke(() => { });
         public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
             ? new FabricMachineSnapshot(1, [], [], [], [])
@@ -331,7 +358,7 @@ public sealed class FabricManagedBehaviorTests
                 LastSampleCapacity = sampleCapacity;
                 FirstAudioRead.TrySetResult();
                 if (AudioFailure is not null) throw AudioFailure;
-                return 0;
+                return Math.Min(FramesToWrite, frameCapacity);
             });
         }
         public void Shutdown() => Invoke(() => { ShutdownCount++; if (ShutdownFailure is not null) throw ShutdownFailure; });
@@ -356,8 +383,9 @@ public sealed class FabricManagedBehaviorTests
         public int StartCount { get; private set; }
         public int StopCount { get; private set; }
         public EmulationAudioFormat? StartedFormat { get; private set; }
+        public int LastPcmBytes { get; private set; }
         public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
-        public void PushPcm(ReadOnlySpan<byte> pcmBytes) { }
+        public void PushPcm(ReadOnlySpan<byte> pcmBytes) => LastPcmBytes = pcmBytes.Length;
         public void Stop() => StopCount++;
         public void Clear() { }
         public void Dispose() { }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -5,6 +5,37 @@ namespace OasisEditor.Tests;
 public sealed class NAudioEmulationAudioSinkTests
 {
     [Theory]
+    [InlineData(50, 10)]
+    [InlineData(100, 10)]
+    [InlineData(10, 5)]
+    [InlineData(1, 1)]
+    public void PrebufferThreshold_IsBoundedByTenMillisecondsAndHalfTheBuffer(int buffer, int expected)
+    {
+        Assert.Equal(expected, AudioPrebufferPolicy.CalculateThresholdMilliseconds(buffer));
+    }
+
+    [Fact]
+    public void Prebuffer_StartsAtThresholdAndResetRequiresPrebufferAgain()
+    {
+        var policy = new AudioPrebufferPolicy(new(48000, 2, 16), 50);
+
+        Assert.Equal(1920, policy.ThresholdBytes);
+        Assert.False(policy.ObserveQueuedBytes(1919));
+        Assert.True(policy.ObserveQueuedBytes(1920));
+        policy.Reset();
+        Assert.False(policy.PlaybackStarted);
+        Assert.False(policy.ObserveQueuedBytes(192));
+    }
+
+    [Theory]
+    [InlineData(48000, 2, 192)]
+    [InlineData(48000, 1, 96)]
+    [InlineData(44100, 2, 176)]
+    public void BufferDepthByteRate_AccountsForChannelsExactlyOnce(int rate, int channels, int expected)
+    {
+        Assert.Equal(expected, new EmulationAudioFormat(rate, channels, 16).BytesPerMillisecond());
+    }
+    [Theory]
     [InlineData(800, 1000, 192, false)]
     [InlineData(900, 1000, 192, true)]
     [InlineData(1000, 1000, 1, true)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -49,7 +49,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             if (string.IsNullOrWhiteSpace(fabric.RuntimePath) || string.IsNullOrWhiteSpace(fabric.AmberPath))
                 throw new InvalidOperationException("Fabric emulation is enabled, but both the Fabric runtime DLL path and Amber API v2 DLL path must be configured.");
             return new FabricEmulationBackend(fabric.RuntimePath, fabric.AmberPath, path => new FabricRuntimeLibrary(path),
-                new NAudioEmulationAudioSink(), new StopwatchFabricClock(), _fabricErrorLogger);
+                new NAudioEmulationAudioSink(_system6AudioBufferLengthMillisecondsProvider()), new StopwatchFabricClock(), _fabricErrorLogger);
         }
         var libraryPath = _system6LibraryPathProvider();
         return string.IsNullOrWhiteSpace(libraryPath)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -6,7 +6,9 @@ namespace OasisEditor;
 
 public sealed class FabricEmulationBackend : IEmulationBackend
 {
-    private const int PumpDelayMilliseconds = 1;
+    private const int EmulationPumpHz = 1000;
+    private const ulong NanosecondsPerPump = 1_000_000;
+    private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
     private static readonly EmulationBackendCapabilities BackendCapabilities =
         new(true, true, true, true, false, false, false, false);
 
@@ -16,7 +18,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly IEmulationAudioSink _audioSink;
     private readonly IFabricClock _clock;
     private readonly Action<string> _errorLogger;
-    private readonly FabricElapsedTime _elapsedTime;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
     private readonly HashSet<int> _assertedInputs = [];
@@ -35,6 +36,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private bool _shutdown;
     private bool _audioStarted;
     private bool _disposed;
+    private long _scheduleGeneration;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -56,13 +58,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioSink = audioSink;
         _clock = clock;
         _errorLogger = errorLogger ?? WriteDebugError;
-        _elapsedTime = new FabricElapsedTime(clock.Frequency);
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
     public EmulationBackendCapabilities Capabilities => BackendCapabilities;
     public EmulationBackendState State { get { lock (_stateGate) return _state; } }
     public Exception? LastFailure { get; private set; }
+    internal IEmulationAudioSink AudioSink => _audioSink;
 
     public event EventHandler<EmulationBackendState>? StateChanged;
     public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
@@ -96,7 +98,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             {
                 _session.Initialise();
                 ConfigureAudio(_session);
-                _elapsedTime.Reset(_clock.GetTimestamp());
+                Interlocked.Increment(ref _scheduleGeneration);
             }
             finally
             {
@@ -160,7 +162,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         ThrowIfDisposed();
         if (State == EmulationBackendState.Paused)
         {
-            _elapsedTime.Reset(_clock.GetTimestamp());
+            Interlocked.Increment(ref _scheduleGeneration);
             SetState(EmulationBackendState.Running);
         }
         return Task.CompletedTask;
@@ -178,7 +180,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             RequireSession().Reset();
             ClearOutputCaches();
             _audioSink.Clear();
-            _elapsedTime.Reset(_clock.GetTimestamp());
+            Interlocked.Increment(ref _scheduleGeneration);
         }
         finally
         {
@@ -241,19 +243,31 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     {
         try
         {
+            var pumpTicks = Math.Max(1L, _clock.Frequency / EmulationPumpHz);
+            var nextDeadline = _clock.GetTimestamp();
+            var scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (State != EmulationBackendState.Running)
                 {
-                    await Task.Delay(PumpDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    nextDeadline = _clock.GetTimestamp();
+                    scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
                     continue;
+                }
+
+                var currentGeneration = Interlocked.Read(ref _scheduleGeneration);
+                if (currentGeneration != scheduleGeneration)
+                {
+                    nextDeadline = _clock.GetTimestamp();
+                    scheduleGeneration = currentGeneration;
                 }
 
                 await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
                     var session = RequireSession();
-                    session.Advance(_elapsedTime.AdvanceTo(_clock.GetTimestamp()));
+                    session.Advance(NanosecondsPerPump);
                     ProcessInputs(session);
                     PublishSnapshot(session.GetSnapshot());
                     ReadAudio(session);
@@ -262,7 +276,23 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 {
                     _sessionGate.Release();
                 }
-                await Task.Delay(PumpDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+
+                nextDeadline += pumpTicks;
+                var now = _clock.GetTimestamp();
+                // Match direct Amber: execute the current slice, then abandon catch-up once over three ticks late.
+                if (now - nextDeadline > pumpTicks * 3)
+                    nextDeadline = now + pumpTicks;
+
+                var remainingTicks = nextDeadline - _clock.GetTimestamp();
+                if (remainingTicks > 0)
+                {
+                    var remaining = TimeSpan.FromSeconds((double)remainingTicks / _clock.Frequency);
+                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await Task.Yield();
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -294,13 +324,20 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             { BitsPerSample: 16, Interleaved: true, SignedSamples: true, LittleEndian: true })
             throw new NotSupportedException($"Unsupported Fabric audio format: {format}.");
         _audioFormat = format;
-        var frameCapacity = Math.Max(1, checked((int)format.SampleRate / 500));
+        var frameCapacity = CalculateAudioFramesPerTick(checked((int)format.SampleRate));
         _audioBuffer = new short[checked(frameCapacity * (int)format.ChannelCount)];
         _audioSink.Start(new(
             checked((int)format.SampleRate),
             checked((int)format.ChannelCount),
             checked((int)format.BitsPerSample)));
         _audioStarted = true;
+    }
+
+    internal static int CalculateAudioFramesPerTick(int sampleRate)
+    {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        return checked((sampleRate + EmulationPumpHz - 1) / EmulationPumpHz);
     }
 
     private void ProcessInputs(IFabricMachineSession session)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
@@ -5,24 +6,33 @@ namespace OasisEditor;
 
 public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 {
+    private const int DiagnosticPushLimit = 32;
     private readonly int _bufferLengthMilliseconds;
 
     private BufferedWaveProvider? _buffer;
     private WasapiOut? _output;
     private EmulationAudioFormat? _format;
+    private AudioPrebufferPolicy? _prebuffer;
     private long _droppedBlocks;
     private long _droppedBytes;
+    private long _runtimeStarvationEvents;
+    private long _pushCount;
+    private int _minimumBufferedBytes = int.MaxValue;
+    private bool _playbackStarted;
 
+    internal int BufferLengthMilliseconds => _bufferLengthMilliseconds;
+    internal int PrebufferThresholdMilliseconds => AudioPrebufferPolicy.CalculateThresholdMilliseconds(_bufferLengthMilliseconds);
+    internal int PrebufferThresholdBytes => _prebuffer?.ThresholdBytes ?? 0;
     internal long DroppedBlocks => Interlocked.Read(ref _droppedBlocks);
     internal long DroppedBytes => Interlocked.Read(ref _droppedBytes);
+    internal long RuntimeStarvationEvents => Interlocked.Read(ref _runtimeStarvationEvents);
+    internal int MinimumObservedBufferedBytes => _minimumBufferedBytes == int.MaxValue ? 0 : _minimumBufferedBytes;
+    internal bool PlaybackStarted => _playbackStarted;
 
     public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
     {
         if (bufferLengthMilliseconds <= 0)
-        {
             throw new ArgumentOutOfRangeException(nameof(bufferLengthMilliseconds), bufferLengthMilliseconds, "Audio buffer length must be greater than zero.");
-        }
-
         _bufferLengthMilliseconds = bufferLengthMilliseconds;
     }
 
@@ -39,42 +49,74 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         };
         _output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
         _output.Init(_buffer);
-        _output.Play();
         _format = format;
-        Interlocked.Exchange(ref _droppedBlocks, 0);
-        Interlocked.Exchange(ref _droppedBytes, 0);
+        _prebuffer = new AudioPrebufferPolicy(format, _bufferLengthMilliseconds);
+        ResetDiagnostics();
+        // Play is deliberately deferred until enough PCM (including digital silence) is queued.
     }
 
     public void PushPcm(ReadOnlySpan<byte> pcmBytes)
     {
         if (pcmBytes.IsEmpty || _buffer is null)
-        {
             return;
+
+        var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
+        var before = _buffer.BufferedBytes;
+        var capacity = _buffer.BufferLength;
+        var push = Interlocked.Increment(ref _pushCount);
+        ObserveMinimum(before);
+
+        if (_playbackStarted && before < format.BytesPerMillisecond())
+        {
+            var starvation = Interlocked.Increment(ref _runtimeStarvationEvents);
+            if (starvation == 1 || IsPowerOfTwo(starvation))
+                WriteDepthDiagnostic("runtime starvation risk", pcmBytes.Length, before, before, capacity);
         }
 
-        _ = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
-        if (ShouldDropIncomingBlock(_buffer.BufferedBytes, _buffer.BufferLength, pcmBytes.Length))
+        if (ShouldDropIncomingBlock(before, capacity, pcmBytes.Length))
         {
             var droppedBlocks = Interlocked.Increment(ref _droppedBlocks);
             Interlocked.Add(ref _droppedBytes, pcmBytes.Length);
-            if (droppedBlocks == 1 || (droppedBlocks & (droppedBlocks - 1)) == 0)
-                System.Diagnostics.Debug.WriteLine($"NAudio emulation buffer: dropped incoming audio block; blocks={droppedBlocks}, bytes={DroppedBytes}, buffered={_buffer.BufferedBytes}, capacity={_buffer.BufferLength}.");
+            if (droppedBlocks == 1 || IsPowerOfTwo(droppedBlocks))
+                WriteDepthDiagnostic("dropped incoming block", pcmBytes.Length, before, before, capacity);
             return;
         }
 
         var bytes = pcmBytes.ToArray();
         _buffer.AddSamples(bytes, 0, bytes.Length);
+        var after = _buffer.BufferedBytes;
+        if (push <= DiagnosticPushLimit)
+            WriteDepthDiagnostic("push", bytes.Length, before, after, capacity);
+
+        if (!_playbackStarted && _prebuffer!.ObserveQueuedBytes(after))
+        {
+            _output!.Play();
+            _playbackStarted = true;
+            Debug.WriteLine($"NAudio emulation buffer: startup prebuffer complete; thresholdBytes={_prebuffer.ThresholdBytes}, bufferedBytes={after}.");
+        }
     }
 
-    public void Clear() => _buffer?.ClearBuffer();
+    public void Clear()
+    {
+        if (_output is not null && _playbackStarted)
+            _output.Stop();
+        _buffer?.ClearBuffer();
+        _playbackStarted = false;
+        _prebuffer?.Reset();
+        _minimumBufferedBytes = int.MaxValue;
+    }
 
     public void Stop()
     {
+        if (_format is not null)
+            Debug.WriteLine($"NAudio emulation buffer: stop summary; pushes={_pushCount}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, starvationRiskEvents={RuntimeStarvationEvents}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
         _output?.Stop();
         _output?.Dispose();
         _output = null;
         _buffer = null;
         _format = null;
+        _prebuffer = null;
+        _playbackStarted = false;
     }
 
     public void Dispose() => Stop();
@@ -82,10 +124,62 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes)
         => incomingBytes > bufferCapacityBytes - bufferedBytes;
 
+    private void ResetDiagnostics()
+    {
+        Interlocked.Exchange(ref _droppedBlocks, 0);
+        Interlocked.Exchange(ref _droppedBytes, 0);
+        Interlocked.Exchange(ref _runtimeStarvationEvents, 0);
+        Interlocked.Exchange(ref _pushCount, 0);
+        _minimumBufferedBytes = int.MaxValue;
+        _playbackStarted = false;
+    }
+
+    private void ObserveMinimum(int bufferedBytes) => _minimumBufferedBytes = Math.Min(_minimumBufferedBytes, bufferedBytes);
+
+    private void WriteDepthDiagnostic(string reason, int incoming, int before, int after, int capacity)
+    {
+        var bytesPerMillisecond = _format!.Value.BytesPerMillisecond();
+        Debug.WriteLine($"NAudio emulation buffer: {reason}; incomingBytes={incoming}, bufferedBefore={before}, bufferedAfter={after}, capacity={capacity}, millisecondsBefore={(double)before / bytesPerMillisecond:F2}, millisecondsAfter={(double)after / bytesPerMillisecond:F2}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
+    }
+
+    private static bool IsPowerOfTwo(long value) => (value & (value - 1)) == 0;
+
     private static void ValidateFormat(EmulationAudioFormat format)
     {
         if (format.SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio sample rate must be greater than zero.");
         if (format.Channels <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio channel count must be greater than zero.");
         if (format.BitsPerSample != 16) throw new NotSupportedException($"Only 16-bit PCM audio is supported; native core reported {format.BitsPerSample} bits per sample.");
     }
+}
+
+internal sealed class AudioPrebufferPolicy
+{
+    internal AudioPrebufferPolicy(EmulationAudioFormat format, int bufferLengthMilliseconds)
+    {
+        ThresholdMilliseconds = CalculateThresholdMilliseconds(bufferLengthMilliseconds);
+        var numerator = checked((long)format.SampleRate * format.Channels * (format.BitsPerSample / 8) * ThresholdMilliseconds);
+        ThresholdBytes = checked((int)((numerator + 999) / 1000));
+    }
+
+    internal int ThresholdMilliseconds { get; }
+    internal int ThresholdBytes { get; }
+    internal bool PlaybackStarted { get; private set; }
+
+    internal bool ObserveQueuedBytes(int bufferedBytes)
+    {
+        if (!PlaybackStarted && bufferedBytes >= ThresholdBytes)
+            PlaybackStarted = true;
+        return PlaybackStarted;
+    }
+
+    internal void Reset() => PlaybackStarted = false;
+
+    internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) =>
+        Math.Max(1, Math.Min(10, bufferLengthMilliseconds / 2));
+}
+
+internal static class EmulationAudioFormatExtensions
+{
+    internal static int BytesPerMillisecond(this EmulationAudioFormat format) =>
+        Math.Max(1, checked((format.SampleRate * format.Channels * (format.BitsPerSample / 8)) / 1000));
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Native/System6NativeBackend.cs
@@ -50,6 +50,7 @@ public sealed class System6NativeBackend : IEmulationBackend
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.NativeSystem6;
+    internal IEmulationAudioSink AudioSink => _audioSink;
     public EmulationBackendCapabilities Capabilities => BackendCapabilities;
     public EmulationBackendState State { get { lock (_stateGate) return _state; } }
     internal int LastCyclesRun { get; private set; }


### PR DESCRIPTION
### Motivation

- Fabric-backed Amber exhibited intermittent crackling due to uneven host-timed advances and bursty audio submits compared with the direct backend's fixed 1 kHz pump. 
- The goal is to bring Fabric scheduling and audio submission into parity with the working `System6NativeBackend` without changing native/Fabric/Amber ABIs. 
- Both backends must use the same `NativeEmulation.AudioBufferLengthMilliseconds` preference and avoid starting playback with an empty NAudio buffer.

### Description

- Replace the Fabric relative-delay pump with a fixed-deadline 1 kHz scheduler in `FabricEmulationBackend.PumpAsync` that advances the Fabric session by exactly `1_000_000 ns` per executed tick and abandons catch-up after three missed ticks similar to direct Amber. 
- Change Fabric per-tick read capacity to the maximum single-tick entitlement using `CalculateAudioFramesPerTick(sampleRate)` (ceil(sampleRate/1000)) and preserve per-frame/channel accounting when converting to interleaved bytes. 
- Wire the configured audio buffer preference into Fabric by constructing `NAudioEmulationAudioSink` with the same `_system6AudioBufferLengthMillisecondsProvider()` in `EmulationBackendFactory`, preserving preference normalization logic. 
- Reimplement `NAudioEmulationAudioSink` to add startup prebuffering (start-on-threshold), bounded diagnostics (buffered before/after, capacity, dropped blocks/bytes, minimum observed depth, runtime starvation events), and to defer `WasapiOut.Play()` until the prebuffer threshold is reached while preserving `DiscardOnBufferOverflow` behaviour and drop-on-overflow policy. 
- Add internal accessors and small helpers used by tests (`FabricEmulationBackend.AudioSink`, `System6NativeBackend.AudioSink`, `CalculateAudioFramesPerTick`, `AudioPrebufferPolicy`, `EmulationAudioFormatExtensions`). 
- Add unit tests to assert: direct/Fabric buffer preference parity, per-tick frame capacity for 48k/44.1k, fixed 1 ms Fabric advances and single read per tick, prebuffer threshold semantics, byte-rate calculations for mono/stereo, and existing overflow-drop decision (`WindowsNetProjects/OasisEditor/OasisEditor.Tests/{FabricManagedBehaviorTests.cs,NAudioEmulationAudioSinkTests.cs,EmulationBackendFactoryTests.cs}`).

### Testing

- `git diff --check` passed and the change was committed as `codex/fix-fabric-audio-pump-and-buffering`; repository status and commit verified. 
- New unit tests were added in `FabricManagedBehaviorTests.cs`, `NAudioEmulationAudioSinkTests.cs`, and `EmulationBackendFactoryTests.cs`, but `dotnet build`/`dotnet test` were not executed in this environment because `WindowsNetProjects/OasisEditor/AGENTS.md` prohibits building or running tests here. 
- Hardware/manual validation (Windows WASAPI listening with direct and Fabric Amber at 50 ms/100 ms, comparison logging on/off) remains required and is documented as the next verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b87865ca88327a86d55d9e5507a80)