### PR TITLE
Preserve Fabric input pulses and transport Amber coin lockout values

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
@@ -24,6 +24,8 @@ public sealed class FabricAbiLayoutTests
         Assert.Equal(24, Marshal.SizeOf<AmberReelNative>());
         Assert.Equal(208, Marshal.SizeOf<AmberReelsNative>());
         Assert.Equal(20, Marshal.SizeOf<AmberCoinChannelNative>());
+        Assert.Equal(12, Marshal.OffsetOf<AmberCoinChannelNative>("LockoutValue").ToInt32());
+        Assert.Equal(16, Marshal.OffsetOf<AmberCoinChannelNative>("LockoutInvert").ToInt32());
         Assert.Equal(32, Marshal.SizeOf<AmberCoinRouteNative>());
         Assert.Equal(408, Marshal.SizeOf<AmberCoinsNative>());
         Assert.Equal(648, Marshal.SizeOf<FabricAmberConfigurationNative>());

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -1,5 +1,7 @@
 using Xunit;
 using OasisEditor;
+using System.Reflection;
+using System.Text.Json;
 
 namespace OasisEditor.Tests;
 
@@ -236,7 +238,7 @@ public sealed class FabricManagedBehaviorTests
             ReelOptos = [new() { ReelIndex = 2, Enabled = false, Steps = 96, OptoStart = 5, OptoEnd = 7, OptoInvert = true }],
             Coins =
             [
-                new() { Num = 1, Enabled = true, CoinEnable = 1, CoinValue = 20, LockoutInvert = 1, CounterIn = 2, CounterOut = 3, PortIndex = 4, Coin = 5, Level = 6, FullLevel = 7 },
+                new() { Num = 1, Enabled = true, CoinEnable = 1, CoinValue = 20, LockoutValue = 2, LockoutInvert = 1, CounterIn = 2, CounterOut = 3, PortIndex = 4, Coin = 5, Level = 6, FullLevel = 7 },
                 new() { Num = 2, Enabled = false }
             ],
             PercentSwitchValue = 12
@@ -248,9 +250,124 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(new FabricAmberReel(2, false, 96, 5, 7, true), Assert.Single(configuration.Reels));
         Assert.Equal(1u << 1, configuration.CoinChannelApplyMask);
         Assert.Equal(1u << 1, configuration.CoinRouteApplyMask);
-        Assert.Equal(new FabricAmberCoinChannel(1, true, 20, true), Assert.Single(configuration.CoinChannels));
+        Assert.Equal(new FabricAmberCoinChannel(1, true, 20, 2, true), Assert.Single(configuration.CoinChannels));
         Assert.Equal(new FabricAmberCoinRoute(1, true, 2, 3, 4, 5, 6, 7), Assert.Single(configuration.CoinRoutes));
         Assert.Equal(12u, configuration.PercentageSwitch);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(2, 1)]
