### PR TITLE
Route System 6 coins through Fabric coin input

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
@@ -134,7 +134,15 @@ public sealed class FabricProviderIntegrationTests
 
     private static FabricLaunchRequest CreateRequest(string amberPath, IReadOnlyList<FabricRomResource> resources)
     {
-        var settings = new System6NativeRomSettings { PercentSwitchValue = 0 };
+        var settings = new System6NativeRomSettings
+        {
+            PercentSwitchValue = 0,
+            CoinCommunicationStyle = AmberCoinCommunicationStyle.Parallel,
+            CoinCommunicationInvert = false,
+            CoinPulseCycles = 800_000,
+            CoinEdcEnabled = false,
+            Coins = [new System6CoinSettings { Num = 0, Enabled = true, CoinEnable = 1, CoinValue = 0 }]
+        };
         return new FabricLaunchRequest(
             "amber", "jpm-system6", amberPath, resources,
             FabricAmberConfiguration.FromSystem6(settings));

--- a/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.NativeIntegrationTests/FabricProviderIntegrationTests.cs
@@ -26,8 +26,8 @@ public sealed class FabricProviderIntegrationTests
 
         for (var iteration = 0; iteration < 1_000; iteration++)
         {
-            session.SubmitInput(new FabricInput("oasis.switch.0", 0, true));
-            session.SubmitInput(new FabricInput("oasis.switch.0", 0, false));
+            session.SubmitInput(new FabricInput("oasis.switch.0", 0, FabricInputKind.Digital, true));
+            session.SubmitInput(new FabricInput("oasis.switch.0", 0, FabricInputKind.Digital, false));
             session.Advance((ulong)(1_000_000 + iteration % 17));
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
@@ -30,8 +30,20 @@ public sealed class FabricAbiLayoutTests
         Assert.Equal(208, Marshal.SizeOf<AmberReelsNative>());
         Assert.Equal(20, Marshal.SizeOf<AmberCoinChannelNative>());
         Assert.Equal(32, Marshal.SizeOf<AmberCoinRouteNative>());
+        Assert.Equal(0, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.Size)).ToInt32());
+        Assert.Equal(4, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.Version)).ToInt32());
+        Assert.Equal(8, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.ChannelMask)).ToInt32());
+        Assert.Equal(12, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.RouteMask)).ToInt32());
+        Assert.Equal(16, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.CommunicationStyle)).ToInt32());
+        Assert.Equal(20, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.CommunicationInvert)).ToInt32());
+        Assert.Equal(24, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.PulseCycles)).ToInt32());
+        Assert.Equal(28, Marshal.OffsetOf<AmberCoinsNative>(nameof(AmberCoinsNative.EdcEnabled)).ToInt32());
+        Assert.Equal(32, Marshal.OffsetOf<AmberCoinsNative>("Channels").ToInt32());
+        Assert.Equal(152, Marshal.OffsetOf<AmberCoinsNative>("Routes").ToInt32());
         Assert.Equal(408, Marshal.SizeOf<AmberCoinsNative>());
         Assert.Equal(648, Marshal.SizeOf<FabricAmberConfigurationNative>());
+        Assert.Equal(224, Marshal.OffsetOf<FabricAmberConfigurationNative>(nameof(FabricAmberConfigurationNative.Coins)).ToInt32());
+        Assert.Equal(632, Marshal.OffsetOf<FabricAmberConfigurationNative>(nameof(FabricAmberConfigurationNative.Percentage)).ToInt32());
         Assert.Equal(1160, Marshal.OffsetOf<FabricLaunchRequestNative>("RomPaths").ToInt32());
         Assert.Equal(16, Marshal.OffsetOf<FabricRomResourceNative>("Path").ToInt32());
         Assert.Equal(1UL << 6, (ulong)FabricCapability.CoinInput);
@@ -54,15 +66,39 @@ public sealed class FabricAbiLayoutTests
             CoinCommunicationStyle = AmberCoinCommunicationStyle.Parallel,
             CoinCommunicationInvert = false,
             CoinPulseCycles = 800_000,
-            CoinEdcEnabled = false
+            CoinEdcEnabled = false,
+            Coins = [new System6CoinSettings { Num = 0, Enabled = true, CoinEnable = 1, CoinValue = 0 }]
         }).ToNativeBytes();
 
         Assert.Equal(648, bytes.Length);
         Assert.Equal(2u, BitConverter.ToUInt32(bytes, 8));
         Assert.Equal(2u, BitConverter.ToUInt32(bytes, 228));
-        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 616));
-        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 620));
-        Assert.Equal(800_000u, BitConverter.ToUInt32(bytes, 624));
-        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 628));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 240));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 244));
+        Assert.Equal(800_000u, BitConverter.ToUInt32(bytes, 248));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 252));
+
+        const int channel0 = 256;
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, channel0));
+        Assert.Equal(1u, BitConverter.ToUInt32(bytes, channel0 + 4));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, channel0 + 8));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, channel0 + 12));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, channel0 + 16));
+    }
+
+    [Fact]
+    public void AmberV2SerializesNonContiguousChannelsAndRoutesIntoIndexedSlots()
+    {
+        var bytes = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            Coins = [new System6CoinSettings { Num = 2, Enabled = true, CoinEnable = 1, CoinValue = 3 }]
+        }).ToNativeBytes();
+
+        Assert.Equal(1u << 2, BitConverter.ToUInt32(bytes, 232));
+        Assert.Equal(1u << 2, BitConverter.ToUInt32(bytes, 236));
+        Assert.All(bytes[256..296], value => Assert.Equal(0, value));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 296));
+        Assert.All(bytes[376..440], value => Assert.Equal(0, value));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 440));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricAbiLayoutTests.cs
@@ -8,12 +8,17 @@ public sealed class FabricAbiLayoutTests
     [Fact]
     public void X64NativeLayoutsMatchPublishedAbi()
     {
-        Assert.Equal(0x00020000u, FabricAbi.Version);
+        Assert.Equal(0x00030000u, FabricAbi.Version);
         if (IntPtr.Size != 8) return;
         Assert.Equal(1208, Marshal.SizeOf<FabricLaunchRequestNative>()); // fixed strings end at 1160; aligned pointers/counts end at 1208.
         Assert.Equal(40, Marshal.SizeOf<FabricRomResourceNative>());
         Assert.Equal(48, Marshal.SizeOf<FabricCapabilitiesNative>());
-        Assert.Equal(84, Marshal.SizeOf<FabricInputNative>());
+        Assert.Equal(88, Marshal.SizeOf<FabricInputNative>());
+        Assert.Equal(72, Marshal.OffsetOf<FabricInputNative>(nameof(FabricInputNative.NumericalIndex)).ToInt32());
+        Assert.Equal(76, Marshal.OffsetOf<FabricInputNative>(nameof(FabricInputNative.Kind)).ToInt32());
+        Assert.Equal(80, Marshal.OffsetOf<FabricInputNative>(nameof(FabricInputNative.Active)).ToInt32());
+        Assert.Equal(81, Marshal.OffsetOf<FabricInputNative>(nameof(FabricInputNative.CoinChannel)).ToInt32());
+        Assert.Equal(82, Marshal.OffsetOf<FabricInputNative>(nameof(FabricInputNative.CoinValue)).ToInt32());
         Assert.Equal(84, Marshal.SizeOf<FabricLampNative>());
         Assert.Equal(80, Marshal.SizeOf<FabricReelNative>());
         Assert.Equal(164, Marshal.SizeOf<FabricCharacterDisplayNative>());
@@ -29,6 +34,8 @@ public sealed class FabricAbiLayoutTests
         Assert.Equal(648, Marshal.SizeOf<FabricAmberConfigurationNative>());
         Assert.Equal(1160, Marshal.OffsetOf<FabricLaunchRequestNative>("RomPaths").ToInt32());
         Assert.Equal(16, Marshal.OffsetOf<FabricRomResourceNative>("Path").ToInt32());
+        Assert.Equal(1UL << 6, (ulong)FabricCapability.CoinInput);
+        Assert.Equal(9, (int)FabricResult.InputRejected);
     }
 
     [Fact]
