### PR TITLE
Fix Fabric Amber backend identifier

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.1.1-integration.md
@@ -1,4 +1,4 @@
-> **Historical document:** This no longer describes the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
+> **Historical document:** This describes the former direct Amber API v1 integration, including `AmberGetApi`, and not the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and its production `amber` backend.
 
 # Amber Bridge v0.1.1 integration contract
 

--- a/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/amber-bridge-v0.2-integration.md
@@ -1,4 +1,4 @@
-> **Historical document:** This no longer describes the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and the production Amber API v2 provider.
+> **Historical document:** This describes the former direct Amber API v2 integration, including `AmberGetApi`, and not the current OasisEditor runtime architecture. Current runtime access is exclusively through FabricRuntime.dll and its production `amber` backend.
 
 # Amber Bridge v0.2 integration
 

--- a/WindowsNetProjects/OasisEditor/Docs/fabric-integration.md
+++ b/WindowsNetProjects/OasisEditor/Docs/fabric-integration.md
@@ -3,11 +3,11 @@
 OasisEditor supports one runtime emulation architecture:
 
 ```text
-OasisEditor -> FabricRuntime.dll -> production Amber API v2 provider DLL
+OasisEditor -> FabricRuntime.dll -> production Amber provider DLL
 ```
 
 Impact projects use `FabricEmulationBackend`. `None` selects no backend; Epoch and every other platform are explicitly unsupported. The editor validates the Fabric runtime and production provider paths independently and never falls back to another runtime.
 
-OasisEditor loads only `FabricRuntime.dll`. The configured production provider path is passed to Fabric with provider identifier `amber-api-v2` and machine identifier `jpm-system6`; OasisEditor never loads or invokes the provider directly.
+OasisEditor loads only `FabricRuntime.dll`. The configured production provider path is passed to Fabric with backend identifier `amber` and machine identifier `jpm-system6`; OasisEditor never loads or invokes the provider directly.
 
 The fixed 1 ms scheduler, nanosecond advancement, bounded catch-up, audio-frame accumulation, snapshot publication, and NAudio buffering remain owned by `FabricEmulationBackend`.

--- a/WindowsNetProjects/OasisEditor/Docs/fabric-migration-test-plan.md
+++ b/WindowsNetProjects/OasisEditor/Docs/fabric-migration-test-plan.md
@@ -3,7 +3,7 @@
 The supported runtime chain is:
 
 ```text
-OasisEditor -> FabricRuntime.dll -> production Amber API v2 provider DLL
+OasisEditor -> FabricRuntime.dll -> production Amber provider DLL
 ```
 
 ## Automated unit tests