+    public void AmberConfiguration_MapsLockoutValuesWithoutInference(int lockoutValue, int lockoutInvert)
+    {
+        var settings = new System6NativeRomSettings
+        {
+            Coins =
+            [
+                new()
+                {
+                    Num = 2, Enabled = true, CoinEnable = 1, CoinValue = 20,
+                    LockoutValue = lockoutValue, LockoutInvert = lockoutInvert
+                }
+            ]
+        };
+
+        var channel = Assert.Single(FabricAmberConfiguration.FromSystem6(settings).CoinChannels);
+
+        Assert.Equal(new FabricAmberCoinChannel(2, true, 20, checked((uint)lockoutValue), lockoutInvert != 0), channel);
+    }
+
+    [Fact]
+    public void AmberConfiguration_NativeBytesUseCurrentChannelLayoutAndPreserveRouteOffset()
+    {
+        var configuration = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            Coins =
+            [
+                new()
+                {
+                    Num = 2, Enabled = true, CoinEnable = 1, CoinValue = 20,
+                    LockoutValue = 1, LockoutInvert = 1, CounterIn = 7
+                }
+            ]
+        });
+
+        var bytes = configuration.ToNativeBytes();
+        const int firstChannelOffset = 240;
+        const int firstRouteOffset = 360;
+
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, firstChannelOffset));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, firstChannelOffset + 4));
+        Assert.Equal(20u, BitConverter.ToUInt32(bytes, firstChannelOffset + 8));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, firstChannelOffset + 12));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, firstChannelOffset + 16));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, firstRouteOffset));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, firstRouteOffset + 4));
+        Assert.Equal(7u, BitConverter.ToUInt32(bytes, firstRouteOffset + 8));
+    }
+
+    [Fact]
+    public async Task Backend_LaunchPreservesLockoutValueAndLogsSourceAndFabricValues()
+    {
+        var session = new FakeSession();
+        var runtime = new FakeRuntime(session);
+        var diagnostics = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => runtime,
+            new FakeAudioSink(), new FakeClock(), diagnosticLogger: diagnostics.Add);
+        var request = new EmulationLaunchRequest(new System6NativeRomSettings
+        {
+            Coins = [new() { Num = 2, Enabled = true, CoinEnable = 1, CoinValue = 20, LockoutValue = 1 }]
+        });
+
+        await backend.StartAsync(request, CancellationToken.None);
+        await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        var configuration = Assert.IsType<FabricAmberConfiguration>(runtime.Request!.Configuration);
+        Assert.Equal(1u, Assert.Single(configuration.CoinChannels).LockoutValue);
+        Assert.Contains("[Coin Config Source] channelIndex=2 enabled=true value=20 lockoutValue=1 lockoutInvert=false", diagnostics);
+        Assert.Contains("[Coin Config Fabric] channelIndex=2 enabled=true value=20 lockoutValue=1 lockoutInvert=false", diagnostics);
+    }
+
+    [Fact]
+    public void CoinSettingsViewModel_EditPreservesLockoutValueInBackingModel()
+    {
+        System6CoinSettings? saved = null;
+        System6CoinSettingsViewModel? viewModel = null;
+        viewModel = new System6CoinSettingsViewModel(new System6CoinSettings { LockoutValue = 0 },
+            () => saved = viewModel!.ToModel());
+
+        viewModel.LockoutValue = 2;
+
+        Assert.Equal(2, saved!.LockoutValue);
+    }
+
+    [Fact]
+    public void ProjectSettingsSerialization_RoundTripsLockoutValue()
+    {
+        var settings = new System6NativeRomSettings
+        {
+            Coins = [new() { Num = 0, Enabled = true, CoinEnable = 1, LockoutValue = 2 }]
+        };
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("project_settings");
+            writer.WriteStartObject();
+            typeof(MainWindowViewModel).GetMethod("WriteSystem6NativeRomSettings",
+                BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, [writer, settings]);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+        using var document = JsonDocument.Parse(stream.ToArray());
+
+        var reloaded = Assert.IsType<System6NativeRomSettings>(
+            typeof(MainWindowViewModel).GetMethod("ResolveSystem6NativeRomSettings",
+                BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, [document.RootElement]));
+
+        Assert.Equal(2, reloaded.Coins[0].LockoutValue);
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -343,6 +343,72 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(2, saved!.LockoutValue);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(255)]
+    public async Task Backend_RawInputPressAndReleaseSubmitIndexUnchanged(int switchIndex)
+    {
+        var session = new FakeSession();
+        var backend = CreateBackend(session, new FakeAudioSink());
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+
+        await backend.SetRawInputStateAsync(switchIndex, true, CancellationToken.None);
+        await WaitForInputCountAsync(session, 1);
+        await backend.SetRawInputStateAsync(switchIndex, false, CancellationToken.None);
+        await WaitForInputCountAsync(session, 2);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Collection(session.Inputs,
+            input => Assert.Equal((switchIndex, true), (input.Input.NumericalIndex, input.Input.Active)),
+            input => Assert.Equal((switchIndex, false), (input.Input.NumericalIndex, input.Input.Active)));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(256)]
+    public async Task Backend_RawInputRejectsIndexesOutsideByteRange(int switchIndex)
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            backend.SetRawInputStateAsync(switchIndex, true, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Backend_RawPulseSpansAtLeastOneAdvanceBeforeRelease()
+    {
+        var session = new FakeSession();
+        var backend = CreateBackend(session, new FakeAudioSink());
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+
+        await backend.PulseRawInputAsync(72, CancellationToken.None);
+        await WaitForInputCountAsync(session, 2);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal((72, true), (session.Inputs[0].Input.NumericalIndex, session.Inputs[0].Input.Active));
+        Assert.Equal((72, false), (session.Inputs[1].Input.NumericalIndex, session.Inputs[1].Input.Active));
+        Assert.True(session.Inputs[1].AdvanceCount > session.Inputs[0].AdvanceCount);
+    }
+
+    [Fact]
+    public async Task Backend_RawInputDoesNotCreateOrModifyProjectInputDefinitions()
+    {
+        var projectInputs = new List<InputDefinitionModel>
+        {
+            new() { Id = "mapped", ButtonNumber = "74" }
+        };
+        var session = new FakeSession();
+        var backend = CreateBackend(session, new FakeAudioSink());
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+
+        await backend.SetRawInputStateAsync(72, true, CancellationToken.None);
+        await WaitForInputCountAsync(session, 1);
+        await backend.StopAsync(CancellationToken.None);
+
+        var input = Assert.Single(projectInputs);
+        Assert.Equal(("mapped", "74"), (input.Id, input.ButtonNumber));
+    }
+
     [Fact]
     public void ProjectSettingsSerialization_RoundTripsLockoutValue()
     {
@@ -585,6 +651,14 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(state, backend.State);
     }
 
+    private static async Task WaitForInputCountAsync(FakeSession session, int count)
+    {
+        var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (session.Inputs.Count < count && DateTime.UtcNow < timeout)
+            await Task.Delay(10);
+        Assert.True(session.Inputs.Count >= count, $"Expected at least {count} submitted inputs.");
+    }
+
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
@@ -620,11 +694,12 @@ public sealed class FabricManagedBehaviorTests
         public int DisposeCount { get; private set; }
         public int FramesToWrite { get; init; }
         public List<ulong> Advances { get; } = [];
+        public List<(FabricInput Input, int AdvanceCount)> Inputs { get; } = [];
         public FabricCapabilities Capabilities => new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
         public void Initialise() => Invoke(() => { });
         public void Reset() => Invoke(() => ResetCount++);
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
-        public void SubmitInput(FabricInput input) => Invoke(() => { });
+        public void SubmitInput(FabricInput input) => Invoke(() => Inputs.Add((input, Advances.Count)));
         public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
             ? new FabricMachineSnapshot(1, [], [], [], [])
             : throw SnapshotFailure);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -396,6 +396,31 @@ public sealed class FmlToOasisMapperTests
     }
 
     [Fact]
