### PR TITLE
Preserve short Fabric input pulses across emulation advances

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
@@ -27,8 +27,44 @@ public sealed class FabricAbiLayoutTests
         Assert.Equal(32, Marshal.SizeOf<AmberCoinRouteNative>());
         Assert.Equal(408, Marshal.SizeOf<AmberCoinsNative>());
         Assert.Equal(648, Marshal.SizeOf<FabricAmberConfigurationNative>());
+        Assert.Equal(0, Marshal.OffsetOf<FabricAmberConfigurationNative>("Magic").ToInt32());
+        Assert.Equal(4, Marshal.OffsetOf<FabricAmberConfigurationNative>("Size").ToInt32());
+        Assert.Equal(8, Marshal.OffsetOf<FabricAmberConfigurationNative>("Version").ToInt32());
+        Assert.Equal(12, Marshal.OffsetOf<FabricAmberConfigurationNative>("Flags").ToInt32());
+        Assert.Equal(16, Marshal.OffsetOf<FabricAmberConfigurationNative>("Reels").ToInt32());
+        Assert.Equal(224, Marshal.OffsetOf<FabricAmberConfigurationNative>("Coins").ToInt32());
+        Assert.Equal(632, Marshal.OffsetOf<FabricAmberConfigurationNative>("Percentage").ToInt32());
+        Assert.Equal(8, Marshal.OffsetOf<AmberCoinsNative>("ChannelMask").ToInt32());
+        Assert.Equal(12, Marshal.OffsetOf<AmberCoinsNative>("RouteMask").ToInt32());
+        Assert.Equal(16, Marshal.OffsetOf<AmberCoinsNative>("Channels").ToInt32());
+        Assert.Equal(136, Marshal.OffsetOf<AmberCoinsNative>("Routes").ToInt32());
         Assert.Equal(1160, Marshal.OffsetOf<FabricLaunchRequestNative>("RomPaths").ToInt32());
         Assert.Equal(16, Marshal.OffsetOf<FabricRomResourceNative>("Path").ToInt32());