@@ -14,7 +14,7 @@ Run on Windows with the .NET/WPF toolchain:
 dotnet test .\OasisEditor.Tests\OasisEditor.Tests.csproj
 ```
 
-The managed suite covers backend selection, configuration validation, Fabric ABI layout, the fixed 1 ms scheduler, bounded catch-up, ROM and provider configuration, input routing and release, output snapshots, partial audio reads, audio buffering, and failure cleanup. It also asserts the `amber-api-v2` provider identifier and `jpm-system6` machine identifier.
+The managed suite covers backend selection, configuration validation, Fabric ABI layout, the fixed 1 ms scheduler, bounded catch-up, ROM and provider configuration, input routing and release, output snapshots, partial audio reads, audio buffering, and failure cleanup. It also asserts the `amber` backend identifier and `jpm-system6` machine identifier.
 
 ## Windows-only native integration tests
 
@@ -28,7 +28,7 @@ These tests validate the native Fabric ABI/layout and runtime/provider integrati
 
 ## Manual end-to-end verification
 
-The following checks were completed by the user after PR #594: the solution builds, the test suite passes, OasisEditor launches, Impact/System 6 emulation starts, and Fabric reaches the production Amber API v2 provider.
+Historical verification after PR #594 used the former experimental Amber API v2 provider path. The current standalone Fabric runtime instead reaches the production `amber` backend.
 
 The following focused checks remain for this verification pass:
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
@@ -136,7 +136,7 @@ public sealed class FabricProviderIntegrationTests
     {
         var settings = new System6NativeRomSettings { PercentSwitchValue = 0 };
         return new FabricLaunchRequest(
-            "amber-api-v2", "jpm-system6", amberPath, resources,
+            "amber", "jpm-system6", amberPath, resources,
             FabricAmberConfiguration.FromSystem6(settings));
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricRuntimeSmokeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricRuntimeSmokeTests.cs
@@ -46,7 +46,7 @@ public sealed class FabricRuntimeSmokeTests
 
     [NativeTheory("FABRIC_RUNTIME_DLL")]
     [InlineData("not-a-provider", "jpm-system6")]
-    [InlineData("amber-api-v2", "not-a-machine")]
+    [InlineData("amber", "not-a-machine")]
     public void Session_InvalidProviderIdentityPreservesResultAndError(string backendKind, string machineIdentifier)
     {
         var runtimePath = NativePrerequisites.RequireFile("FABRIC_RUNTIME_DLL");

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -107,7 +107,7 @@ public sealed class FabricManagedBehaviorTests
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Equal("C:/fabric/FabricRuntime.dll", runtimePath);
-        Assert.Equal("amber-api-v2", runtime.Request!.BackendKind);
+        Assert.Equal("amber", runtime.Request!.BackendKind);
         Assert.Equal("jpm-system6", runtime.Request.MachineIdentifier);
         Assert.Equal("D:/amber/amber.dll", runtime.Request.BackendPath);
         Assert.Equal(1, session.MaximumConcurrentCalls);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -6,6 +6,8 @@ namespace OasisEditor;
 
 public sealed class FabricEmulationBackend : IEmulationBackend
 {
+    private const string AmberBackendKind = "amber";
+    private const string JpmSystem6MachineIdentifier = "jpm-system6";
     private const int EmulationPumpHz = 1000;
     private const ulong NanosecondsPerPump = 1_000_000;
     private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
@@ -89,7 +91,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             cancellationToken.ThrowIfCancellationRequested();
             _runtime = _runtimeFactory(_runtimePath);
             _session = _runtime.CreateSession(new FabricLaunchRequest(
-                "amber-api-v2", "jpm-system6", _amberPath, resources,
+                AmberBackendKind, JpmSystem6MachineIdentifier, _amberPath, resources,
                 FabricAmberConfiguration.FromSystem6(settings)));
 
             await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
### Motivation

- The Fabric standalone runtime no longer exposes the experimental API-v2 provider path, so the OasisEditor Fabric launch must request the production Amber backend `amber` while preserving the `jpm-system6` machine identifier to allow System 6 emulation to start. 

### Description

- Replace the production launch `backend_kind` from `"amber-api-v2"` to `"amber"` in the Fabric backend and define focused constants `AmberBackendKind` and `JpmSystem6MachineIdentifier` to hold those values. 
- Update managed unit and native integration tests to assert and use the new backend identifier (`"amber"`) while keeping the machine identifier `"jpm-system6"`. 
- Update current Fabric documentation and migration test plan to describe the production `amber` backend and mark direct `AmberGetApi` references as historical. 
- Key files changed: `OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs`, `OasisEditor.Tests/FabricManagedBehaviorTests.cs`, `OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs`, `OasisEditor.NativeIntegrationTests/FabricRuntimeSmokeTests.cs`, and docs under `WindowsNetProjects/OasisEditor/Docs/`.

### Testing

- Ran `git diff --check` and it passed with no whitespace or diff errors. 
- Searched the repository for `amber-api-v2|AmberApiV2|AmberGetApi|FakeAmberApiV2` and confirmed there are no remaining active `amber-api-v2` occurrences; remaining `AmberGetApi` matches are only in historical documentation and are explicitly marked as historical. 
- Did not run `dotnet test` for managed or native test projects because `WindowsNetProjects/OasisEditor/AGENTS.md` prohibits building or running the Windows/.NET/WPF test toolchain in this environment, so the updated tests were not executed here. 
- Confirmed changes are limited to the backend identity, test assertions/fixtures, and documentation with no modifications to runtime DLL paths, ROM handling, configuration, scheduling, audio, snapshots, input handling, or lifecycle behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6be2a98e6883279d50f0c25fe29f62)