+    public void Map_WithCoinInput_ReportsSelectedSourceAndBoundedRawMetadata()
+    {
+        var lamp = CreateLamp();
+        SetExplicitUInt(lamp, "ButtonNumber", 72);
+        SetExplicitBool(lamp, "Coin / Note Selected", true);
+        lamp.Int32s["Coin Number"] = 3;
+        lamp.UInt32s["Shortcut 1"] = 0x35;
+        lamp.Booleans["Shortcut 1 Enabled"] = true;
+        lamp.Strings["SelectedCoinNote"] = "50p";
+        lamp.Strings["ImageBlob"] = new string('x', 1000);
+
+        var diagnostic = Assert.Single(Map(lamp).InputDiagnostics);
+
+        Assert.Contains("[MFME Input Decode] component=0 type=Lamp", diagnostic);
+        Assert.Contains("coin=true selectedButtonNumber=72 sourceField=\"ButtonNumber\"", diagnostic);
+        Assert.Contains("int32={Coin Number=3}", diagnostic);
+        Assert.Contains("ButtonNumber=72", diagnostic);
+        Assert.Contains("Shortcut 1=53", diagnostic);
+        Assert.Contains("Coin / Note Selected=True", diagnostic);
+        Assert.Contains("SelectedCoinNote=\"50p\"", diagnostic);
+        Assert.DoesNotContain("ImageBlob", diagnostic);
+        Assert.DoesNotContain(new string('x', 100), diagnostic);
+    }
+
+    [Fact]
     public void Map_WithPlaceholderCoinNote_DoesNotCreateInput()
     {
         var lamp = CreateLamp();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -48,6 +48,14 @@ public sealed class PlayViewInputRouterTests
         Assert.Equal([(first.Id, true), (first.Id, false), (second.Id, true), (second.Id, false)], backend.Inputs);
     }
 
+    [Fact]
+    public void BackendWithoutRawDiagnosticInterfaceReportsUnsupportedCleanly()
+    {
+        IEmulationBackend backend = new RecordingBackend();
+
+        Assert.Null(backend as IRawInputDiagnosticBackend);
+    }
+
     private sealed class RecordingBackend : IEmulationBackend
     {
         public List<(string, bool)> Inputs { get; } = [];

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -27,6 +27,13 @@ public interface IEmulationBackend : IAsyncDisposable
     Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
 }
 
+public interface IRawInputDiagnosticBackend
+{
+    bool IsRawInputDiagnosticAvailable { get; }
+    Task SetRawInputStateAsync(int switchIndex, bool isPressed, CancellationToken cancellationToken);
+    Task PulseRawInputAsync(int switchIndex, CancellationToken cancellationToken);
+}
+
 public enum EmulationBackendKind
 {
     Fabric

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -16,12 +16,14 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     private readonly Func<int, IEmulationAudioSink> _audioSinkFactory;
     private readonly IFabricClock _clock;
     private readonly Action<string>? _errorLogger;
+    private readonly Action<string>? _diagnosticLogger;
 
     public EmulationBackendFactory(
         Func<string?> fabricRuntimePathProvider,
         Func<string?> productionAmberPathProvider,
         Func<int>? audioBufferLengthMillisecondsProvider = null,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? diagnosticLogger = null)
         : this(
             fabricRuntimePathProvider,
             productionAmberPathProvider,
@@ -29,7 +31,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             static path => new FabricRuntimeLibrary(path),
             static bufferLength => new NAudioEmulationAudioSink(bufferLength),
             new StopwatchFabricClock(),
-            errorLogger)
+            errorLogger,
+            diagnosticLogger)
     {
     }
 
@@ -40,7 +43,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         Func<int, IEmulationAudioSink> audioSinkFactory,
         IFabricClock clock,
-        Action<string>? errorLogger)
+        Action<string>? errorLogger,
+        Action<string>? diagnosticLogger = null)
     {
         _fabricRuntimePathProvider = fabricRuntimePathProvider ?? throw new ArgumentNullException(nameof(fabricRuntimePathProvider));
         _productionAmberPathProvider = productionAmberPathProvider ?? throw new ArgumentNullException(nameof(productionAmberPathProvider));
@@ -49,6 +53,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         _audioSinkFactory = audioSinkFactory ?? throw new ArgumentNullException(nameof(audioSinkFactory));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _errorLogger = errorLogger;
+        _diagnosticLogger = diagnosticLogger;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -76,6 +81,6 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             throw new FileNotFoundException("The production Amber API v2 provider DLL was not found at the configured path. Select a valid provider under Preferences > Fabric Emulation.", amberPath);
 
         return new FabricEmulationBackend(runtimePath, amberPath, _runtimeFactory,
-            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger);
+            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger, _diagnosticLogger);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
@@ -4,7 +4,7 @@ public sealed record FabricAmberReel(
     uint Index, bool Enabled, uint Steps, uint OptoStart, uint OptoEnd, bool OptoInvert);
 
 public sealed record FabricAmberCoinChannel(
-    uint Index, bool Enabled, uint Value, bool LockoutInvert);
+    uint Index, bool Enabled, uint Value, uint LockoutValue, bool LockoutInvert);
 
 public sealed record FabricAmberCoinRoute(
     uint Index, bool Enabled, uint CounterIn, uint CounterOut,
@@ -34,7 +34,8 @@ public sealed record FabricAmberConfiguration(
             coins.Aggregate(0u, (mask, coin) => mask | 1u << coin.Num),
             coins.Aggregate(0u, (mask, coin) => mask | 1u << coin.Num),
             coins.Select(coin => new FabricAmberCoinChannel(
-                checked((uint)coin.Num), coin.CoinEnable != 0, checked((uint)coin.CoinValue), coin.LockoutInvert != 0)).ToArray(),
+                checked((uint)coin.Num), coin.CoinEnable != 0, checked((uint)coin.CoinValue),
+                checked((uint)coin.LockoutValue), coin.LockoutInvert != 0)).ToArray(),
             coins.Select(coin => new FabricAmberCoinRoute(
                 checked((uint)coin.Num), coin.Enabled, checked((uint)coin.CounterIn), checked((uint)coin.CounterOut),
                 checked((uint)coin.PortIndex), checked((uint)coin.Coin), checked((uint)coin.Level), checked((uint)coin.FullLevel))).ToArray(),