+    }
+
+    [Fact]
+    public void AmberConfigurationBytesContainPublishedHeaderAndCoinMasks()
+    {
+        var configuration = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            Coins = [new() { Num = 2, Enabled = true, CoinEnable = 1, CoinValue = 20 }]
+        });
+
+        var bytes = configuration.ToNativeBytes();
+
+        Assert.Equal(648, bytes.Length);
+        Assert.Equal(FabricAmberConfiguration.NativeMagic, BitConverter.ToUInt32(bytes, 0));
+        Assert.Equal(648u, BitConverter.ToUInt32(bytes, 4));
+        Assert.Equal(FabricAmberConfiguration.NativeVersion, BitConverter.ToUInt32(bytes, 8));
+        Assert.Equal(7u, BitConverter.ToUInt32(bytes, 12));
+        Assert.Equal(408u, BitConverter.ToUInt32(bytes, 224));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, 228));
+        Assert.Equal(1u << 2, BitConverter.ToUInt32(bytes, 232));
+        Assert.Equal(1u << 2, BitConverter.ToUInt32(bytes, 236));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 240));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, 244));
+        Assert.Equal(20u, BitConverter.ToUInt32(bytes, 248));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 360));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricInputSchedulerTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricInputSchedulerTests.cs
@@ -1,0 +1,87 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class FabricInputSchedulerTests
+{
+    [Fact]
+    public void RapidClick_IsAssertedForOneAdvance()
+    {
+        var scheduler = new FabricInputScheduler();
+        var session = new RecordingSession();
+        scheduler.Request(34, true);
+        scheduler.Request(34, false);
+
+        Pump(scheduler, session, 1);
+        Pump(scheduler, session, 2);
+
+        Assert.Equal(["Submit 34 True", "Advance", "Submit 34 False", "Advance"], session.Operations);
+    }
+
+    [Fact]
+    public void HeldAndRepeatedPress_RemainsAssertedWithoutRedundantSubmissions()
+    {
+        var scheduler = new FabricInputScheduler();
+        var session = new RecordingSession();
+        scheduler.Request(7, true);
+        scheduler.Request(7, true);
+        Pump(scheduler, session, 1);
+        Pump(scheduler, session, 2);
+        scheduler.Request(7, false);
+        Pump(scheduler, session, 3);
+
+        Assert.Equal(["Submit 7 True", "Advance", "Advance", "Submit 7 False", "Advance"], session.Operations);
+    }
+
+    [Fact]
+    public void MultipleSwitchesAndZero_AreScheduledIndependentlyAndUnchanged()
+    {
+        var scheduler = new FabricInputScheduler();
+        var session = new RecordingSession();
+        scheduler.Request(0, true);
+        scheduler.Request(9, true);
+        Pump(scheduler, session, 1);
+        scheduler.Request(0, false);
+        Pump(scheduler, session, 2);
+        scheduler.Request(9, false);
+        Pump(scheduler, session, 3);
+
+        Assert.Equal(["Submit 0 True", "Submit 9 True", "Advance", "Submit 0 False", "Advance", "Submit 9 False", "Advance"], session.Operations);
+    }
+
+    [Fact]
+    public void ResetOrShutdown_ReleasesEveryAppliedSwitch()
+    {
+        var scheduler = new FabricInputScheduler();
+        var session = new RecordingSession();
+        scheduler.Request(2, true);
+        scheduler.Request(3, true);
+        Pump(scheduler, session, 1);
+
+        scheduler.ReleaseAll(session);
+
+        Assert.Equal(["Submit 2 True", "Submit 3 True", "Advance", "Submit 2 False", "Submit 3 False"], session.Operations);
+    }
+
+    private static void Pump(FabricInputScheduler scheduler, RecordingSession session, long sequence)
+    {
+        scheduler.ApplyBeforeAdvance(session, sequence, null);
+        session.Advance(1_000_000);
+        scheduler.MarkAdvanced();
+    }
+
+    private sealed class RecordingSession : IFabricMachineSession
+    {
+        public List<string> Operations { get; } = [];
+        public FabricCapabilities Capabilities => new((ulong)FabricCapability.DigitalInput);
+        public void Initialise() { }
+        public void Reset() { }
+        public void Advance(ulong elapsedNanoseconds) => Operations.Add("Advance");
+        public void SubmitInput(FabricInput input) => Operations.Add($"Submit {input.NumericalIndex} {input.Active}");
+        public FabricMachineSnapshot GetSnapshot() => new(0, [], [], [], []);
+        public FabricAudioFormat GetAudioFormat() => default;
+        public int ReadAudio(Span<short> samples, int frameCapacity) => 0;
+        public void Shutdown() { }
+        public void Dispose() { }
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -254,6 +254,50 @@ public sealed class FabricManagedBehaviorTests
     }
 
     [Fact]
+    public void AmberConfiguration_CoinTranslationMatchesFormerDirectAmberPayload()
+    {
+        var settings = new System6NativeRomSettings
+        {
+            Coins =
+            [
+                new() { Num = 0, Enabled = true, CoinEnable = 1, CoinValue = 10, LockoutInvert = 0, CounterIn = 1, CounterOut = 2, PortIndex = 3, Coin = 4, Level = 5, FullLevel = 6 },
+                new() { Num = 1, Enabled = false, CoinEnable = 1, CoinValue = 20 },
+                new() { Num = 3, Enabled = true, CoinEnable = 0, CoinValue = 50, LockoutInvert = 1, CounterIn = 7, CounterOut = 8, PortIndex = 9, Coin = 10, Level = 11, FullLevel = 12 }
+            ]
+        };
+
+        var configuration = FabricAmberConfiguration.FromSystem6(settings);
+
+        Assert.Equal(0b1001u, configuration.CoinChannelApplyMask);
+        Assert.Equal(0b1001u, configuration.CoinRouteApplyMask);
+        Assert.Equal([
+            new FabricAmberCoinChannel(0, true, 10, false),
+            new FabricAmberCoinChannel(3, false, 50, true)
+        ], configuration.CoinChannels);
+        Assert.Equal([
+            new FabricAmberCoinRoute(0, true, 1, 2, 3, 4, 5, 6),
+            new FabricAmberCoinRoute(3, true, 7, 8, 9, 10, 11, 12)
+        ], configuration.CoinRoutes);
+        Assert.Equal(FabricAmberConfiguration.CoinsFlag,
+            configuration.NativeFlags & FabricAmberConfiguration.CoinsFlag);
+    }
+
+    [Fact]
+    public void AmberConfiguration_NoEnabledCoinRowsProducesNoCoinPayloadOrFlag()
+    {
+        var configuration = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            Coins = [new() { Num = 0, Enabled = false, CoinEnable = 1, CoinValue = 20 }]
+        });
+
+        Assert.Equal(0u, configuration.CoinChannelApplyMask);
+        Assert.Equal(0u, configuration.CoinRouteApplyMask);
+        Assert.Empty(configuration.CoinChannels);
+        Assert.Empty(configuration.CoinRoutes);
+        Assert.Equal(0u, configuration.NativeFlags & FabricAmberConfiguration.CoinsFlag);
+    }
+
+    [Fact]
     public async Task Backend_UsesExactLaunchValuesAndSerializesResetWithPump()
     {
         var clock = new FakeClock();
@@ -267,7 +311,9 @@ public sealed class FabricManagedBehaviorTests
 
         await backend.StartAsync(request, CancellationToken.None);
         await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var advancesBeforeReset = session.Advances.Count;
         await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        await WaitForAdvanceCountAsync(session, advancesBeforeReset + 1);
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Equal("C:/fabric/FabricRuntime.dll", runtimePath);
@@ -281,6 +327,12 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(1, runtime.DisposeCount);
         Assert.Equal(1, audio.StartCount);
         Assert.Equal(1, audio.StopCount);
+        Assert.NotNull(runtime.Request!.Configuration);
+        Assert.NotEmpty(runtime.Request.Configuration!.ToNativeBytes());
+        Assert.Equal("Initialise", session.Operations[0]);
+        Assert.Contains("Reset", session.Operations);
+        Assert.True(session.Operations.IndexOf("Initialise") < session.Operations.IndexOf("Advance"));
+        Assert.True(session.Operations.IndexOf("Reset") < session.Operations.LastIndexOf("Advance"));
     }
 
     [Fact]
