### PR TITLE
Fix FML input eligibility by tracking explicit extended-tag presence

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecoderRegressionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecoderRegressionTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using MfmeFmlDecoder.Decoder;
 using MfmeFmlDecoder.src.Decoder.Component.Core;
 using MfmeFmlDecoder.src.Model;
+using MfmeFmlDecoder.Model;
 using Xunit;
 
 namespace OasisEditor.Tests;
@@ -33,6 +34,24 @@ public sealed class FmlDecoderRegressionTests
         Assert.Equal("Header notes", layout.TextNotes);
         Assert.False(layout.HasSplash);
         Assert.Empty(layout.Images);
+    }
+
+    [Fact]
+    public void ExtendedTags_DistinguishAbsentDefaultFromExplicitZero()
+    {
+        var tagMap = new ComponentTagMap
+        {
+            { 0x18, new TagInfo(4, "ButtonNumber", [0, 0, 0, 0], ValueRole.UINT32) }
+        };
+        var parser = new ExtendedTagParser();
+
+        var absent = parser.Parse(tagMap, [0x00], 0, ExtendedTagParser.Options.Default.WithoutMatchedTagLogging());
+        var explicitZero = parser.Parse(tagMap, [0x18, 0x00, 0x00, 0x00, 0x00, 0x00], 0, ExtendedTagParser.Options.Default.WithoutMatchedTagLogging());
+
+        Assert.Equal(0u, absent.UInt32sByAttributeName["ButtonNumber"]);
+        Assert.DoesNotContain(0x18u, absent.PresentTagIds);
+        Assert.Equal(0u, explicitZero.UInt32sByAttributeName["ButtonNumber"]);
+        Assert.Contains(0x18u, explicitZero.PresentTagIds);
     }
 
     private static byte[] BuildTlv(params (uint Tag, byte[] Value)[] records)

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -217,7 +217,7 @@ public sealed class FmlToOasisMapperTests
         var lamp = new Lamp { X = 1, Y = 2, Width = 30, Height = 40, SublampTable = [new LampSublampTableEntry(1, 9)] };
         lamp.Colours["Sublamp1Colour"] = "#112233FF";
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.UInt32s["Button Number"] = 1;
+        SetExplicitUInt(button, "Button Number", 1);
         button.Strings["Label"] = "START";
 
         var images = new Dictionary<FmlDecodedImageKey, string>
