### PR TITLE
Standardize Oasis reel numbering as zero-based

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -9,6 +9,21 @@ namespace OasisEditor.Tests;
 public sealed class FmlToOasisMapperTests
 {
     [Fact]
+    public void Map_WithFourMfmeReels_PreservesZeroBasedMachineIdentifiers()
+    {
+        var reels = Enumerable.Range(0, 4)
+            .Select(number => new BandReel { Number = number, Width = 30, Height = 100 })
+            .ToArray();
+
+        var result = new FmlToOasisMapper().Map(new Layout(reels), new Dictionary<FmlDecodedImageKey, string>());
+        var mappedReels = result.Elements.Where(element => element.Kind == PanelElementKind.Reel).ToArray();
+
+        Assert.Equal(["Reel 0", "Reel 1", "Reel 2", "Reel 3"], mappedReels.Select(element => element.Name));
+        Assert.Equal([0, 1, 2, 3], mappedReels.Select(element => element.DisplayNumber.GetValueOrDefault()));
+        Assert.DoesNotContain(mappedReels, element => element.Name == "Reel 4");
+    }
+
+    [Fact]
     public void Map_WithTextOnlyLamp_PreservesNumberTextColourAndNoAssets()
     {
         var lamp = new Lamp

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineObjectReferenceResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/MachineObjectReferenceResolverTests.cs
@@ -7,6 +7,7 @@ public sealed class MachineObjectReferenceResolverTests
 {
     [Theory]
     [InlineData("lamp", 17, MachineObjectKind.Lamp, "17")]
+    [InlineData("reel", 0, MachineObjectKind.Reel, "0")]
     [InlineData("reel", 2, MachineObjectKind.Reel, "2")]
     [InlineData("alpha", 0, MachineObjectKind.AlphaDisplay, "0")]
     [InlineData("sevenSegment", 12, MachineObjectKind.SevenSegmentDisplay, "12")]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
@@ -1,0 +1,56 @@
+using OasisEditor;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class ZeroBasedReelRuntimeTests
+{
+    [Fact]
+    public void FabricSnapshot_UsesExactZeroBasedReelIds()
+    {
+        var backend = new FabricEmulationBackend("fabric", "amber");
+        var changes = new List<MachineReelChangedEventArgs>();
+        backend.ReelChanged += (_, change) => changes.Add(change);
+
+        backend.PublishSnapshot(CreateSnapshot());
+
+        Assert.Equal([0, 1, 2, 3], changes.Select(change => change.ReelId));
+    }
+
+    [Fact]
+    public void FabricSnapshot_ThroughRuntimeAdapter_UpdatesEveryZeroBasedReel()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements(Enumerable.Range(0, 4).Select(reelId => new PanelElementModel
+        {
+            ObjectId = $"reel-{reelId}",
+            Name = $"Reel {reelId}",
+            Kind = PanelElementKind.Reel,
+            DisplayNumber = reelId,
+            Stops = 24
+        }).ToArray());
+        var dispatches = new List<Action>();
+        var adapter = new MachineReelRuntimeAdapter(() => [document], () => FruitMachinePlatformType.Impact,
+            () => false, _ => { }, dispatches.Add);
+        var backend = new FabricEmulationBackend("fabric", "amber");
+        backend.ReelChanged += (_, change) => adapter.ApplyReelState(change.ReelId, change.Position);
+
+        backend.PublishSnapshot(CreateSnapshot());
+        Assert.Single(dispatches)();
+
+        Assert.Equal(10, document.RuntimeState.GetReelPosition("reel-0"));
+        Assert.Equal(20, document.RuntimeState.GetReelPosition("reel-1"));
+        Assert.Equal(30, document.RuntimeState.GetReelPosition("reel-2"));
+        Assert.Equal(40, document.RuntimeState.GetReelPosition("reel-3"));
+        Assert.Equal(10, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(0)));
+        Assert.Equal(40, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(3)));
+    }
+
+    private static FabricMachineSnapshot CreateSnapshot() => new(1, [],
+    [
+        new FabricReel("amber.reel.0", 0, 10),
+        new FabricReel("amber.reel.1", 1, 20),
+        new FabricReel("amber.reel.2", 2, 30),
+        new FabricReel("amber.reel.3", 3, 40)
+    ], [], []);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -379,6 +379,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
         foreach (var reel in snapshot.Reels)
         {
+            // Fabric and Oasis both use the native zero-based reel identifier.
             if (_reels.TryGetValue(reel.NumericalIndex, out var previous) && previous == reel.Position)
                 continue;
             _reels[reel.NumericalIndex] = reel.Position;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -139,10 +139,11 @@ internal sealed class FmlToOasisMapper
         if (stops == 0) warnings.Add(new LayoutImportWarning("fml.import.reel.stops.invalid", "Reel stops must be greater than zero to calculate visible scale.", index.ToString(CultureInfo.InvariantCulture)));
         var lampsEnabled = Bool(c, "LampsEnabled") ?? true;
         var reelLamps = MapReelLamps(c);
-        var reelName = $"Reel {Number(c).GetValueOrDefault(c.Number) + 1}";
+        var reelNumber = Number(c).GetValueOrDefault(c.Number);
+        var reelName = $"Reel {reelNumber}";
         Debug.WriteLine($"Reel '{reelName}': {FormatMfmeCommonReelLampSlots(c)} -> Oasis [top={FormatLamp(reelLamps[0].LampNumber)}, middle={FormatLamp(reelLamps[1].LampNumber)}, bottom={FormatLamp(reelLamps[2].LampNumber)}], enabled={lampsEnabled.ToString().ToLowerInvariant()}");
         AddReelLampImportWarnings(c, reelName, reelLamps, lampsEnabled, index, warnings);
-        return new PanelElementModel { ObjectId = Guid.NewGuid().ToString("N"), Name = reelName, Kind = PanelElementKind.Reel, X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height), DisplayNumber = Number(c).GetValueOrDefault(c.Number) + 1, AssetPath = FirstRoleImage(images, index, IsReelBand) ?? FirstImage(images, index), SecondaryAssetPath = FirstRoleImage(images, index, IsOverlay), Stops = (int)stops, IsReversed = Bool(c, "Reversed") ?? Bool(c, "Reverse") ?? false, VisibleScale = scale, ReelLampsEnabled = lampsEnabled, ReelLamps = reelLamps, IsOpaqueReel = Bool(c, "OpaqueBand") ?? Bool(c, "Opaque") ?? false, SourceComponentIndex = index, ImportSource = Source(c, index) };
+        return new PanelElementModel { ObjectId = Guid.NewGuid().ToString("N"), Name = reelName, Kind = PanelElementKind.Reel, X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height), DisplayNumber = reelNumber, AssetPath = FirstRoleImage(images, index, IsReelBand) ?? FirstImage(images, index), SecondaryAssetPath = FirstRoleImage(images, index, IsOverlay), Stops = (int)stops, IsReversed = Bool(c, "Reversed") ?? Bool(c, "Reverse") ?? false, VisibleScale = scale, ReelLampsEnabled = lampsEnabled, ReelLamps = reelLamps, IsOpaqueReel = Bool(c, "OpaqueBand") ?? Bool(c, "Opaque") ?? false, SourceComponentIndex = index, ImportSource = Source(c, index) };
     }
 
     private static IReadOnlyList<ReelLampSlotModel> MapReelLamps(BaseComponent c)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -3413,7 +3413,7 @@ public sealed class System6ReelOptoSettingsViewModel : INotifyPropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public int ReelIndex { get; }
