### PR TITLE
Clarify Fabric-only migration docs and remove stale MAME layout objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - Enable creation of interactive 3d arcade machines for use in arcade environments.
 - Importing of 3d models from packages such as Blender (probably as GLTF files), to build machines plus other environment assets.
 - For fruit machines, support for extracting and importing 2d layouts from Mfme.
-- For MAME, export function for text only 'classic' internal layouts for inclusion in MAME source, plus graphical 'dx' layouts.
 
 # Architecture
 <!-- Mermaid diagram tools/info:

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
@@ -1,5 +1,6 @@
+> **Historical document:** This no longer describes the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
+
 # Amber Bridge v0.1.1 integration contract
-> **Historical:** This document describes a removed direct integration and is not the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
 
 This is Oasis's durable copy of the integration contract for the separately maintained
 [`johnparker007/AmberOasisBridge`](https://github.com/johnparker007/AmberOasisBridge). The immutable baseline is tag

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-integration.md
@@ -1,5 +1,6 @@
+> **Historical document:** This no longer describes the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
+
 # Amber Bridge v0.2 integration
-> **Historical:** This document describes a removed direct integration and is not the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
 
 ## Authoritative contract
 

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-requirements.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-requirements.md
@@ -1,5 +1,6 @@
+> **Historical document:** This no longer describes the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
+
 # Amber Bridge missing-operation evidence
-> **Historical:** This document describes a removed direct integration and is not the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
 
 This document records integration evidence only; it does not propose ABI signatures.
 

--- a/WindowsNetProjects/OasisEditor/Docs/fabric-migration-test-plan.md
+++ b/WindowsNetProjects/OasisEditor/Docs/fabric-migration-test-plan.md
@@ -1,14 +1,42 @@
 # Fabric-only Amber migration test plan
 
-## Managed coverage
+The supported runtime chain is:
 
-Factory tests cover no-backend selection, Impact selection, unsupported platforms before configuration validation, independent blank/missing DLL errors, and configured audio buffering. Fabric behavior tests retain lifecycle, 1 ms timing, ROM/configuration mapping, input, output snapshots, partial audio reads, failure cleanup, and exact provider/core identifiers.
+```text
+OasisEditor -> FabricRuntime.dll -> production Amber API v2 provider DLL
+```
 
-## Windows native verification
+## Automated unit tests
 
-1. Configure valid Fabric runtime and production Amber API v2 provider DLL paths.
-2. Start an Impact project and verify lamp, reel, display, input, and audio behavior.
-3. Verify missing runtime and provider paths produce distinct actionable errors with no fallback.
-4. Verify Epoch and other platforms report unsupported-platform errors even when paths are blank.
-5. Inspect loaded modules: OasisEditor loads FabricRuntime.dll; provider loading occurs through Fabric.
-6. Confirm no external emulator process is launched.
+Run on Windows with the .NET/WPF toolchain:
+
+```powershell
+dotnet test .\OasisEditor.Tests\OasisEditor.Tests.csproj
+```
+
+The managed suite covers backend selection, configuration validation, Fabric ABI layout, the fixed 1 ms scheduler, bounded catch-up, ROM and provider configuration, input routing and release, output snapshots, partial audio reads, audio buffering, and failure cleanup. It also asserts the `amber-api-v2` provider identifier and `jpm-system6` machine identifier.
+
+## Windows-only native integration tests
+
+With the required native binaries configured, run:
+
+```powershell
+dotnet test .\OasisEditor.NativeIntegrationTests\OasisEditor.NativeIntegrationTests.csproj
+```
+
+These tests validate the native Fabric ABI/layout and runtime/provider integration. They are separate from the managed unit suite because they require Windows and the native deployment.
+
+## Manual end-to-end verification
+
+The following checks were completed by the user after PR #594: the solution builds, the test suite passes, OasisEditor launches, Impact/System 6 emulation starts, and Fabric reaches the production Amber API v2 provider.
+
+The following focused checks remain for this verification pass:
+
+1. Open OasisEditor and confirm Preferences exposes only the Fabric runtime path, production Amber provider path, and audio buffer setting for emulation.
+2. Open an Impact/System 6 project; start emulation and verify lamps, reels, segments/VFD, audio, and input.
+3. Stop and restart emulation, then verify focus loss releases every asserted input.
+4. Verify a missing Fabric runtime produces an actionable Fabric error and no fallback.
+5. Verify a missing Amber provider produces an actionable provider error and no fallback.
+6. Verify Epoch reports unsupported before Fabric path validation.
+7. Confirm no `mame.exe` process starts and no MAME setup, debugger, download, or `.lay` export UI exists.
+8. Inspect process modules with suitable Windows diagnostics: OasisEditor loads `FabricRuntime.dll`, does not directly load the production Amber provider, and Fabric loads and uses that provider.


### PR DESCRIPTION
### Motivation
- Ensure repository documentation and migration-test-plan unambiguously describe the Fabric-only runtime chain and do not advertise or imply any remaining MAME or direct-Amber runtime support. 
- Strengthen historical warnings for retained Amber-bridge materials so readers are not misled about the current OasisEditor architecture.

### Description
- Removed the stale MAME layout-export objective from the top-level `README.md`. 
- Added a prominent "Historical document" warning at the top of `Docs/amber-bridge-v0.1.1-integration.md`, `Docs/amber-bridge-v0.2-integration.md` and `Docs/amber-bridge-v0.2-requirements.md` to make clear these documents do not describe current runtime architecture. 
- Expanded `Docs/fabric-migration-test-plan.md` to state the supported call graph (`OasisEditor -> FabricRuntime.dll -> production Amber API v2 provider DLL`), document exact Windows test commands for managed and native suites, record the user-verified checks completed after PR #594, and enumerate the remaining manual Windows verification checklist. 

### Testing
- Created branch `verify-fabric-only-migration` from starting commit `179f0b8f1d65f55e67ebdec6e6767a231d02084b` and committed the changes as `d54a043cd6a905128c81bea646ac0b11ab272064`. 
- Ran targeted static validations and repository searches (case-insensitive `rg` scans for direct-native loading APIs, Amber/MAME symbols, `.lay` seams, legacy launch fields and UI bindings), plus `git diff --check` and `git status`, all of which completed successfully and show only the documentation edits. 
- Did not run `dotnet build` or `dotnet test` because `WindowsNetProjects/OasisEditor/AGENTS.md` and the execution environment prohibit building or running Windows/WPF tests here; the migration test plan now records the exact `dotnet test` commands to run on Windows for the managed and native suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6bb6f6002883278a3d4bd0e1c9695e)