@@ -99,6 +100,7 @@ public sealed record FabricAmberConfiguration(
                     Index = channel.Index,
                     Enabled = channel.Enabled ? 1u : 0,
                     Value = channel.Value,
+                    LockoutValue = channel.LockoutValue,
                     LockoutInvert = channel.LockoutInvert ? 1u : 0
                 };
             }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -20,6 +20,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly IEmulationAudioSink _audioSink;
     private readonly IFabricClock _clock;
     private readonly Action<string> _errorLogger;
+    private readonly Action<string> _diagnosticLogger;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
     private readonly HashSet<int> _assertedInputs = [];
@@ -53,7 +54,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         IEmulationAudioSink audioSink,
         IFabricClock clock,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? diagnosticLogger = null)
     {
         _runtimePath = runtimePath;
         _amberPath = amberPath;
@@ -61,6 +63,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioSink = audioSink;
         _clock = clock;
         _errorLogger = errorLogger ?? WriteDebugError;
+        _diagnosticLogger = diagnosticLogger ?? WriteDebugError;
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
@@ -89,6 +92,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             var settings = request.System6Configuration;
             var resources = BuildRomResources(settings);
+            LogCoinConfiguration(settings);
             cancellationToken.ThrowIfCancellationRequested();
             _runtime = _runtimeFactory(_runtimePath);
             _session = _runtime.CreateSession(new FabricLaunchRequest(
@@ -120,6 +124,26 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             throw;
         }
     }
+
+    private void LogCoinConfiguration(System6NativeRomSettings settings)
+    {
+        foreach (var coin in settings.Coins.Where(coin => coin.Enabled))
+        {
+            _diagnosticLogger(
+                $"[Coin Config Source] channelIndex={coin.Num} enabled={FormatBoolean(coin.CoinEnable != 0)} value={coin.CoinValue} " +
+                $"lockoutValue={coin.LockoutValue} lockoutInvert={FormatBoolean(coin.LockoutInvert != 0)}");
+        }
+
+        var configuration = FabricAmberConfiguration.FromSystem6(settings);
+        foreach (var channel in configuration.CoinChannels)
+        {
+            _diagnosticLogger(
+                $"[Coin Config Fabric] channelIndex={channel.Index} enabled={FormatBoolean(channel.Enabled)} value={channel.Value} " +
+                $"lockoutValue={channel.LockoutValue} lockoutInvert={FormatBoolean(channel.LockoutInvert)}");
+        }
+    }
+
+    private static string FormatBoolean(bool value) => value ? "true" : "false";
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
-public sealed class FabricEmulationBackend : IEmulationBackend
+public sealed class FabricEmulationBackend : IEmulationBackend, IRawInputDiagnosticBackend
 {
     private const string AmberBackendKind = "amber";
     private const string JpmSystem6MachineIdentifier = "jpm-system6";
@@ -23,6 +23,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly Action<string> _diagnosticLogger;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
+    private readonly Dictionary<int, long> _rawPulseReleases = [];
     private readonly HashSet<int> _assertedInputs = [];
     private readonly Dictionary<int, (bool State, float Brightness)> _lamps = [];
     private readonly Dictionary<int, int> _reels = [];
@@ -41,6 +42,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private bool _audioStarted;
     private bool _disposed;
     private long _scheduleGeneration;
+    private long _pumpNumber;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -71,6 +73,9 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     public EmulationBackendState State { get { lock (_stateGate) return _state; } }
     public Exception? LastFailure { get; private set; }
     internal IEmulationAudioSink AudioSink => _audioSink;
+    public bool IsRawInputDiagnosticAvailable =>
+        State is EmulationBackendState.Running or EmulationBackendState.Paused
+        && _session?.Capabilities.Has(FabricCapability.DigitalInput) == true;
 
     public event EventHandler<EmulationBackendState>? StateChanged;
     public event EventHandler<MachineLampChangedEventArgs>? LampChanged;
@@ -228,6 +233,37 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         return Task.CompletedTask;
     }
 
+    public Task SetRawInputStateAsync(int switchIndex, bool isPressed, CancellationToken cancellationToken)
+    {
+        ValidateRawSwitchIndex(switchIndex);
+        EnsureDigitalInputAvailable(cancellationToken);
+        _inputCommands.Enqueue(new(switchIndex, isPressed, true));
+        return Task.CompletedTask;
+    }
+
+    public Task PulseRawInputAsync(int switchIndex, CancellationToken cancellationToken)
+    {
+        ValidateRawSwitchIndex(switchIndex);
+        EnsureDigitalInputAvailable(cancellationToken);
+        _inputCommands.Enqueue(new(switchIndex, true, true, true));
+        return Task.CompletedTask;
+    }
+
+    private static void ValidateRawSwitchIndex(int switchIndex)
+    {
+        if (switchIndex is < 0 or > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(switchIndex), switchIndex, "Raw switch index must be from 0 to 255.");
+    }
+
+    private void EnsureDigitalInputAvailable(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfDisposed();
+        EnsureAcceptingOperations();
+        if (_session?.Capabilities.Has(FabricCapability.DigitalInput) != true)
+            throw new NotSupportedException("Fabric session does not support raw digital input diagnostics.");
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_disposed)
@@ -294,6 +330,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 {
                     var session = RequireSession();
                     session.Advance(NanosecondsPerPump);
+                    _pumpNumber++;
                     ProcessInputs(session);
                     PublishSnapshot(session.GetSnapshot());
                     ReadAudio(session);
@@ -368,14 +405,29 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
     private void ProcessInputs(IFabricMachineSession session)
     {
+        foreach (var release in _rawPulseReleases.Where(pair => pair.Value <= _pumpNumber).ToArray())
+        {
+            SubmitInput(session, release.Key, false, isRaw: true);
+            _rawPulseReleases.Remove(release.Key);
+        }
+
         while (_inputCommands.TryDequeue(out var input))
         {
-            session.SubmitInput(new($"oasis.switch.{input.Index}", input.Index, input.Active));
-            if (input.Active)
-                _assertedInputs.Add(input.Index);
-            else
-                _assertedInputs.Remove(input.Index);
+            SubmitInput(session, input.Index, input.Active, input.IsRaw);
+            if (input.IsPulse)
+                _rawPulseReleases[input.Index] = _pumpNumber + 1;
         }
+    }
+
+    private void SubmitInput(IFabricMachineSession session, int index, bool active, bool isRaw)
+    {
+        session.SubmitInput(new($"oasis.switch.{index}", index, active));
+        if (active)
+            _assertedInputs.Add(index);
+        else
+            _assertedInputs.Remove(index);
+        if (isRaw)
+            _diagnosticLogger($"[Fabric Raw Input] switch={index} state={(active ? "pressed" : "released")} pump={_pumpNumber}");
     }
 
     private void ReadAudio(IFabricMachineSession session)
@@ -526,6 +578,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private void ClearPendingInputs()
     {
         while (_inputCommands.TryDequeue(out _)) { }
+        _rawPulseReleases.Clear();
     }
 
     private void ClearOutputCaches()
@@ -558,7 +611,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         StateChanged?.Invoke(this, state);
     }
 
-    private readonly record struct InputCommand(int Index, bool Active);
+    private readonly record struct InputCommand(int Index, bool Active, bool IsRaw = false, bool IsPulse = false);
     private readonly record struct DisplayOutputIdentity(DisplayOutputFamily Family, string Identifier, int DisplayOrdinal, int Position);
     private readonly record struct DisplayBrightnessIdentity(DisplayOutputFamily Family, string Identifier, int DisplayOrdinal);
     private enum DisplayOutputFamily { Character, Segment }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
@@ -17,7 +17,7 @@ internal static class FabricAbi { internal const uint Version = 0x00020000; inte
 
 [StructLayout(LayoutKind.Sequential)] internal struct AmberReelNative { internal uint Index,Enabled,Steps,OptoStart,OptoEnd,OptoInvert; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberReelsNative { internal uint Size,Version,Count,ApplyMask; internal fixed byte Reels[8*24]; }
-[StructLayout(LayoutKind.Sequential)] internal struct AmberCoinChannelNative { internal uint Index,Enabled,Value,LockoutInvert,Reserved; }
+[StructLayout(LayoutKind.Sequential)] internal struct AmberCoinChannelNative { internal uint Index,Enabled,Value,LockoutValue,LockoutInvert; }
 [StructLayout(LayoutKind.Sequential)] internal struct AmberCoinRouteNative { internal uint Index,Enabled,CounterIn,CounterOut,PortIndex,CoinCode,Level,FullLevel; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberCoinsNative { internal uint Size,Version,ChannelMask,RouteMask; internal fixed byte Channels[6*20]; internal fixed byte Routes[8*32]; internal uint LockoutBase,LockoutValue,Flags,Reserved; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricAmberConfigurationNative { internal uint Magic,Size,Version,Flags; internal AmberReelsNative Reels; internal AmberCoinsNative Coins; internal uint Percentage; internal fixed uint Reserved[3]; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlImportService.cs
@@ -128,6 +128,7 @@ internal sealed class FmlImportService : IFmlImportService
         diagnostics.Add($"Generated image count: {imagePaths.Count}; image root: {stagingDirectory}; image paths: {FormatImagePaths(imagePaths.Values)}");
         diagnostics.Add($"Decoded FML component counts by Type: {FormatCounts(CountDecodedTypes(layout))}");
         diagnostics.Add($"Mapped input definition count: {mapResult.InputDefinitions.Count}; button inputs: {mapResult.InputDefinitions.Count(input => !input.CoinInput)}; coin inputs: {mapResult.InputDefinitions.Count(input => input.CoinInput)}; with shortcuts: {mapResult.InputDefinitions.Count(input => !string.IsNullOrWhiteSpace(input.KeyboardShortcut))}; without shortcuts: {mapResult.InputDefinitions.Count(input => string.IsNullOrWhiteSpace(input.KeyboardShortcut))}");
+        diagnostics.AddRange(mapResult.InputDiagnostics);
 
         var assetCopyStopwatch = Stopwatch.StartNew();
         var assetResult = _assetCopier.CopyAssetsFromStaging(

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -23,6 +23,7 @@ internal sealed class FmlToOasisMapper
         var elements = new List<PanelElementModel>();
         var warnings = new List<LayoutImportWarning>();
         var inputs = new List<InputDefinitionModel>();
+        var inputDiagnostics = new List<string>();
         var unsupported = new List<string>();
 
         for (var index = 0; index < layout.Components.Count; index++)
@@ -40,7 +41,7 @@ internal sealed class FmlToOasisMapper
                     AddUnsupportedComponent(component, unsupported, warnings);
                     break;
                 case Lamp or PrismLamp or Button or Checkbox:
-                    MapLampLike(component, index, exportedImages, elements, inputs, warnings);
+                    MapLampLike(component, index, exportedImages, elements, inputs, inputDiagnostics, warnings);
                     break;
                 case Reel or BandReel or DiscReel or FlipReel:
                     elements.Add(MapReel(component, index, exportedImages, warnings));
@@ -60,7 +61,7 @@ internal sealed class FmlToOasisMapper
             }
         }
 
-        return new FmlToOasisMapResult { Elements = elements, Warnings = warnings, InputDefinitions = inputs, UnsupportedComponentTypes = unsupported };
+        return new FmlToOasisMapResult { Elements = elements, Warnings = warnings, InputDefinitions = inputs, InputDiagnostics = inputDiagnostics, UnsupportedComponentTypes = unsupported };
     }
 
     private static PanelElementModel MapBackground(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images) => new()
@@ -84,7 +85,7 @@ internal sealed class FmlToOasisMapper
         warnings.Add(new LayoutImportWarning("fml.import.component.unsupported", $"Unsupported FML component '{componentType}' was skipped.", componentType));
     }
 
-    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs, ICollection<LayoutImportWarning> warnings)
+    private static void MapLampLike(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, List<PanelElementModel> elements, List<InputDefinitionModel> inputs, List<string> inputDiagnostics, ICollection<LayoutImportWarning> warnings)
     {
         var entries = GetSublamps(c).Where(e => e.SublampNumber != UndefinedSublampNumber && e.SublampNumber >= 0).OrderBy(e => e.SublampIndex).ToArray();
         if (entries.Length == 0)
@@ -119,6 +120,7 @@ internal sealed class FmlToOasisMapper
         if (input is not null)
         {
             inputs.Add(input);
+            inputDiagnostics.Add(BuildInputDiagnostic(c, index, input));
         }
         else if (HasInputMetadata(c))
         {
@@ -130,6 +132,40 @@ internal sealed class FmlToOasisMapper
                 $"FML component {index.ToString(CultureInfo.InvariantCulture)} ({c.GetType().Name}) contains input metadata but no input could be mapped. UInt32 keys=[{string.Join(", ", c.UInt32s.Keys.OrderBy(key => key, StringComparer.Ordinal))}]; Boolean keys=[{string.Join(", ", c.Booleans.Keys.OrderBy(key => key, StringComparer.Ordinal))}]; shortcut codes=[{string.Join(", ", shortcutCodes)}].",
                 index.ToString(CultureInfo.InvariantCulture)));
         }
+    }
+
+    private static string BuildInputDiagnostic(BaseComponent component, int componentIndex, InputDefinitionModel input)
+    {
+        var sourceField = component.WasValuePresent("Button Number") ? "Button Number"
+            : component.WasValuePresent("ButtonNumber") ? "ButtonNumber"
+            : "none";
+        return $"[MFME Input Decode] component={componentIndex} type={component.GetType().Name} " +
+            $"name=\"{EscapeDiagnostic(input.Name)}\" coin={input.CoinInput.ToString().ToLowerInvariant()} " +
+            $"selectedButtonNumber={input.ButtonNumber} sourceField=\"{sourceField}\" " +
+            $"shortcut=\"{EscapeDiagnostic(input.KeyboardShortcut)}\" " +
+            $"int32={FormatDiagnosticDictionary(component.Int32s)} " +
+            $"uint32={FormatDiagnosticDictionary(component.UInt32s)} " +
+            $"bool={FormatDiagnosticDictionary(component.Booleans)} " +
+            $"strings={FormatDiagnosticDictionary(component.Strings, value => $"\"{EscapeDiagnostic(value)}\"")}";
+    }
+
+    private static string FormatDiagnosticDictionary<T>(
+        IReadOnlyDictionary<string, T> values, Func<T, string>? formatValue = null)
+    {
+        formatValue ??= value => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+        return "{" + string.Join(", ", values
+            .Where(pair => !pair.Key.Contains("image", StringComparison.OrdinalIgnoreCase)
+                && !pair.Key.Contains("bitmap", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => $"{pair.Key}={formatValue(pair.Value)}")) + "}";
+    }
+
+    private static string EscapeDiagnostic(string value)
+    {
+        const int maximumLength = 200;
+        var bounded = value.Length <= maximumLength ? value : value[..maximumLength] + "…";
+        return bounded.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal);
     }
 
     private static PanelElementModel MapReel(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images, ICollection<LayoutImportWarning> warnings)