@@ -468,6 +520,14 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(state, backend.State);
     }
 
+    private static async Task WaitForAdvanceCountAsync(FakeSession session, int count)
+    {
+        var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (session.Advances.Count < count && DateTime.UtcNow < timeout)
+            await Task.Delay(10);
+        Assert.True(session.Advances.Count >= count);
+    }
+
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
@@ -503,10 +563,11 @@ public sealed class FabricManagedBehaviorTests
         public int DisposeCount { get; private set; }
         public int FramesToWrite { get; init; }
         public List<ulong> Advances { get; } = [];
+        public List<string> Operations { get; } = [];
         public FabricCapabilities Capabilities => new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
-        public void Initialise() => Invoke(() => { });
-        public void Reset() => Invoke(() => ResetCount++);
-        public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
+        public void Initialise() => Invoke(() => Operations.Add("Initialise"));
+        public void Reset() => Invoke(() => { Operations.Add("Reset"); ResetCount++; });
+        public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Operations.Add("Advance"); Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
         public void SubmitInput(FabricInput input) => Invoke(() => { });
         public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
             ? new FabricMachineSnapshot(1, [], [], [], [])

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -48,9 +48,37 @@ public sealed class PlayViewInputRouterTests
         Assert.Equal([(first.Id, true), (first.Id, false), (second.Id, true), (second.Id, false)], backend.Inputs);
     }
 
+    [Fact]
+    public async Task KeyboardAndPointer_RouteCoinButtonNumberUnchangedForPressAndRelease()
+    {
+        var backend = new RecordingBackend();
+        var visualId = Guid.NewGuid();
+        var coin = new InputDefinitionModel
+        {
+            Id = "20p-coin",
+            Name = "20p Coin",
+            ButtonNumber = "34",
+            CoinInput = true,
+            KeyboardShortcut = "C",
+            LinkedVisualElementId = visualId
+        };
+        var shared = new PlayViewInputRouter(backend);
+        var keyboard = new PlayViewKeyboardInputRouter(shared, [coin]);
+        var pointer = new PlayViewPointerInputRouter(shared, [coin]);
+
+        Assert.True(await keyboard.TryHandleKeyDownAsync(FruitMachinePlatformType.Impact, "C", true, false, CancellationToken.None));
+        Assert.True(await keyboard.TryHandleKeyUpAsync(FruitMachinePlatformType.Impact, "C", true, CancellationToken.None));
+        Assert.True(await pointer.TryHandlePointerDownAsync(FruitMachinePlatformType.Impact, visualId, true, CancellationToken.None));
+        Assert.True(await pointer.TryHandlePointerUpAsync(FruitMachinePlatformType.Impact, visualId, true, CancellationToken.None));
+
+        Assert.Equal([("20p-coin", "34", true, true), ("20p-coin", "34", true, false),
+            ("20p-coin", "34", true, true), ("20p-coin", "34", true, false)], backend.RoutedInputs);
+    }
+
     private sealed class RecordingBackend : IEmulationBackend
     {
         public List<(string, bool)> Inputs { get; } = [];
+        public List<(string Id, string ButtonNumber, bool CoinInput, bool Pressed)> RoutedInputs { get; } = [];
         public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
         public EmulationBackendState State => EmulationBackendState.Running;
         public EmulationBackendCapabilities Capabilities { get; } = new(true, true, true, true, false, false, false);
@@ -65,7 +93,7 @@ public sealed class PlayViewInputRouterTests
         public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, isPressed)); return Task.CompletedTask; }
