### PR TITLE
Fix Project Settings platform dropdown hit testing

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Content Include="..\OasisEditor\MfmeFonts\*.ttf" Link="MfmeFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\OasisEditor\MfmeFonts\*.TTF" Link="MfmeFonts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\OasisEditor\Views\ProjectSettingsView.xaml" Link="Views\ProjectSettingsView.xaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectSettingsViewXamlTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectSettingsViewXamlTests.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using Xunit;
 
 namespace OasisEditor.Tests;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectSettingsViewXamlTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ProjectSettingsViewXamlTests.cs
@@ -1,0 +1,85 @@
+using System.Xml.Linq;
+
+namespace OasisEditor.Tests;
+
+public sealed class ProjectSettingsViewXamlTests
+{
+    private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+    [Fact]
+    public void CategoryRootsCollapseUnlessTheirCategoryIsSelected()
+    {
+        var document = LoadView();
+        var contentGrid = document
+            .Descendants(Presentation + "Grid")
+            .Single(grid => grid.Elements(Presentation + "ScrollViewer").Any(IsGeneralCategoryRoot));
+        var categoryRoots = contentGrid.Elements(Presentation + "ScrollViewer").ToArray();
+
+        Assert.Equal(2, categoryRoots.Length);
+        AssertCategoryVisibility(categoryRoots.Single(IsGeneralCategoryRoot), "General");
+        AssertCategoryVisibility(categoryRoots.Single(IsImpactFabricCategoryRoot), "Impact / Fabric");
+    }
+
+    [Fact]
+    public void ImpactFabricVisibilityBelongsToOuterScrollViewer()
+    {
+        var impactRoot = LoadView()
+            .Descendants(Presentation + "ScrollViewer")
+            .Single(IsImpactFabricCategoryRoot);
+
+        Assert.NotNull(impactRoot.Element(Presentation + "ScrollViewer.Style"));
+        Assert.Null(impactRoot.Element(Presentation + "Grid")?.Element(Presentation + "Grid.Style"));
+    }
+
+    [Fact]
+    public void FruitMachinePlatformComboBoxIsEnabledAndBoundToPlatformValues()
+    {
+        var comboBox = LoadView()
+            .Descendants(Presentation + "ComboBox")
+            .Single(element => element.Attribute("ItemsSource")?.Value == "{Binding FruitMachinePlatformTypes}");
+
+        Assert.False(string.Equals("False", comboBox.Attribute("IsEnabled")?.Value, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("{Binding SelectedFruitMachinePlatform}", comboBox.Attribute("SelectedItem")?.Value);
+        Assert.NotEmpty(Enum.GetValues<FruitMachinePlatformType>());
+    }
+
+    private static XDocument LoadView()
+    {
+        return XDocument.Load(Path.Combine(AppContext.BaseDirectory, "Views", "ProjectSettingsView.xaml"));
+    }
+
+    private static void AssertCategoryVisibility(XElement categoryRoot, string category)
+    {
+        var style = categoryRoot.Element(Presentation + "ScrollViewer.Style")?.Element(Presentation + "Style");
+        Assert.NotNull(style);
+        Assert.Contains(
+            style.Elements(Presentation + "Setter"),
+            setter => setter.Attribute("Property")?.Value == "Visibility"
+                && setter.Attribute("Value")?.Value == "Collapsed");
+
+        var triggers = style.Element(Presentation + "Style.Triggers")?.Elements(Presentation + "DataTrigger").ToArray();
+        var trigger = Assert.Single(triggers!);
+        Assert.Equal("{Binding SelectedProjectSettingsCategory}", trigger.Attribute("Binding")?.Value);
+        Assert.Equal(category, trigger.Attribute("Value")?.Value);
+        Assert.Contains(
+            trigger.Elements(Presentation + "Setter"),
+            setter => setter.Attribute("Property")?.Value == "Visibility"
+                && setter.Attribute("Value")?.Value == "Visible");
+    }
+
+    private static bool IsGeneralCategoryRoot(XElement element)
+    {
+        return HasHeading(element, "General");
+    }
+
+    private static bool IsImpactFabricCategoryRoot(XElement element)
+    {
+        return HasHeading(element, "Impact / Fabric");
+    }
+
+    private static bool HasHeading(XElement element, string heading)
+    {
+        return element.Descendants(Presentation + "TextBlock")
+            .Any(textBlock => textBlock.Attribute("Text")?.Value == heading);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -51,17 +51,17 @@
             </ScrollViewer>
 
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <Grid>
-                <Grid.Style>
-                    <Style TargetType="Grid">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedProjectSettingsCategory}" Value="Impact / Fabric">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                            </Style.Triggers>
+                <ScrollViewer.Style>
+                    <Style TargetType="ScrollViewer">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedProjectSettingsCategory}" Value="Impact / Fabric">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
                     </Style>
-                </Grid.Style>
+                </ScrollViewer.Style>
+                <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />


### PR DESCRIPTION
### Motivation

- The Fruit Machine Platform ComboBox in Project Settings could not open because an overlapping sibling `ScrollViewer` intercepted pointer input. 
- The root cause was that the Impact / Fabric category applied its visibility trigger to an inner `Grid` while its outer `ScrollViewer` remained visible and hit-testable. 
- The intent is to ensure only the active category root is `Visible` while inactive category roots are `Collapsed` so controls underneath receive pointer events.

### Description

- In `OasisEditor/Views/ProjectSettingsView.xaml` moved the `DataTrigger`-based visibility style for the "Impact / Fabric" category from the child `Grid` to the category's outer `ScrollViewer` and removed the redundant inner `Grid.Style`.
- Added `OasisEditor.Tests/ProjectSettingsViewXamlTests.cs` to provide focused static XAML regression checks that validate category-root visibility ownership and the platform `ComboBox` bindings/items. 
- Updated `OasisEditor.Tests/OasisEditor.Tests.csproj` to copy `Views/ProjectSettingsView.xaml` into the test output so the tests can load the view XML at runtime. 
- Preserved existing `ComboBox` bindings, the `FruitMachinePlatformType` enum, serialization, global styles, and avoided code-behind changes.

### Testing

- Ran a static XML parse/assertion (Python) that validated both category `ScrollViewer` roots default to `Collapsed` with category-specific `Visible` triggers, that the Impact / Fabric visibility now belongs to the outer `ScrollViewer`, and that the Fruit machine platform `ComboBox` remains enabled and correctly bound, and these assertions passed. 
- Ran repository validation checks including `git diff --check` and staging checks which reported no whitespace or diff errors. 
- Did not run `dotnet test` or WPF UI interaction tests in this environment because the required Windows/.NET/WPF toolchain is unavailable; please run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` on Windows and verify at runtime that selecting `Project Settings` -> `General` allows the Fruit machine platform dropdown to open and update `SelectedFruitMachinePlatform`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6db078513883278f33c6b44eff19f9)