### PR TITLE
Fix Fabric seven-segment cell addressing (publish dense Oasis digit-cell IDs)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
@@ -1,0 +1,115 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FabricSevenSegmentRuntimeTests
+{
+    [Fact]
+    public void Snapshot_UsesDenseDigitCellsAndUpdatesPanelAndLinkedFaceDisplays()
+    {
+        var document = CreateDocument();
+        var panelNotifications = new List<IReadOnlyDictionary<string, object>>();
+        var faceNotifications = new List<IReadOnlyCollection<string>>();
+        document.PanelVisualStateChanged += change => panelNotifications.Add(change.ValuesByObjectId);
+        document.FaceVisualStateChanged += change => faceNotifications.Add(change.ObjectIds);
+        var dispatches = new List<Action>();
+        var diagnostics = new List<string>();
+        var adapter = new MachineSegmentRuntimeAdapter(
+            () => [document], dispatches.Add, diagnosticLogger: diagnostics.Add);
+        var backend = new FabricEmulationBackend("fabric", "amber");
+        backend.SegmentChanged += (_, change) =>
+            adapter.ApplySegmentState(change.CellId, change.SegmentMask, change.OutputType);
+
+        backend.PublishSnapshot(new FabricMachineSnapshot(1, [], [], [],
+        [
+            new FabricSegmentDisplay("amber.display.0", [0x3FUL, 0x06UL]),
+            new FabricSegmentDisplay("amber.display.1", [0x5BUL])
+        ]));
+        Assert.Single(dispatches)();
+
+        Assert.Equal([0x3F], document.RuntimeState.GetSegmentCellMasks("seven-0", 1));
+        Assert.Equal([0x06], document.RuntimeState.GetSegmentCellMasks("seven-1", 1));
+        Assert.Equal([0x5B], document.RuntimeState.GetSegmentCellMasks("seven-2", 1));
+        var reference = MachineObjectReference.SevenSegmentDisplay(1);
+        Assert.Equal([0x06, 0x5B], document.RuntimeState.GetSegmentCellMasks(reference, 2));
+        Assert.Contains(panelNotifications.SelectMany(values => values.Keys), id => id == "seven-0");
+        Assert.Contains(panelNotifications.SelectMany(values => values.Keys), id => id == "seven-2");
+        Assert.Contains(faceNotifications.SelectMany(ids => ids), id => id == "face-seven-1");
+        Assert.Contains(diagnostics, message => message.Contains("cellId=0") && message.Contains("mask=0x3F"));
+        Assert.Contains(diagnostics, message => message.Contains("face=face-seven-1") && message.Contains("0x5B"));
+    }
+
+    [Fact]
+    public void Snapshot_ZeroTurnsDigitOffAndDuplicateSnapshotDoesNotDispatchAgain()
+    {
+        var document = CreateDocument();
+        var dispatches = new List<Action>();
+        var adapter = new MachineSegmentRuntimeAdapter(() => [document], dispatches.Add);
+        var backend = new FabricEmulationBackend("fabric", "amber");
+        backend.SegmentChanged += (_, change) =>
+            adapter.ApplySegmentState(change.CellId, change.SegmentMask, change.OutputType);
+
+        backend.PublishSnapshot(new FabricMachineSnapshot(1, [], [], [],
+            [new FabricSegmentDisplay("amber.display.0", [0x7FUL])]));
+        Assert.Single(dispatches)();
+        Assert.Equal([0x7F], document.RuntimeState.GetSegmentCellMasks("seven-0", 1));
+
+        backend.PublishSnapshot(new FabricMachineSnapshot(2, [], [], [],
+            [new FabricSegmentDisplay("amber.display.0", [0UL])]));
+        Assert.Single(dispatches.Skip(1))();
+        Assert.Equal([0], document.RuntimeState.GetSegmentCellMasks("seven-0", 1));
+
+        backend.PublishSnapshot(new FabricMachineSnapshot(3, [], [], [],
+            [new FabricSegmentDisplay("amber.display.0", [0UL])]));
+        Assert.Equal(2, dispatches.Count);
+    }
+
+    [Fact]
+    public void Snapshot_AlphaAddressingAndMasksRemainUnchanged()
+    {
+        var backend = new FabricEmulationBackend("fabric", "amber");
+        var changes = new List<MachineSegmentChangedEventArgs>();
+        backend.SegmentChanged += (_, change) => changes.Add(change);
+
+        backend.PublishSnapshot(new FabricMachineSnapshot(1, [], [],
+        [
+            new FabricCharacterDisplay("alpha.0", [1u], [0]),
+            new FabricCharacterDisplay("alpha.1", [2u], [0])
+        ], []));
+
+        Assert.Collection(changes,
+            change =>
+            {
+                Assert.Equal(0, change.CellId);
+                Assert.Equal(1, change.SegmentMask);
+                Assert.Equal(SegmentOutputType.NativeAlpha, change.OutputType);
+            },
+            change =>
+            {
+                Assert.Equal(FabricAbi.CharacterCapacity, change.CellId);
+                Assert.Equal(2, change.SegmentMask);
+                Assert.Equal(SegmentOutputType.NativeAlpha, change.OutputType);
+            });
+    }
+
+    private static DocumentTabViewModel CreateDocument()
+    {
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements([
+            new PanelElementModel { ObjectId = "seven-0", Kind = PanelElementKind.SevenSegment, DisplayNumber = 0 },
+            new PanelElementModel { ObjectId = "seven-1", Kind = PanelElementKind.SevenSegment, DisplayNumber = 1 },
+            new PanelElementModel { ObjectId = "seven-2", Kind = PanelElementKind.SevenSegment, DisplayNumber = 2 }
+        ]);
+        document.SetFaceElements([
+            new FaceSevenSegmentDisplayElement
+            {
+                ObjectId = "face-seven-1",
+                DigitCount = 2,
+                LinkedMachineObjectReference = MachineObjectReference.SevenSegmentDisplay(1)
+            }
+        ]);
+        return document;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceRuntimeStateResolverTests.cs
@@ -59,6 +59,22 @@ public sealed class FaceRuntimeStateResolverTests
     }
 
     [Fact]
+    public void GetSevenSegmentCellMasks_UsesConfiguredDigitCount()
+    {
+        var runtimeState = new MachineRuntimeState();
+        var reference = MachineObjectReference.SevenSegmentDisplay(3);
+        runtimeState.SetSegmentCellMasksIfChanged(reference, [0x06, 0x5B]);
+        var display = new FaceSevenSegmentDisplayElement
+        {
+            LinkedMachineObjectReference = reference,
+            DigitCount = 2
+        };
+
+        Assert.Equal([0x06, 0x5B],
+            FaceRuntimeStateResolver.Instance.GetSevenSegmentCellMasks(display, runtimeState));
+    }
+
+    [Fact]
     public void GetSevenSegmentCellMasks_IgnoresLinkedPanel2DElementIdWhenMachineReferenceIsMissing()
     {
         var runtimeState = new MachineRuntimeState();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -95,6 +95,7 @@ public sealed class MachineReelChangedEventArgs : EventArgs
 
 public sealed class MachineSegmentChangedEventArgs : EventArgs
 {
+    /// <param name="cellId">For digit output, the dense zero-based Oasis digit-cell ID. For alpha output, the flattened character-cell ID.</param>
     public MachineSegmentChangedEventArgs(int cellId, int segmentMask, SegmentOutputType outputType)
     {
         CellId = cellId;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -401,6 +401,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 SegmentChanged?.Invoke(this, new(eventIndex, unchecked((int)publishedMask), SegmentOutputType.NativeAlpha));
             }
         }
+        var oasisCellId = 0;
         for (var displayOrdinal = 0; displayOrdinal < snapshot.SegmentDisplays.Count; displayOrdinal++)
         {
             var display = snapshot.SegmentDisplays[displayOrdinal];
@@ -409,10 +410,19 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 var identity = new DisplayOutputIdentity(DisplayOutputFamily.Segment, display.Identifier, displayOrdinal, position);
                 var mask = display.SegmentMasks[position];
                 if (_displayOutputs.TryGetValue(identity, out var previous) && previous == mask)
+                {
+                    oasisCellId++;
                     continue;
+                }
                 _displayOutputs[identity] = mask;
-                var eventIndex = checked(displayOrdinal * FabricAbi.SegmentCapacity + position);
-                SegmentChanged?.Invoke(this, new(eventIndex, unchecked((int)mask), SegmentOutputType.Digit));
+                SegmentChanged?.Invoke(this, new(oasisCellId, unchecked((int)mask), SegmentOutputType.Digit));
+                if (Debugger.IsAttached)
+                {
+                    Debug.WriteLine(
+                        $"Fabric segment changed: identifier='{display.Identifier}', ordinal={displayOrdinal}, " +
+                        $"position={position}, oasisCellId={oasisCellId}, mask=0x{mask:X}.");
+                }
+                oasisCellId++;
             }
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -101,8 +101,8 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         ArgumentNullException.ThrowIfNull(runtimeState);
 
         return TryGetSevenSegmentDisplayReference(display, out var reference)
-            ? runtimeState.GetSegmentCellMasks(reference, 1)
-            : new int[1];
+            ? runtimeState.GetSegmentCellMasks(reference, Math.Max(1, display.DigitCount))
+            : new int[Math.Max(1, display.DigitCount)];
     }
 
     public double[] GetSevenSegmentCellBrightness(FaceSevenSegmentDisplayElement display, MachineRuntimeState runtimeState)
@@ -111,8 +111,8 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         ArgumentNullException.ThrowIfNull(runtimeState);
 
         return TryGetSevenSegmentDisplayReference(display, out var reference)
-            ? runtimeState.GetSegmentCellBrightness(reference, 1)
-            : [1d];
+            ? runtimeState.GetSegmentCellBrightness(reference, Math.Max(1, display.DigitCount))
+            : Enumerable.Repeat(1d, Math.Max(1, display.DigitCount)).ToArray();
     }
 
     public int[] GetAlphaCellMasks(FaceAlphaDisplayElement display, MachineRuntimeState runtimeState)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineSegmentRuntimeAdapter.cs
@@ -94,6 +94,8 @@ public sealed class MachineSegmentRuntimeAdapter : IMachineSegmentRuntimeAdapter
             {
                 var objectId = element.ObjectId!;
                 var baseIndex = ResolveBaseIndex(element);
+                // A panel seven-segment element is one physical digit. Its display number is
+                // the dense Oasis digit-cell ID published by the backend.
                 var cellCount = element.Kind == PanelElementKind.SevenSegment ? 1 : 16;
                 var cellMasks = new int[cellCount];
                 var cellBrightness = new double[cellCount];
@@ -125,6 +127,10 @@ public sealed class MachineSegmentRuntimeAdapter : IMachineSegmentRuntimeAdapter
                 {
                     LogAlphaTrace(element, baseIndex, snapshot, cellMasks);
                 }
+                else
+                {
+                    LogDigitTrace(element, baseIndex, snapshot, cellMasks, maskChanged);
+                }
                 var brightnessChanged = element.Kind == PanelElementKind.Alpha
                     && document.RuntimeState.SetSegmentCellBrightnessIfChanged(objectId, cellBrightness);
                 if (_machineObjectReferenceResolver.TryGetReference(element, out var machineReference)
@@ -153,17 +159,39 @@ public sealed class MachineSegmentRuntimeAdapter : IMachineSegmentRuntimeAdapter
                     || faceDisplay.LinkedMachineObjectReference is not MachineObjectReference reference
                     || reference.Kind != MachineObjectKind.SevenSegmentDisplay
                     || reference.IsEmpty
-                    || !int.TryParse(reference.Id, out var cellId)
-                    || !_latestDigitMasksByCell.TryGetValue(cellId, out var mask))
+                    || !int.TryParse(reference.Id, out var cellId))
                 {
                     continue;
                 }
 