@@ -415,5 +451,6 @@ internal sealed class FmlToOasisMapResult
     public required IReadOnlyList<PanelElementModel> Elements { get; init; }
     public required IReadOnlyList<LayoutImportWarning> Warnings { get; init; }
     public required IReadOnlyList<InputDefinitionModel> InputDefinitions { get; init; }
+    public required IReadOnlyList<string> InputDiagnostics { get; init; }
     public required IReadOnlyList<string> UnsupportedComponentTypes { get; init; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -168,6 +168,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         HardResetEmulationCommand = new RelayCommand(HardResetEmulation, CanResetEmulation);
 
         _outputLog = new OutputLogViewModel();
+        _outputLog.ConfigureRawInputProbe(() => _activeEmulationBackend as IRawInputDiagnosticBackend);
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
         SkiaRenderDiagnostics.IsEnabled = kDebugSkiaPerformanceOutput;
         if (kDebugSkiaPerformanceOutput)
@@ -239,7 +240,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _emulationBackendFactory = new EmulationBackendFactory(
             () => FabricRuntimeLibraryPath, () => ProductionAmberLibraryPath,
             () => System6AudioBufferLengthMilliseconds,
-            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error));
+            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error),
+            diagnosticLogger: message => AddOutputEntry(message, OutputLogStatus.Info));
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();
@@ -2007,6 +2009,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             ?? throw new InvalidOperationException($"No emulation backend is available for platform '{SelectedFruitMachinePlatform}'.");
 
         _activeEmulationBackend = backend;