+        public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, isPressed)); RoutedInputs.Add((inputDefinition.Id, inputDefinition.ButtonNumber, inputDefinition.CoinInput, isPressed)); return Task.CompletedTask; }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -16,12 +16,14 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     private readonly Func<int, IEmulationAudioSink> _audioSinkFactory;
     private readonly IFabricClock _clock;
     private readonly Action<string>? _errorLogger;
+    private readonly Action<string>? _inputLogger;
 
     public EmulationBackendFactory(
         Func<string?> fabricRuntimePathProvider,
         Func<string?> productionAmberPathProvider,
         Func<int>? audioBufferLengthMillisecondsProvider = null,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? inputLogger = null)
         : this(
             fabricRuntimePathProvider,
             productionAmberPathProvider,
@@ -29,7 +31,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             static path => new FabricRuntimeLibrary(path),
             static bufferLength => new NAudioEmulationAudioSink(bufferLength),
             new StopwatchFabricClock(),
-            errorLogger)
+            errorLogger,
+            inputLogger)
     {
     }
 
@@ -40,7 +43,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         Func<int, IEmulationAudioSink> audioSinkFactory,
         IFabricClock clock,
-        Action<string>? errorLogger)
+        Action<string>? errorLogger,
+        Action<string>? inputLogger = null)
     {
         _fabricRuntimePathProvider = fabricRuntimePathProvider ?? throw new ArgumentNullException(nameof(fabricRuntimePathProvider));
         _productionAmberPathProvider = productionAmberPathProvider ?? throw new ArgumentNullException(nameof(productionAmberPathProvider));
@@ -49,6 +53,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         _audioSinkFactory = audioSinkFactory ?? throw new ArgumentNullException(nameof(audioSinkFactory));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _errorLogger = errorLogger;
+        _inputLogger = inputLogger;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -76,6 +81,6 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             throw new FileNotFoundException("The production Amber API v2 provider DLL was not found at the configured path. Select a valid provider under Preferences > Fabric Emulation.", amberPath);
 
         return new FabricEmulationBackend(runtimePath, amberPath, _runtimeFactory,
-            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger);
+            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger, _inputLogger);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
@@ -19,6 +19,16 @@ public sealed record FabricAmberConfiguration(
     IReadOnlyList<FabricAmberCoinRoute> CoinRoutes,
     uint? PercentageSwitch) : IFabricBackendConfiguration
 {
+    internal const uint NativeMagic = 0x32424146;
+    internal const uint NativeVersion = 1;
+    internal const uint ReelsFlag = 1;
+    internal const uint CoinsFlag = 2;
+    internal const uint PercentageFlag = 4;
+
+    internal uint NativeFlags => (Reels.Count > 0 ? ReelsFlag : 0)
+        | (CoinChannels.Count > 0 || CoinRoutes.Count > 0 ? CoinsFlag : 0)
+        | (PercentageSwitch.HasValue ? PercentageFlag : 0);
+
     public static FabricAmberConfiguration FromSystem6(System6NativeRomSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -56,12 +66,10 @@ public sealed record FabricAmberConfiguration(
 
         var native = new FabricAmberConfigurationNative
         {
-            Magic = 0x32424146,
+            Magic = NativeMagic,
             Size = (uint)sizeof(FabricAmberConfigurationNative),
-            Version = 1,
-            Flags = (Reels.Count > 0 ? 1u : 0)
-                | (CoinChannels.Count > 0 || CoinRoutes.Count > 0 ? 2u : 0)
-                | (PercentageSwitch.HasValue ? 4u : 0),
+            Version = NativeVersion,
+            Flags = NativeFlags,
             Percentage = PercentageSwitch ?? 0
         };
         native.Reels.Size = (uint)sizeof(AmberReelsNative);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -93,11 +93,14 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             var settings = request.System6Configuration;
             var resources = BuildRomResources(settings);
+            var configuration = FabricAmberConfiguration.FromSystem6(settings);
+            LogCoinConfiguration(settings, configuration);
             cancellationToken.ThrowIfCancellationRequested();
             _runtime = _runtimeFactory(_runtimePath);
             _session = _runtime.CreateSession(new FabricLaunchRequest(
                 AmberBackendKind, JpmSystem6MachineIdentifier, _amberPath, resources,
-                FabricAmberConfiguration.FromSystem6(settings)));
+                configuration));
+            _inputLogger?.Invoke("[Coin Config Lifecycle] FabricCreateSession accepted configuration; blob was supplied during session creation before initialise; initialise follows; no startup reset is issued by Oasis.");
 
             await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
@@ -348,6 +351,28 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             throw new ArgumentOutOfRangeException(nameof(sampleRate));
         return checked((sampleRate + EmulationPumpHz - 1) / EmulationPumpHz);
     }