@@ -37,5 +44,25 @@ public sealed class FabricAbiLayoutTests
         foreach (var type in typeof(FabricNativeExports).GetNestedTypes(BindingFlags.NonPublic))
             if (typeof(Delegate).IsAssignableFrom(type))
                 Assert.Equal(CallingConvention.Cdecl, type.GetCustomAttribute<UnmanagedFunctionPointerAttribute>()!.CallingConvention);
+    }
+
+    [Fact]
+    public void AmberV2SerializesGlobalCoinMechanismWithoutTruncatingPulseCycles()
+    {
+        var bytes = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            CoinCommunicationStyle = AmberCoinCommunicationStyle.Parallel,
+            CoinCommunicationInvert = false,
+            CoinPulseCycles = 800_000,
+            CoinEdcEnabled = false
+        }).ToNativeBytes();
+
+        Assert.Equal(648, bytes.Length);
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 8));
+        Assert.Equal(2u, BitConverter.ToUInt32(bytes, 228));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 616));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 620));
+        Assert.Equal(800_000u, BitConverter.ToUInt32(bytes, 624));
+        Assert.Equal(0u, BitConverter.ToUInt32(bytes, 628));
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -254,6 +254,20 @@ public sealed class FabricManagedBehaviorTests
     }
 
     [Fact]
+    public void AmberConfiguration_FormatsBoundedFabricV2StartupDiagnostics()
+    {
+        var configuration = FabricAmberConfiguration.FromSystem6(new System6NativeRomSettings
+        {
+            Coins = [new System6CoinSettings { Num = 0, Enabled = true, CoinEnable = 1, CoinValue = 0 }]
+        });
+
+        Assert.Equal([
+            "[Coin Config Fabric v2] size=408 version=2 channelMask=0x00000001 routeMask=0x00000001 style=0 invert=0 cycles=800000 edc=0",
+            "[Coin Config Fabric v2] slot=0 index=0 enabled=1 value=0 lockoutInvert=0 reserved=0"
+        ], FabricEmulationBackend.BuildCoinConfigurationDiagnostics(configuration));
+    }
+
+    [Fact]
     public async Task Backend_UsesExactLaunchValuesAndSerializesResetWithPump()
     {
         var clock = new FakeClock();

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -236,7 +236,7 @@ public sealed class FabricManagedBehaviorTests
             ReelOptos = [new() { ReelIndex = 2, Enabled = false, Steps = 96, OptoStart = 5, OptoEnd = 7, OptoInvert = true }],
             Coins =
             [
-                new() { Num = 1, Enabled = true, CoinEnable = 1, CoinValue = 20, LockoutInvert = 1, CounterIn = 2, CounterOut = 3, PortIndex = 4, Coin = 5, Level = 6, FullLevel = 7 },
+                new() { Num = 1, Enabled = true, CoinEnable = 1, CoinValue = 3, LockoutInvert = 1, CounterIn = 2, CounterOut = 3, PortIndex = 4, Coin = 5, Level = 6, FullLevel = 7 },
                 new() { Num = 2, Enabled = false }
             ],
             PercentSwitchValue = 12
@@ -248,7 +248,7 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(new FabricAmberReel(2, false, 96, 5, 7, true), Assert.Single(configuration.Reels));
         Assert.Equal(1u << 1, configuration.CoinChannelApplyMask);
         Assert.Equal(1u << 1, configuration.CoinRouteApplyMask);
-        Assert.Equal(new FabricAmberCoinChannel(1, true, 20, true), Assert.Single(configuration.CoinChannels));
+        Assert.Equal(new FabricAmberCoinChannel(1, true, 3, true), Assert.Single(configuration.CoinChannels));
         Assert.Equal(new FabricAmberCoinRoute(1, true, 2, 3, 4, 5, 6, 7), Assert.Single(configuration.CoinRoutes));
         Assert.Equal(12u, configuration.PercentageSwitch);
     }
@@ -507,7 +507,7 @@ public sealed class FabricManagedBehaviorTests
         public void Initialise() => Invoke(() => { });
         public void Reset() => Invoke(() => ResetCount++);
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
-        public void SubmitInput(FabricInput input) => Invoke(() => { });
+        public FabricResult SubmitInput(FabricInput input) => Invoke(() => FabricResult.Ok);
         public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
             ? new FabricMachineSnapshot(1, [], [], [], [])
             : throw SnapshotFailure);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -379,7 +379,7 @@ public sealed class FmlToOasisMapperTests
     }
 
     [Fact]
-    public void Map_WithCurrentCoinFields_CreatesNamedCoinInputAndRetainsButtonNumber()
+    public void Map_WithCoinMarker_CreatesUnresolvedCoinWithoutGuessingFromSwitch()
     {
         var lamp = CreateLamp();
         SetExplicitUInt(lamp, "ButtonNumber", 6);
@@ -391,7 +391,10 @@ public sealed class FmlToOasisMapperTests
 
         Assert.Equal(InputDefinitionKind.Coin, input.Kind);
         Assert.True(input.CoinInput);
-        Assert.Equal("6", input.ButtonNumber);
+        Assert.Equal(string.Empty, input.ButtonNumber);
+        Assert.Null(input.CoinChannel);
+        Assert.Null(input.CoinValue);
+        Assert.Contains("without a resolved Amber coin channel or denomination", input.Notes);
         Assert.Equal("£1 Coin", input.Name);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -48,6 +48,32 @@ public sealed class PlayViewInputRouterTests
         Assert.Equal([(first.Id, true), (first.Id, false), (second.Id, true), (second.Id, false)], backend.Inputs);
     }
 
+    [Fact]
+    public async Task CoinPressIsSingleShotUntilReleaseAndReleaseAllUsesCoinRelease()
+    {
+        var backend = new RecordingBackend();
+        var router = new PlayViewInputRouter(backend);
+        var coin = new InputDefinitionModel { Id = "coin", CoinInput = true, CoinChannel = 2, CoinValue = 3 };
+
+        Assert.True(await router.TryPressAsync(FruitMachinePlatformType.Impact, coin, CancellationToken.None));
+        Assert.False(await router.TryPressAsync(FruitMachinePlatformType.Impact, coin, CancellationToken.None));
+        Assert.True(await router.TryReleaseAsync(FruitMachinePlatformType.Impact, coin, CancellationToken.None));
+        Assert.True(await router.TryPressAsync(FruitMachinePlatformType.Impact, coin, CancellationToken.None));
+        Assert.Equal(1, await router.ReleaseAllAsync(FruitMachinePlatformType.Impact,
+            new Dictionary<string, InputDefinitionModel> { [coin.Id] = coin }, CancellationToken.None));
+        Assert.Equal([(coin.Id, true), (coin.Id, false), (coin.Id, true), (coin.Id, false)], backend.Inputs);
+    }
+
+    [Fact]
+    public async Task UnresolvedCoinIsNotActivated()
+    {
+        var backend = new RecordingBackend();
+        var router = new PlayViewInputRouter(backend);
+        Assert.False(await router.TryPressAsync(FruitMachinePlatformType.Impact,
+            new InputDefinitionModel { Id = "coin", CoinInput = true }, CancellationToken.None));
+        Assert.Empty(backend.Inputs);
+    }
+
     private sealed class RecordingBackend : IEmulationBackend
     {
         public List<(string, bool)> Inputs { get; } = [];
@@ -66,6 +92,8 @@ public sealed class PlayViewInputRouterTests
         public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken) => Task.CompletedTask;
         public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, isPressed)); return Task.CompletedTask; }
