### PR TITLE
Update Fabric alpha-display brightness integration for ABI v2

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricNativeLayoutProbeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricNativeLayoutProbeTests.cs
@@ -32,7 +32,7 @@ public sealed class FabricNativeLayoutProbeTests
             ["sizeof.FabricInput"] = 84,
             ["sizeof.FabricLamp"] = 84,
             ["sizeof.FabricReel"] = 80,
-            ["sizeof.FabricCharacterDisplay"] = 160,
+            ["sizeof.FabricCharacterDisplay"] = 164,
             ["sizeof.FabricSegmentDisplay"] = 208,
             ["sizeof.FabricMachineSnapshot"] = 80,
             ["sizeof.FabricAudioFormat"] = 20,
@@ -49,7 +49,8 @@ public sealed class FabricNativeLayoutProbeTests
             ["offsetof.FabricMachineSnapshot.lamps"] = 16,
             ["offsetof.FabricMachineSnapshot.reels"] = 32,
             ["offsetof.FabricMachineSnapshot.character_displays"] = 48,
-            ["offsetof.FabricMachineSnapshot.segment_displays"] = 64
+            ["offsetof.FabricMachineSnapshot.segment_displays"] = 64,
+            ["offsetof.FabricCharacterDisplay.brightness"] = 160
         };
 
         Assert.Equal(expected.Count, values.Count);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/NativeProbe/fabric_layout_probe.c
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/NativeProbe/fabric_layout_probe.c
@@ -13,7 +13,7 @@ typedef struct FabricCapabilities { uint32_t struct_size, struct_version; uint64
 typedef struct FabricInput { uint32_t struct_size, struct_version; char identifier[ID]; int32_t numerical_index; uint8_t active, reserved[7]; } FabricInput;
 typedef struct FabricLamp { uint32_t struct_size, struct_version; char identifier[ID]; int32_t numerical_index; uint8_t logical_state, reserved[3]; float brightness; } FabricLamp;
 typedef struct FabricReel { uint32_t struct_size, struct_version; char identifier[ID]; int32_t numerical_index, position; } FabricReel;
-typedef struct FabricCharacterDisplay { uint32_t struct_size, struct_version; char identifier[ID]; uint32_t character_count, character_capacity, characters[CHARS]; uint8_t attributes[CHARS]; } FabricCharacterDisplay;
+typedef struct FabricCharacterDisplay { uint32_t struct_size, struct_version; char identifier[ID]; uint32_t character_count, character_capacity, characters[CHARS]; uint8_t attributes[CHARS]; float brightness; } FabricCharacterDisplay;
 typedef struct FabricSegmentDisplay { uint32_t struct_size, struct_version; char identifier[ID]; uint32_t digit_count, digit_capacity; uint64_t segment_masks[DIGITS]; } FabricSegmentDisplay;
 typedef struct FabricMachineSnapshot { uint32_t struct_size, struct_version; uint64_t sequence; FabricLamp *lamps; uint32_t lamp_capacity, lamp_count; FabricReel *reels; uint32_t reel_capacity, reel_count; FabricCharacterDisplay *character_displays; uint32_t character_display_capacity, character_display_count; FabricSegmentDisplay *segment_displays; uint32_t segment_display_capacity, segment_display_count; } FabricMachineSnapshot;
 typedef struct FabricAudioFormat { uint32_t struct_size, struct_version, sample_rate; uint16_t channel_count, bits_per_sample; uint8_t interleaved, signed_samples, little_endian, reserved; } FabricAudioFormat;
@@ -36,5 +36,6 @@ int main(void) {
     OFF(FabricLaunchRequest, rom_resources); OFF(FabricRomResource, path);
     OFF(FabricMachineSnapshot, lamps); OFF(FabricMachineSnapshot, reels);
     OFF(FabricMachineSnapshot, character_displays); OFF(FabricMachineSnapshot, segment_displays);
+    OFF(FabricCharacterDisplay, brightness);
     return 0;
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
@@ -8,6 +8,7 @@ public sealed class FabricAbiLayoutTests
     [Fact]
     public void X64NativeLayoutsMatchPublishedAbi()
     {
+        Assert.Equal(0x00020000u, FabricAbi.Version);
         if (IntPtr.Size != 8) return;
         Assert.Equal(1208, Marshal.SizeOf<FabricLaunchRequestNative>()); // fixed strings end at 1160; aligned pointers/counts end at 1208.
         Assert.Equal(40, Marshal.SizeOf<FabricRomResourceNative>());
@@ -15,7 +16,8 @@ public sealed class FabricAbiLayoutTests
         Assert.Equal(84, Marshal.SizeOf<FabricInputNative>());
         Assert.Equal(84, Marshal.SizeOf<FabricLampNative>());
         Assert.Equal(80, Marshal.SizeOf<FabricReelNative>());
-        Assert.Equal(160, Marshal.SizeOf<FabricCharacterDisplayNative>());
+        Assert.Equal(164, Marshal.SizeOf<FabricCharacterDisplayNative>());
+        Assert.Equal(160, Marshal.OffsetOf<FabricCharacterDisplayNative>("Brightness").ToInt32());
         Assert.Equal(208, Marshal.SizeOf<FabricSegmentDisplayNative>());
         Assert.Equal(80, Marshal.SizeOf<FabricMachineSnapshotNative>());
         Assert.Equal(20, Marshal.SizeOf<FabricAudioFormatNative>());

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -5,6 +5,18 @@ namespace OasisEditor.Tests;
 
 public sealed class FabricManagedBehaviorTests
 {
+    [Fact]
+    public unsafe void NativeCharacterDisplayConversionPreservesBrightnessAndRejectsNonFiniteValues()
+    {
+        var native = new FabricCharacterDisplayNative { Brightness = 0.625f };
+
+        var managed = FabricMachineSession.ConvertCharacterDisplay(ref native);
+
+        Assert.Equal(0.625f, managed.Brightness);
+        native.Brightness = float.NaN;
+        Assert.Throws<InvalidDataException>(() => FabricMachineSession.ConvertCharacterDisplay(ref native));
+    }
+
     public static TheoryData<int, int> System6AlphaBitMapping => new()
     {
         { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 3 },
@@ -71,7 +83,7 @@ public sealed class FabricManagedBehaviorTests
         var nativeAlphaMask = (1u << 8) | (1u << 14);
         const ulong sevenSegmentMask = 0x5a;
         var snapshot = new FabricMachineSnapshot(1, [], [],
-            [new FabricCharacterDisplay("alpha", [nativeAlphaMask], [0b11])],
+            [new FabricCharacterDisplay("alpha", [nativeAlphaMask], [0b11], 0.5f)],
             [new FabricSegmentDisplay("seven", [sevenSegmentMask])]);
 
         backend.PublishSnapshot(snapshot);
@@ -88,6 +100,56 @@ public sealed class FabricManagedBehaviorTests
                 Assert.Equal(0x2d, sevenSegmentChange.SegmentMask);
                 Assert.Equal(SegmentOutputType.Digit, sevenSegmentChange.OutputType);
             });
+    }
+
+    [Fact]
+    public void Backend_PublishesDisplayBrightnessIndependentlyFromSegmentChanges()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+        var brightnessChanges = new List<MachineVfdBrightnessChangedEventArgs>();
+        var segmentChanges = new List<MachineSegmentChangedEventArgs>();
+        backend.VfdBrightnessChanged += (_, change) => brightnessChanges.Add(change);
+        backend.SegmentChanged += (_, change) => segmentChanges.Add(change);
+
+        backend.PublishSnapshot(new(1, [], [],
+        [
+            new("alpha.0", [1u], [0], 0.25f),
+            new("alpha.1", [2u], [0], 0.75f)
+        ], []));
+        backend.PublishSnapshot(new(2, [], [],
+        [
+            new("alpha.0", [1u], [0], 0.5f),
+            new("alpha.1", [2u], [0], 0.75f)
+        ], []));
+        backend.PublishSnapshot(new(3, [], [],
+        [
+            new("alpha.0", [4u], [0], 0.5f),
+            new("alpha.1", [2u], [0], 0.75f)
+        ], []));
+
+        Assert.Collection(brightnessChanges,
+            change => { Assert.Equal(0, change.CellId); Assert.Equal(0.25, change.NormalizedBrightness); },
+            change => { Assert.Equal(FabricAbi.CharacterCapacity, change.CellId); Assert.Equal(0.75, change.NormalizedBrightness); },
+            change => { Assert.Equal(0, change.CellId); Assert.Equal(0.5, change.NormalizedBrightness); });
+        Assert.Equal(3, segmentChanges.Count);
+    }
+
+    [Fact]
+    public async Task Backend_ResetClearsDisplayBrightnessCache()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+        var brightnessChanges = new List<MachineVfdBrightnessChangedEventArgs>();
+        backend.VfdBrightnessChanged += (_, change) => brightnessChanges.Add(change);
+        var snapshot = new FabricMachineSnapshot(1, [], [],
+            [new("alpha", [], [], 0.4f)], []);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        backend.PublishSnapshot(snapshot);
+        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        backend.PublishSnapshot(snapshot);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(2, brightnessChanges.Count);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
@@ -6,6 +6,28 @@ namespace OasisEditor.Tests;
 public sealed class FabricSevenSegmentRuntimeTests
 {
     [Fact]
+    public void AlphaBrightnessAtEachDisplayBaseIndexReachesRuntimeCells()
+    {
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements([
+            new PanelElementModel { ObjectId = "alpha-0", Kind = PanelElementKind.Alpha, DisplayNumber = 0 },
+            new PanelElementModel { ObjectId = "alpha-1", Kind = PanelElementKind.Alpha, DisplayNumber = 1 }
+        ]);
+        var dispatches = new List<Action>();
+        var adapter = new MachineSegmentRuntimeAdapter(() => [document], dispatches.Add);
+
+        adapter.ApplyVfdBrightness(0, 0.5);
+        adapter.ApplyVfdBrightness(FabricAbi.CharacterCapacity, 0.25);
+        Assert.Single(dispatches)();
+
+        Assert.All(document.RuntimeState.GetSegmentCellBrightness("alpha-0", 16),
+            brightness => Assert.Equal(0.5, brightness));
+        Assert.All(document.RuntimeState.GetSegmentCellBrightness("alpha-1", 16),
+            brightness => Assert.Equal(0.25, brightness));
+    }
+
+    [Fact]
     public void Snapshot_UsesDenseDigitCellsAndUpdatesPanelAndLinkedFaceDisplays()
     {
         var document = CreateDocument();
@@ -74,8 +96,8 @@ public sealed class FabricSevenSegmentRuntimeTests
 
         backend.PublishSnapshot(new FabricMachineSnapshot(1, [], [],
         [
-            new FabricCharacterDisplay("alpha.0", [1u], [0]),
-            new FabricCharacterDisplay("alpha.1", [2u], [0])
+            new FabricCharacterDisplay("alpha.0", [1u], [0], 1f),
+            new FabricCharacterDisplay("alpha.1", [2u], [0], 1f)
         ], []));
 
         Assert.Collection(changes,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -26,6 +26,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly Dictionary<int, (bool State, float Brightness)> _lamps = [];
     private readonly Dictionary<int, int> _reels = [];
     private readonly Dictionary<DisplayOutputIdentity, ulong> _displayOutputs = [];
+    private readonly Dictionary<DisplayBrightnessIdentity, float> _displayBrightnessOutputs = [];
     private readonly object _stateGate = new();
 
     private IFabricRuntimeLibrary? _runtime;
@@ -386,6 +387,15 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         for (var displayOrdinal = 0; displayOrdinal < snapshot.CharacterDisplays.Count; displayOrdinal++)
         {
             var display = snapshot.CharacterDisplays[displayOrdinal];
+            var brightnessIdentity = new DisplayBrightnessIdentity(
+                DisplayOutputFamily.Character, display.Identifier, displayOrdinal);
+            if (!_displayBrightnessOutputs.TryGetValue(brightnessIdentity, out var previousBrightness)
+                || previousBrightness != display.Brightness)
+            {
+                _displayBrightnessOutputs[brightnessIdentity] = display.Brightness;
+                var displayBaseIndex = checked(displayOrdinal * FabricAbi.CharacterCapacity);
+                VfdBrightnessChanged?.Invoke(this, new(displayBaseIndex, display.Brightness));
+            }
             for (var position = 0; position < display.Characters.Length; position++)
             {
                 var identity = new DisplayOutputIdentity(DisplayOutputFamily.Character, display.Identifier, displayOrdinal, position);
@@ -498,6 +508,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _lamps.Clear();
         _reels.Clear();
         _displayOutputs.Clear();
+        _displayBrightnessOutputs.Clear();
     }
 
     private IFabricMachineSession RequireSession() =>
@@ -524,5 +535,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     private readonly record struct InputCommand(int Index, bool Active);
     private readonly record struct DisplayOutputIdentity(DisplayOutputFamily Family, string Identifier, int DisplayOrdinal, int Position);
+    private readonly record struct DisplayBrightnessIdentity(DisplayOutputFamily Family, string Identifier, int DisplayOrdinal);
     private enum DisplayOutputFamily { Character, Segment }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricMachineSession.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricMachineSession.cs
@@ -295,14 +295,7 @@ internal sealed unsafe class FabricMachineSession : IFabricMachineSession
         for (var index = 0; index < snapshot.CharacterCount; index++)
         {
             ref var display = ref _characters[index];
-            var values = new uint[display.Count];
-            var attributes = new byte[display.Count];
-            fixed (uint* source = display.Characters)
-                new ReadOnlySpan<uint>(source, values.Length).CopyTo(values);
-            fixed (byte* source = display.Attributes)
-                new ReadOnlySpan<byte>(source, attributes.Length).CopyTo(attributes);
-            fixed (byte* identifier = display.Identifier)
-                characters.Add(new(ReadIdentifier(identifier), values, attributes));
+            characters.Add(ConvertCharacterDisplay(ref display, index));
         }
 
         var segments = new List<FabricSegmentDisplay>((int)snapshot.SegmentCount);
@@ -316,6 +309,22 @@ internal sealed unsafe class FabricMachineSession : IFabricMachineSession
                 segments.Add(new(ReadIdentifier(identifier), masks));
         }
         return new(snapshot.Sequence, lamps, reels, characters, segments);
+    }
+
+    internal static FabricCharacterDisplay ConvertCharacterDisplay(
+        ref FabricCharacterDisplayNative display,
+        int displayIndex = 0)
+    {
+        if (!float.IsFinite(display.Brightness))
+            throw new InvalidDataException($"Fabric character display {displayIndex} returned non-finite brightness.");
+        var values = new uint[display.Count];
+        var attributes = new byte[display.Count];
+        fixed (uint* source = display.Characters)
+            new ReadOnlySpan<uint>(source, values.Length).CopyTo(values);
+        fixed (byte* source = display.Attributes)
+            new ReadOnlySpan<byte>(source, attributes.Length).CopyTo(attributes);
+        fixed (byte* identifier = display.Identifier)
+            return new(ReadIdentifier(identifier), values, attributes, display.Brightness);
     }
 
     private static string ReadIdentifier(byte* pointer)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
@@ -12,7 +12,7 @@ public sealed record FabricInput(string Identifier, int NumericalIndex, bool Act
 public readonly record struct FabricCapabilities(ulong Flags) { public bool Has(FabricCapability value) => (Flags & (ulong)value) != 0; }
 public readonly record struct FabricLamp(string Identifier, int NumericalIndex, bool LogicalState, float Brightness);
 public readonly record struct FabricReel(string Identifier, int NumericalIndex, int Position);
-public sealed record FabricCharacterDisplay(string Identifier, uint[] Characters, byte[] Attributes);
+public sealed record FabricCharacterDisplay(string Identifier, uint[] Characters, byte[] Attributes, float Brightness);
 public sealed record FabricSegmentDisplay(string Identifier, ulong[] SegmentMasks);
 public sealed record FabricMachineSnapshot(ulong Sequence, IReadOnlyList<FabricLamp> Lamps, IReadOnlyList<FabricReel> Reels,
     IReadOnlyList<FabricCharacterDisplay> CharacterDisplays, IReadOnlyList<FabricSegmentDisplay> SegmentDisplays);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
-internal static class FabricAbi { internal const uint Version = 0x00010000; internal const int IdentifierCapacity=64, PathCapacity=1024, CharacterCapacity=16, SegmentCapacity=16; }
+internal static class FabricAbi { internal const uint Version = 0x00020000; internal const int IdentifierCapacity=64, PathCapacity=1024, CharacterCapacity=16, SegmentCapacity=16; }
 
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricLaunchRequestNative { internal uint Size,Version; internal fixed byte BackendKind[64],MachineIdentifier[64],BackendPath[1024]; internal nint RomPaths; internal uint RomPathCount; internal nint Configuration; internal uint ConfigurationSize,Reserved; internal nint Resources; internal uint ResourceCount; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricRomResourceNative { internal uint Size,Version,Role,Slot; internal nint Path; internal fixed ulong Reserved[2]; }
@@ -10,7 +10,7 @@ internal static class FabricAbi { internal const uint Version = 0x00010000; inte
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricInputNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index; internal byte Active; internal fixed byte Reserved[7]; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricLampNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index; internal byte LogicalState; internal fixed byte Reserved[3]; internal float Brightness; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricReelNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index,Position; }
-[StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricCharacterDisplayNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal uint Count,Capacity; internal fixed uint Characters[16]; internal fixed byte Attributes[16]; }
+[StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricCharacterDisplayNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal uint Count,Capacity; internal fixed uint Characters[16]; internal fixed byte Attributes[16]; internal float Brightness; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricSegmentDisplayNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal uint Count,Capacity; internal fixed ulong Masks[16]; }
 [StructLayout(LayoutKind.Sequential)] internal struct FabricMachineSnapshotNative { internal uint Size,Version; internal ulong Sequence; internal nint Lamps; internal uint LampCapacity,LampCount; internal nint Reels; internal uint ReelCapacity,ReelCount; internal nint Characters; internal uint CharacterCapacity,CharacterCount; internal nint Segments; internal uint SegmentCapacity,SegmentCount; }
 [StructLayout(LayoutKind.Sequential)] internal struct FabricAudioFormatNative { internal uint Size,Version,SampleRate; internal ushort Channels,BitsPerSample; internal byte Interleaved,Signed,LittleEndian,Reserved; }


### PR DESCRIPTION
### Motivation

- Fabric bumped its strict ABI to v2 and the native `FabricCharacterDisplay` now contains a display-wide `brightness` `float` that must be consumed by Oasis.
- The editor runtime expects display-wide alpha brightness keyed by the display base cell index, so the Fabric backend must surface that normalized brightness into the existing `VfdBrightnessChanged` path.
- Changes must be small, ABI-only, and preserve all existing alpha/mask mapping behavior while adding brightness transport and tests asserting the native layout.

### Description

- Updated the strict Fabric ABI constant to `0x00020000` via `FabricAbi.Version` and extended `FabricCharacterDisplayNative` with `internal float Brightness` in the merged ABI position so the native layout is 164 bytes with `Brightness` at offset 160. (`Emulation/Fabric/FabricNativeTypes.cs`, `OasisEditor.NativeIntegrationTests/NativeProbe/fabric_layout_probe.c`)
- Added `Brightness` to the managed model `FabricCharacterDisplay` and wired native→managed conversion to copy `display.Brightness` directly, rejecting non-finite values. (`Emulation/Fabric/FabricManagedModels.cs`, `Emulation/Fabric/FabricMachineSession.cs`)
- Implemented display-wide brightness publication in `FabricEmulationBackend.PublishSnapshot()` using the display base index `displayOrdinal * FabricAbi.CharacterCapacity` and an independent brightness cache keyed by display identity so brightness events are emitted only when changed and are not tied to per-character mask changes. Cache is cleared by the existing reset/cleanup path. (`Emulation/Fabric/FabricEmulationBackend.cs`)
- Updated ABI layout probes and managed layout assertions to the new sizes/offsets and added unit tests and focused coverage: native-to-managed conversion, non-finite rejection, brightness publication behavior, reset clearing, and a runtime-adapter test verifying brightness arrives at alpha runtime cells. (tests under `OasisEditor.Tests` and `OasisEditor.NativeIntegrationTests`)

### Testing

- Ran static checks: `git diff --check` reported no whitespace/patch errors and repository status is clean after changes.
- Added and updated automated tests: `FabricAbiLayoutTests`, `FabricManagedBehaviorTests` (native conversion, brightness publication and reset coverage), and `FabricSevenSegmentRuntimeTests` (runtime-adapter brightness coverage); these tests were added but not executed in this environment due to toolchain constraints documented in `WindowsNetProjects/OasisEditor/AGENTS.md`.
- Per project guidance, no managed builds or unit test runs were attempted here because the environment lacks the required Windows/.NET/WPF toolchain; local execution instructions: run the test suite locally (e.g. `dotnet test` in `OasisEditor.Tests`) to verify all new and updated tests pass and to confirm native probe executable results when available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d1ec0b3b48327859967b6fca04c1c)