-                var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(reference, [mask]);
-                var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, [1d]);
+                var cellCount = Math.Max(1, faceDisplay.DigitCount);
+                var cellMasks = new int[cellCount];
+                var cellBrightness = Enumerable.Repeat(1d, cellCount).ToArray();
+                var hasLiveCell = false;
+                for (var position = 0; position < cellCount; position++)
+                {
+                    if (_latestDigitMasksByCell.TryGetValue(cellId + position, out var mask))
+                    {
+                        cellMasks[position] = mask;
+                        hasLiveCell = true;
+                    }
+                }
+                if (!hasLiveCell)
+                {
+                    continue;
+                }
+
+                var maskChanged = document.RuntimeState.SetSegmentCellMasksIfChanged(reference, cellMasks);
+                var brightnessChanged = document.RuntimeState.SetSegmentCellBrightnessIfChanged(reference, cellBrightness);
                 if (maskChanged || brightnessChanged || changedMachineReferences.Contains(reference))
                 {
                     FaceRuntimeDisplayReferenceIndex.AddObjectIdsForReference<FaceSevenSegmentDisplayElement>(document, reference, changedFaceObjectIds);
+                    if (_diagnosticLogger is not null && maskChanged)
+                    {
+                        _diagnosticLogger(
+                            $"Seven-segment face update: face={faceDisplay.ObjectId}; reference={reference}; " +
+                            $"baseCellId={cellId}; digitCount={cellCount}; masks=[{string.Join(", ", cellMasks.Select(value => $"0x{value:X}"))}].");
+                    }
                 }
             }
 