+        public Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, true)); return Task.FromResult(CoinInputResult.Accepted); }
+        public Task ReleaseCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, false)); return Task.CompletedTask; }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -32,6 +32,10 @@ public sealed class System6NativeRomSettings
     public string SoundRom4Path { get; set; } = string.Empty;
     public bool FlashSwitch { get; set; }
     public int PercentSwitchValue { get; set; } = DefaultPercentSwitchValue;
+    public AmberCoinCommunicationStyle CoinCommunicationStyle { get; set; } = AmberCoinCommunicationStyle.Parallel;
+    public bool CoinCommunicationInvert { get; set; }
+    public uint CoinPulseCycles { get; set; } = 800_000;
+    public bool CoinEdcEnabled { get; set; }
 
     public IReadOnlyList<string> ProgramRomPaths => [ProgramRom1Path, ProgramRom2Path, ProgramRom3Path, ProgramRom4Path];
     public IReadOnlyList<string> SoundRomPaths => [SoundRom1Path, SoundRom2Path, SoundRom3Path, SoundRom4Path];
@@ -92,7 +96,6 @@ public sealed class System6CoinSettings
     public const int DefaultCoin = 0;
     public const int DefaultCoinValue = 0;
     public const int DefaultCoinEnable = 1;
-    public const int DefaultLockoutValue = 0;
     public const int DefaultLockoutInvert = 0;
 
     public string Name { get; set; } = string.Empty;
@@ -101,7 +104,6 @@ public sealed class System6CoinSettings
     public int Coin { get; set; } = DefaultCoin;
     public int CoinValue { get; set; } = DefaultCoinValue;
     public int CoinEnable { get; set; } = DefaultCoinEnable;
-    public int LockoutValue { get; set; } = DefaultLockoutValue;
     public int LockoutInvert { get; set; } = DefaultLockoutInvert;
     public int CounterIn { get; set; }
     public int CounterOut { get; set; }
@@ -117,7 +119,25 @@ public sealed class System6CoinSettings
         Coin = DefaultCoin,
         CoinValue = DefaultCoinValue,
         CoinEnable = DefaultCoinEnable,
-        LockoutValue = DefaultLockoutValue,
         LockoutInvert = DefaultLockoutInvert
+    };
+}
+
+public enum AmberCoinCommunicationStyle { Parallel = 0 }
+
+public enum AmberCoinDenomination
+{
+    TwoPence = 0, FivePence = 1, TenPence = 2, TwentyPence = 3, FiftyPence = 4,
+    OnePound = 5, TwoPounds = 6, FivePenceToken = 7, TenPenceToken = 8,
+    TwentyPenceToken = 9, FiftyPenceToken = 10, OnePoundToken = 11, TwoPoundsToken = 12
+}
+
+public static class AmberCoinDenominations
+{
+    public static string GetLabel(int value) => value switch
+    {
+        0 => "2p", 1 => "5p", 2 => "10p", 3 => "20p", 4 => "50p", 5 => "£1", 6 => "£2",
+        7 => "5p token", 8 => "10p token", 9 => "20p token", 10 => "50p token", 11 => "£1 token", 12 => "£2 token",
+        _ => throw new ArgumentOutOfRangeException(nameof(value))
     };
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -25,7 +25,11 @@ public interface IEmulationBackend : IAsyncDisposable
     Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
 
     Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
+    Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken);
+    Task ReleaseCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken);
 }