+
+    private void LogCoinConfiguration(System6NativeRomSettings settings, FabricAmberConfiguration configuration)
+    {
+        if (_inputLogger is null)
+            return;
+
+        _inputLogger($"[Coin Config Source] rowCount={settings.Coins.Count} enabledRowCount={settings.Coins.Count(coin => coin.Enabled)}");
+        for (var slot = 0; slot < settings.Coins.Count; slot++)
+        {
+            var coin = settings.Coins[slot];
+            _inputLogger($"[Coin Config Source] slot={slot} enabled={Lower(coin.Enabled)} num={coin.Num} coinEnable={coin.CoinEnable} value={coin.CoinValue} lockoutInvert={coin.LockoutInvert} counterIn={coin.CounterIn} counterOut={coin.CounterOut} port={coin.PortIndex} coin={coin.Coin} level={coin.Level} fullLevel={coin.FullLevel}");
+        }
+        foreach (var channel in configuration.CoinChannels)
+            _inputLogger($"[Coin Config Fabric] channelIndex={channel.Index} enabled={Lower(channel.Enabled)} value={channel.Value} lockoutInvert={Lower(channel.LockoutInvert)}");
+        foreach (var route in configuration.CoinRoutes)
+            _inputLogger($"[Coin Config Fabric] routeIndex={route.Index} enabled={Lower(route.Enabled)} counterIn={route.CounterIn} counterOut={route.CounterOut} port={route.PortIndex} coinCode={route.CoinCode} level={route.Level} fullLevel={route.FullLevel}");
+
+        var nativeSize = configuration.ToNativeBytes().Length;
+        _inputLogger($"[Coin Config Fabric] channelMask=0x{configuration.CoinChannelApplyMask:X8} routeMask=0x{configuration.CoinRouteApplyMask:X8} coinsFlag={Lower((configuration.NativeFlags & FabricAmberConfiguration.CoinsFlag) != 0)} nativeMagic=0x{FabricAmberConfiguration.NativeMagic:X8} nativeVersion={FabricAmberConfiguration.NativeVersion} nativeSize={nativeSize} blobNonEmpty={Lower(nativeSize != 0)}");
+    }
+
+    private static string Lower(bool value) => value.ToString().ToLowerInvariant();
 
     private void ProcessInputs()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -20,9 +20,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly IEmulationAudioSink _audioSink;
     private readonly IFabricClock _clock;
     private readonly Action<string> _errorLogger;
+    private readonly Action<string>? _inputLogger;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
-    private readonly HashSet<int> _assertedInputs = [];
+    private readonly FabricInputScheduler _inputScheduler = new();
     private readonly Dictionary<int, (bool State, float Brightness)> _lamps = [];
     private readonly Dictionary<int, int> _reels = [];
     private readonly Dictionary<DisplayOutputIdentity, ulong> _displayOutputs = [];
@@ -40,6 +41,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private bool _audioStarted;
     private bool _disposed;
     private long _scheduleGeneration;