+        _outputLog.NotifyRawInputAvailabilityChanged();
         backend.StateChanged += OnActiveBackendStateChanged;
         backend.LampChanged += OnActiveBackendLampChanged;
         backend.ReelChanged += OnActiveBackendReelChanged;
@@ -2026,6 +2029,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             backend.VfdBrightnessChanged -= OnActiveBackendVfdBrightnessChanged;
             await backend.DisposeAsync().ConfigureAwait(false);
             _activeEmulationBackend = null;
+            _outputLog.NotifyRawInputAvailabilityChanged();
             throw;
         }
     }
@@ -2265,6 +2269,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         DispatchToUiThread(() =>
         {
             EmulationState = state;
+            _outputLog.NotifyRawInputAvailabilityChanged();
             AddOutputEntry($"Emulation backend state changed to {state}.", OutputLogStatus.Info);
         });
     }
@@ -2312,6 +2317,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         backend.VfdBrightnessChanged -= OnActiveBackendVfdBrightnessChanged;
         await backend.DisposeAsync();
         _activeEmulationBackend = null;
+        _outputLog.NotifyRawInputAvailabilityChanged();
         _playViewInputRouter = null;
         _playViewInputDispatcher = null;
         EmulationState = EmulationBackendState.Stopped;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/ViewModels/OutputLogViewModel.cs