-    public int ReelNumber => ReelIndex + 1;
+    public int ReelNumber => ReelIndex;
 
     public bool Enabled { get => _enabled; set => SetAndSave(ref _enabled, value, nameof(Enabled)); }
     public int Steps { get => _steps; set => SetAndSave(ref _steps, value, nameof(Steps)); }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelFactory.cs
@@ -86,9 +86,9 @@ internal static class PanelElementModelFactory
     private static PanelElementFile CreateReelElement(Point panelPoint)
     {
         var objectId = Guid.NewGuid().ToString("N");
-        return CreateBaseElement(PanelElementKind.Reel, objectId, "Reel 1", panelPoint, NewReelWidth, NewReelHeight) with
+        return CreateBaseElement(PanelElementKind.Reel, objectId, "Reel 0", panelPoint, NewReelWidth, NewReelHeight) with
         {
-            DisplayNumber = 1,
+            DisplayNumber = 0,
             Stops = 24,
             VisibleScale = 3d / 24d,
             IsReversed = false


### PR DESCRIPTION
### Motivation

- Fix a mismatch where the MFME importer converted decoded reel identifiers to one-based values, causing Fabric-published zero-based reels to not match imported elements.
- Ensure a single consistent contract where Amber/Fabric numerical reel indexes, Oasis machine object references, panel `DisplayNumber`s, and visible imported names are all zero-based.
- Keep counts and unrelated ordinal semantics unchanged while removing only conversions that made reel identity one-based.

### Description

- Preserve the decoded MFME reel number in `MapReel` by resolving it once into `reelNumber` and using it for both `Name` and `DisplayNumber` instead of adding `+ 1` (updated `Features/FmlImport/FmlToOasisMapper.cs`).
- Default newly created Panel2D reel templates to `Name = "Reel 0"` and `DisplayNumber = 0` (updated `PanelElementModelFactory.cs`).
- Stop exposing a one-based label in System 6 reel opto settings by changing `ReelNumber` to return `ReelIndex` (updated `MainWindowViewModel.cs`).
- Add a concise code comment clarifying that Fabric publishes zero-based `NumericalIndex` and Oasis uses the same zero-based identifiers (updated `Emulation/Fabric/FabricEmulationBackend.cs`).
- Add and update focused tests: a MFME import test asserting `Reel 0..3` names and `DisplayNumber` values, a runtime regression test confirming Fabric snapshot `0..3` propagate through `MachineReelRuntimeAdapter`, and an update to `MachineObjectReferenceResolver` tests to include `DisplayNumber = 0` resolution (new/modified files in `OasisEditor.Tests`).
- Do not change persisted schema versions because the serialized shape remained numeric and unchanged; this corrects the semantic meaning without migration.

### Testing

- Ran repository checks including `git diff --check` and verified the working tree and commit were clean after applying the changes and committing the patch.
- Added automated unit tests covering MFME import and Fabric-to-runtime propagation, but automated tests were not executed in this environment due to the repository `AGENTS.md` constraint that the required Windows/.NET/WPF toolchain is unavailable here.
- Manual runtime/editor verification was not performed in this non-Windows environment; local verification steps are: import a four-reel FML and confirm `Reel 0..3` names and `DisplayNumber`s, run Amber via Fabric and verify Fabric `NumericalIndex` `0..3` map directly to Oasis reel references `0..3`, save/reopen, and generate a runtime package and confirm Player updates all four reels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6dd068d7748327a5884ce4a6bf1724)