+
+public enum CoinInputResult { Accepted, Rejected }
 
 public enum EmulationBackendKind
 {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
@@ -103,10 +103,13 @@ public sealed record FabricAmberConfiguration(
         }
         pointer = native.Coins.Channels;
         {
-            for (var index = 0; index < CoinChannels.Count; index++)
+            foreach (var channel in CoinChannels)
             {
-                var channel = CoinChannels[index];
-                ((AmberCoinChannelNative*)pointer)[index] = new AmberCoinChannelNative
+                if (channel.Index >= 6)
+                    throw new ArgumentOutOfRangeException(nameof(CoinChannels), channel.Index, "Amber coin channel index must be from 0 to 5.");
+                if (channel.Value > 12)
+                    throw new ArgumentOutOfRangeException(nameof(CoinChannels), channel.Value, "Amber coin denomination must be from 0 to 12.");
+                ((AmberCoinChannelNative*)pointer)[channel.Index] = new AmberCoinChannelNative
                 {
                     Index = channel.Index,
                     Enabled = channel.Enabled ? 1u : 0,
@@ -117,10 +120,11 @@ public sealed record FabricAmberConfiguration(
         }
         pointer = native.Coins.Routes;
         {
-            for (var index = 0; index < CoinRoutes.Count; index++)
+            foreach (var route in CoinRoutes)
             {
-                var route = CoinRoutes[index];
-                ((AmberCoinRouteNative*)pointer)[index] = new AmberCoinRouteNative
+                if (route.Index >= 8)
+                    throw new ArgumentOutOfRangeException(nameof(CoinRoutes), route.Index, "Amber coin route index must be from 0 to 7.");
+                ((AmberCoinRouteNative*)pointer)[route.Index] = new AmberCoinRouteNative
                 {
                     Index = route.Index,
                     Enabled = route.Enabled ? 1u : 0,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/Amber/FabricAmberConfiguration.cs
@@ -17,6 +17,10 @@ public sealed record FabricAmberConfiguration(
     uint CoinRouteApplyMask,
     IReadOnlyList<FabricAmberCoinChannel> CoinChannels,
     IReadOnlyList<FabricAmberCoinRoute> CoinRoutes,
+    AmberCoinCommunicationStyle CommunicationStyle,
+    bool CommunicationInvert,
+    uint PulseCycles,
+    bool EdcEnabled,
     uint? PercentageSwitch) : IFabricBackendConfiguration
 {
     public static FabricAmberConfiguration FromSystem6(System6NativeRomSettings settings)
@@ -38,6 +42,10 @@ public sealed record FabricAmberConfiguration(
             coins.Select(coin => new FabricAmberCoinRoute(
                 checked((uint)coin.Num), coin.Enabled, checked((uint)coin.CounterIn), checked((uint)coin.CounterOut),
                 checked((uint)coin.PortIndex), checked((uint)coin.Coin), checked((uint)coin.Level), checked((uint)coin.FullLevel))).ToArray(),
+            settings.CoinCommunicationStyle,
+            settings.CoinCommunicationInvert,
+            settings.CoinPulseCycles,
+            settings.CoinEdcEnabled,
             ValidatePercentageSwitch(settings.PercentSwitchValue));
     }
 
@@ -58,7 +66,7 @@ public sealed record FabricAmberConfiguration(
         {
             Magic = 0x32424146,
             Size = (uint)sizeof(FabricAmberConfigurationNative),
-            Version = 1,
+            Version = 2,
             Flags = (Reels.Count > 0 ? 1u : 0)
                 | (CoinChannels.Count > 0 || CoinRoutes.Count > 0 ? 2u : 0)
                 | (PercentageSwitch.HasValue ? 4u : 0),
@@ -69,9 +77,13 @@ public sealed record FabricAmberConfiguration(
         native.Reels.Count = (uint)Reels.Count;
         native.Reels.ApplyMask = ReelApplyMask;
         native.Coins.Size = (uint)sizeof(AmberCoinsNative);
-        native.Coins.Version = 1;
+        native.Coins.Version = 2;
         native.Coins.ChannelMask = CoinChannelApplyMask;
         native.Coins.RouteMask = CoinRouteApplyMask;
+        native.Coins.CommunicationStyle = (uint)CommunicationStyle;
+        native.Coins.CommunicationInvert = CommunicationInvert ? 1u : 0u;
+        native.Coins.PulseCycles = PulseCycles != 0 ? PulseCycles : throw new ArgumentOutOfRangeException(nameof(PulseCycles));
+        native.Coins.EdcEnabled = EdcEnabled ? 1u : 0u;
 
         byte* pointer = native.Reels.Reels;
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -91,9 +91,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             var resources = BuildRomResources(settings);
             cancellationToken.ThrowIfCancellationRequested();
             _runtime = _runtimeFactory(_runtimePath);
+            var configuration = FabricAmberConfiguration.FromSystem6(settings);
+            WriteCoinConfigurationDiagnostics(configuration);
             _session = _runtime.CreateSession(new FabricLaunchRequest(
                 AmberBackendKind, JpmSystem6MachineIdentifier, _amberPath, resources,
-                FabricAmberConfiguration.FromSystem6(settings)));
+                configuration));
 
             await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
@@ -254,6 +256,23 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         AddRomRole(resources, settings.ProgramRomPaths, FabricRomRole.Program);
         AddRomRole(resources, settings.SoundRomPaths, FabricRomRole.Sound);
         return resources;
+    }
+
+    internal static IReadOnlyList<string> BuildCoinConfigurationDiagnostics(FabricAmberConfiguration configuration)
+    {
+        var lines = new List<string>(configuration.CoinChannels.Count + 1)
+        {
+            $"[Coin Config Fabric v2] size={Marshal.SizeOf<AmberCoinsNative>()} version=2 channelMask=0x{configuration.CoinChannelApplyMask:X8} routeMask=0x{configuration.CoinRouteApplyMask:X8} style={(uint)configuration.CommunicationStyle} invert={(configuration.CommunicationInvert ? 1 : 0)} cycles={configuration.PulseCycles} edc={(configuration.EdcEnabled ? 1 : 0)}"
+        };
+        lines.AddRange(configuration.CoinChannels.Select(channel =>
+            $"[Coin Config Fabric v2] slot={channel.Index} index={channel.Index} enabled={(channel.Enabled ? 1 : 0)} value={channel.Value} lockoutInvert={(channel.LockoutInvert ? 1 : 0)} reserved=0"));
+        return lines;
+    }
+
+    private static void WriteCoinConfigurationDiagnostics(FabricAmberConfiguration configuration)
+    {
+        foreach (var line in BuildCoinConfigurationDiagnostics(configuration))
+            Debug.WriteLine(line);
     }
 
     private static void AddRomRole(List<FabricRomResource> resources, IReadOnlyList<string> paths, FabricRomRole role)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -204,6 +204,40 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         return Task.CompletedTask;
     }
 
+    public Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) =>
+        SetCoinStateAsync(inputDefinition, true, cancellationToken);
+
+    public async Task ReleaseCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) =>
+        _ = await SetCoinStateAsync(inputDefinition, false, cancellationToken).ConfigureAwait(false);
+
+    private async Task<CoinInputResult> SetCoinStateAsync(InputDefinitionModel inputDefinition, bool active, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(inputDefinition);
+        ThrowIfDisposed();
+        EnsureAcceptingOperations();
+        var session = RequireSession();
+        if (!session.Capabilities.Has(FabricCapability.CoinInput))
+            throw new NotSupportedException("Fabric session does not support coin input.");
+        if (inputDefinition.CoinChannel is not (>= 0 and <= 5) || inputDefinition.CoinValue is not (>= 0 and <= 12))
+            throw new InvalidOperationException($"Coin input '{inputDefinition.Id}' requires a channel from 0 to 5 and denomination from 0 to 12.");
+
+        await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var channel = checked((byte)inputDefinition.CoinChannel.Value);
+            var value = checked((byte)inputDefinition.CoinValue.Value);
+            var result = session.SubmitInput(new(inputDefinition.Name, 0, FabricInputKind.Coin, active, channel, value));
+            Debug.WriteLine(active
+                ? $"[Fabric Coin Input] channel={channel} value={value} result={(result == FabricResult.InputRejected ? "rejected" : "accepted")}"
+                : $"[Fabric Coin Input] channel={channel} value={value} state=released");
+            return result == FabricResult.InputRejected ? CoinInputResult.Rejected : CoinInputResult.Accepted;
+        }
+        finally
+        {
+            _sessionGate.Release();
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_disposed)
@@ -346,7 +380,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     {
         while (_inputCommands.TryDequeue(out var input))
         {
-            session.SubmitInput(new($"oasis.switch.{input.Index}", input.Index, input.Active));
+            session.SubmitInput(new($"oasis.switch.{input.Index}", input.Index, FabricInputKind.Digital, input.Active));
             if (input.Active)
                 _assertedInputs.Add(input.Index);
             else
@@ -495,7 +529,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         var session = _session;
         if (session is not null)
             foreach (var index in _assertedInputs)
-                session.SubmitInput(new($"oasis.switch.{index}", index, false));
+                session.SubmitInput(new($"oasis.switch.{index}", index, FabricInputKind.Digital, false));
         _assertedInputs.Clear();
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricMachineSession.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricMachineSession.cs
@@ -49,18 +49,24 @@ internal sealed unsafe class FabricMachineSession : IFabricMachineSession
         Check(_exports.AdvanceFn(_handle, elapsedNanoseconds), "FabricSessionAdvance");
     }
 
-    public void SubmitInput(FabricInput input)
+    public FabricResult SubmitInput(FabricInput input)
     {
         var native = new FabricInputNative
         {
             Size = (uint)sizeof(FabricInputNative),
             Version = FabricAbi.Version,
-            Index = input.NumericalIndex,
-            Active = input.Active ? (byte)1 : (byte)0
+            NumericalIndex = input.NumericalIndex,
+            Kind = input.Kind,
+            Active = input.Active ? (byte)1 : (byte)0,
+            CoinChannel = input.CoinChannel,
+            CoinValue = input.CoinValue
         };
         byte* identifier = native.Identifier;
         FabricRuntimeLibrary.WriteFixed(input.Identifier, identifier, FabricAbi.IdentifierCapacity);
-        Check(_exports.SubmitInputFn(_handle, &native), "FabricSessionSubmitInput");
+        var result = _exports.SubmitInputFn(_handle, &native);
+        if (result is not (FabricResult.Ok or FabricResult.InputRejected))
+            Check(result, "FabricSessionSubmitInput");
+        return result;
     }
 
     public FabricAudioFormat GetAudioFormat()

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricManagedModels.cs
@@ -1,14 +1,14 @@
 namespace OasisEditor;
 
 [Flags]
-public enum FabricCapability : ulong { DigitalInput=1, Lamps=2, Reels=4, CharacterDisplays=8, SegmentDisplays=16, Audio=32 }
+public enum FabricCapability : ulong { DigitalInput=1, Lamps=2, Reels=4, CharacterDisplays=8, SegmentDisplays=16, Audio=32, CoinInput=1UL << 6 }
 public enum FabricRomRole : uint { Other, Program, Sound }
 
 public sealed record FabricRomResource(FabricRomRole Role, uint Slot, string Path);
 public interface IFabricBackendConfiguration { byte[] ToNativeBytes(); }
 public sealed record FabricLaunchRequest(string BackendKind, string MachineIdentifier, string BackendPath,
     IReadOnlyList<FabricRomResource> RomResources, IFabricBackendConfiguration? Configuration = null);
-public sealed record FabricInput(string Identifier, int NumericalIndex, bool Active);
+public sealed record FabricInput(string Identifier, int NumericalIndex, FabricInputKind Kind, bool Active, byte CoinChannel = 0, byte CoinValue = 0);
 public readonly record struct FabricCapabilities(ulong Flags) { public bool Has(FabricCapability value) => (Flags & (ulong)value) != 0; }
 public readonly record struct FabricLamp(string Identifier, int NumericalIndex, bool LogicalState, float Brightness);
 public readonly record struct FabricReel(string Identifier, int NumericalIndex, int Position);
@@ -23,11 +23,11 @@ public interface IFabricRuntimeLibrary : IDisposable { IFabricMachineSession Cre
 public interface IFabricMachineSession : IDisposable
 {
     FabricCapabilities Capabilities { get; }
-    void Initialise(); void Reset(); void Advance(ulong elapsedNanoseconds); void SubmitInput(FabricInput input);
+    void Initialise(); void Reset(); void Advance(ulong elapsedNanoseconds); FabricResult SubmitInput(FabricInput input);
     FabricMachineSnapshot GetSnapshot(); FabricAudioFormat GetAudioFormat(); int ReadAudio(Span<short> samples, int frameCapacity); void Shutdown();
 }
 
-public enum FabricResult { Ok, InvalidArgument, UnsupportedVersion, NotFound, InvalidState, BufferTooSmall, NotSupported, BackendError, InternalError }
+public enum FabricResult { Ok, InvalidArgument, UnsupportedVersion, NotFound, InvalidState, BufferTooSmall, NotSupported, BackendError, InternalError, InputRejected }
 public sealed class FabricException : Exception
 {
     public FabricException(FabricResult result, string operation, string? detail = null, Exception? inner = null)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
@@ -2,12 +2,14 @@ using System.Runtime.InteropServices;
 
 namespace OasisEditor;
 
-internal static class FabricAbi { internal const uint Version = 0x00020000; internal const int IdentifierCapacity=64, PathCapacity=1024, CharacterCapacity=16, SegmentCapacity=16; }
+internal static class FabricAbi { internal const uint Version = 0x00030000; internal const int IdentifierCapacity=64, PathCapacity=1024, CharacterCapacity=16, SegmentCapacity=16; }
+
+public enum FabricInputKind : uint { Digital = 0, Coin = 1 }
 
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricLaunchRequestNative { internal uint Size,Version; internal fixed byte BackendKind[64],MachineIdentifier[64],BackendPath[1024]; internal nint RomPaths; internal uint RomPathCount; internal nint Configuration; internal uint ConfigurationSize,Reserved; internal nint Resources; internal uint ResourceCount; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricRomResourceNative { internal uint Size,Version,Role,Slot; internal nint Path; internal fixed ulong Reserved[2]; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricCapabilitiesNative { internal uint Size,Version; internal ulong Flags; internal fixed ulong Reserved[4]; }
-[StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricInputNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index; internal byte Active; internal fixed byte Reserved[7]; }
+[StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricInputNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int NumericalIndex; internal FabricInputKind Kind; internal byte Active,CoinChannel,CoinValue; internal fixed byte Reserved[5]; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricLampNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index; internal byte LogicalState; internal fixed byte Reserved[3]; internal float Brightness; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricReelNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal int Index,Position; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricCharacterDisplayNative { internal uint Size,Version; internal fixed byte Identifier[64]; internal uint Count,Capacity; internal fixed uint Characters[16]; internal fixed byte Attributes[16]; internal float Brightness; }
@@ -19,5 +21,5 @@ internal static class FabricAbi { internal const uint Version = 0x00020000; inte
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberReelsNative { internal uint Size,Version,Count,ApplyMask; internal fixed byte Reels[8*24]; }
 [StructLayout(LayoutKind.Sequential)] internal struct AmberCoinChannelNative { internal uint Index,Enabled,Value,LockoutInvert,Reserved; }
 [StructLayout(LayoutKind.Sequential)] internal struct AmberCoinRouteNative { internal uint Index,Enabled,CounterIn,CounterOut,PortIndex,CoinCode,Level,FullLevel; }
-[StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberCoinsNative { internal uint Size,Version,ChannelMask,RouteMask; internal fixed byte Channels[6*20]; internal fixed byte Routes[8*32]; internal uint LockoutBase,LockoutValue,Flags,Reserved; }
+[StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberCoinsNative { internal uint Size,Version,ChannelMask,RouteMask; internal fixed byte Channels[6*20]; internal fixed byte Routes[8*32]; internal uint CommunicationStyle,CommunicationInvert,PulseCycles,EdcEnabled; }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricAmberConfigurationNative { internal uint Magic,Size,Version,Flags; internal AmberReelsNative Reels; internal AmberCoinsNative Coins; internal uint Percentage; internal fixed uint Reserved[3]; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricNativeTypes.cs
@@ -21,5 +21,12 @@ public enum FabricInputKind : uint { Digital = 0, Coin = 1 }
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberReelsNative { internal uint Size,Version,Count,ApplyMask; internal fixed byte Reels[8*24]; }
 [StructLayout(LayoutKind.Sequential)] internal struct AmberCoinChannelNative { internal uint Index,Enabled,Value,LockoutInvert,Reserved; }
 [StructLayout(LayoutKind.Sequential)] internal struct AmberCoinRouteNative { internal uint Index,Enabled,CounterIn,CounterOut,PortIndex,CoinCode,Level,FullLevel; }
-[StructLayout(LayoutKind.Sequential)] internal unsafe struct AmberCoinsNative { internal uint Size,Version,ChannelMask,RouteMask; internal fixed byte Channels[6*20]; internal fixed byte Routes[8*32]; internal uint CommunicationStyle,CommunicationInvert,PulseCycles,EdcEnabled; }
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct AmberCoinsNative
+{
+    internal uint Size, Version, ChannelMask, RouteMask;
+    internal uint CommunicationStyle, CommunicationInvert, PulseCycles, EdcEnabled;
+    internal fixed byte Channels[6 * 20];
+    internal fixed byte Routes[8 * 32];
+}
 [StructLayout(LayoutKind.Sequential)] internal unsafe struct FabricAmberConfigurationNative { internal uint Magic,Size,Version,Flags; internal AmberReelsNative Reels; internal AmberCoinsNative Coins; internal uint Percentage; internal fixed uint Reserved[3]; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -304,13 +304,19 @@ internal sealed class FmlToOasisMapper
             Id = Guid.NewGuid().ToString("N"),
             Name = name,
             Kind = isCoinInput ? InputDefinitionKind.Coin : InputDefinitionKind.Button,
-            ButtonNumber = buttonNumber?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            // Decoded FML identifies a coin component but contains no independent Amber
+            // channel and denomination fields.  Never reinterpret its legacy switch value.
+            ButtonNumber = isCoinInput ? string.Empty : buttonNumber?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
             CoinInput = isCoinInput,
+            CoinChannel = null,
+            CoinValue = null,
             Inverted = Bool(c, "Inverted") ?? false,
             RawMfmeShortcut = rawShortcut,
             KeyboardShortcut = keyboardShortcut,
             LinkedVisualElementId = Guid.TryParse(linkedObjectId, out var id) ? id : null,
-            Notes = shortcut is null && hasEnabledShortcut ? FormatUnknownShortcutNotes(c) : string.Empty
+            Notes = isCoinInput
+                ? "Coin input imported without a resolved Amber coin channel or denomination."
+                : shortcut is null && hasEnabledShortcut ? FormatUnknownShortcutNotes(c) : string.Empty
         };
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InputDefinitionModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InputDefinitionModel.cs
@@ -7,6 +7,8 @@ public sealed class InputDefinitionModel
     public InputDefinitionKind Kind { get; set; } = InputDefinitionKind.Unknown;
     public string ButtonNumber { get; set; } = string.Empty;
     public bool CoinInput { get; set; }
+    public int? CoinChannel { get; set; }
+    public int? CoinValue { get; set; }
     public bool Inverted { get; set; }
     public string RawMfmeShortcut { get; set; } = string.Empty;
     public string KeyboardShortcut { get; set; } = string.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -57,6 +57,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _system6SoundRom4Path = string.Empty;
     private bool _system6FlashSwitch;
     private int _system6PercentSwitchValue = System6NativeRomSettings.DefaultPercentSwitchValue;
+    private AmberCoinCommunicationStyle _system6CoinCommunicationStyle = AmberCoinCommunicationStyle.Parallel;
+    private bool _system6CoinCommunicationInvert;
+    private uint _system6CoinPulseCycles = 800_000;
+    private bool _system6CoinEdcEnabled;
     private string _system6NativeRomStatus = "Program ROM 1 and 2 are required for Fabric Amber launch.";
     private ObservableCollection<System6ReelOptoSettingsViewModel> _system6ReelOptos = [];
     private ObservableCollection<System6CoinSettingsViewModel> _system6Coins = [];
@@ -522,6 +526,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             }
         }
     }
+    public AmberCoinCommunicationStyle System6CoinCommunicationStyle { get => _system6CoinCommunicationStyle; set { if (SetProperty(ref _system6CoinCommunicationStyle, value)) SaveSystem6NativeRomSettings(); } }
+    public bool System6CoinCommunicationInvert { get => _system6CoinCommunicationInvert; set { if (SetProperty(ref _system6CoinCommunicationInvert, value)) SaveSystem6NativeRomSettings(); } }
+    public uint System6CoinPulseCycles { get => _system6CoinPulseCycles; set { if (SetProperty(ref _system6CoinPulseCycles, value)) SaveSystem6NativeRomSettings(); } }
+    public bool System6CoinEdcEnabled { get => _system6CoinEdcEnabled; set { if (SetProperty(ref _system6CoinEdcEnabled, value)) SaveSystem6NativeRomSettings(); } }
     public string System6NativeRomStatus { get => _system6NativeRomStatus; private set => SetProperty(ref _system6NativeRomStatus, value); }
     public ObservableCollection<System6ReelOptoSettingsViewModel> System6ReelOptos { get => _system6ReelOptos; private set => SetProperty(ref _system6ReelOptos, value); }
     public ObservableCollection<System6CoinSettingsViewModel> System6Coins { get => _system6Coins; private set => SetProperty(ref _system6Coins, value); }
@@ -2123,6 +2131,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = System6SoundRom4Path,
             FlashSwitch = System6FlashSwitch,
             PercentSwitchValue = System6PercentSwitchValue,
+            CoinCommunicationStyle = System6CoinCommunicationStyle,
+            CoinCommunicationInvert = System6CoinCommunicationInvert,
+            CoinPulseCycles = System6CoinPulseCycles,
+            CoinEdcEnabled = System6CoinEdcEnabled,
             ReelOptos = System6ReelOptos.Select(reel => reel.ToModel()).ToList(),
             Coins = System6Coins.Select(coin => coin.ToModel()).ToList()
         };
@@ -2141,6 +2153,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _system6SoundRom4Path = settings.SoundRom4Path;
         _system6FlashSwitch = settings.FlashSwitch;
         _system6PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15);
+        _system6CoinCommunicationStyle = settings.CoinCommunicationStyle;
+        _system6CoinCommunicationInvert = settings.CoinCommunicationInvert;
+        _system6CoinPulseCycles = settings.CoinPulseCycles;
+        _system6CoinEdcEnabled = settings.CoinEdcEnabled;
         System6ReelOptos = new ObservableCollection<System6ReelOptoSettingsViewModel>((settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos()).Select(reel => new System6ReelOptoSettingsViewModel(reel, SaveSystem6NativeRomSettings)));
         System6Coins = new ObservableCollection<System6CoinSettingsViewModel>(NormalizeSystem6CoinSettings(settings.Coins).Select(coin => new System6CoinSettingsViewModel(coin, SaveSystem6NativeRomSettings)));
         OnPropertyChanged(nameof(System6ProgramRom1Path)); OnPropertyChanged(nameof(System6ProgramRom2Path));
@@ -2149,6 +2165,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(System6SoundRom3Path)); OnPropertyChanged(nameof(System6SoundRom4Path));
         OnPropertyChanged(nameof(System6FlashSwitch));
         OnPropertyChanged(nameof(System6PercentSwitchValue));
+        OnPropertyChanged(nameof(System6CoinCommunicationStyle));
+        OnPropertyChanged(nameof(System6CoinCommunicationInvert));
+        OnPropertyChanged(nameof(System6CoinPulseCycles));
+        OnPropertyChanged(nameof(System6CoinEdcEnabled));
     }
 
     private void RefreshSystem6NativeRomStatus()
@@ -2213,11 +2233,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = ResolveProjectRelativePath(settings.SoundRom4Path, LoadedProject.ProjectDirectory),
             FlashSwitch = settings.FlashSwitch,
             PercentSwitchValue = Math.Clamp(settings.PercentSwitchValue, 0, 15),
+            CoinCommunicationStyle = settings.CoinCommunicationStyle,
+            CoinCommunicationInvert = settings.CoinCommunicationInvert,
+            CoinPulseCycles = settings.CoinPulseCycles,
+            CoinEdcEnabled = settings.CoinEdcEnabled,
             ReelOptos = (settings.ReelOptos is { Count: > 0 } ? settings.ReelOptos : System6NativeRomSettings.CreateDefaultReelOptos())
                 .Select(reel => new System6ReelOptoSettings { ReelIndex = reel.ReelIndex, Enabled = reel.Enabled, Steps = reel.Steps, OptoStart = reel.OptoStart, OptoEnd = reel.OptoEnd, OptoInvert = reel.OptoInvert })
                 .ToList(),
             Coins = NormalizeSystem6CoinSettings(settings.Coins)
-                .Select(coin => new System6CoinSettings { Name = coin.Name, Enabled = coin.Enabled, Num = coin.Num, Coin = coin.Coin, CoinValue = coin.CoinValue, CoinEnable = coin.CoinEnable, LockoutValue = coin.LockoutValue, LockoutInvert = coin.LockoutInvert, CounterIn = coin.CounterIn, CounterOut = coin.CounterOut, PortIndex = coin.PortIndex, Level = coin.Level, FullLevel = coin.FullLevel })
+                .Select(coin => new System6CoinSettings { Name = coin.Name, Enabled = coin.Enabled, Num = coin.Num, Coin = coin.Coin, CoinValue = coin.CoinValue, CoinEnable = coin.CoinEnable, LockoutInvert = coin.LockoutInvert, CounterIn = coin.CounterIn, CounterOut = coin.CounterOut, PortIndex = coin.PortIndex, Level = coin.Level, FullLevel = coin.FullLevel })
                 .ToList()
         };
     }
@@ -2720,6 +2744,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         writer.WriteString("SoundRom4Path", settings.SoundRom4Path);
         writer.WriteBoolean("FlashSwitch", settings.FlashSwitch);
         writer.WriteNumber("PercentSwitchValue", Math.Clamp(settings.PercentSwitchValue, 0, 15));
+        writer.WriteNumber("CoinCommunicationStyle", (uint)settings.CoinCommunicationStyle);
+        writer.WriteBoolean("CoinCommunicationInvert", settings.CoinCommunicationInvert);
+        writer.WriteNumber("CoinPulseCycles", settings.CoinPulseCycles);
+        writer.WriteBoolean("CoinEdcEnabled", settings.CoinEdcEnabled);
         writer.WritePropertyName("ReelOptos");
         writer.WriteStartArray();
         foreach (var reel in settings.ReelOptos)
@@ -2745,7 +2773,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             writer.WriteNumber("Coin", coin.Coin);
             writer.WriteNumber("CoinValue", coin.CoinValue);
             writer.WriteNumber("CoinEnable", coin.CoinEnable);
-            writer.WriteNumber("LockoutValue", coin.LockoutValue);
             writer.WriteNumber("LockoutInvert", coin.LockoutInvert);
             writer.WriteNumber("CounterIn", coin.CounterIn);
             writer.WriteNumber("CounterOut", coin.CounterOut);
@@ -2778,6 +2805,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             SoundRom4Path = GetOptionalString(romsElement, "SoundRom4Path"),
             FlashSwitch = romsElement.TryGetProperty("FlashSwitch", out var flashElement) && flashElement.ValueKind == JsonValueKind.True,
             PercentSwitchValue = Math.Clamp(GetOptionalInt(romsElement, "PercentSwitchValue", System6NativeRomSettings.DefaultPercentSwitchValue), 0, 15),
+            CoinCommunicationStyle = (AmberCoinCommunicationStyle)GetOptionalInt(romsElement, "CoinCommunicationStyle", 0),
+            CoinCommunicationInvert = romsElement.TryGetProperty("CoinCommunicationInvert", out var communicationInvert) && communicationInvert.ValueKind == JsonValueKind.True,
+            CoinPulseCycles = checked((uint)GetOptionalInt(romsElement, "CoinPulseCycles", 800_000)),
+            CoinEdcEnabled = romsElement.TryGetProperty("CoinEdcEnabled", out var edcEnabled) && edcEnabled.ValueKind == JsonValueKind.True,
             ReelOptos = ResolveSystem6ReelOptoSettings(romsElement),
             Coins = ResolveSystem6CoinSettings(romsElement)
         };
@@ -2827,7 +2858,6 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 Coin = GetOptionalInt(coinElement, "Coin", System6CoinSettings.DefaultCoin),
                 CoinValue = GetOptionalInt(coinElement, "CoinValue", System6CoinSettings.DefaultCoinValue),
                 CoinEnable = GetOptionalInt(coinElement, "CoinEnable", System6CoinSettings.DefaultCoinEnable),
-                LockoutValue = GetOptionalInt(coinElement, "LockoutValue", System6CoinSettings.DefaultLockoutValue),
                 LockoutInvert = GetOptionalInt(coinElement, "LockoutInvert", System6CoinSettings.DefaultLockoutInvert),
                 CounterIn = GetOptionalInt(coinElement, "CounterIn"),
                 CounterOut = GetOptionalInt(coinElement, "CounterOut"),
@@ -2885,6 +2915,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             writer.WriteString("Kind", input.Kind.ToString());
             writer.WriteString("ButtonNumber", input.ButtonNumber);
             writer.WriteBoolean("CoinInput", input.CoinInput);
+            if (input.CoinChannel.HasValue) writer.WriteNumber("CoinChannel", input.CoinChannel.Value);
+            if (input.CoinValue.HasValue) writer.WriteNumber("CoinValue", input.CoinValue.Value);
             writer.WriteBoolean("Inverted", input.Inverted);
             writer.WriteString("RawMfmeShortcut", input.RawMfmeShortcut);
             writer.WriteString("KeyboardShortcut", input.KeyboardShortcut);
@@ -2939,6 +2971,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
                 Kind = kind,
                 ButtonNumber = inputElement.TryGetProperty("ButtonNumber", out var buttonNumberElement) ? buttonNumberElement.GetString() ?? string.Empty : string.Empty,
                 CoinInput = inputElement.TryGetProperty("CoinInput", out var coinInputElement) && coinInputElement.ValueKind == JsonValueKind.True,
+                CoinChannel = inputElement.TryGetProperty("CoinChannel", out var coinChannelElement) && coinChannelElement.TryGetInt32(out var coinChannel) ? coinChannel : null,
+                CoinValue = inputElement.TryGetProperty("CoinValue", out var inputCoinValueElement) && inputCoinValueElement.TryGetInt32(out var inputCoinValue) ? inputCoinValue : null,
                 Inverted = inputElement.TryGetProperty("Inverted", out var invertedElement) && invertedElement.ValueKind == JsonValueKind.True,
                 RawMfmeShortcut = inputElement.TryGetProperty("RawMfmeShortcut", out var rawShortcutElement) ? rawShortcutElement.GetString() ?? string.Empty : string.Empty,
                 KeyboardShortcut = inputElement.TryGetProperty("KeyboardShortcut", out var keyboardShortcutElement) ? keyboardShortcutElement.GetString() ?? string.Empty : string.Empty,
@@ -3318,7 +3352,6 @@ public sealed class System6CoinSettingsViewModel : INotifyPropertyChanged
     private int _coin;
     private int _coinValue;
     private int _coinEnable;
-    private int _lockoutValue;
     private int _lockoutInvert;
     private int _counterIn;
     private int _counterOut;
@@ -3334,7 +3367,6 @@ public sealed class System6CoinSettingsViewModel : INotifyPropertyChanged
         _coin = model.Coin;
         _coinValue = model.CoinValue;
         _coinEnable = model.CoinEnable;
-        _lockoutValue = model.LockoutValue;
         _lockoutInvert = model.LockoutInvert;
         _counterIn = model.CounterIn;
         _counterOut = model.CounterOut;
@@ -3352,7 +3384,6 @@ public sealed class System6CoinSettingsViewModel : INotifyPropertyChanged
     public int Coin { get => _coin; set => SetAndSave(ref _coin, Math.Clamp(value, 0, byte.MaxValue), nameof(Coin)); }
     public int CoinValue { get => _coinValue; set => SetAndSave(ref _coinValue, Math.Clamp(value, 0, byte.MaxValue), nameof(CoinValue)); }
     public int CoinEnable { get => _coinEnable; set => SetAndSave(ref _coinEnable, Math.Clamp(value, 0, byte.MaxValue), nameof(CoinEnable)); }
-    public int LockoutValue { get => _lockoutValue; set => SetAndSave(ref _lockoutValue, Math.Clamp(value, 0, byte.MaxValue), nameof(LockoutValue)); }
     public int LockoutInvert { get => _lockoutInvert; set => SetAndSave(ref _lockoutInvert, Math.Clamp(value, 0, byte.MaxValue), nameof(LockoutInvert)); }
     public int CounterIn { get => _counterIn; set => SetAndSave(ref _counterIn, Math.Clamp(value, 0, byte.MaxValue), nameof(CounterIn)); }
     public int CounterOut { get => _counterOut; set => SetAndSave(ref _counterOut, Math.Clamp(value, 0, byte.MaxValue), nameof(CounterOut)); }
@@ -3368,7 +3399,6 @@ public sealed class System6CoinSettingsViewModel : INotifyPropertyChanged
         Coin = Coin,
         CoinValue = CoinValue,
         CoinEnable = CoinEnable,
-        LockoutValue = LockoutValue,
         LockoutInvert = LockoutInvert,
         CounterIn = CounterIn,
         CounterOut = CounterOut,

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlayViewInputRouter.cs
@@ -78,7 +78,19 @@ public sealed class PlayViewInputRouter
     {
         try
         {
-            await _backend.SetInputStateAsync(inputDefinition, isPressed, cancellationToken).ConfigureAwait(false);
+            if (inputDefinition.CoinInput)
+            {
+                if (inputDefinition.CoinChannel is not (>= 0 and <= 5) || inputDefinition.CoinValue is not (>= 0 and <= 12))
+                    return false;
+                if (isPressed)
+                    await _backend.InsertCoinAsync(inputDefinition, cancellationToken).ConfigureAwait(false);
+                else
+                    await _backend.ReleaseCoinAsync(inputDefinition, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _backend.SetInputStateAsync(inputDefinition, isPressed, cancellationToken).ConfigureAwait(false);
+            }
             return true;
         }
         catch

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/InputMapView.xaml
@@ -16,7 +16,7 @@
                   Grid.Row="0"
                   ItemsSource="{Binding InputDefinitions}"
                   AutoGenerateColumns="False"
-                  IsReadOnly="True"
+                  IsReadOnly="False"
                   CanUserAddRows="False"
                   CanUserDeleteRows="False"
                   HeadersVisibility="Column"
@@ -38,6 +38,8 @@
                 <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="0.7*" />
                 <DataGridTextColumn Header="Button No" Binding="{Binding ButtonNumber}" Width="0.8*" />
                 <DataGridCheckBoxColumn Header="Coin" Binding="{Binding CoinInput}" Width="0.6*" />
+                <DataGridTextColumn Header="Coin Channel (0-5)" Binding="{Binding CoinChannel, UpdateSourceTrigger=LostFocus}" Width="1.0*" />
+                <DataGridTextColumn Header="Coin Value / Denomination (0-12)" Binding="{Binding CoinValue, UpdateSourceTrigger=LostFocus}" Width="1.4*" />
                 <DataGridTextColumn Header="Key" Binding="{Binding KeyboardShortcut}" Width="0.8*" />
                 <DataGridTextColumn Header="Raw MFME Key" Binding="{Binding RawMfmeShortcut}" Width="0.9*" />
                 <DataGridTextColumn Header="Linked Visual" Binding="{Binding LinkedVisualElementId}" Width="1.3*" />

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/ProjectSettingsView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:OasisEditor"
              mc:Ignorable="d"
              d:DesignHeight="640"
              d:DesignWidth="620">
@@ -184,6 +185,15 @@
                         </Style>
                     </ScrollViewer.Style>
                     <StackPanel>
+                        <TextBlock Margin="0,0,0,4" Text="Coin Mechanism" FontWeight="SemiBold" />
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <TextBlock VerticalAlignment="Center" Text="Communication Style:" />
+                            <ComboBox Margin="8,0,16,0" Width="120" SelectedValue="{Binding System6CoinCommunicationStyle}" SelectedValuePath="Tag"><ComboBoxItem Content="Parallel" Tag="{x:Static local:AmberCoinCommunicationStyle.Parallel}" /></ComboBox>
+                            <CheckBox Margin="0,0,16,0" VerticalAlignment="Center" Content="Communication Invert" IsChecked="{Binding System6CoinCommunicationInvert}" />
+                            <TextBlock VerticalAlignment="Center" Text="Pulse Cycles:" />
+                            <TextBox Margin="8,0,16,0" Width="100" Text="{Binding System6CoinPulseCycles, UpdateSourceTrigger=LostFocus}" />
+                            <CheckBox VerticalAlignment="Center" Content="EDC Enabled" IsChecked="{Binding System6CoinEdcEnabled}" />
+                        </StackPanel>
                         <TextBlock Margin="0,0,0,4" Text="System6 Coin Setup" Foreground="{DynamicResource TextSecondaryBrush}" />
                         <DataGrid ItemsSource="{Binding System6Coins}"
                                   AutoGenerateColumns="False"
@@ -198,7 +208,6 @@
                                 <DataGridTextColumn Header="Coin" Binding="{Binding Coin, UpdateSourceTrigger=LostFocus}" Width="70" />
                                 <DataGridTextColumn Header="Coin Value" Binding="{Binding CoinValue, UpdateSourceTrigger=LostFocus}" Width="90" />
                                 <DataGridTextColumn Header="Coin Enable" Binding="{Binding CoinEnable, UpdateSourceTrigger=LostFocus}" Width="100" />
-                                <DataGridTextColumn Header="Lockout Value" Binding="{Binding LockoutValue, UpdateSourceTrigger=LostFocus}" Width="110" />
                                 <DataGridTextColumn Header="Lockout Invert" Binding="{Binding LockoutInvert, UpdateSourceTrigger=LostFocus}" Width="110" />
                                 <DataGridTextColumn Header="Counter In" Binding="{Binding CounterIn, UpdateSourceTrigger=LostFocus}" Width="90" />
                                 <DataGridTextColumn Header="Counter Out" Binding="{Binding CounterOut, UpdateSourceTrigger=LostFocus}" Width="95" />


### PR DESCRIPTION
### Motivation

- Fabric ABI v3 introduces a dedicated coin input path and global Amber coin-mechanism v2 settings, so Oasis must stop submitting coins as matrix switches and instead use the new coin contract.
- The existing model conflated matrix switches and coin actions; inputs must carry explicit Amber channel and denomination fields and coin rejections must be handled as valid machine outcomes. 

### Description

- Upgraded the managed Fabric ABI to `0x00030000` and replaced the old `FabricInput` layout with the 88-byte v3 structure containing `NumericalIndex`, `Kind`, `Active`, `CoinChannel`, and `CoinValue`, and added `FabricInputKind` (`Digital`, `Coin`).
- Added `FabricResult.InputRejected` and the `FabricCapability.CoinInput` capability bit, and updated `FabricMachineSession.SubmitInput` to return and tolerate `InputRejected` without faulting the backend.
- Separated coin handling from held digital inputs by adding `CoinChannel`/`CoinValue` to `InputDefinitionModel`, adding `InsertCoinAsync`/`ReleaseCoinAsync` to the backend abstraction, and routing coin presses/releases through the shared `PlayViewInputRouter` (ordinary inputs still use `SetInputStateAsync`).
- Implemented Amber coin-mechanism v2 transport and UI: added strongly typed `AmberCoinCommunicationStyle`, `CoinPulseCycles`, `CoinCommunicationInvert`, and `CoinEdcEnabled` to `System6NativeRomSettings` and exposed a compact "Coin Mechanism" section in Project Settings; removed static per-channel `LockoutValue` transport and UI fields.
- Updated MFME import to avoid guessing channel/denomination from legacy switch numbers and import coin components as unresolved (`CoinChannel = null`, `CoinValue = null`) with a diagnostic note prompting user configuration.
- Updated and added unit tests and layout assertions: ABI layout offsets and sizes, Amber v2 configuration serialization (including exact `800000` pulse cycles), input-router coin routing/repeat suppression tests, and FML import expectations for unresolved coin rows.

### Testing

- Ran repository static checks and scans: `git diff --check` succeeded, XAML parsing with `xml.etree.ElementTree` verified `InputMapView.xaml` and `ProjectSettingsView.xaml`, and repository grep scans confirmed removal of obsolete ABI-v2 constants, `LockoutValue` transport, and hard-coded coin switches `72–77` (all checks passed).
- Updated unit tests were added and local test source edits were exercised (tests updated: `FabricAbiLayoutTests`, `FabricManagedBehaviorTests`, `FmlToOasisMapperTests`, `PlayViewInputRouterTests`), but `dotnet test` was not executed in this environment due to missing Windows/.NET/WPF toolchain.
- To run full automated verification locally on Windows, run: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.sln` and validate that new and updated tests pass and that `FabricAbiLayoutTests` assertions for ABI v3, field offsets, and Amber v2 serialization succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a70deef61688327adb1ebe81fd959be)