@@ -22,6 +22,9 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
     private string _searchText = string.Empty;
     private string _searchTextNormalized = string.Empty;
     private IReadOnlyList<OutputLogEntry> _selectedEntries = Array.Empty<OutputLogEntry>();
+    private Func<IRawInputDiagnosticBackend?>? _rawInputBackendProvider;
+    private string _rawSwitchIndexText = "0";
+    private bool _isRawSwitchAsserted;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -38,12 +41,35 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         FilteredEntries = CollectionViewSource.GetDefaultView(OutputEntries);
         FilteredEntries.Filter = ShouldShowEntry;
         ClearOutputCommand = new RelayCommand(ClearOutput, CanClearOutput);
+        PressRawSwitchCommand = new RelayCommand(() => SetRawSwitch(true), CanUseRawSwitchProbe);
+        ReleaseRawSwitchCommand = new RelayCommand(() => SetRawSwitch(false), CanUseRawSwitchProbe);
+        PulseRawSwitchCommand = new RelayCommand(PulseRawSwitch, CanUseRawSwitchProbe);
         _diskWriter.Initialize();
     }
 
     public ObservableCollection<OutputLogEntry> OutputEntries { get; }
     public ICollectionView FilteredEntries { get; }
     public ICommand ClearOutputCommand { get; }
+    public ICommand PressRawSwitchCommand { get; }
+    public ICommand ReleaseRawSwitchCommand { get; }
+    public ICommand PulseRawSwitchCommand { get; }
+    public string RawSwitchIndexText
+    {
+        get => _rawSwitchIndexText;
+        set
+        {
+            if (string.Equals(_rawSwitchIndexText, value, StringComparison.Ordinal)) return;
+            _rawSwitchIndexText = value ?? string.Empty;
+            IsRawSwitchAsserted = false;
+            OnPropertyChanged();
+            NotifyRawInputAvailabilityChanged();
+        }
+    }
+    public bool IsRawSwitchAsserted
+    {
+        get => _isRawSwitchAsserted;
+        private set { if (_isRawSwitchAsserted != value) { _isRawSwitchAsserted = value; OnPropertyChanged(); } }
+    }
     public string CurrentLogPath => _diskWriter.CurrentLogPath;
     public string LogDirectoryPath => Path.GetDirectoryName(CurrentLogPath) ?? string.Empty;
     public string CopySelectionHeader => SelectedEntries.Count == 1 ? "Copy Row" : "Copy Rows";
