### PR TITLE
Preserve all 32 Alpha display brightness levels

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AlphaElementRendererTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/AlphaElementRendererTests.cs
@@ -1,0 +1,77 @@
+using OasisEditor.Rendering;
+using SkiaSharp;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class AlphaElementRendererTests
+{
+    [Theory]
+    [InlineData(0d, 0)]
+    [InlineData(1d, 31)]
+    [InlineData(-0.01d, 0)]
+    [InlineData(1.01d, 31)]
+    public void ToBrightnessBucket_ClampsToAmberRange(double brightness, int expectedBucket)
+    {
+        Assert.Equal(expectedBucket, AlphaElementRenderer.ToBrightnessBucket(brightness));
+    }
+
+    [Fact]
+    public void ToBrightnessBucket_PreservesEveryNativeAmberLevel()
+    {
+        var buckets = Enumerable.Range(0, 32)
+            .Select(level => AlphaElementRenderer.ToBrightnessBucket(level / 31d))
+            .ToArray();
+
+        Assert.Equal(Enumerable.Range(0, 32), buckets);
+        Assert.Equal(15, AlphaElementRenderer.ToBrightnessBucket(15d / 31d));
+        Assert.DoesNotContain(15d / 31d, new[] { 0d, 0.25d, 0.5d, 0.75d, 1d });
+    }
+
+    [Fact]
+    public void FromBrightnessBucket_ReconstructsAmberNormalizedBrightness()
+    {
+        Assert.Equal(15d / 31d, AlphaElementRenderer.FromBrightnessBucket(15));
+        Assert.NotEqual(15d / 4d, AlphaElementRenderer.FromBrightnessBucket(15));
+    }
+
+    [Fact]
+    public void RenderAlphaDisplay_SameMaskAndBrightness_ReusesCachedVisual()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(137, 59));
+        AlphaElementRenderer.ResetDiagnosticsCounters();
+
+        Render(surface.Canvas, 0x1357, 12d / 31d, "#FF12A4C8");
+        Render(surface.Canvas, 0x1357, 12d / 31d, "#FF12A4C8");
+
+        Assert.Equal(1, AlphaElementRenderer.DiagnosticsCacheMisses);
+        Assert.Equal(1, AlphaElementRenderer.DiagnosticsCacheHits);
+    }
+
+    [Fact]
+    public void RenderAlphaDisplay_AdjacentAmberLevels_CreateDistinctCachedVisuals()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(139, 61));
+        AlphaElementRenderer.ResetDiagnosticsCounters();
+
+        Render(surface.Canvas, 0x2468, 14d / 31d, "#FF7B35D1");
+        Render(surface.Canvas, 0x2468, 15d / 31d, "#FF7B35D1");
+
+        Assert.Equal(2, AlphaElementRenderer.DiagnosticsCacheMisses);
+        Assert.Equal(0, AlphaElementRenderer.DiagnosticsCacheHits);
+    }
+
+    private static void Render(SKCanvas canvas, int mask, double brightness, string onColorHex)
+    {
+        AlphaElementRenderer.RenderAlphaDisplay(
+            canvas,
+            SKRect.Create(137f, 59f),
+            [mask],
+            [brightness],
+            "led16seg",
+            onColorHex,
+            "#FF010203",
+            showDecimalPoint: true,
+            showCommaTail: true);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Rendering/AlphaElementRenderer.cs
@@ -4,6 +4,7 @@ namespace OasisEditor.Rendering;
 
 internal sealed class AlphaElementRenderer : IPanelElementRenderer
 {
+    private const int BrightnessBucketMaximum = 31;
     private const int MaxVisualCacheEntries = 4096;
     private static readonly Dictionary<string, Lazy<AlphaSkiaDefinition?>> DefinitionsByType = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<AlphaVisualCacheKey, SKImage> VisualCache = new();
@@ -106,8 +107,8 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
             // source display addressing and is consumed by the runtime adapter.
             var dataIndex = cellIndex;
             var mask = dataIndex < cellMasks.Length ? cellMasks[dataIndex] : defaultMask;
-            var litAmount = dataIndex < cellBrightness.Length ? Math.Clamp(cellBrightness[dataIndex], 0d, 1d) : 1d;
-            var brightnessBucket = (int)Math.Round(litAmount * 4d);
+            var litAmount = dataIndex < cellBrightness.Length ? cellBrightness[dataIndex] : 1d;
+            var brightnessBucket = ToBrightnessBucket(litAmount);
             var key = new AlphaVisualCacheKey(displayType, cellPixelWidth, cellPixelHeight, mask, brightnessBucket, onColor, offColor, showDecimalPoint, showCommaTail);
             var visual = GetOrCreateVisual(key, definition);
             var cellRect = SKRect.Create(originX + (cellIndex * scaledPitch), originY, scaledCellWidth, scaledCellHeight);
@@ -150,7 +151,7 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         canvas.Save();
         canvas.Translate(offsetX, offsetY);
         canvas.Scale(scale, scale);
-        var litAmount = key.BrightnessBucket / 4d;
+        var litAmount = FromBrightnessBucket(key.BrightnessBucket);
         foreach (var segment in definition.Segments)
         {
             var lit = (key.Mask & (1 << segment.Index)) != 0;
@@ -239,6 +240,21 @@ internal sealed class AlphaElementRenderer : IPanelElementRenderer
         var clamped = Math.Clamp(factor, 0d, 1d);
         byte Scale(byte value) => (byte)Math.Clamp(Math.Round(value * clamped), 0d, 255d);
         return new SKColor(Scale(color.Red), Scale(color.Green), Scale(color.Blue), 255);
+    }
+
+    internal static int ToBrightnessBucket(double brightness)
+    {
+        var clamped = Math.Clamp(brightness, 0d, 1d);
+        return Math.Clamp(
+            (int)Math.Round(clamped * BrightnessBucketMaximum),
+            0,
+            BrightnessBucketMaximum);
+    }
+
+    internal static double FromBrightnessBucket(int bucket)
+    {
+        return Math.Clamp(bucket, 0, BrightnessBucketMaximum)
+            / (double)BrightnessBucketMaximum;
     }
 
     private static SKColor Lerp(SKColor from, SKColor to, double t)


### PR DESCRIPTION
### Motivation

- The Alpha renderer previously quantized normalized brightness into five visual buckets (`0.00, 0.25, 0.50, 0.75, 1.00`) which produced a visibly stepped fade, while the Amber source provides a 5‑bit (0–31) brightness value.

### Description

- Introduce `private const int BrightnessBucketMaximum = 31` and replace the `* 4` / `/ 4d` quantization with `ToBrightnessBucket` and `FromBrightnessBucket` helpers that clamp inputs and map to/from the 0–31 integer range. 
- Replace in-place quantization with `var brightnessBucket = ToBrightnessBucket(litAmount);` and reconstruct normalized brightness with `FromBrightnessBucket(key.BrightnessBucket)`, which divides by `31.0`.
- Preserve the existing bounded visual cache and keep `BrightnessBucket` as part of `AlphaVisualCacheKey` so identical mask/level combinations reuse cached visuals while adjacent Amber levels create distinct cache entries. 
- Add focused unit tests in `OasisEditor.Tests/AlphaElementRendererTests.cs` that assert clamping, 0→0 and 1→31 mappings, distinct mapping for all 32 native levels (0/31..31/31), the intermediate `15/31` behavior, reconstruction via division by `31.0`, cache reuse for same mask+level, and distinct cached visuals for adjacent levels; leave `SevenSegmentElementRenderer` unchanged after inspection. 

### Testing

- Ran `git diff --check` which produced no whitespace or diff-check errors. 
- Created and committed changes and new test file, but did not execute `dotnet test` here because `WindowsNetProjects/OasisEditor/AGENTS.md` documents that the environment lacks the Windows/.NET/WPF toolchain and prohibits running builds/tests; the added tests must be run locally with `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` on a supported Windows dev machine. 
- Static validation performed: source replacement reviewed and the visual cache bounding behavior was retained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6d2280dbc483279fe13986dc1a5816)