### PR TITLE
Add multi-row selection and deletion to Input Map

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDeletionServiceTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InputMapDeletionServiceTests.cs
@@ -1,0 +1,61 @@
+namespace OasisEditor.Tests;
+
+public sealed class InputMapDeletionServiceTests
+{
+    [Fact]
+    public void DeleteSelected_DeletesOneRow()
+    {
+        var inputs = CreateInputs("one", "two", "three");
+
+        var deleted = InputMapDeletionService.DeleteSelected(inputs, [inputs[1]]);
+
+        Assert.Equal(1, deleted);
+        Assert.Equal(["one", "three"], inputs.Select(input => input.Id));
+    }
+
+    [Fact]
+    public void DeleteSelected_DeletesContiguousRowsAndPreservesRemainingOrder()
+    {
+        var inputs = CreateInputs("one", "two", "three", "four", "five");
+
+        InputMapDeletionService.DeleteSelected(inputs, [inputs[1], inputs[2], inputs[3]]);
+
+        Assert.Equal(["one", "five"], inputs.Select(input => input.Id));
+    }
+
+    [Fact]
+    public void DeleteSelected_DeletesNonContiguousRowsAndPreservesRemainingOrder()
+    {
+        var inputs = CreateInputs("one", "two", "three", "four", "five");
+
+        InputMapDeletionService.DeleteSelected(inputs, [inputs[3], inputs[1]]);
+
+        Assert.Equal(["one", "three", "five"], inputs.Select(input => input.Id));
+    }
+
+    [Fact]
+    public void DeleteSelected_DeletesAllRows()
+    {
+        var inputs = CreateInputs("one", "two", "three");
+
+        InputMapDeletionService.DeleteSelected(inputs, inputs.ToArray());
+
+        Assert.Empty(inputs);
+    }
+
+    [Fact]
+    public void DeleteSelected_IgnoresRowsFromAnotherModel()
+    {
+        var inputs = CreateInputs("one", "two");
+
+        var deleted = InputMapDeletionService.DeleteSelected(
+            inputs,
+            [new InputDefinitionModel { Id = "one" }]);
+
+        Assert.Equal(0, deleted);
+        Assert.Equal(["one", "two"], inputs.Select(input => input.Id));
+    }
+
+    private static List<InputDefinitionModel> CreateInputs(params string[] ids) =>
+        ids.Select(id => new InputDefinitionModel { Id = id, Name = id }).ToList();
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDeletionService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InputMapDeletionService.cs
@@ -1,0 +1,28 @@
+namespace OasisEditor;
+
+/// <summary>
+/// Applies Input Map deletions to the project model while preserving surviving row order.
+/// </summary>
+public static class InputMapDeletionService
+{
+    public static int DeleteSelected(
+        IList<InputDefinitionModel> inputs,
+        IEnumerable<InputDefinitionModel> selectedInputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentNullException.ThrowIfNull(selectedInputs);
+
+        var selected = selectedInputs.ToHashSet(ReferenceEqualityComparer.Instance);
+        var indexes = Enumerable.Range(0, inputs.Count)
+            .Where(index => selected.Contains(inputs[index]))
+            .OrderDescending()
+            .ToArray();
+
+        foreach (var index in indexes)
+        {
+            inputs.RemoveAt(index);
+        }
+
+        return indexes.Length;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -404,6 +404,29 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public int InputMapWarningCount => InputMapDiagnostics.Count(d => d.Severity == InputMapDiagnosticSeverity.Warning);
     public bool HasInputMapDiagnostics => InputMapDiagnostics.Count > 0;
 
+    public int DeleteInputDefinitions(IReadOnlyCollection<InputDefinitionModel> selectedInputs)
+    {
+        if (LoadedProject is null || selectedInputs.Count == 0)
+        {
+            return 0;
+        }
+
+        // TODO: Wrap this project-level mutation when the Editor exposes project-scoped undo history;
+        // the existing Undo/Redo service is scoped exclusively to the active content document.
+        var deletedCount = InputMapDeletionService.DeleteSelected(LoadedProject.InputDefinitions, selectedInputs);
+        if (deletedCount == 0)
+        {
+            return 0;
+        }
+
+        SaveLoadedProjectMetadata();
+        SelectedDocument?.MarkDirty();
+        OnPropertyChanged(nameof(InputDefinitions));
+        RefreshInputMapDiagnostics();
+        AddOutputEntry($"Deleted {deletedCount} input definition(s).", OutputLogStatus.Info);
+        return deletedCount;
+    }
+
 
     public FruitMachinePlatformType SelectedFruitMachinePlatform
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
@@ -12,7 +12,8 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <DataGrid Grid.Row="0"
+        <DataGrid x:Name="InputMapGrid"
+                  Grid.Row="0"
                   ItemsSource="{Binding InputDefinitions}"
                   AutoGenerateColumns="False"
                   IsReadOnly="True"
@@ -21,8 +22,17 @@
                   HeadersVisibility="Column"
                   GridLinesVisibility="Horizontal"
                   RowHeaderWidth="0"
-                  SelectionMode="Single"
-                  SelectionUnit="FullRow">
+                  SelectionMode="Extended"
+                  SelectionUnit="FullRow"
+                  PreviewKeyDown="InputMapGrid_OnPreviewKeyDown"
+                  PreviewMouseRightButtonDown="InputMapGrid_OnPreviewMouseRightButtonDown">
+            <DataGrid.ContextMenu>
+                <ContextMenu Opened="InputMapContextMenu_OnOpened">
+                    <MenuItem x:Name="DeleteMenuItem"
+                              Header="_Delete"
+                              Click="DeleteMenuItem_OnClick" />
+                </ContextMenu>
+            </DataGrid.ContextMenu>
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="1.2*" />
                 <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="0.7*" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml.cs
@@ -61,8 +61,16 @@ public partial class InputMapView : UserControl
             return;
         }
 
-        viewModel.DeleteInputDefinitions(selectedInputs);
+        // InputDefinitions is intentionally the project's List-backed model rather than an
+        // ObservableCollection. Detach DataGrid selection from those items before mutating the
+        // list, then explicitly refresh the view so its cached rows and indexes cannot go stale.
         InputMapGrid.SelectedItems.Clear();
+        InputMapGrid.CurrentItem = null;
+
+        if (viewModel.DeleteInputDefinitions(selectedInputs) > 0)
+        {
+            InputMapGrid.Items.Refresh();
+        }
     }
 
     private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml.cs
@@ -1,4 +1,7 @@
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace OasisEditor.Views;
 
@@ -7,5 +10,73 @@ public partial class InputMapView : UserControl
     public InputMapView()
     {
         InitializeComponent();
+    }
+
+    private void InputMapGrid_OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.A && Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            InputMapGrid.SelectAll();
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Delete && Keyboard.Modifiers == ModifierKeys.None)
+        {
+            DeleteSelectedRows();
+            e.Handled = true;
+        }
+    }
+
+    private void InputMapGrid_OnPreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        var row = FindVisualParent<DataGridRow>(e.OriginalSource as DependencyObject);
+        if (row is null || row.IsSelected)
+        {
+            return;
+        }
+
+        InputMapGrid.SelectedItems.Clear();
+        row.IsSelected = true;
+        InputMapGrid.CurrentItem = row.Item;
+    }
+
+    private void InputMapContextMenu_OnOpened(object sender, RoutedEventArgs e)
+    {
+        DeleteMenuItem.IsEnabled = InputMapGrid.SelectedItems.Count > 0;
+    }
+
+    private void DeleteMenuItem_OnClick(object sender, RoutedEventArgs e) => DeleteSelectedRows();
+
+    private void DeleteSelectedRows()
+    {
+        if (DataContext is not MainWindowViewModel viewModel)
+        {
+            return;
+        }
+
+        var selectedInputs = InputMapGrid.SelectedItems.OfType<InputDefinitionModel>().ToArray();
+        if (selectedInputs.Length == 0)
+        {
+            return;
+        }
+
+        viewModel.DeleteInputDefinitions(selectedInputs);
+        InputMapGrid.SelectedItems.Clear();
+    }
+
+    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
+    {
+        while (child is not null)
+        {
+            if (child is T parent)
+            {
+                return parent;
+            }
+
+            child = VisualTreeHelper.GetParent(child);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
### Motivation

- The Input Map view previously allowed only single-row viewing and lacked deletion, so users could not remove multiple imported inputs efficiently.
- The change implements standard Windows-style multi-row selection and deletion while keeping model persistence and editor state consistent.

### Description

- Enable extended selection in the grid by setting the `DataGrid` to `SelectionMode="Extended"` and wiring keyboard and mouse handlers in `Views/InputMapView.xaml` and `Views/InputMapView.xaml.cs` to support click, `Shift`+click, `Ctrl`+click, `Ctrl+A`, right-click selection behavior, `Delete` key handling, and a context-menu `Delete` command.  
- Add `InputMapDeletionService` implementing stable-identity deletion by collecting selected indexes and removing in descending order to avoid index-shift bugs and preserve remaining row order.  
- Add `MainWindowViewModel.DeleteInputDefinitions` which applies deletions to the project `LoadedProject.InputDefinitions`, calls `SaveLoadedProjectMetadata()`, marks the active document dirty via `SelectedDocument.MarkDirty()`, refreshes `InputDefinitions` and diagnostics, and logs the change.  
- Add unit tests `InputMapDeletionServiceTests` covering single-row, contiguous multi-row, non-contiguous multi-row, all-row deletion, ordering preservation, and ignoring foreign-model inputs; and include a TODO noting Undo/Redo is deferred because the existing command history is scoped to content documents rather than project-level data.  

### Testing

- Ran repository checks: `git diff --cached --check` and local staging/commit verification (passed).  
- Added unit tests in `OasisEditor.Tests/InputMapDeletionServiceTests.cs`, but they were not executed in this environment because the `AGENTS.md` for this project disallows running the Windows/.NET/WPF toolchain here.  
- Manual WPF verification is required on Windows and should exercise `Shift`/`Ctrl` selection, `Ctrl+A`, `Delete` key, both right-click selection behaviors, context-menu `Delete`, save/reopen persistence, and undo/redo verification if a future project-scoped command is integrated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6dc2e93e0c83279f69b30c4e68e140)