@@ -154,6 +180,57 @@ public sealed class OutputLogViewModel : INotifyPropertyChanged
         if (ClearOutputCommand is RelayCommand clearRelayCommand)
         {
             clearRelayCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public void ConfigureRawInputProbe(Func<IRawInputDiagnosticBackend?> backendProvider)
+    {
+        _rawInputBackendProvider = backendProvider ?? throw new ArgumentNullException(nameof(backendProvider));
+        NotifyRawInputAvailabilityChanged();
+    }
+
+    public void NotifyRawInputAvailabilityChanged()
+    {
+        (PressRawSwitchCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (ReleaseRawSwitchCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        (PulseRawSwitchCommand as RelayCommand)?.RaiseCanExecuteChanged();
+    }
+
+    private bool CanUseRawSwitchProbe() => TryGetRawSwitchIndex(out _)
+        && _rawInputBackendProvider?.Invoke()?.IsRawInputDiagnosticAvailable == true;
+
+    private bool TryGetRawSwitchIndex(out int switchIndex) =>
+        int.TryParse(RawSwitchIndexText, out switchIndex) && switchIndex is >= 0 and <= byte.MaxValue;
+
+    private async void SetRawSwitch(bool pressed)
+    {
+        var backend = _rawInputBackendProvider?.Invoke();
+        if (backend is null || !TryGetRawSwitchIndex(out var switchIndex)) return;
+        AddOutputEntry($"[Raw Input] switch={switchIndex} action={(pressed ? "press" : "release")}", OutputLogStatus.Info);
+        try
+        {
+            await backend.SetRawInputStateAsync(switchIndex, pressed, CancellationToken.None);
+            IsRawSwitchAsserted = pressed;
+        }
+        catch (Exception exception)
+        {
+            AddOutputEntry($"[Raw Input] switch={switchIndex} failed: {exception.Message}", OutputLogStatus.Error);
+        }
+    }
+
+    private async void PulseRawSwitch()
+    {
+        var backend = _rawInputBackendProvider?.Invoke();
+        if (backend is null || !TryGetRawSwitchIndex(out var switchIndex)) return;
+        AddOutputEntry($"[Raw Input] switch={switchIndex} action=pulse", OutputLogStatus.Info);
+        try
+        {
+            await backend.PulseRawInputAsync(switchIndex, CancellationToken.None);
+            IsRawSwitchAsserted = false;
+        }
+        catch (Exception exception)
+        {
+            AddOutputEntry($"[Raw Input] switch={switchIndex} failed: {exception.Message}", OutputLogStatus.Error);
         }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/OutputLogView.xaml
@@ -9,6 +9,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -68,8 +69,22 @@
             </StackPanel>
         </Grid>
 
+        <StackPanel Grid.Row="1" Margin="0,6,0,0" Orientation="Horizontal">
+            <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource TextPrimaryBrush}" Text="Raw switch probe" FontWeight="SemiBold" />
+            <TextBox Width="52" Margin="8,0,0,0" VerticalContentAlignment="Center"
+                     ToolTip="Raw Amber/Fabric digital switch index (0–255)"
+                     Text="{Binding RawSwitchIndexText, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Margin="8,0,0,0" Padding="8,2" Content="Press" Command="{Binding PressRawSwitchCommand}" />
+            <Button Margin="4,0,0,0" Padding="8,2" Content="Release" Command="{Binding ReleaseRawSwitchCommand}" />
+            <Button Margin="4,0,0,0" Padding="8,2" Content="Pulse" Command="{Binding PulseRawSwitchCommand}" />
+            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Foreground="{DynamicResource TextSecondaryBrush}"
+                       Text="{Binding IsRawSwitchAsserted, StringFormat=Asserted: {0}}" />
+            <TextBlock Margin="12,0,0,0" VerticalAlignment="Center" Foreground="{DynamicResource TextSecondaryBrush}"
+                       Text="Warning: raw switches directly control emulated machine inputs." />
+        </StackPanel>
+
         <ListBox x:Name="OutputList"
-                 Grid.Row="1"
+                 Grid.Row="2"
                  Margin="0,8,0,0"
                  BorderThickness="0"
                  ItemsSource="{Binding FilteredEntries}"


### PR DESCRIPTION
### Motivation
- Fabric Amber channel configuration gained an explicit `lockout_value` field that was being dropped at the managed/native boundary, causing lockout transport to be lost. 
- The change aligns Oasis with the corrected Fabric header ordering: `channel_index`, `enabled`, `value`, `lockout_value`, `lockout_invert`. 
- Diagnostics and UI round-trip must show the exact configured `LockoutValue` so launch-time transport can be verified with the updated Fabric DLL. 

### Description
- Extend the managed coin channel record to include `uint LockoutValue` and map `System6CoinSettings.LockoutValue` directly without inferring from denomination, slot, or channel. 
- Replace the native channel layout field (formerly reserved) with `LockoutValue` and update `ToNativeBytes` to write `Index`, `Enabled`, `Value`, `LockoutValue`, `LockoutInvert` in that order while preserving overall configuration sizes and route offsets. 
- Add startup diagnostics that log both source and Fabric coin channel values including `lockoutValue` with consistent boolean formatting. 
- Add and update unit tests covering translation, native-byte offsets and values (including lockoutValue 0/1/2 and invert), settings save/load round-trip, view-model-to-model preservation, and a fake Fabric launch path asserting the transported lockout value. 

### Testing
- Static checks (`git diff --check`) and targeted contract assertions (`rg` checks for the new managed/native mappings) were executed and passed in this environment. 
- New unit tests were added/updated in `OasisEditor.Tests` (notably `FabricManagedBehaviorTests` and `FabricAbiLayoutTests`) to validate mapping, native offsets and serialization, but automated test execution and solution build were not run here because `AGENTS.md` prohibits building or running tests in this environment. 
- Manual verification steps required locally are listed in the PR body and include installing the corrected Fabric DLL, saving/reopening Project Settings to confirm `LockoutValue` persistence, launching and checking both `[Coin Config Source]` and `[Coin Config Fabric]` diagnostics, and observing Amber `SetLockoutVal(channel, N)` on real hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6de8fa32ec8327bc1c430065771bcc)