+    private long _pumpSequence;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -53,7 +55,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         IEmulationAudioSink audioSink,
         IFabricClock clock,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? inputLogger = null)
     {
         _runtimePath = runtimePath;
         _amberPath = amberPath;
@@ -61,6 +64,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioSink = audioSink;
         _clock = clock;
         _errorLogger = errorLogger ?? WriteDebugError;
+        _inputLogger = inputLogger;
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
@@ -269,8 +273,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 try
                 {
                     var session = RequireSession();
+                    ProcessInputs();
+                    var pumpSequence = Interlocked.Increment(ref _pumpSequence);
+                    _inputScheduler.ApplyBeforeAdvance(session, pumpSequence, _inputLogger);
                     session.Advance(NanosecondsPerPump);
-                    ProcessInputs(session);
+                    _inputScheduler.MarkAdvanced();
                     PublishSnapshot(session.GetSnapshot());
                     ReadAudio(session);
                 }
@@ -342,16 +349,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         return checked((sampleRate + EmulationPumpHz - 1) / EmulationPumpHz);
     }
 
-    private void ProcessInputs(IFabricMachineSession session)
+    private void ProcessInputs()
     {
         while (_inputCommands.TryDequeue(out var input))
-        {
-            session.SubmitInput(new($"oasis.switch.{input.Index}", input.Index, input.Active));
-            if (input.Active)
-                _assertedInputs.Add(input.Index);
-            else
-                _assertedInputs.Remove(input.Index);
-        }
+            _inputScheduler.Request(input.Index, input.Active);
     }
 
     private void ReadAudio(IFabricMachineSession session)
@@ -492,16 +493,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     private void ReleaseAssertedInputs()
     {
-        var session = _session;
-        if (session is not null)
-            foreach (var index in _assertedInputs)
-                session.SubmitInput(new($"oasis.switch.{index}", index, false));
-        _assertedInputs.Clear();
+        _inputScheduler.ReleaseAll(_session);
     }
 
     private void ClearPendingInputs()
     {
         while (_inputCommands.TryDequeue(out _)) { }
+        _inputScheduler.Clear();
     }
 
     private void ClearOutputCaches()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricInputScheduler.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricInputScheduler.cs
@@ -1,0 +1,81 @@
+namespace OasisEditor;
+
+/// <summary>Schedules digital input changes around Fabric advances.</summary>
+internal sealed class FabricInputScheduler
+{
+    private readonly Dictionary<int, InputState> _states = [];
+
+    public void Request(int index, bool active)
+    {
+        if (!_states.TryGetValue(index, out var state))
+            state = new InputState();
+        state.Desired = active;
+        if (active && !state.Applied)
+            state.AssertionPending = true;
+        _states[index] = state;
+    }
+
+    public void ApplyBeforeAdvance(IFabricMachineSession session, long pumpSequence, Action<string>? logger)
+    {
+        foreach (var pair in _states.ToArray())
+        {
+            var index = pair.Key;
+            var state = pair.Value;
+            if (state.AssertionPending && !state.Applied)
+            {
+                Submit(session, index, true, pumpSequence, false, logger);
+                state.Applied = true;
+                state.AssertionPending = false;
+                state.AdvancedSinceAssertion = false;
+            }
+            else if (state.Applied && !state.Desired && state.AdvancedSinceAssertion)
+            {
+                Submit(session, index, false, pumpSequence, true, logger);
+                state.Applied = false;
+            }
+
+            if (!state.Applied && !state.Desired && !state.AssertionPending)
+                _states.Remove(index);
+            else
+                _states[index] = state;
+        }
+    }
+
+    public void MarkAdvanced()
+    {
+        foreach (var index in _states.Keys.ToArray())
+        {
+            var state = _states[index];
+            if (state.Applied)
+                state.AdvancedSinceAssertion = true;
+            _states[index] = state;
+        }
+    }
+
+    public void ReleaseAll(IFabricMachineSession? session)
+    {
+        if (session is not null)
+            foreach (var pair in _states.Where(pair => pair.Value.Applied))
+                session.SubmitInput(CreateInput(pair.Key, false));
+        _states.Clear();
+    }
+
+    public void Clear() => _states.Clear();
+
+    private static void Submit(IFabricMachineSession session, int index, bool active, long pumpSequence,
+        bool advancedSinceAssertion, Action<string>? logger)
+    {
+        session.SubmitInput(CreateInput(index, active));
+        logger?.Invoke($"[Fabric Input] switch={index} state={(active ? "pressed" : "released")} pump={pumpSequence} advanceSincePress={advancedSinceAssertion.ToString().ToLowerInvariant()}");
+    }
+
+    private static FabricInput CreateInput(int index, bool active) => new($"oasis.switch.{index}", index, active);
+
+    private struct InputState
+    {
+        public bool Desired;
+        public bool Applied;
+        public bool AssertionPending;
+        public bool AdvancedSinceAssertion;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceInputRouting.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceInputRouting.cs
@@ -103,7 +103,7 @@ public sealed class FacePlayViewPointerInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken, "pointer");
     }
 
     public Task<bool> TryHandlePointerUpAsync(FruitMachinePlatformType platform, MachineInputReference inputReference, bool isFocused, CancellationToken cancellationToken)
