### PR TITLE
Fix System 6 alpha segment mapping in Fabric backend

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -5,6 +5,59 @@ namespace OasisEditor.Tests;
 
 public sealed class FabricManagedBehaviorTests
 {
+    public static TheoryData<int, int> System6AlphaBitMapping => new()
+    {
+        { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 3 },
+        { 4, 4 }, { 5, 5 }, { 6, 6 }, { 7, 7 },
+        { 8, 10 }, { 9, 14 }, { 10, 9 }, { 11, 15 },
+        { 12, 11 }, { 13, 12 }, { 14, 8 }, { 15, 13 },
+    };
+
+    [Theory]
+    [MemberData(nameof(System6AlphaBitMapping))]
+    public void System6AlphaMapper_MapsEveryNativeBitToItsOasisBit(int nativeBit, int oasisBit)
+    {
+        Assert.Equal(1 << oasisBit,
+            System6AlphaSegmentMapper.MapNativeMaskToOasisMask(1 << nativeBit));
+    }
+
+    [Fact]
+    public void System6AlphaMapper_MapsZeroAndMultipleBits()
+    {
+        Assert.Equal(0, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(0));
+
+        var nativeMask = (1 << 2) | (1 << 8) | (1 << 10) | (1 << 14);
+        var expectedOasisMask = (1 << 2) | (1 << 10) | (1 << 9) | (1 << 8);
+        Assert.Equal(expectedOasisMask, System6AlphaSegmentMapper.MapNativeMaskToOasisMask(nativeMask));
+    }
+
+    [Fact]
+    public void Backend_PublishesMappedAlphaWithPunctuationAndLeavesSevenSegmentUnchanged()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+        var changes = new List<MachineSegmentChangedEventArgs>();
+        backend.SegmentChanged += (_, change) => changes.Add(change);
+        var nativeAlphaMask = (1u << 8) | (1u << 14);
+        const ulong sevenSegmentMask = 0x5a;
+        var snapshot = new FabricMachineSnapshot(1, [], [],
+            [new FabricCharacterDisplay("alpha", [nativeAlphaMask], [0b11])],
+            [new FabricSegmentDisplay("seven", [sevenSegmentMask])]);
+
+        backend.PublishSnapshot(snapshot);
+
+        Assert.Collection(changes,
+            alphaChange =>
+            {
+                Assert.Equal((1 << 10) | (1 << 8) | (1 << 16) | (1 << 17), alphaChange.SegmentMask);
+                Assert.Equal(SegmentOutputType.NativeAlpha, alphaChange.OutputType);
+            },
+            sevenSegmentChange =>
+            {
+                Assert.Equal(unchecked((int)sevenSegmentMask), sevenSegmentChange.SegmentMask);
+                Assert.Equal(SegmentOutputType.Digit, sevenSegmentChange.OutputType);
+            });
+    }
+
     [Fact]
     public void ElapsedTime_PreservesFractionalRemainderWithoutDrift()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/System6AlphaSegmentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/System6AlphaSegmentMapper.cs
@@ -1,0 +1,36 @@
+namespace OasisEditor;
+
+internal static class System6AlphaSegmentMapper
+{
+    private static readonly int[] NativeBitToOasisBit =
+    [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        10,
+        14,
+        9,
+        15,
+        11,
+        12,
+        8,
+        13,
+    ];
+
+    internal static int MapNativeMaskToOasisMask(int nativeMask)
+    {
+        var oasisMask = 0;
+        for (var nativeBit = 0; nativeBit < NativeBitToOasisBit.Length; nativeBit++)
+        {
+            if ((nativeMask & (1 << nativeBit)) != 0)
+                oasisMask |= 1 << NativeBitToOasisBit[nativeBit];
+        }
+
+        return oasisMask;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -389,8 +389,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             for (var position = 0; position < display.Characters.Length; position++)
             {
                 var identity = new DisplayOutputIdentity(DisplayOutputFamily.Character, display.Identifier, displayOrdinal, position);
-                // Oasis's alpha event carries one integer. Keep the native mask in its low 32 bits and punctuation in bits 16/17.
-                var publishedMask = display.Characters[position] | ((uint)display.Attributes[position] << 16);
+                // Oasis's alpha event carries one integer. Convert Amber's low 16 segment bits,
+                // then retain punctuation in bits 16/17.
+                var oasisMask = System6AlphaSegmentMapper.MapNativeMaskToOasisMask(
+                    unchecked((int)display.Characters[position]));
+                var publishedMask = unchecked((uint)oasisMask) | ((uint)display.Attributes[position] << 16);
                 if (_displayOutputs.TryGetValue(identity, out var previous) && previous == publishedMask)
                     continue;
                 _displayOutputs[identity] = publishedMask;


### PR DESCRIPTION
### Motivation

- Fabric was publishing Amber/System 6 alpha masks in native bit order while Oasis rendering expects Oasis canonical bit ordering, which scrambled inner alpha segments.
- Restore a focused, minimal mapping at the Fabric/Amber character-display boundary so alpha masks are converted to Oasis ordering without changing Fabric ABI or seven-segment behavior.

### Description

- Added a small mapper `OasisEditor/Emulation/Fabric/Amber/System6AlphaSegmentMapper.cs` that implements the exact 16-entry native->Oasis bit table and only touches the lower 16 bits.
- Applied the mapper in `OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs` inside `PublishSnapshot` so `display.Characters[position]` is remapped before punctuation is preserved in bits 16 and 17, and events continue to be published as `SegmentOutputType.NativeAlpha`.
- Left Fabric seven-segment publishing unchanged (still emitted as `SegmentOutputType.Digit`).
- Added focused tests in `OasisEditor.Tests/FabricManagedBehaviorTests.cs` that assert each native bit maps correctly to its Oasis bit, verify zero and multi-bit masks, check punctuation is preserved in bits 16/17, and verify that `PublishSnapshot` emits the mapped alpha mask while seven-segment output remains unchanged.

### Testing

- Ran `git diff --check` and `git diff --cached --check` to ensure no whitespace/indexing issues were introduced and validated the working tree was clean after staging.
- Performed a static validation script (Python) to verify the mapping is a complete permutation of bits 0–15 and that a representative multi-bit example produces the expected Oasis mask.
- Added managed unit tests but did not run `dotnet test` in this environment because `AGENTS.md` explicitly prohibits building or executing the Windows/.NET/WPF projects here, so the new tests are for local execution.
- Recommended local verification: run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` to execute the added tests and confirm the fix end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d0b3ce3dc8327af7b86494d04ed05)