@@ -240,7 +240,7 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithButtonLabel_MapsToLampDisplayTextAndInputDefinition()
     {
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.UInt32s["Button Number"] = 1;
+        SetExplicitUInt(button, "Button Number", 1);
         button.Strings["Label"] = "START";
 
         var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
@@ -258,7 +258,7 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithDecodedButtonUtf16Label_MapsToLampDisplayText()
     {
         var button = new Button { X = 5, Y = 6, Width = 20, Height = 20, SublampTable = [new LampSublampTableEntry(1, 12)] };
-        button.UInt32s["Button Number"] = 1;
+        SetExplicitUInt(button, "Button Number", 1);
         button.Strings["Label (UTF-16)"] = "START";
 
         var result = new FmlToOasisMapper().Map(new Layout([button]), new Dictionary<FmlDecodedImageKey, string>());
@@ -296,9 +296,9 @@ public sealed class FmlToOasisMapperTests
     {
         var button = CreateButton();
         button.Strings["Label"] = "START";
-        button.UInt32s["Button Number"] = 0;
-        button.Booleans["Shortcut 1 Enabled"] = true;
-        button.UInt32s["Shortcut 1"] = 0x20;
+        SetExplicitUInt(button, "Button Number", 0);
+        SetExplicitBool(button, "Shortcut 1 Enabled", true);
+        SetExplicitUInt(button, "Shortcut 1", 0x20);
         button.Booleans["Inverted"] = true;
 
         var result = Map(button);
@@ -317,11 +317,11 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithCurrentLampInputFields_UsesSecondEnabledShortcut()
     {
         var lamp = CreateLamp();
-        lamp.UInt32s["ButtonNumber"] = 2;
-        lamp.Booleans["Shortcut 1 Enabled"] = false;
-        lamp.UInt32s["Shortcut 1"] = 0x41;
-        lamp.Booleans["Shortcut 2 Enabled"] = true;
-        lamp.UInt32s["Shortcut 2"] = 0x31;
+        SetExplicitUInt(lamp, "ButtonNumber", 2);
+        SetExplicitBool(lamp, "Shortcut 1 Enabled", false);
+        SetExplicitUInt(lamp, "Shortcut 1", 0x41);
+        SetExplicitBool(lamp, "Shortcut 2 Enabled", true);
+        SetExplicitUInt(lamp, "Shortcut 2", 0x31);
 
         var input = Assert.Single(Map(lamp).InputDefinitions);
 
@@ -334,11 +334,11 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithUnknownPrimaryShortcut_FallsBackToValidSecondaryShortcut()
     {
         var button = CreateButton();
-        button.UInt32s["Button Number"] = 3;
-        button.Booleans["Shortcut 1 Enabled"] = true;
-        button.UInt32s["Shortcut 1"] = uint.MaxValue;
-        button.Booleans["Shortcut 2 Enabled"] = true;
-        button.UInt32s["Shortcut 2"] = 0x25;
+        SetExplicitUInt(button, "Button Number", 3);
+        SetExplicitBool(button, "Shortcut 1 Enabled", true);
+        SetExplicitUInt(button, "Shortcut 1", uint.MaxValue);
+        SetExplicitBool(button, "Shortcut 2 Enabled", true);
+        SetExplicitUInt(button, "Shortcut 2", 0x25);
 
         var input = Assert.Single(Map(button).InputDefinitions);
 
@@ -350,11 +350,11 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithNoOrUnknownShortcut_StillCreatesInputRows()
     {
         var noShortcut = CreateButton();
-        noShortcut.UInt32s["Button Number"] = 4;
+        SetExplicitUInt(noShortcut, "Button Number", 4);
         var unknownShortcut = CreateButton();
-        unknownShortcut.UInt32s["Button Number"] = 5;
-        unknownShortcut.Booleans["Shortcut 1 Enabled"] = true;
-        unknownShortcut.UInt32s["Shortcut 1"] = uint.MaxValue;
+        SetExplicitUInt(unknownShortcut, "Button Number", 5);
+        SetExplicitBool(unknownShortcut, "Shortcut 1 Enabled", true);
+        SetExplicitUInt(unknownShortcut, "Shortcut 1", uint.MaxValue);
 
         var result = new FmlToOasisMapper().Map(new Layout([noShortcut, unknownShortcut]), new Dictionary<FmlDecodedImageKey, string>());
 
@@ -367,9 +367,10 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithCurrentCoinFields_CreatesNamedCoinInputAndRetainsButtonNumber()
     {
         var lamp = CreateLamp();
-        lamp.UInt32s["ButtonNumber"] = 6;
-        lamp.Booleans["Coin / Note Selected"] = true;
+        SetExplicitUInt(lamp, "ButtonNumber", 6);
+        SetExplicitBool(lamp, "Coin / Note Selected", true);
         lamp.Strings["SelectedCoinNote"] = "£1 Coin";
+        lamp.PresentValueKeys.Add("SelectedCoinNoteId");
 
         var input = Assert.Single(Map(lamp).InputDefinitions);
 
@@ -397,7 +398,7 @@ public sealed class FmlToOasisMapperTests
             Height = 20,
             SublampTable = [new LampSublampTableEntry(1, 7), new LampSublampTableEntry(2, 8)]
         };
-        lamp.UInt32s["ButtonNumber"] = 7;
+        SetExplicitUInt(lamp, "ButtonNumber", 7);
 
         var result = Map(lamp);
 
@@ -410,6 +411,70 @@ public sealed class FmlToOasisMapperTests
     public void Map_WithoutCurrentInputMetadata_DoesNotCreateInput()
     {
         Assert.Empty(Map(CreateButton()).InputDefinitions);
+    }
+
+    [Fact]
+    public void Map_WithDefaultedLampInputFields_DoesNotCreateInput()
+    {
+        var lamp = CreateLamp();
+        lamp.UInt32s["ButtonNumber"] = 0;
+        lamp.UInt32s["Shortcut 1"] = 0;
+        lamp.UInt32s["Shortcut 2"] = 0;
+        lamp.Booleans["Shortcut 1 Enabled"] = false;
+        lamp.Booleans["Shortcut 2 Enabled"] = false;
+        lamp.Booleans["Coin / Note Selected"] = false;
+
+        Assert.Empty(Map(lamp).InputDefinitions);
+    }
+
+    [Fact]
+    public void Map_WithExplicitZeroLampButtonNumber_CreatesInputWithZero()
+    {
+        var lamp = CreateLamp();
+        lamp.UInt32s["ButtonNumber"] = 0; // Decoder value alone is not source presence.
+        lamp.PresentValueKeys.Add("ButtonNumber");
+
+        var input = Assert.Single(Map(lamp).InputDefinitions);
+
+        Assert.Equal("0", input.ButtonNumber);
+    }
+
+    [Fact]
+    public void Map_WithEnabledLampShortcutAndNoButtonNumber_CreatesInput()
+    {
+        var lamp = CreateLamp();
+        SetExplicitBool(lamp, "Shortcut 1 Enabled", true);
+        SetExplicitUInt(lamp, "Shortcut 1", 0x41);
+
+        var input = Assert.Single(Map(lamp).InputDefinitions);
+
+        Assert.Equal(string.Empty, input.ButtonNumber);
+        Assert.Equal("A", input.KeyboardShortcut);
+    }
+
+    [Fact]
+    public void Map_WithMultiSublampDefaultedLamp_CreatesNoInput()
+    {
+        var lamp = CreateLamp();
+        lamp.SublampTable = [new LampSublampTableEntry(1, 7), new LampSublampTableEntry(2, 8)];
+        lamp.UInt32s["ButtonNumber"] = 0;
+
+        var result = Map(lamp);
+
+        Assert.Equal(2, result.Elements.Count);
+        Assert.Empty(result.InputDefinitions);
+    }
+
+    private static void SetExplicitUInt(BaseComponent component, string key, uint value)
+    {
+        component.UInt32s[key] = value;
+        component.PresentValueKeys.Add(key);
+    }
+
+    private static void SetExplicitBool(BaseComponent component, string key, bool value)
+    {
+        component.Booleans[key] = value;
+        component.PresentValueKeys.Add(key);
     }
 
     private static Button CreateButton() => new()

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -5,6 +5,35 @@ namespace OasisEditor.Tests;
 public sealed class PlayViewInputRouterTests
 {
     [Fact]
+    public async Task PointerRouter_ReturnsFalseForVisualWithoutGenuineInput()
+    {
+        var backend = new RecordingBackend();
+        var router = new PlayViewPointerInputRouter(new PlayViewInputRouter(backend), []);
+
+        Assert.False(await router.TryHandlePointerDownAsync(
+            FruitMachinePlatformType.Impact, Guid.NewGuid(), isFocused: true, CancellationToken.None));
+        Assert.Empty(backend.Inputs);
+    }
+
+    [Fact]
+    public async Task PointerRouter_RoutesVisualLinkedByGenuineInput()
+    {
+        var backend = new RecordingBackend();
+        var visualId = Guid.NewGuid();
+        var input = new InputDefinitionModel
+        {
+            Id = "genuine",
+            ButtonNumber = "0",
+            LinkedVisualElementId = visualId
+        };
+        var router = new PlayViewPointerInputRouter(new PlayViewInputRouter(backend), [input]);
+
+        Assert.True(await router.TryHandlePointerDownAsync(
+            FruitMachinePlatformType.Impact, visualId, isFocused: true, CancellationToken.None));
+        Assert.Equal([("genuine", true)], backend.Inputs);
+    }
+
+    [Fact]
     public async Task PressReleaseAndReleaseAll_UseActiveBackendOnly()
     {
         var backend = new RecordingBackend();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs
@@ -131,11 +131,21 @@ internal sealed class FmlImportDiagnosticsWriter
         AppendSection(sb, "Summary");
         AppendList(sb, "Unsupported component summary", CountStrings(report.UnsupportedComponentTypes).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
         AppendList(sb, "Component counts by type", report.Layout is null ? [] : CountComponents(report.Layout).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
+        var inputCapableComponents = report.Layout?.Components.Count(component => component is Lamp or Button) ?? 0;
+        var defaultOnlyInputComponents = report.Layout?.Components.Count(component =>
+            (component is Lamp or Button)
+            && (component.UInt32s.ContainsKey("Button Number") || component.UInt32s.ContainsKey("ButtonNumber"))
+            && !component.WasValuePresent("Button Number")
+            && !component.WasValuePresent("ButtonNumber")
+            && !component.PresentValueKeys.Any(key => key is "Shortcut 1 Enabled" or "Shortcut 2 Enabled" or "Coin / Note Selected" or "SelectedCoinNoteId")) ?? 0;
+        AppendLine(sb, "Lamp/Button component count", inputCapableComponents.ToString());
         AppendLine(sb, "Image count", report.ImagePaths.Count.ToString());
         AppendList(sb, "Image filenames", report.ImagePaths.Values.OrderBy(v => v, StringComparer.Ordinal));
         AppendList(sb, "Panel element counts", CountStrings(report.MapResult?.Elements.Select(e => e.Kind.ToString()) ?? []).Select(kvp => $"{kvp.Key}: {kvp.Value}"));
         var inputs = report.MapResult?.InputDefinitions ?? [];
         AppendLine(sb, "Mapped input definition count", inputs.Count.ToString());
+        AppendLine(sb, "Genuine input component count", inputs.Count.ToString());
+        AppendLine(sb, "Components rejected with default-only input fields", defaultOnlyInputComponents.ToString());
         AppendLine(sb, "Button input count", inputs.Count(input => !input.CoinInput).ToString());
         AppendLine(sb, "Coin input count", inputs.Count(input => input.CoinInput).ToString());
         AppendLine(sb, "Inputs with shortcuts", inputs.Count(input => !string.IsNullOrWhiteSpace(input.KeyboardShortcut)).ToString());

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -278,9 +278,11 @@ internal sealed class FmlToOasisMapper
     private static PanelElementImportSourceModel Source(BaseComponent c, int index, int? n = null) => new() { Format = ImportSourceFormat, Reference = n.HasValue ? $"{c.GetType().Name}:{index}:{n.Value}" : $"{c.GetType().Name}:{index}" };
     private static InputDefinitionModel? BuildInput(BaseComponent c, string linkedObjectId)
     {
-        var buttonNumber = GetInputButtonNumber(c);
+        var buttonNumber = GetExplicitInputButtonNumber(c);
         var coinNote = GetSelectedCoinNote(c);
-        var isCoinInput = Bool(c, "Coin / Note Selected") == true || coinNote is not null;
+        var isCoinInput =
+            (c.WasValuePresent("Coin / Note Selected") && Bool(c, "Coin / Note Selected") == true)
+            || (c.WasValuePresent("SelectedCoinNoteId") && coinNote is not null);
         var shortcut = GetPrimaryShortcut(c);
         var hasEnabledShortcut = HasEnabledShortcut(c);
         if (!buttonNumber.HasValue && !isCoinInput && !hasEnabledShortcut)
@@ -313,6 +315,11 @@ internal sealed class FmlToOasisMapper
 
     private static uint? GetInputButtonNumber(BaseComponent c)
         => UInt(c, "Button Number") ?? UInt(c, "ButtonNumber");
+
+    private static uint? GetExplicitInputButtonNumber(BaseComponent c)
+        => c.WasValuePresent("Button Number") || c.WasValuePresent("ButtonNumber")
+            ? GetInputButtonNumber(c)
+            : null;
 
     private static string? GetSelectedCoinNote(BaseComponent c)
     {
@@ -379,11 +386,15 @@ internal sealed class FmlToOasisMapper
     }
 
     private static bool HasEnabledShortcut(BaseComponent c)
-        => Bool(c, "Shortcut 1 Enabled") == true || Bool(c, "Shortcut 2 Enabled") == true;
+        => Enumerable.Range(1, 2).Any(number =>
+            c.WasValuePresent($"Shortcut {number} Enabled")
+            && Bool(c, $"Shortcut {number} Enabled") == true);
 
     private static bool HasInputMetadata(BaseComponent c)
-        => GetInputButtonNumber(c).HasValue || GetSelectedCoinNote(c) is not null || Bool(c, "Coin / Note Selected") == true
-            || HasEnabledShortcut(c) || Bool(c, "Inverted") == true;
+        => GetExplicitInputButtonNumber(c).HasValue
+            || (c.WasValuePresent("SelectedCoinNoteId") && GetSelectedCoinNote(c) is not null)
+            || (c.WasValuePresent("Coin / Note Selected") && Bool(c, "Coin / Note Selected") == true)
+            || HasEnabledShortcut(c);
 
     private static string FormatUnknownShortcutNotes(BaseComponent c)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ComponentParserBase.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ComponentParserBase.cs
@@ -199,6 +199,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
 
             ExtendedTagParser.ParseResult parseResult =
                 new ExtendedTagParser().Parse(componentTagMap, data, offset, options);
+            RecordPresentValueKeys(component, componentTagMap, parseResult);
             AssignStringsFromParseResult(component, parseResult);
             AssignFloatsFromParseResult(component, parseResult);
             AssignUInt32sFromParseResult(component, parseResult);
@@ -211,6 +212,25 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
             AssignBitmapEntriesFromParseResult(component, parseResult, componentTagMap);
             ApplyNestedTagBlockOrientation(component, parseResult);
             return parseResult;
+        }
+
+        private static void RecordPresentValueKeys(
+            BaseComponent component,
+            ComponentTagMap componentTagMap,
+            ExtendedTagParser.ParseResult parseResult)
+        {
+            foreach (uint tagId in parseResult.PresentTagIds)
+            {
+                if (componentTagMap.TryGetValue(tagId, out TagInfo tagInfo))
+                {
+                    component.PresentValueKeys.Add(tagInfo.AttributeName);
+                }
+            }
+
+            if (componentTagMap.NestedTagBlockMap is not null && parseResult.NestedTagBlockResult is not null)
+            {
+                RecordPresentValueKeys(component, componentTagMap.NestedTagBlockMap, parseResult.NestedTagBlockResult);
+            }
         }
 
         /// <summary>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ExtendedTagParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ExtendedTagParser.cs
@@ -88,6 +88,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
         internal sealed record ParseResult(
             long Offset,
             IReadOnlyDictionary<uint, object> ValuesByTag,
+            IReadOnlySet<uint> PresentTagIds,
             IReadOnlyDictionary<string, FontTagEntry> FontsByRole,
             IReadOnlyDictionary<string, string> StringsByAttributeName,
             IReadOnlyDictionary<string, float> FloatsByAttributeName,
@@ -172,6 +173,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                     return new ParseResult(
                         offset,
                         valuesByTag,
+                        new HashSet<uint>(encounteredTags),
                         fontsByRole,
                         stringsByAttributeName,
                         floatsByAttributeName,
@@ -427,6 +429,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
                 return new ParseResult(
                     offset,
                     valuesByTag,
+                    new HashSet<uint>(encounteredTags),
                     fontsByRole,
                     stringsByAttributeName,
                     floatsByAttributeName,
@@ -2435,4 +2438,3 @@ namespace MfmeFmlDecoder.src.Decoder.Component.Core
         }
     }
 }
-

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/BaseComponent.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/BaseComponent.cs
@@ -53,6 +53,16 @@ namespace MfmeFmlDecoder.src.Model.Component
         public Dictionary<string, string> Colours { get; } = new Dictionary<string, string>(StringComparer.Ordinal);
         public Dictionary<string, BitmapEntry> Images { get; } = new Dictionary<string, BitmapEntry>(StringComparer.Ordinal);
 
+        /// <summary>
+        /// Decoder value names whose extended tags were physically present in the source component.
+        /// Value dictionaries also contain schema defaults, so callers must use this metadata when
+        /// source presence is significant (notably for MFME input fields where zero is valid).
+        /// </summary>
+        [JsonIgnore]
+        public HashSet<string> PresentValueKeys { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        public bool WasValuePresent(string key) => PresentValueKeys.Contains(key);
+
         private static readonly JsonSerializerOptions ToJsonOptions = CreateToJsonOptions();
 
         internal static JsonSerializerOptions CreateJsonWriteOptions(bool writeIndented)


### PR DESCRIPTION
### Motivation

- Ordinary Lamps were being imported as interactive because the decoder provided schema-default numeric zeros (e.g. `ButtonNumber = 0`) and the mapper treated the defaulted values as source-declared inputs.
- The decoder already yields parsed values and defaults; the fix must preserve the decoder distinction between "tag absent (schema default)" and "tag present with value 0" so that genuine MFME inputs alone create `InputDefinitionModel` rows.

### Description

- Record which extended-tag IDs were physically encountered by adding `PresentTagIds` to `ExtendedTagParser.ParseResult` and propagate that into the decoded component as `BaseComponent.PresentValueKeys` with helper `WasValuePresent(string)`. (decoder) 【F:WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ExtendedTagParser.cs†L88-L105】【F:WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Model/Component/BaseComponent.cs†L56-L64】
- Populate `PresentValueKeys` during parsing by adding `RecordPresentValueKeys(...)` in `ComponentParserBase.ParseExtendedTags(...)`, including nested tag-block propagation. 【F:WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/Core/ComponentParserBase.cs†L200-L233】
- Change mapping eligibility rules in `FmlToOasisMapper.BuildInput()` to require genuine source presence for inputs by using `GetExplicitInputButtonNumber(...)`, presence-checked shortcut enable flags, and presence-aware coin selection logic; preserve explicitly encoded button zero as valid. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs†L279-L312】【F:WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs†L319-L322】
- Update tests to distinguish decoder-default values from explicitly parsed tags by adding `SetExplicitUInt`/`SetExplicitBool` helpers and new regression cases for: defaulted Lamp with `ButtonNumber = 0` (no input), explicitly-present zero (creates input), shortcut-only Lamp, multi-sublamp defaults, and an ExtendedTagParser-level test that validates `PresentTagIds`. 【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs†L443-L477】【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecoderRegressionTests.cs†L39-L54】
- Add Play View pointer-routing tests to assert ordinary visuals without genuine inputs return false and visuals linked by genuine inputs route correctly, leaving Play View cursor/hit-testing code unchanged. 【F:WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs†L7-L34】
- Extended import diagnostics to report Lamp/Button component counts and components rejected because only default input fields were present, without emitting noisy per-lamp warnings. 【F:WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportDiagnosticsWriter.cs†L131-L152】

### Testing

- Ran repository checks: `git diff --check` and `git status --short` to verify there are no diff-check issues and the working tree after commit is consistent, both succeeded. 
- Updated and added unit tests (decoder parse presence test, mapper tests, pointer-routing tests) to exercise the new presence-aware behavior but did not execute `dotnet test` in this environment due to the repository AGENTS.md constraint that the Windows/.NET/WPF toolchain is unavailable. 
- Performed static validation of changed files under the allowed project scope to ensure all edits are limited to `WindowsNetProjects/OasisEditor` and validated that the new decoder-to-mapper wiring compiles conceptually by checking modified locations; execution of full test suite and real-FML fixture regression must be run locally where the proper toolchain and the real fixture corpus are available. 
- Environment limitation: automated test execution was intentionally skipped because the environment disallows building/running the solution per project `AGENTS.md` and the Windows/.NET toolchain is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6dbe1d033c83278fca37b1fe0dcd8c)