@@ -113,7 +113,7 @@ public sealed class FacePlayViewPointerInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken, "pointer");
     }
 
     private bool TryResolveInput(MachineInputReference inputReference, out InputDefinitionModel input)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -239,7 +239,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _emulationBackendFactory = new EmulationBackendFactory(
             () => FabricRuntimeLibraryPath, () => ProductionAmberLibraryPath,
             () => System6AudioBufferLengthMilliseconds,
-            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error));
+            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error),
+            inputLogger: message => AddOutputEntry(message, OutputLogStatus.Info));
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
@@ -1803,7 +1804,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             return false;
         }
 
-        _playViewInputRouter ??= new PlayViewInputRouter(_activeEmulationBackend);
+        _playViewInputRouter ??= new PlayViewInputRouter(
+            _activeEmulationBackend, message => AddOutputEntry(message, OutputLogStatus.Info));
         return true;
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -4,13 +4,15 @@ public sealed class PlayViewInputRouter
 {
     private readonly IEmulationBackend _backend;
     private readonly HashSet<string> _activeInputIds = [];
+    private readonly Action<string>? _inputLogger;
 
-    public PlayViewInputRouter(IEmulationBackend backend)
+    public PlayViewInputRouter(IEmulationBackend backend, Action<string>? inputLogger = null)
     {
         _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _inputLogger = inputLogger;
     }
 
-    public async Task<bool> TryPressAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken)
+    public async Task<bool> TryPressAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken, string source = "shared")
     {
         ArgumentNullException.ThrowIfNull(inputDefinition);
 
@@ -25,6 +27,8 @@ public sealed class PlayViewInputRouter
         }
 
         var wrote = await TrySendInputStateAsync(platform, inputDefinition, isPressed: true, cancellationToken).ConfigureAwait(false);
+        if (wrote)
+            LogRoute(source, inputDefinition, true);
         if (!wrote)
         {
             _activeInputIds.Remove(inputDefinition.Id);
@@ -33,7 +37,7 @@ public sealed class PlayViewInputRouter
         return wrote;
     }
 
-    public async Task<bool> TryReleaseAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken)
+    public async Task<bool> TryReleaseAsync(FruitMachinePlatformType platform, InputDefinitionModel inputDefinition, CancellationToken cancellationToken, string source = "shared")
     {
         ArgumentNullException.ThrowIfNull(inputDefinition);
 
@@ -42,7 +46,10 @@ public sealed class PlayViewInputRouter
             return false;
         }
 
-        return await TrySendInputStateAsync(platform, inputDefinition, isPressed: false, cancellationToken).ConfigureAwait(false);
+        var wrote = await TrySendInputStateAsync(platform, inputDefinition, isPressed: false, cancellationToken).ConfigureAwait(false);
+        if (wrote)
+            LogRoute(source, inputDefinition, false);
+        return wrote;
     }
 
     public async Task<int> ReleaseAllAsync(FruitMachinePlatformType platform, IReadOnlyDictionary<string, InputDefinitionModel> inputDefinitionsById, CancellationToken cancellationToken)
@@ -86,4 +93,7 @@ public sealed class PlayViewInputRouter
             return false;
         }
     }
