### PR TITLE
Map Amber System 6 seven-segment masks to Oasis ordering

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -13,6 +13,37 @@ public sealed class FabricManagedBehaviorTests
         { 12, 11 }, { 13, 12 }, { 14, 8 }, { 15, 13 },
     };
 
+    public static TheoryData<int, int> System6SevenSegmentBitMapping => new()
+    {
+        { 0, 6 }, // G -> G
+        { 1, 5 }, // F -> F
+        { 2, 4 }, // E -> E
+        { 3, 3 }, // D -> D
+        { 4, 2 }, // C -> C
+        { 5, 1 }, // B -> B
+        { 6, 0 }, // A -> A
+        { 7, 7 }, // DP -> DP
+    };
+
+    [Theory]
+    [MemberData(nameof(System6SevenSegmentBitMapping))]
+    public void System6SevenSegmentMapper_MapsEachNativeNamedSegmentToTheCanonicalOasisSegment(
+        int nativeBit, int oasisBit)
+    {
+        Assert.Equal(1 << oasisBit,
+            System6SevenSegmentMapper.MapNativeMaskToOasisMask(1 << nativeBit));
+    }
+
+    [Fact]
+    public void System6SevenSegmentMapper_MapsZeroCombinedSegmentsAndIgnoresUnknownBits()
+    {
+        Assert.Equal(0, System6SevenSegmentMapper.MapNativeMaskToOasisMask(0));
+
+        var nativeMask = (1 << 0) | (1 << 4) | (1 << 7) | (1 << 12);
+        var expectedOasisMask = (1 << 6) | (1 << 2) | (1 << 7);
+        Assert.Equal(expectedOasisMask, System6SevenSegmentMapper.MapNativeMaskToOasisMask(nativeMask));
+    }
+
     [Theory]
     [MemberData(nameof(System6AlphaBitMapping))]
     public void System6AlphaMapper_MapsEveryNativeBitToItsOasisBit(int nativeBit, int oasisBit)
@@ -32,7 +63,7 @@ public sealed class FabricManagedBehaviorTests
     }
 
     [Fact]
-    public void Backend_PublishesMappedAlphaWithPunctuationAndLeavesSevenSegmentUnchanged()
+    public void Backend_PublishesMappedAlphaWithPunctuationAndMappedSevenSegmentMask()
     {
         var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
         var changes = new List<MachineSegmentChangedEventArgs>();
@@ -53,9 +84,27 @@ public sealed class FabricManagedBehaviorTests
             },
             sevenSegmentChange =>
             {
-                Assert.Equal(unchecked((int)sevenSegmentMask), sevenSegmentChange.SegmentMask);
+                Assert.Equal(0x5a, unchecked((int)sevenSegmentMask));
+                Assert.Equal(0x2d, sevenSegmentChange.SegmentMask);
                 Assert.Equal(SegmentOutputType.Digit, sevenSegmentChange.OutputType);
             });
+    }
+
+    [Fact]
+    public void Backend_DoesNotRepublishAnUnchangedMappedSevenSegmentMask()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+        var changes = new List<MachineSegmentChangedEventArgs>();
+        backend.SegmentChanged += (_, change) => changes.Add(change);
+        var snapshot = new FabricMachineSnapshot(1, [], [], [],
+            [new FabricSegmentDisplay("seven", [0x41UL])]);
+
+        backend.PublishSnapshot(snapshot);
+        backend.PublishSnapshot(new FabricMachineSnapshot(2, [], [], [],
+            [new FabricSegmentDisplay("seven", [0x141UL])]));
+
+        var change = Assert.Single(changes);
+        Assert.Equal(0x41, change.SegmentMask);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
@@ -28,16 +28,16 @@ public sealed class FabricSevenSegmentRuntimeTests
         ]));
         Assert.Single(dispatches)();
 
-        Assert.Equal([0x3F], document.RuntimeState.GetSegmentCellMasks("seven-0", 1));
-        Assert.Equal([0x06], document.RuntimeState.GetSegmentCellMasks("seven-1", 1));
-        Assert.Equal([0x5B], document.RuntimeState.GetSegmentCellMasks("seven-2", 1));
+        Assert.Equal([0x7E], document.RuntimeState.GetSegmentCellMasks("seven-0", 1));
+        Assert.Equal([0x30], document.RuntimeState.GetSegmentCellMasks("seven-1", 1));
+        Assert.Equal([0x6D], document.RuntimeState.GetSegmentCellMasks("seven-2", 1));
         var reference = MachineObjectReference.SevenSegmentDisplay(1);