@@ -272,6 +300,29 @@ public sealed class MachineSegmentRuntimeAdapter : IMachineSegmentRuntimeAdapter
             $"Alpha ordering trace: platform={platform}; element={element.ObjectId}; displayNumber={element.DisplayNumber?.ToString() ?? "null"}; " +
             $"reference={reference}; baseIndex={baseIndex}; reversed={reversed}; raw=[{string.Join(", ", raw)}]; " +
             $"mapping=[{string.Join(", ", mapping)}]; canonical=[{string.Join(", ", canonicalMasks.Select(mask => $"0x{mask:X}"))}]");
+    }
+
+    private void LogDigitTrace(
+        PanelElementModel element,
+        int cellId,
+        IReadOnlyDictionary<int, (int Mask, SegmentOutputType OutputType)> updates,
+        IReadOnlyList<int> masks,
+        bool updated)
+    {
+        if (_diagnosticLogger is null
+            || !updates.TryGetValue(cellId, out var state)
+            || state.OutputType != SegmentOutputType.Digit)
+        {
+            return;
+        }
+
+        var reference = _machineObjectReferenceResolver.TryGetReference(element, out var resolvedReference)
+            ? resolvedReference.ToString()
+            : "unresolved";
+        _diagnosticLogger(
+            $"Seven-segment panel update: cellId={cellId}; mask=0x{state.Mask:X}; element={element.ObjectId}; " +
+            $"displayNumber={element.DisplayNumber?.ToString() ?? "null"}; reference={reference}; updated={updated}; " +
+            $"runtimeMasks=[{string.Join(", ", masks.Select(value => $"0x{value:X}"))}].");
     }
 
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -22,7 +22,6 @@ namespace OasisEditor;
 
 public sealed class MainWindowViewModel : INotifyPropertyChanged
 {
-    private const int System6SevenSegmentCellStride = 16;
     private static readonly bool kDebugSkiaPerformanceOutput = false;
     private readonly RecentProjectsStore _recentProjectsStore = new();
     private readonly IApplicationThemeService _applicationThemeService;
@@ -2052,7 +2051,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         {
             foreach (var element in document.GetPanelElements())
             {
-                if (element.Kind == PanelElementKind.SevenSegment && element.DisplayNumber is int displayId && displayId is >= 0 and <= ushort.MaxValue / System6SevenSegmentCellStride)
+                if (element.Kind == PanelElementKind.SevenSegment && element.DisplayNumber is int displayId && displayId is >= 0 and <= ushort.MaxValue)
                 {
                     displayIds.Add(displayId);
                 }
@@ -2063,7 +2062,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 if (faceDisplay.LinkedMachineObjectReference is MachineObjectReference reference
                     && reference.Kind == MachineObjectKind.SevenSegmentDisplay
                     && int.TryParse(reference.Id, out var displayId)
-                    && displayId is >= 0 and <= ushort.MaxValue / System6SevenSegmentCellStride)
+                    && displayId is >= 0 and <= ushort.MaxValue)
                 {
                     displayIds.Add(displayId);
                 }


### PR DESCRIPTION
### Motivation

- Restore live seven-segment rendering by fixing a mismatch between how Fabric/Amber published segment cells and how Oasis expects seven-segment display IDs. 
- Fabric snapshots publish masks per segment-record; the code had treated `FabricAbi.SegmentCapacity` as an address stride which produced sparse IDs that Oasis elements did not reference.

### Description

- Treat Fabric segment display records as a sequence of masks that map to consecutive, dense Oasis digit-cell IDs instead of computing `displayOrdinal * SegmentCapacity + position`, and publish `SegmentChanged` digit events with dense Oasis cell IDs. (Changed: `Emulation/Fabric/FabricEmulationBackend.cs`.)
- Make panel seven-segment elements represent a single physical digit whose `DisplayNumber`/`MachineObjectReference.Id` is the dense digit-cell ID, and log targeted diagnostics when digit state changes. (Changed: `MachineSegmentRuntimeAdapter.cs`.)
- Ensure face-linked seven-segment displays collect consecutive cells beginning at the referenced machine-object ID according to the `DigitCount` and publish them as a multi-digit mask/brightness array to the runtime state, with change-gated diagnostics for face updates. (Changed: `MachineSegmentRuntimeAdapter.cs`, `FaceRuntimeStateResolver.cs`.)
- Remove the obsolete System 6 ×16 stride constraint from the launch-time configured display ID validation so configured display IDs are validated as current dense cell IDs. (Changed: `MainWindowViewModel.cs`.)
- Document event semantics by clarifying that `MachineSegmentChangedEventArgs.CellId` uses dense digit-cell IDs for digit output and the existing flattened character-cell IDs for alpha output. (Changed: `Emulation/EmulationBackendAbstractions.cs`.)
- Add end-to-end managed tests that simulate representative `FabricMachineSnapshot` inputs and assert correct propagation into panel elements, face-linked multi-digit displays, duplicate-suppression, zero/off behavior, and unchanged alpha addressing. (Added: `OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs`; also updated `FaceRuntimeStateResolver` tests.)

### Testing

- No automated test runner was executed in this environment because the repository's `AGENTS.md` prohibits attempting Windows/.NET/WPF builds or running `dotnet test` here; consequently no unit tests were executed in this run. 
- Added unit tests exercising the end-to-end managed path from `FabricMachineSnapshot` through `FabricEmulationBackend.SegmentChanged` into `MachineSegmentRuntimeAdapter` and into `MachineRuntimeState`: `FabricSevenSegmentRuntimeTests` (covers dense addressing, zero/off masks, duplicate-snapshot suppression, multi-record grouping, and alpha addressing) and an added `FaceRuntimeStateResolver` test for `DigitCount` behavior. 
- A local developer should run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` and build `OasisEditor.sln` on Windows with the required WPF/.NET toolchain to verify all tests and visually confirm live emulation with Fabric/Amber; diagnostic traces are change-gated and suitable for a debug session as described in the PR summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d0facc8c88327acbe54e2573bdd07)