### PR TITLE
Refactor emulation runtime: ring buffer, pull-based wave provider, runner thread & UI marshal

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationPcmWaveProviderTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationPcmWaveProviderTests.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class EmulationPcmWaveProviderTests
+{
+    [Fact] public void DeliversExactStereoBytesAndFullCount() { var ring = new PcmFrameRingBuffer(2, 4); ring.Write([0x0102, unchecked((short)0xF304)],1); var p=new EmulationPcmWaveProvider(ring,new(48000,2,16),4); var bytes=new byte[4]; Assert.Equal(4,p.Read(bytes,0,4)); Assert.Equal([0x02,0x01,0x04,0xF3], bytes); Assert.Equal(1,p.FramesDelivered); }
+    [Fact] public void PartialUnderrunFillsSilenceAndCountsEpisode() { var ring = new PcmFrameRingBuffer(1, 4); ring.Write([123],1); var p=new EmulationPcmWaveProvider(ring,new(48000,1,16),4); var bytes=Enumerable.Repeat((byte)0xFF,6).ToArray(); p.Read(bytes,0,6); Assert.Equal([123,0,0,0,0,0], bytes); Assert.Equal(2,p.SilenceFrames); Assert.Equal(1,p.UnderrunEpisodes); }
+    [Fact] public void CompleteUnderrunAndRecoveryDoesNotRepeatStaleSamples() { var ring = new PcmFrameRingBuffer(1, 4); var p=new EmulationPcmWaveProvider(ring,new(48000,1,16),4); var bytes=Enumerable.Repeat((byte)0x7F,4).ToArray(); p.Read(bytes,0,4); Assert.Equal([0,0,0,0], bytes); ring.Write([44,55],2); p.Read(bytes,0,4); Assert.Equal([44,0,55,0], bytes); Assert.Equal(1,p.UnderrunEpisodes); }
+    [Fact] public void NonFrameAlignedRequestClearsTrailingBytes() { var ring = new PcmFrameRingBuffer(2, 4); ring.Write([1,2],1); var p=new EmulationPcmWaveProvider(ring,new(48000,2,16),4); var bytes=Enumerable.Repeat((byte)0xFF,5).ToArray(); Assert.Equal(5,p.Read(bytes,0,5)); Assert.Equal([1,0,2,0,0], bytes); }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -4,27 +4,32 @@ namespace OasisEditor.Tests;
 
 public sealed class NAudioEmulationAudioSinkTests
 {
-    [Theory]
-    [InlineData(50, 10)]
-    [InlineData(100, 10)]
-    [InlineData(10, 5)]
-    [InlineData(1, 1)]
-    public void PrebufferThreshold_IsBoundedByTenMillisecondsAndHalfTheBuffer(int buffer, int expected)
+    [Fact]
+    public void PrebufferThreshold_UsesSeventyFivePercentAndStaysBelowCapacity()
     {
-        Assert.Equal(expected, AudioPrebufferPolicy.CalculateThresholdMilliseconds(buffer));
+        var capacity = AudioPrebufferPolicy.CalculateCapacityFrames(48000, 50);
+        Assert.Equal(2400, capacity);
+        Assert.Equal(1800, AudioPrebufferPolicy.CalculateThresholdFrames(48000, capacity));
     }
 
     [Fact]
-    public void Prebuffer_StartsAtThresholdAndResetRequiresPrebufferAgain()
+    public void Prebuffer_StartsAtThresholdOnceAndResetRequiresPrebufferAgain()
     {
-        var policy = new AudioPrebufferPolicy(new(48000, 2, 16), 50);
-
-        Assert.Equal(1920, policy.ThresholdBytes);
-        Assert.False(policy.ObserveQueuedBytes(1919));
-        Assert.True(policy.ObserveQueuedBytes(1920));
+        var policy = new AudioPrebufferPolicy(new(48000, 2, 16), 2400);
+        Assert.False(policy.ObserveQueuedFrames(1799));
+        Assert.True(policy.ObserveQueuedFrames(1800));
+        Assert.True(policy.ObserveQueuedFrames(1));
         policy.Reset();
         Assert.False(policy.PlaybackStarted);
-        Assert.False(policy.ObserveQueuedBytes(192));
+        Assert.False(policy.ObserveQueuedFrames(1799));
+    }
+
+    [Fact]
+    public void SmallPrebufferThreshold_RemainsSafeAndBelowCapacity()
+    {
+        var capacity = AudioPrebufferPolicy.CalculateCapacityFrames(48000, 10);
+        var threshold = AudioPrebufferPolicy.CalculateThresholdFrames(48000, capacity);
+        Assert.InRange(threshold, 1, capacity - 1);
     }
 
     [Theory]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PcmFrameRingBufferTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PcmFrameRingBufferTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class PcmFrameRingBufferTests
+{
+    [Fact] public void MonoOrdering() { var b = new PcmFrameRingBuffer(1, 4); Assert.Equal(3, b.Write([1,2,3], 3)); short[] r = [0,0,0]; Assert.Equal(3, b.Read(r, 3)); Assert.Equal([1,2,3], r); }
+    [Fact] public void StereoOrdering() { var b = new PcmFrameRingBuffer(2, 3); Assert.Equal(2, b.Write([10,11,20,21], 2)); short[] r = [0,0,0,0]; Assert.Equal(2, b.Read(r, 2)); Assert.Equal([10,11,20,21], r); }
+    [Fact] public void WraparoundPreservesOrder() { var b = new PcmFrameRingBuffer(1, 3); b.Write([1,2,3], 3); short[] a=[0,0]; b.Read(a,2); Assert.Equal(2, b.Write([4,5], 2)); short[] r=[0,0,0]; Assert.Equal(3,b.Read(r,3)); Assert.Equal([3,4,5], r); }
+    [Fact] public void PartialWritesAndFullRejectionDoNotOverwrite() { var b = new PcmFrameRingBuffer(1, 2); Assert.Equal(2,b.Write([1,2,3],3)); Assert.Equal(0,b.Write([9],1)); short[] r=[0,0]; b.Read(r,2); Assert.Equal([1,2], r); }
+    [Fact] public void PartialReadsLeaveRemainder() { var b = new PcmFrameRingBuffer(1, 3); b.Write([1,2,3],3); short[] r=[0,0]; Assert.Equal(2,b.Read(r,2)); Assert.Equal([1,2],r); short[] r2=[0]; b.Read(r2,1); Assert.Equal([3],r2); }
+    [Fact] public void ClearRemovesStaleData() { var b = new PcmFrameRingBuffer(2, 2); b.Write([1,2,3,4],2); b.Clear(); Assert.Equal(0,b.ReadableFrames); short[] r=[7,7]; Assert.Equal(0,b.Read(r,1)); Assert.Equal([7,7], r); }
+    [Fact] public void CompleteFrameAlignmentIsRequired() { var b = new PcmFrameRingBuffer(2, 2); Assert.Throws<ArgumentException>(() => b.Write([1],1)); Assert.Throws<ArgumentException>(() => b.Read(new short[1],1)); }
+    [Fact] public void StressPreservesAcceptedFrames() { var b = new PcmFrameRingBuffer(1, 8); var expected = new List<short>(); for(short i=0;i<100;i++){ if(b.Write([i],1)==1) expected.Add(i); if(i%3==0){ short[] t=[0]; if(b.Read(t,1)==1) Assert.Equal(expected[0], t[0]); if(expected.Count>0) expected.RemoveAt(0); }} foreach(var e in expected){ short[] t=[0]; Assert.Equal(1,b.Read(t,1)); Assert.Equal(e,t[0]); }}
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationPcmWaveProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationPcmWaveProvider.cs
@@ -1,0 +1,58 @@
+using System.Buffers.Binary;
+using NAudio.Wave;
+
+namespace OasisEditor;
+
+internal sealed class EmulationPcmWaveProvider : IWaveProvider
+{
+    private readonly PcmFrameRingBuffer _ringBuffer;
+    private readonly short[] _scratch;
+    private bool _underrunActive;
+    private long _framesDelivered;
+    private long _silenceFrames;
+    private long _underrunEpisodes;
+
+    public EmulationPcmWaveProvider(PcmFrameRingBuffer ringBuffer, EmulationAudioFormat format, int maxReadFrames)
+    {
+        _ringBuffer = ringBuffer ?? throw new ArgumentNullException(nameof(ringBuffer));
+        if (format.BitsPerSample != 16) throw new NotSupportedException("Only 16-bit PCM is supported.");
+        if (format.Channels != ringBuffer.Channels) throw new ArgumentException("Format channel count must match the ring buffer.", nameof(format));
+        if (maxReadFrames <= 0) throw new ArgumentOutOfRangeException(nameof(maxReadFrames));
+        Format = format;
+        WaveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
+        _scratch = new short[checked(maxReadFrames * format.Channels)];
+    }
+
+    public WaveFormat WaveFormat { get; }
+    internal EmulationAudioFormat Format { get; }
+    internal long FramesDelivered => Interlocked.Read(ref _framesDelivered);
+    internal long SilenceFrames => Interlocked.Read(ref _silenceFrames);
+    internal long UnderrunEpisodes => Interlocked.Read(ref _underrunEpisodes);
+
+    public int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        if ((uint)offset > (uint)buffer.Length || count < 0 || count > buffer.Length - offset) throw new ArgumentOutOfRangeException(nameof(count));
+        var bytesPerFrame = checked(Format.Channels * sizeof(short));
+        var requestedFrames = count / bytesPerFrame;
+        var requestedSamples = checked(requestedFrames * Format.Channels);
+        var requestedFrameBytes = checked(requestedFrames * bytesPerFrame);
+        var framesRead = requestedFrames == 0 ? 0 : _ringBuffer.Read(_scratch.AsSpan(0, requestedSamples), requestedFrames);
+        var samplesRead = checked(framesRead * Format.Channels);
+        var span = buffer.AsSpan(offset, count);
+        for (var i = 0; i < samplesRead; i++)
+            BinaryPrimitives.WriteInt16LittleEndian(span.Slice(i * sizeof(short), sizeof(short)), _scratch[i]);
+        var silenceBytesStart = checked(samplesRead * sizeof(short));
+        span[silenceBytesStart..requestedFrameBytes].Clear();
+        span[requestedFrameBytes..].Clear();
+        Interlocked.Add(ref _framesDelivered, framesRead);
+        var silenceFrames = requestedFrames - framesRead;
+        if (silenceFrames > 0)
+        {
+            Interlocked.Add(ref _silenceFrames, silenceFrames);
+            if (!_underrunActive) { Interlocked.Increment(ref _underrunEpisodes); _underrunActive = true; }
+        }
+        else _underrunActive = false;
+        return count;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -32,7 +32,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private IFabricRuntimeLibrary? _runtime;
     private IFabricMachineSession? _session;
     private CancellationTokenSource? _pumpCancellation;
-    private Task? _pumpTask;
+    private Thread? _pumpThread;
     private FabricAudioFormat? _audioFormat;
     private short[] _audioBuffer = [];
     private EmulationBackendState _state = EmulationBackendState.Stopped;
@@ -97,7 +97,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 AmberBackendKind, JpmSystem6MachineIdentifier, _amberPath, resources,
                 configuration));
 
-            await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            _sessionGate.Wait(cancellationToken);
             try
             {
                 _session.Initialise();
@@ -112,7 +112,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _shutdown = false;
             LastFailure = null;
             _pumpCancellation = new CancellationTokenSource();
-            _pumpTask = Task.Run(() => PumpAsync(_pumpCancellation.Token), CancellationToken.None);
+            _pumpThread = new Thread(() => Pump(_pumpCancellation.Token))
+            {
+                IsBackground = true,
+                Name = "Oasis Fabric Emulation Runner"
+            };
+            _pumpThread.Start();
             SetState(EmulationBackendState.Running);
         }
         catch
@@ -132,19 +137,21 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
         if (_pumpCancellation is not null)
             await _pumpCancellation.CancelAsync().ConfigureAwait(false);
-        if (_pumpTask is not null && Task.CurrentId != _pumpTask.Id)
+        if (_pumpThread is { } pumpThread && pumpThread != Thread.CurrentThread)
         {
             try
             {
-                await _pumpTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                while (pumpThread.IsAlive)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (pumpThread.Join(TimeSpan.FromMilliseconds(25)))
+                        break;
+                    Thread.Yield();
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // The caller may stop waiting, but native cleanup below is never abandoned.
-            }
-            catch
-            {
-                // LastFailure retains the pump exception; cleanup must continue.
             }
         }
         await CleanupResourcesAsync().ConfigureAwait(false);
@@ -176,7 +183,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     {
         ThrowIfDisposed();
         EnsureAcceptingOperations();
-        await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _sessionGate.Wait(cancellationToken);
         try
         {
             ReleaseAssertedInputs();
@@ -223,7 +230,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (inputDefinition.CoinChannel is not (>= 0 and <= 5) || inputDefinition.CoinValue is not (>= 0 and <= 12))
             throw new InvalidOperationException($"Coin input '{inputDefinition.Id}' requires a channel from 0 to 5 and denomination from 0 to 12.");
 
-        await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _sessionGate.Wait(cancellationToken);
         try
         {
             var channel = checked((byte)inputDefinition.CoinChannel.Value);
@@ -294,7 +301,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private async Task PumpAsync(CancellationToken cancellationToken)
+    private void Pump(CancellationToken cancellationToken)
     {
         try
         {
@@ -305,7 +312,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             {
                 if (State != EmulationBackendState.Running)
                 {
-                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    cancellationToken.WaitHandle.WaitOne(PumpInterval);
                     nextDeadline = _clock.GetTimestamp();
                     scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
                     continue;
@@ -318,7 +325,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     scheduleGeneration = currentGeneration;
                 }
 
-                await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                _sessionGate.Wait(cancellationToken);
                 try
                 {
                     var session = RequireSession();
@@ -342,11 +349,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 if (remainingTicks > 0)
                 {
                     var remaining = TimeSpan.FromSeconds((double)remainingTicks / _clock.Frequency);
-                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+                    cancellationToken.WaitHandle.WaitOne(remaining);
                 }
                 else
                 {
-                    await Task.Yield();
+                    Thread.Yield();
                 }
             }
         }
@@ -360,7 +367,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _pumpCancellation?.Cancel();
             try
             {
-                await CleanupResourcesAsync().ConfigureAwait(false);
+                CleanupResourcesAsync().GetAwaiter().GetResult();
             }
             catch (Exception cleanupException)
             {
@@ -413,6 +420,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             return;
         var frameCapacity = _audioBuffer.Length / format.ChannelCount;
         var framesWritten = session.ReadAudio(_audioBuffer, frameCapacity);
+        if (framesWritten > frameCapacity)
+            throw new InvalidOperationException($"Fabric returned {framesWritten} audio frames after {frameCapacity} were requested.");
         var sampleCount = checked(framesWritten * format.ChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
         if (!bytes.IsEmpty)
@@ -521,7 +530,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _audioFormat = null;
             _pumpCancellation?.Dispose();
             _pumpCancellation = null;
-            _pumpTask = null;
+            _pumpThread = null;
             ClearPendingInputs();
         }
         finally

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -1,38 +1,37 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
-using NAudio.Wave;
 
 namespace OasisEditor;
 
 public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 {
-    private const int DiagnosticPushLimit = 32;
     private readonly int _bufferLengthMilliseconds;
-
-    private BufferedWaveProvider? _buffer;
+    private readonly object _gate = new();
+    private PcmFrameRingBuffer? _ringBuffer;
+    private EmulationPcmWaveProvider? _provider;
     private WasapiOut? _output;
     private EmulationAudioFormat? _format;
     private AudioPrebufferPolicy? _prebuffer;
-    private long _droppedBlocks;
-    private long _droppedBytes;
-    private long _runtimeStarvationEvents;
-    private long _pushCount;
-    private int _minimumBufferedBytes = int.MaxValue;
-    private bool _playbackStarted;
+    private long _framesOffered;
+    private long _framesWritten;
+    private long _framesRejected;
+    private bool _overflowWarned;
 
     internal int BufferLengthMilliseconds => _bufferLengthMilliseconds;
-    internal int PrebufferThresholdMilliseconds => AudioPrebufferPolicy.CalculateThresholdMilliseconds(_bufferLengthMilliseconds);
-    internal int PrebufferThresholdBytes => _prebuffer?.ThresholdBytes ?? 0;
-    internal long DroppedBlocks => Interlocked.Read(ref _droppedBlocks);
-    internal long DroppedBytes => Interlocked.Read(ref _droppedBytes);
-    internal long RuntimeStarvationEvents => Interlocked.Read(ref _runtimeStarvationEvents);
-    internal int MinimumObservedBufferedBytes => _minimumBufferedBytes == int.MaxValue ? 0 : _minimumBufferedBytes;
-    internal bool PlaybackStarted => _playbackStarted;
+    internal int PrebufferThresholdFrames => _prebuffer?.ThresholdFrames ?? 0;
+    internal int CapacityFrames => _ringBuffer?.CapacityFrames ?? 0;
+    internal long FramesOffered => Interlocked.Read(ref _framesOffered);
+    internal long FramesWritten => Interlocked.Read(ref _framesWritten);
+    internal long FramesRejected => Interlocked.Read(ref _framesRejected);
+    internal long FramesDelivered => _provider?.FramesDelivered ?? 0;
+    internal long SilenceFrames => _provider?.SilenceFrames ?? 0;
+    internal long UnderrunEpisodes => _provider?.UnderrunEpisodes ?? 0;
+    internal bool PlaybackStarted => _prebuffer?.PlaybackStarted ?? false;
 
     public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
     {
-        if (bufferLengthMilliseconds <= 0)
-            throw new ArgumentOutOfRangeException(nameof(bufferLengthMilliseconds), bufferLengthMilliseconds, "Audio buffer length must be greater than zero.");
+        if (bufferLengthMilliseconds <= 0) throw new ArgumentOutOfRangeException(nameof(bufferLengthMilliseconds));
         _bufferLengthMilliseconds = bufferLengthMilliseconds;
     }
 
@@ -40,146 +39,96 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     {
         ValidateFormat(format);
         Stop();
-
-        var waveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
-        _buffer = new BufferedWaveProvider(waveFormat)
+        var capacityFrames = AudioPrebufferPolicy.CalculateCapacityFrames(format.SampleRate, _bufferLengthMilliseconds);
+        var ringBuffer = new PcmFrameRingBuffer(format.Channels, capacityFrames);
+        var provider = new EmulationPcmWaveProvider(ringBuffer, format, capacityFrames);
+        var output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
+        output.Init(provider);
+        lock (_gate)
         {
-            BufferDuration = TimeSpan.FromMilliseconds(_bufferLengthMilliseconds),
-            DiscardOnBufferOverflow = true
-        };
-        _output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
-        _output.Init(_buffer);
-        _format = format;
-        _prebuffer = new AudioPrebufferPolicy(format, _bufferLengthMilliseconds);
-        ResetDiagnostics();
-        // Play is deliberately deferred until enough PCM (including digital silence) is queued.
+            _format = format;
+            _ringBuffer = ringBuffer;
+            _provider = provider;
+            _output = output;
+            _prebuffer = new AudioPrebufferPolicy(format, capacityFrames);
+            _overflowWarned = false;
+            ResetCounters();
+        }
+        Debug.WriteLine($"NAudio emulation ring: format={format.SampleRate}Hz/{format.Channels}ch/{format.BitsPerSample}bit capacityFrames={capacityFrames} thresholdFrames={_prebuffer.ThresholdFrames}.");
     }
 
     public void PushPcm(ReadOnlySpan<byte> pcmBytes)
     {
-        if (pcmBytes.IsEmpty || _buffer is null)
-            return;
-
+        if (pcmBytes.IsEmpty) return;
         var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
-        var before = _buffer.BufferedBytes;
-        var capacity = _buffer.BufferLength;
-        var push = Interlocked.Increment(ref _pushCount);
-        ObserveMinimum(before);
-
-        if (_playbackStarted && before < format.BytesPerMillisecond())
+        var bytesPerFrame = checked(format.Channels * sizeof(short));
+        var frameCount = pcmBytes.Length / bytesPerFrame;
+        if (frameCount == 0) return;
+        var samples = MemoryMarshal.Cast<byte, short>(pcmBytes[..checked(frameCount * bytesPerFrame)]);
+        var written = _ringBuffer?.Write(samples, frameCount) ?? 0;
+        Interlocked.Add(ref _framesOffered, frameCount);
+        Interlocked.Add(ref _framesWritten, written);
+        var rejected = frameCount - written;
+        if (rejected > 0)
         {
-            var starvation = Interlocked.Increment(ref _runtimeStarvationEvents);
-            if (starvation == 1 || IsPowerOfTwo(starvation))
-                WriteDepthDiagnostic("runtime starvation risk", pcmBytes.Length, before, before, capacity);
+            Interlocked.Add(ref _framesRejected, rejected);
+            if (!_overflowWarned)
+            {
+                _overflowWarned = true;
+                Debug.WriteLine($"NAudio emulation ring: first overflow; rejectedFrames={rejected} totalRejectedFrames={FramesRejected}.");
+            }
         }
-
-        if (ShouldDropIncomingBlock(before, capacity, pcmBytes.Length))
-        {
-            var droppedBlocks = Interlocked.Increment(ref _droppedBlocks);
-            Interlocked.Add(ref _droppedBytes, pcmBytes.Length);
-            if (droppedBlocks == 1 || IsPowerOfTwo(droppedBlocks))
-                WriteDepthDiagnostic("dropped incoming block", pcmBytes.Length, before, before, capacity);
-            return;
-        }
-
-        var bytes = pcmBytes.ToArray();
-        _buffer.AddSamples(bytes, 0, bytes.Length);
-        var after = _buffer.BufferedBytes;
-        if (push <= DiagnosticPushLimit)
-            WriteDepthDiagnostic("push", bytes.Length, before, after, capacity);
-
-        if (!_playbackStarted && _prebuffer!.ObserveQueuedBytes(after))
-        {
-            _output!.Play();
-            _playbackStarted = true;
-            Debug.WriteLine($"NAudio emulation buffer: startup prebuffer complete; thresholdBytes={_prebuffer.ThresholdBytes}, bufferedBytes={after}.");
-        }
+        var prebuffer = _prebuffer;
+        if (prebuffer is not null && !prebuffer.PlaybackStarted && prebuffer.ObserveQueuedFrames(_ringBuffer!.ReadableFrames))
+            _output?.Play();
     }
 
     public void Clear()
     {
-        if (_output is not null && _playbackStarted)
-            _output.Stop();
-        _buffer?.ClearBuffer();
-        _playbackStarted = false;
+        _output?.Stop();
+        _ringBuffer?.Clear();
         _prebuffer?.Reset();
-        _minimumBufferedBytes = int.MaxValue;
     }
 
     public void Stop()
     {
-        if (_format is not null)
-            Debug.WriteLine($"NAudio emulation buffer: stop summary; pushes={_pushCount}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, starvationRiskEvents={RuntimeStarvationEvents}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
         _output?.Stop();
         _output?.Dispose();
         _output = null;
-        _buffer = null;
+        _ringBuffer?.Clear();
+        _ringBuffer = null;
+        _provider = null;
         _format = null;
         _prebuffer = null;
-        _playbackStarted = false;
+        Debug.WriteLine($"NAudio emulation ring: stop summary; offered={FramesOffered}, written={FramesWritten}, rejected={FramesRejected}, delivered={FramesDelivered}, silence={SilenceFrames}, underruns={UnderrunEpisodes}.");
     }
 
     public void Dispose() => Stop();
-
-    internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes)
-        => incomingBytes > bufferCapacityBytes - bufferedBytes;
-
-    private void ResetDiagnostics()
-    {
-        Interlocked.Exchange(ref _droppedBlocks, 0);
-        Interlocked.Exchange(ref _droppedBytes, 0);
-        Interlocked.Exchange(ref _runtimeStarvationEvents, 0);
-        Interlocked.Exchange(ref _pushCount, 0);
-        _minimumBufferedBytes = int.MaxValue;
-        _playbackStarted = false;
-    }
-
-    private void ObserveMinimum(int bufferedBytes) => _minimumBufferedBytes = Math.Min(_minimumBufferedBytes, bufferedBytes);
-
-    private void WriteDepthDiagnostic(string reason, int incoming, int before, int after, int capacity)
-    {
-        var bytesPerMillisecond = _format!.Value.BytesPerMillisecond();
-        Debug.WriteLine($"NAudio emulation buffer: {reason}; incomingBytes={incoming}, bufferedBefore={before}, bufferedAfter={after}, capacity={capacity}, millisecondsBefore={(double)before / bytesPerMillisecond:F2}, millisecondsAfter={(double)after / bytesPerMillisecond:F2}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
-    }
-
-    private static bool IsPowerOfTwo(long value) => (value & (value - 1)) == 0;
-
-    private static void ValidateFormat(EmulationAudioFormat format)
-    {
-        if (format.SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio sample rate must be greater than zero.");
-        if (format.Channels <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio channel count must be greater than zero.");
-        if (format.BitsPerSample != 16) throw new NotSupportedException($"Only 16-bit PCM audio is supported; native core reported {format.BitsPerSample} bits per sample.");
-    }
+    internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes) => incomingBytes > bufferCapacityBytes - bufferedBytes;
+    private void ResetCounters() { Interlocked.Exchange(ref _framesOffered, 0); Interlocked.Exchange(ref _framesWritten, 0); Interlocked.Exchange(ref _framesRejected, 0); }
+    private static void ValidateFormat(EmulationAudioFormat format) { if (format.SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(format)); if (format.Channels <= 0) throw new ArgumentOutOfRangeException(nameof(format)); if (format.BitsPerSample != 16) throw new NotSupportedException("Only 16-bit PCM audio is supported."); }
 }
 
 internal sealed class AudioPrebufferPolicy
 {
-    internal AudioPrebufferPolicy(EmulationAudioFormat format, int bufferLengthMilliseconds)
-    {
-        ThresholdMilliseconds = CalculateThresholdMilliseconds(bufferLengthMilliseconds);
-        var numerator = checked((long)format.SampleRate * format.Channels * (format.BitsPerSample / 8) * ThresholdMilliseconds);
-        ThresholdBytes = checked((int)((numerator + 999) / 1000));
-    }
-
-    internal int ThresholdMilliseconds { get; }
-    internal int ThresholdBytes { get; }
+    internal AudioPrebufferPolicy(EmulationAudioFormat format, int capacityFrames) => ThresholdFrames = CalculateThresholdFrames(format.SampleRate, capacityFrames);
+    internal int ThresholdFrames { get; }
     internal bool PlaybackStarted { get; private set; }
-
-    internal bool ObserveQueuedBytes(int bufferedBytes)
-    {
-        if (!PlaybackStarted && bufferedBytes >= ThresholdBytes)
-            PlaybackStarted = true;
-        return PlaybackStarted;
-    }
-
+    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) PlaybackStarted = true; return PlaybackStarted; }
     internal void Reset() => PlaybackStarted = false;
-
-    internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) =>
-        Math.Max(1, Math.Min(10, bufferLengthMilliseconds / 2));
+    internal static int CalculateCapacityFrames(int sampleRate, int bufferLengthMilliseconds) => checked((int)(((long)sampleRate * bufferLengthMilliseconds + 999) / 1000));
+    internal static int CalculateThresholdFrames(int sampleRate, int capacityFrames)
+    {
+        if (sampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        if (capacityFrames <= 1) return 1;
+        var seventyFivePercent = checked((capacityFrames * 3 + 3) / 4);
+        var minimumTwentyMs = CalculateCapacityFrames(sampleRate, 20);
+        var threshold = capacityFrames > minimumTwentyMs ? Math.Max(seventyFivePercent, minimumTwentyMs) : seventyFivePercent;
+        return Math.Min(capacityFrames - 1, Math.Max(1, threshold));
+    }
 }
 
 internal static class EmulationAudioFormatExtensions
 {
-    internal static int BytesPerMillisecond(this EmulationAudioFormat format) =>
-        Math.Max(1, checked((format.SampleRate * format.Channels * (format.BitsPerSample / 8)) / 1000));
+    internal static int BytesPerMillisecond(this EmulationAudioFormat format) => Math.Max(1, checked((format.SampleRate * format.Channels * (format.BitsPerSample / 8)) / 1000));
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
+using NAudio.Wave;
 
 namespace OasisEditor;
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmFrameRingBuffer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmFrameRingBuffer.cs
@@ -1,0 +1,81 @@
+namespace OasisEditor;
+
+internal sealed class PcmFrameRingBuffer
+{
+    private readonly object _gate = new();
+    private readonly short[] _samples;
+    private int _readFrame;
+    private int _writeFrame;
+    private int _readableFrames;
+
+    public PcmFrameRingBuffer(int channels, int capacityFrames)
+    {
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels));
+        if (capacityFrames <= 0) throw new ArgumentOutOfRangeException(nameof(capacityFrames));
+        Channels = channels;
+        CapacityFrames = capacityFrames;
+        _samples = new short[checked(channels * capacityFrames)];
+    }
+
+    public int Channels { get; }
+    public int CapacityFrames { get; }
+    public int ReadableFrames { get { lock (_gate) return _readableFrames; } }
+    public int WritableFrames { get { lock (_gate) return CapacityFrames - _readableFrames; } }
+
+    public int Write(ReadOnlySpan<short> interleavedSamples, int frameCount)
+    {
+        if (frameCount < 0) throw new ArgumentOutOfRangeException(nameof(frameCount));
+        var sampleCount = checked(frameCount * Channels);
+        if (interleavedSamples.Length < sampleCount) throw new ArgumentException("Source does not contain the requested complete frames.", nameof(interleavedSamples));
+        lock (_gate)
+        {
+            var framesToWrite = Math.Min(frameCount, CapacityFrames - _readableFrames);
+            CopyIn(interleavedSamples[..checked(framesToWrite * Channels)], _writeFrame);
+            _writeFrame = (_writeFrame + framesToWrite) % CapacityFrames;
+            _readableFrames += framesToWrite;
+            return framesToWrite;
+        }
+    }
+
+    public int Read(Span<short> destination, int frameCount)
+    {
+        if (frameCount < 0) throw new ArgumentOutOfRangeException(nameof(frameCount));
+        var sampleCount = checked(frameCount * Channels);
+        if (destination.Length < sampleCount) throw new ArgumentException("Destination cannot contain the requested complete frames.", nameof(destination));
+        lock (_gate)
+        {
+            var framesToRead = Math.Min(frameCount, _readableFrames);
+            CopyOut(destination[..checked(framesToRead * Channels)], _readFrame);
+            _readFrame = (_readFrame + framesToRead) % CapacityFrames;
+            _readableFrames -= framesToRead;
+            return framesToRead;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            Array.Clear(_samples);
+            _readFrame = 0;
+            _writeFrame = 0;
+            _readableFrames = 0;
+        }
+    }
+
+    private void CopyIn(ReadOnlySpan<short> source, int startFrame)
+    {
+        var firstFrames = Math.Min(source.Length / Channels, CapacityFrames - startFrame);
+        source[..checked(firstFrames * Channels)].CopyTo(_samples.AsSpan(checked(startFrame * Channels)));
+        var remainingSamples = source.Length - checked(firstFrames * Channels);
+        if (remainingSamples > 0) source[^remainingSamples..].CopyTo(_samples);
+    }
+
+    private void CopyOut(Span<short> destination, int startFrame)
+    {
+        var firstFrames = Math.Min(destination.Length / Channels, CapacityFrames - startFrame);
+        _samples.AsSpan(checked(startFrame * Channels), checked(firstFrames * Channels)).CopyTo(destination);
+        var remainingSamples = destination.Length - checked(firstFrames * Channels);
+        if (remainingSamples > 0) _samples.AsSpan(0, remainingSamples).CopyTo(destination[^remainingSamples..]);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -2268,22 +2268,31 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private void OnActiveBackendLampChanged(object? sender, MachineLampChangedEventArgs e)
     {
-        _lampRuntimeAdapter.ApplyLampState(e.LampId, e.Value);
+        RunMachineOutputOnUiThread(() => _lampRuntimeAdapter.ApplyLampState(e.LampId, e.Value));
     }
 
     private void OnActiveBackendReelChanged(object? sender, MachineReelChangedEventArgs e)
     {
-        _reelRuntimeAdapter.ApplyReelState(e.ReelId, e.Position);
+        RunMachineOutputOnUiThread(() => _reelRuntimeAdapter.ApplyReelState(e.ReelId, e.Position));
     }
 
     private void OnActiveBackendSegmentChanged(object? sender, MachineSegmentChangedEventArgs e)
     {
-        _segmentRuntimeAdapter.ApplySegmentState(e.CellId, e.SegmentMask, e.OutputType);
+        RunMachineOutputOnUiThread(() => _segmentRuntimeAdapter.ApplySegmentState(e.CellId, e.SegmentMask, e.OutputType));
     }
 
     private void OnActiveBackendVfdBrightnessChanged(object? sender, MachineVfdBrightnessChangedEventArgs e)
     {
-        _segmentRuntimeAdapter.ApplyVfdBrightness(e.CellId, e.NormalizedBrightness);
+        RunMachineOutputOnUiThread(() => _segmentRuntimeAdapter.ApplyVfdBrightness(e.CellId, e.NormalizedBrightness));
+    }
+
+    private void RunMachineOutputOnUiThread(Action apply)
+    {
+        var dispatcher = _ownerWindow.Dispatcher;
+        if (dispatcher.CheckAccess())
+            apply();
+        else
+            _ = dispatcher.BeginInvoke(apply);
     }
 
     private void OnActiveBackendStateChanged(object? sender, EmulationBackendState state)


### PR DESCRIPTION
### Motivation

- Eliminate live-playback crackle and host-scheduling sensitivity by separating emulation timing, UI delivery, and audio-device timing into a conventional producer/consumer model.
- Ensure the emulator owns all Fabric/Amber native calls while audio is produced, queued, and pulled independently by NAudio.
- Provide a small, testable frame-oriented audio queue and pull provider so the same concept can be reused later by Oasis Player.

### Description

- Add a bounded, frame-oriented ring buffer implemented as `PcmFrameRingBuffer` (`Emulation/PcmFrameRingBuffer.cs`) that preserves interleaved PCM16 ordering, supports partial reads/writes, handles wraparound, and never overwrites unread frames. 
- Add `EmulationPcmWaveProvider` (`Emulation/EmulationPcmWaveProvider.cs`) implementing `NAudio.IWaveProvider` that pulls complete frames from the ring, writes little-endian PCM16 bytes, zero-fills missing frames on underrun, clears trailing non-frame bytes, and reports delivery/underrun counters. 
- Replace the previous `BufferedWaveProvider` push path with a single managed queue in `NAudioEmulationAudioSink` (`Emulation/NAudioEmulationAudioSink.cs`), which now owns the ring/provider, applies a 75% startup prebuffer policy (with sensible 20 ms minimum), starts playback once per start/reset cycle, and tracks compact diagnostics and rejected frames. 
- Move the Fabric emulation pump from a `Task.Run`/`Task.Delay` loop to a named background `Thread` (the emulation runner) in `FabricEmulationBackend` (`Emulation/Fabric/FabricEmulationBackend.cs`) so Fabric session advancement, input processing, snapshot retrieval, and native audio reads are owned by a dedicated runner thread; also harden audio-frame validation so native reads cannot report more frames than requested. 
- Marshal machine visual output events to the WPF dispatcher instead of invoking UI adapters directly from the runner thread by updating `MainWindowViewModel` output handlers to use a small `RunMachineOutputOnUiThread` helper. 
- Add deterministic unit tests for the ring buffer and the wave provider and update prebuffer-policy tests: `OasisEditor.Tests/PcmFrameRingBufferTests.cs`, `OasisEditor.Tests/EmulationPcmWaveProviderTests.cs`, and updates to `OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs`.

### Testing

- Automated tests added: ring-buffer tests (`PcmFrameRingBufferTests`), wave-provider tests (`EmulationPcmWaveProviderTests`), and updated prebuffer-policy tests (`NAudioEmulationAudioSinkTests`). These tests were added to the test project but were not executed in this environment because the agent environment lacks the Windows/.NET/WPF toolchain as noted in `WindowsNetProjects/OasisEditor/AGENTS.md`.
- Repository consistency checks performed: search/inspection confirmed `BufferedWaveProvider` is no longer used for emulator streaming and the new pump thread and audio-provider files are present; local `git` status and diffs were produced as part of the rollout.
- Local verification required (to be run on Windows with the Fabric runtime and audio hardware): run `dotnet test` for the test project, then perform the manual audio/visual validation described in the design (60s baseline playback, repeated alt-tab/focus/window movement stress, and lifecycle tests for pause/resume/reset/stop) to confirm no crackle, no PCM rejection, and independent UI/audio timing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7254d1a46883279f2cec3c3103824d)