-        Assert.Equal([0x06, 0x5B], document.RuntimeState.GetSegmentCellMasks(reference, 2));
+        Assert.Equal([0x30, 0x6D], document.RuntimeState.GetSegmentCellMasks(reference, 2));
         Assert.Contains(panelNotifications.SelectMany(values => values.Keys), id => id == "seven-0");
         Assert.Contains(panelNotifications.SelectMany(values => values.Keys), id => id == "seven-2");
         Assert.Contains(faceNotifications.SelectMany(ids => ids), id => id == "face-seven-1");
-        Assert.Contains(diagnostics, message => message.Contains("cellId=0") && message.Contains("mask=0x3F"));
-        Assert.Contains(diagnostics, message => message.Contains("face=face-seven-1") && message.Contains("0x5B"));
+        Assert.Contains(diagnostics, message => message.Contains("cellId=0") && message.Contains("mask=0x7E"));
+        Assert.Contains(diagnostics, message => message.Contains("face=face-seven-1") && message.Contains("0x6D"));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/Panel2DRendererTests.cs
@@ -440,6 +440,23 @@ public sealed class Panel2DRendererTests
             PanelViewportTransform.Identity);
     }
 
+    [Fact]
+    public void SevenSegmentRenderer_DecimalPointBitControlsIlluminationAndBrightness()
+    {
+        using var offSurface = SKSurface.Create(new SKImageInfo(100, 100));
+        using var litSurface = SKSurface.Create(new SKImageInfo(100, 100));
+        SevenSegmentElementRenderer.RenderSegmentDisplay(offSurface.Canvas, SKRect.Create(100, 100), [0], [0.5d], "#FFFF0000", "#FF100000");
+        SevenSegmentElementRenderer.RenderSegmentDisplay(litSurface.Canvas, SKRect.Create(100, 100), [1 << 7], [0.5d], "#FFFF0000", "#FF100000");
+
+        using var offBitmap = SKBitmap.FromImage(offSurface.Snapshot());
+        using var litBitmap = SKBitmap.FromImage(litSurface.Snapshot());
+        var offPixel = offBitmap.GetPixel(82, 85);
+        var litPixel = litBitmap.GetPixel(82, 85);
+
+        Assert.True(litPixel.Red > offPixel.Red);
+        Assert.True(litPixel.Red < 255);
+    }
+
 
     [Fact]
     public void Render_WithAlphaRenderer_DoesNotThrow()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/System6SevenSegmentMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/System6SevenSegmentMapper.cs
