### PR TITLE
Restore MFME input-map generation during FML import

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -217,7 +217,7 @@ public sealed class FmlToOasisMapperTests
         var lamp = new Lamp { X = 1, Y = 2, Width = 30, Height = 40, SublampTable = [new LampSublampTableEntry(1, 9)] };
         lamp.Colours["Sublamp1Colour"] = "#112233FF";
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.Strings["ButtonNumber"] = "1";
+        button.UInt32s["Button Number"] = 1;
         button.Strings["Label"] = "START";
 
         var images = new Dictionary<FmlDecodedImageKey, string>
@@ -240,7 +240,7 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithButtonLabel_MapsToLampDisplayTextAndInputDefinition()
     {
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.Strings["ButtonNumber"] = "1";
+        button.UInt32s["Button Number"] = 1;
         button.Strings["Label"] = "START";
 
         var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
@@ -258,7 +258,7 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithDecodedButtonUtf16Label_MapsToLampDisplayText()
     {
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.Strings["ButtonNumber"] = "1";
+        button.UInt32s["Button Number"] = 1;
         button.Strings["Label (UTF-16)"] = "START";
 
         var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
@@ -290,6 +290,144 @@ public sealed class FmlToOasisMapperTests
         Assert.Equal(PanelElementKind.Lamp, element.Kind);
         Assert.Equal("HOLD", element.DisplayText);
     }
+
+    [Fact]
+    public void Map_WithCurrentButtonInputFields_PreservesZeroShortcutInversionAndVisualLink()
+    {
+        var button = CreateButton();
+        button.Strings["Label"] = "START";
+        button.UInt32s["Button Number"] = 0;
+        button.Booleans["Shortcut 1 Enabled"] = true;
+        button.UInt32s["Shortcut 1"] = 0x20;
+        button.Booleans["Inverted"] = true;
+
+        var result = Map(button);
+
+        var element = Assert.Single(result.Elements);
+        var input = Assert.Single(result.InputDefinitions);
+        Assert.Equal("START", input.Name);
+        Assert.Equal("0", input.ButtonNumber);
+        Assert.Equal("SPACE", input.RawMfmeShortcut);
+        Assert.Equal("Space", input.KeyboardShortcut);
+        Assert.True(input.Inverted);
+        Assert.Equal(element.ObjectId, input.LinkedVisualElementId?.ToString("N"));
+    }
+
+    [Fact]
+    public void Map_WithCurrentLampInputFields_UsesSecondEnabledShortcut()
+    {
+        var lamp = CreateLamp();
+        lamp.UInt32s["ButtonNumber"] = 2;
+        lamp.Booleans["Shortcut 1 Enabled"] = false;
+        lamp.UInt32s["Shortcut 1"] = 0x41;
+        lamp.Booleans["Shortcut 2 Enabled"] = true;
+        lamp.UInt32s["Shortcut 2"] = 0x31;
+
+        var input = Assert.Single(Map(lamp).InputDefinitions);
+
+        Assert.Equal("2", input.ButtonNumber);
+        Assert.Equal("1", input.RawMfmeShortcut);
+        Assert.Equal("D1", input.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void Map_WithUnknownPrimaryShortcut_FallsBackToValidSecondaryShortcut()
+    {
+        var button = CreateButton();
+        button.UInt32s["Button Number"] = 3;
+        button.Booleans["Shortcut 1 Enabled"] = true;
+        button.UInt32s["Shortcut 1"] = uint.MaxValue;
+        button.Booleans["Shortcut 2 Enabled"] = true;
+        button.UInt32s["Shortcut 2"] = 0x25;
+
+        var input = Assert.Single(Map(button).InputDefinitions);
+
+        Assert.Equal("LEFT", input.RawMfmeShortcut);
+        Assert.Equal("Left", input.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void Map_WithNoOrUnknownShortcut_StillCreatesInputRows()
+    {
+        var noShortcut = CreateButton();
+        noShortcut.UInt32s["Button Number"] = 4;
+        var unknownShortcut = CreateButton();
+        unknownShortcut.UInt32s["Button Number"] = 5;
+        unknownShortcut.Booleans["Shortcut 1 Enabled"] = true;
+        unknownShortcut.UInt32s["Shortcut 1"] = uint.MaxValue;
+
+        var result = new FmlToOasisMapper().Map(new Layout([noShortcut, unknownShortcut]), new Dictionary<FmlDecodedImageKey, string>());
+
+        Assert.Equal(2, result.InputDefinitions.Count);
+        Assert.All(result.InputDefinitions, input => Assert.Equal(string.Empty, input.KeyboardShortcut));
+        Assert.Contains(result.InputDefinitions, input => input.ButtonNumber == "5" && input.Notes.Contains(uint.MaxValue.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Map_WithCurrentCoinFields_CreatesNamedCoinInputAndRetainsButtonNumber()
+    {
+        var lamp = CreateLamp();
+        lamp.UInt32s["ButtonNumber"] = 6;
+        lamp.Booleans["Coin / Note Selected"] = true;
+        lamp.Strings["SelectedCoinNote"] = "£1 Coin";
+
+        var input = Assert.Single(Map(lamp).InputDefinitions);
+
+        Assert.Equal(InputDefinitionKind.Coin, input.Kind);
+        Assert.True(input.CoinInput);
+        Assert.Equal("6", input.ButtonNumber);
+        Assert.Equal("£1 Coin", input.Name);
+    }
+
+    [Fact]
+    public void Map_WithPlaceholderCoinNote_DoesNotCreateInput()
+    {
+        var lamp = CreateLamp();
+        lamp.Strings["SelectedCoinNote"] = "(none)";
+
+        Assert.Empty(Map(lamp).InputDefinitions);
+    }
+
+    [Fact]
+    public void Map_WithMultiSublampInput_CreatesOneInputLinkedToLastVisual()
+    {
+        var lamp = new Lamp
+        {
+            Width = 20,
+            Height = 20,
+            SublampTable = [new LampSublampTableEntry(1, 7), new LampSublampTableEntry(2, 8)]
+        };
+        lamp.UInt32s["ButtonNumber"] = 7;
+
+        var result = Map(lamp);
+
+        Assert.Equal(2, result.Elements.Count);
+        var input = Assert.Single(result.InputDefinitions);
+        Assert.Equal(result.Elements[1].ObjectId, input.LinkedVisualElementId?.ToString("N"));
+    }
+
+    [Fact]
+    public void Map_WithoutCurrentInputMetadata_DoesNotCreateInput()
+    {
+        Assert.Empty(Map(CreateButton()).InputDefinitions);
+    }
+
+    private static Button CreateButton() => new()
+    {
+        Width = 20,
+        Height = 20,
+        SublampTable = [new LampSublampTableEntry(1, 1)]
+    };
+
+    private static Lamp CreateLamp() => new()
+    {
+        Width = 20,
+        Height = 20,
+        SublampTable = [new LampSublampTableEntry(1, 1)]
+    };
+
+    private static FmlToOasisMapResult Map(BaseComponent component)
+        => new FmlToOasisMapper().Map(new Layout([component]), new Dictionary<FmlDecodedImageKey, string>());
 
 
     [Theory]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
@@ -134,7 +134,12 @@ internal sealed class FmlImportDiagnosticsWriter
         AppendLine(sb, "Image count", report.ImagePaths.Count.ToString());
         AppendList(sb, "Image filenames", report.ImagePaths.Values.OrderBy(v => v, StringComparer.Ordinal));
         AppendList(sb, "Panel element counts", CountStrings(report.MapResult?.Elements.Select(e => e.Kind.ToString()) ?? []).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
-        AppendLine(sb, "Input definition count", (report.MapResult?.InputDefinitions.Count ?? 0).ToString());
+        var inputs = report.MapResult?.InputDefinitions ?? [];
+        AppendLine(sb, "Mapped input definition count", inputs.Count.ToString());
+        AppendLine(sb, "Button input count", inputs.Count(input => !input.CoinInput).ToString());
+        AppendLine(sb, "Coin input count", inputs.Count(input => input.CoinInput).ToString());
+        AppendLine(sb, "Inputs with shortcuts", inputs.Count(input => !string.IsNullOrWhiteSpace(input.KeyboardShortcut)).ToString());
+        AppendLine(sb, "Inputs without shortcuts", inputs.Count(input => string.IsNullOrWhiteSpace(input.KeyboardShortcut)).ToString());
         AppendLine(sb, "Imported asset count", report.ImportedAssetCount.ToString());
         AppendBackgroundDiagnostics(sb, report);
         sb.AppendLine();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -127,6 +127,7 @@ internal sealed class FmlImportService : IFmlImportService
 
         diagnostics.Add($"Generated image count: {imagePaths.Count}; image root: {stagingDirectory}; image paths: {FormatImagePaths(imagePaths.Values)}");
         diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(layout))}");
+        diagnostics.Add($"Mapped input definition count: {mapResult.InputDefinitions.Count}; button inputs: {mapResult.InputDefinitions.Count(input => !input.CoinInput)}; coin inputs: {mapResult.InputDefinitions.Count(input => input.CoinInput)}; with shortcuts: {mapResult.InputDefinitions.Count(input => !string.IsNullOrWhiteSpace(input.KeyboardShortcut))}; without shortcuts: {mapResult.InputDefinitions.Count(input => string.IsNullOrWhiteSpace(input.KeyboardShortcut))}");
 
         var assetCopyStopwatch = Stopwatch.StartNew();
         var assetResult = _assetCopier.CopyAssetsFromStaging(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -40,7 +40,7 @@ internal sealed class FmlToOasisMapper
                     AddUnsupportedComponent(component, unsupported, warnings);
                     break;
                 case Lamp or PrismLamp or Button or Checkbox:
-                    MapLampLike(component, index, exportedImages, elements, inputs);
+                    MapLampLike(component, index, exportedImages, elements, inputs, warnings);
                     break;
                 case Reel or BandReel or DiscReel or FlipReel:
                     elements.Add(MapReel(component, index, exportedImages, warnings));
@@ -84,7 +84,7 @@ internal sealed class FmlToOasisMapper
         warnings.Add(new LayoutImportWarning("fml.import.component.unsupported", $"Unsupported FML component '{componentType}' was skipped.", componentType));
     }
 
-    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs)
+    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs, ICollection<LayoutImportWarning> warnings)
     {
         var entries = GetSublamps(c).Where(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0).OrderBy(e => e.SublampIndex).ToArray();
         if (entries.Length == 0)
@@ -116,7 +116,20 @@ internal sealed class FmlToOasisMapper
         }
 
         var input = BuildInput(c, elements.LastOrDefault(e => e.SourceComponentIndex == index)?.ObjectId ?? string.Empty);
-        if (input is not null) inputs.Add(input);
+        if (input is not null)
+        {
+            inputs.Add(input);
+        }
+        else if (HasInputMetadata(c))
+        {
+            var shortcutCodes = c.UInt32s
+                .Where(pair => pair.Key is "Shortcut 1" or "Shortcut 2")
+                .Select(pair => $"{pair.Key}={pair.Value.ToString(CultureInfo.InvariantCulture)}");
+            warnings.Add(new LayoutImportWarning(
+                "fml.import.input.unmapped",
+                $"FML component {index.ToString(CultureInfo.InvariantCulture)} ({c.GetType().Name}) contains input metadata but no input could be mapped. UInt32 keys=[{string.Join(", ", c.UInt32s.Keys.OrderBy(key => key, StringComparer.Ordinal))}]; Boolean keys=[{string.Join(", ", c.Booleans.Keys.OrderBy(key => key, StringComparer.Ordinal))}]; shortcut codes=[{string.Join(", ", shortcutCodes)}].",
+                index.ToString(CultureInfo.InvariantCulture)));
+        }
     }
 
     private static PanelElementModel MapReel(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, ICollection<LayoutImportWarning> warnings)
@@ -263,7 +276,126 @@ internal sealed class FmlToOasisMapper
     private static bool IsMainBackgroundImage(string k) { var n = Norm(k); return n.Contains("background") && !n.Contains("mask") && !IsOverlay(k); }
     private static string Norm(string s) { var n = new string(s.Select(ch => char.IsLetterOrDigit(ch) ? char.ToLowerInvariant(ch) : '_').ToArray()); while (n.Contains("__", StringComparison.Ordinal)) n = n.Replace("__", "_", StringComparison.Ordinal); return n.Trim('_'); }
     private static PanelElementImportSourceModel Source(BaseComponent c, int index, int? n = null) => new() { Format = ImportSourceFormat, Reference = n.HasValue ? $"{c.GetType().Name}:{index}:{n.Value}" : $"{c.GetType().Name}:{index}" };
-    private static InputDefinitionModel? BuildInput(BaseComponent c, string linkedObjectId) { var button = Str(c, "ButtonNumber") ?? Str(c, "Button"); var has = button is not null || Bool(c, "HasButtonInput") == true || Bool(c, "HasCoinInput") == true; if (!has) return null; var raw = Str(c, "Shortcut1") ?? string.Empty; MfmeShortcutKeyMapper.TryMap(raw, out var mapped); return new InputDefinitionModel { Id = Guid.NewGuid().ToString("N"), Name = Text(c) ?? "Imported Input", Kind = Bool(c, "HasCoinInput") == true ? InputDefinitionKind.Coin : InputDefinitionKind.Button, ButtonNumber = button ?? string.Empty, CoinInput = Bool(c, "HasCoinInput") == true, Inverted = Bool(c, "Inverted") ?? false, RawMfmeShortcut = raw, KeyboardShortcut = mapped.ToString(), LinkedVisualElementId = Guid.TryParse(linkedObjectId, out var id) ? id : null, Notes = string.Empty }; }
+    private static InputDefinitionModel? BuildInput(BaseComponent c, string linkedObjectId)
+    {
+        var buttonNumber = GetInputButtonNumber(c);
+        var coinNote = GetSelectedCoinNote(c);
+        var isCoinInput = Bool(c, "Coin / Note Selected") == true || coinNote is not null;
+        var shortcut = GetPrimaryShortcut(c);
+        var hasEnabledShortcut = HasEnabledShortcut(c);
+        if (!buttonNumber.HasValue && !isCoinInput && !hasEnabledShortcut)
+        {
+            return null;
+        }
+
+        var rawShortcut = shortcut?.Text ?? string.Empty;
+        var keyboardShortcut = string.Empty;
+        if (shortcut is not null && MfmeShortcutKeyMapper.TryMap(rawShortcut, out var mappedKey))
+        {
+            keyboardShortcut = mappedKey.ToString();
+        }
+
+        var name = LampText(c) ?? (isCoinInput ? coinNote ?? "Imported Coin Input" : "Imported Button Input");
+        return new InputDefinitionModel
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Name = name,
+            Kind = isCoinInput ? InputDefinitionKind.Coin : InputDefinitionKind.Button,
+            ButtonNumber = buttonNumber?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            CoinInput = isCoinInput,
+            Inverted = Bool(c, "Inverted") ?? false,
+            RawMfmeShortcut = rawShortcut,
+            KeyboardShortcut = keyboardShortcut,
+            LinkedVisualElementId = Guid.TryParse(linkedObjectId, out var id) ? id : null,
+            Notes = shortcut is null && hasEnabledShortcut ? FormatUnknownShortcutNotes(c) : string.Empty
+        };
+    }
+
+    private static uint? GetInputButtonNumber(BaseComponent c)
+        => UInt(c, "Button Number") ?? UInt(c, "ButtonNumber");
+
+    private static string? GetSelectedCoinNote(BaseComponent c)
+    {
+        var value = Str(c, "SelectedCoinNote");
+        return value is null || value.Equals("none", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("(none)", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("not selected", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : value;
+    }
+
+    private static MfmeDecodedShortcut? GetPrimaryShortcut(BaseComponent c)
+    {
+        foreach (var number in new[] { 1, 2 })
+        {
+            if (Bool(c, $"Shortcut {number} Enabled") != true || UInt(c, $"Shortcut {number}") is not uint code)
+            {
+                continue;
+            }
+
+            if (TryDecodeMfmeShortcut(code, out var text))
+            {
+                return new MfmeDecodedShortcut(code, text);
+            }
+        }
+
+        return null;
+    }
+
+    // MFME persists shortcuts as Win32 virtual-key codes, not character code points.
+    private static bool TryDecodeMfmeShortcut(uint code, out string text)
+    {
+        text = code switch
+        {
+            0x08 => "BACKSPACE",
+            0x09 => "TAB",
+            0x0D => "ENTER",
+            0x10 => "SHIFT",
+            0x11 => "CTRL",
+            0x12 => "ALT",
+            0x1B => "ESCAPE",
+            0x20 => "SPACE",
+            0x25 => "LEFT",
+            0x26 => "UP",
+            0x27 => "RIGHT",
+            0x28 => "DOWN",
+            0x30 or >= 0x31 and <= 0x39 => ((char)code).ToString(),
+            >= 0x41 and <= 0x5A => ((char)code).ToString(),
+            0xBA => ";",
+            0xBB => "=",
+            0xBC => ",",
+            0xBD => "-",
+            0xBE => ".",
+            0xBF => "/",
+            0xC0 => "`",
+            0xDB => "[",
+            0xDC => "\\",
+            0xDD => "]",
+            0xDE => "'",
+            0xDF => "#",
+            _ => string.Empty
+        };
+        return text.Length > 0;
+    }
+
+    private static bool HasEnabledShortcut(BaseComponent c)
+        => Bool(c, "Shortcut 1 Enabled") == true || Bool(c, "Shortcut 2 Enabled") == true;
+
+    private static bool HasInputMetadata(BaseComponent c)
+        => GetInputButtonNumber(c).HasValue || GetSelectedCoinNote(c) is not null || Bool(c, "Coin / Note Selected") == true
+            || HasEnabledShortcut(c) || Bool(c, "Inverted") == true;
+
+    private static string FormatUnknownShortcutNotes(BaseComponent c)
+    {
+        var codes = new[] { 1, 2 }
+            .Where(number => Bool(c, $"Shortcut {number} Enabled") == true)
+            .Select(number => UInt(c, $"Shortcut {number}") is uint code
+                ? $"Shortcut {number} code: {code.ToString(CultureInfo.InvariantCulture)}"
+                : $"Shortcut {number} code unavailable");
+        return string.Join("; ", codes);
+    }
+
+    private sealed record MfmeDecodedShortcut(uint Code, string Text);
 }
 
 internal sealed class FmlToOasisMapResult


### PR DESCRIPTION
### Motivation

- Imported FML layouts lost input definitions because `FmlToOasisMapper.BuildInput()` still used the old extraction shape (string flags like `ButtonNumber`, `HasCoinInput`, `Shortcut1`) instead of the integrated `MfmeFmlDecoder` typed dictionaries.
- The goal is to restore Input Map rows by mapping the decoder's `UInt32s`, `Booleans`, and `Strings` contract directly, preserve zero-valued button numbers, correctly detect coin inputs, and decode numeric MFME shortcut codes into human-readable and WPF-mappable values.

### Description

- Reworked input extraction: replaced the old `BuildInput` implementation with a decoder-driven implementation that reads `UInt32s[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6db5b9bed08327bd2339697c0a9aec)