+
+    private void LogRoute(string source, InputDefinitionModel input, bool pressed) =>
+        _inputLogger?.Invoke($"[Input] source={source} name=\"{input.Name}\" coin={input.CoinInput.ToString().ToLowerInvariant()} switch={input.ButtonNumber} state={(pressed ? "pressed" : "released")}");
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewKeyboardInputRouter.cs
@@ -43,7 +43,7 @@ public sealed class PlayViewKeyboardInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken, "keyboard");
     }
 
     public Task<bool> TryHandleKeyUpAsync(FruitMachinePlatformType platform, string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
@@ -53,7 +53,7 @@ public sealed class PlayViewKeyboardInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken, "keyboard");
     }
 
     private bool TryGetInputForShortcut(string keyboardShortcut, out InputDefinitionModel input)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewPointerInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewPointerInputRouter.cs
@@ -32,7 +32,7 @@ public sealed class PlayViewPointerInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryPressAsync(platform, input, cancellationToken);
+        return _inputRouter.TryPressAsync(platform, input, cancellationToken, "pointer");
     }
 
     public Task<bool> TryHandlePointerUpAsync(FruitMachinePlatformType platform, Guid visualElementId, bool isFocused, CancellationToken cancellationToken)
@@ -42,7 +42,7 @@ public sealed class PlayViewPointerInputRouter
             return Task.FromResult(false);
         }
 
-        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken);
+        return _inputRouter.TryReleaseAsync(platform, input, cancellationToken, "pointer");
     }
 
     public Task<int> ReleaseAllActiveAsync(FruitMachinePlatformType platform, CancellationToken cancellationToken)


### PR DESCRIPTION
### Motivation

- Short coin/key pulses queued between Fabric pumps could be submitted as press+release before Amber ran, so the switch was never observed asserted by the emulator.
- The goal is to implement the backend-side timing contract so every new assertion survives at least one Fabric `Advance` before its release is allowed, without UI delays or coin-specific hacks.

### Description

- Add a deterministic scheduler `FabricInputScheduler` that tracks per-switch `Desired`, `Applied`, `AssertionPending`, and `AdvancedSinceAssertion` state and submits inputs to Fabric only when the timing contract is satisfied (file: `Emulation/Fabric/FabricInputScheduler.cs`).
- Change `FabricEmulationBackend` to drain queued requests into the scheduler, call `ApplyBeforeAdvance` before `session.Advance(...)`, then call `MarkAdvanced` after the advance; replace the previous naive immediate-submit approach (file: `Emulation/Fabric/FabricEmulationBackend.cs`).
- Preserve cleanup semantics by releasing all applied switches on reset/stop/cleanup through `FabricInputScheduler.ReleaseAll` and clearing scheduled state on pending-clear (file: `FabricEmulationBackend.cs`).
- Propagate lightweight diagnostics: route-level logs from `PlayViewInputRouter` and source-tagged press/release calls from keyboard/pointer/face routers, and native submission logs from the scheduler; wire the `inputLogger` from `MainWindowViewModel` (files: `PlayViewInputRouter.cs`, `PlayViewKeyboardInputRouter.cs`, `PlayViewPointerInputRouter.cs`, `FaceInputRouting.cs`, `MainWindowViewModel.cs`).
- Pass an `inputLogger` through `EmulationBackendFactory` to `FabricEmulationBackend` to enable Editor Output diagnostics (file: `Emulation/EmulationBackendFactory.cs`).
- Add focused unit tests for the scheduler and routing: `FabricInputSchedulerTests` validates rapid click ordering, held keys, multiple simultaneous switches, zero index handling, and cleanup releases; `PlayViewInputRouterTests` extended with a regression fixture ensuring coin metadata and `ButtonNumber` are preserved across keyboard/pointer routing (files: `OasisEditor.Tests/FabricInputSchedulerTests.cs`, `OasisEditor.Tests/PlayViewInputRouterTests.cs`).

### Testing

- Ran repository static checks: `git diff --check` and `git status --short --branch` (both OK) and committed the change as `Preserve Fabric input pulses across emulation advances`.
- Added automated unit tests (`FabricInputSchedulerTests` and updated `PlayViewInputRouterTests`) but did not run them in this environment because `AGENTS.md` prohibits building/running Windows/.NET/WPF tests here; tests are intended to run on the normal Windows development machines.
- Manual verification steps are documented in the change (start Fabric-backed System 6 machine, perform keyboard and Play View coin presses, hold/release buttons, validate no stuck switches, and inspect Editor Output for `[Input]` and `[Fabric Input]` lines showing `advanceSincePress=true` on releases).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6dd5a73b748327b38ef866dc5b2c53)