@@ -1,0 +1,32 @@
+namespace OasisEditor;
+
+internal static class System6SevenSegmentMapper
+{
+    // The array index is the Amber/System 6 native bit; the array value is the
+    // Oasis canonical bit. Oasis bits 0..7 are A, B, C, D, E, F, G and DP.
+    // System 6's seven main segments use the historical reversed bit order;
+    // DP remains bit 7. Keep this explicit table easy to correct after live testing.
+    private static readonly int[] NativeBitToOasisBit =
+    [
+        6, // native bit 0 (G)  -> Oasis bit 6 (G)
+        5, // native bit 1 (F)  -> Oasis bit 5 (F)
+        4, // native bit 2 (E)  -> Oasis bit 4 (E)
+        3, // native bit 3 (D)  -> Oasis bit 3 (D)
+        2, // native bit 4 (C)  -> Oasis bit 2 (C)
+        1, // native bit 5 (B)  -> Oasis bit 1 (B)
+        0, // native bit 6 (A)  -> Oasis bit 0 (A)
+        7, // native bit 7 (DP) -> Oasis bit 7 (DP)
+    ];
+
+    internal static int MapNativeMaskToOasisMask(int nativeMask)
+    {
+        var oasisMask = 0;
+        for (var nativeBit = 0; nativeBit < NativeBitToOasisBit.Length; nativeBit++)
+        {
+            if ((nativeMask & (1 << nativeBit)) != 0)
+                oasisMask |= 1 << NativeBitToOasisBit[nativeBit];
+        }
+
+        return oasisMask;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -408,19 +408,21 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             for (var position = 0; position < display.SegmentMasks.Length; position++)
             {
                 var identity = new DisplayOutputIdentity(DisplayOutputFamily.Segment, display.Identifier, displayOrdinal, position);
-                var mask = display.SegmentMasks[position];
-                if (_displayOutputs.TryGetValue(identity, out var previous) && previous == mask)
+                var oasisMask = System6SevenSegmentMapper.MapNativeMaskToOasisMask(
+                    unchecked((int)display.SegmentMasks[position]));
+                var publishedMask = unchecked((uint)oasisMask);
+                if (_displayOutputs.TryGetValue(identity, out var previous) && previous == publishedMask)
                 {
                     oasisCellId++;
                     continue;
                 }
-                _displayOutputs[identity] = mask;
-                SegmentChanged?.Invoke(this, new(oasisCellId, unchecked((int)mask), SegmentOutputType.Digit));
+                _displayOutputs[identity] = publishedMask;
+                SegmentChanged?.Invoke(this, new(oasisCellId, oasisMask, SegmentOutputType.Digit));
                 if (Debugger.IsAttached)
                 {
                     Debug.WriteLine(
                         $"Fabric segment changed: identifier='{display.Identifier}', ordinal={displayOrdinal}, " +
-                        $"position={position}, oasisCellId={oasisCellId}, mask=0x{mask:X}.");
+                        $"position={position}, oasisCellId={oasisCellId}, mask=0x{publishedMask:X}.");
                 }
                 oasisCellId++;
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/SevenSegmentElementRenderer.cs
@@ -117,7 +117,8 @@ internal sealed class SevenSegmentElementRenderer : IPanelElementRenderer
         }
         if (definition.DecimalPoint is not null)
         {
-            paint.Color = cacheKey.OffColor;
+            var lit = (cacheKey.SegmentMask & (1 << SevenSegmentBitMapping.DecimalPoint)) != 0;
+            paint.Color = lit ? Lerp(cacheKey.OffColor, cacheKey.OnColor, litAmount) : cacheKey.OffColor;
             canvas.DrawPath(definition.DecimalPoint, paint);
         }
         canvas.Restore();


### PR DESCRIPTION
### Motivation

- Fabric/Amber seven-segment masks were being forwarded unchanged and the individual segments did not match Oasis’s canonical 7-segment bit ordering.
- There is already a correct 16-segment alpha mapping via `System6AlphaSegmentMapper`, so a dedicated 7-segment mapper following the same pattern is required.
- The decimal point geometry was present but always rendered with the off colour, so DP needed to follow the same mask-and-brightness behaviour as the main segments.

### Description

- Added a dedicated mapper `System6SevenSegmentMapper` with an explicit native-to-Oasis mapping table for native bits 0..7 -> Oasis bits `[6, 5, 4, 3, 2, 1, 0, 7]` (native G,F,E,D,C,B,A,DP -> canonical G,F,E,D,C,B,A,DP) in `Emulation/Fabric/Amber/System6SevenSegmentMapper.cs` to make the mapping direct and easy to adjust after live testing. 
- Canonicalized Fabric seven-segment masks inside `FabricEmulationBackend.PublishSnapshot` so mapping happens prior to change detection, caching (`_displayOutputs`), `SegmentChanged` publication, and diagnostic logging, while leaving display-cell addressing unchanged (`OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs`).
- Fixed decimal-point rendering so bit 7 controls illumination and brightness interpolation like the seven main segments by updating `SevenSegmentElementRenderer` to check `SevenSegmentBitMapping.DecimalPoint` and apply the same `Lerp` logic (`OasisEditor/Rendering/SevenSegmentElementRenderer.cs`).
- Added table-driven unit tests and coverage to validate the mapper and Fabric publication behaviour, including mapping each named native bit, zero/combined masks, ignoring unknown high bits, mapped publication and deduplication, and DP rendering; tests live in `OasisEditor.Tests` and include updates to `FabricManagedBehaviorTests`, `FabricSevenSegmentRuntimeTests`, and `Panel2DRendererTests`.
- Files changed: `Emulation/Fabric/Amber/System6SevenSegmentMapper.cs` (new), `Emulation/Fabric/FabricEmulationBackend.cs`, `Rendering/SevenSegmentElementRenderer.cs`, and test updates in `OasisEditor.Tests/FabricManagedBehaviorTests.cs`, `OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs`, and `OasisEditor.Tests/Panel2DRendererTests.cs`.

### Testing

- Repository checks: `git diff --check` passed and the changes were committed (commit `9359035 Map System 6 seven-segment output`).
- No project build or unit tests were executed in this environment because the repository `AGENTS.md` documents that the Codex environment lacks the required Windows/.NET/WPF toolchain and prohibits running builds/tests here. 
- Added automated unit tests (table-driven mapping tests, Fabric publish/dedup tests, and a decimal-point renderer test) which should be executed locally with `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` or by running the focused tests `FabricManagedBehaviorTests`, `FabricSevenSegmentRuntimeTests`, and `Panel2DRendererTests` on a Windows development machine with the proper .NET/WPF toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d14911c248327b07d06b0d0e8e240)