### PR TITLE
Stable emulation runtime: coalesced UI delivery, PCM ring buffer, pull-based wave provider, and pump hardening

### DIFF
--- a/WindowsNetProjects/OasisEditor/Docs/emulation-runtime-architecture.md
+++ b/WindowsNetProjects/OasisEditor/Docs/emulation-runtime-architecture.md
@@ -1,0 +1,27 @@
+# Oasis Editor Emulation Runtime Architecture
+
+The Fabric-backed Oasis Editor runtime is paced by one persistent background thread owned by `FabricEmulationBackend`. The thread is named `Oasis Fabric Emulation Runner`, remains alive for the active session, and owns the regular Fabric session calls that advance emulation, process queued inputs, read PCM, and retrieve lower-frequency machine-output snapshots.
+
+## Timing and session ownership
+
+The runner uses a monotonic deadline at a 1 ms emulation cadence. Each executed slice advances the deadline by one slice, so ordinary short host delays become retained timing debt rather than discarded elapsed time. The runner limits immediate catch-up batches and also limits executable slices by the audio ring's writable frame capacity so produced PCM is not overwritten or dropped during recovery.
+
+On Windows, `FabricRunnerTimer` uses a waitable timer when available and falls back to the managed wake event if timer creation is unavailable. MMCSS registration is scoped to the runner thread through `FabricRunnerMmcssRegistration`; registration failure is non-fatal, and the registration is reverted on the same thread as the runner exits. The managed thread priority remains normal.
+
+Lifecycle methods stay asynchronous at the public API boundary. Stop signals cancellation, wakes the runner, joins the runner thread from outside the runner, then stops audio and disposes Fabric resources. Reset and pause/resume reset scheduling baselines so the next active run starts from a fresh deadline.
+
+## Audio pipeline
+
+Fabric audio is read after every executed 1 ms emulation slice. PCM16 samples are written into one bounded `PcmFrameRingBuffer` using frame-based writes with explicit channel count. The producer never blocks on the audio consumer; if a defensive overflow occurs, unread audio is not overwritten and rejected frames are counted.
+
+NAudio pulls from the same ring through `PcmRingWaveProvider`. The provider copies complete PCM frames into the device buffer and fills genuine runtime underruns with silence rather than replaying stale samples or restarting `WasapiOut`. Playback starts once the startup prebuffer threshold is reached. The current low-latency defaults remain a 50 ms PCM reserve, approximately 38 ms startup prebuffer, and 25 ms WASAPI latency.
+
+## Visual output pipeline
+
+The 1 kHz audio/emulation path does not retrieve and publish full machine snapshots every slice. Instead, the runner samples the latest native machine-output snapshot at a lower cadence (`VisualSnapshotCadenceSlices`) and after catch-up batches. Snapshot publication is separate from audio production.
+
+Machine output delivery to WPF is bounded by `CoalescedMachineOutputDispatcher`. Pending lamp, reel, segment, and VFD values are keyed by output identity, repeated writes collapse to the latest value, and at most one UI dispatcher callback is pending. Detach clears pending state and prevents late UI application after backend teardown.
+
+## Runtime logging
+
+Normal startup and stop messages are informational. The startup line reports audio format, ring capacity, prebuffer threshold, output backend, and WASAPI latency. The stop summary is intentionally concise and limited to production health counters: wall/emulated time, ratio, slices, maximum catch-up batch, exceptional discarded time, Fabric audio frames, ring writes/rejections, device PCM frames, silence frames, underrun episodes, minimum ring depth, ring capacity, and the active timing/MMCSS configuration.

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -77,6 +77,8 @@ public sealed class EmulationBackendFactoryTests
         public void Stop() { }
         public void Clear() { }
         public EmulationAudioPlaybackStatistics GetStatistics() => default;
+        public int WritableFrames => int.MaxValue;
+        public int CapacityFrames => int.MaxValue;
         public void Dispose() { }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendFactoryTests.cs
@@ -76,6 +76,7 @@ public sealed class EmulationBackendFactoryTests
         public void PushPcm(ReadOnlySpan<byte> pcmBytes) { }
         public void Stop() { }
         public void Clear() { }
+        public EmulationAudioPlaybackStatistics GetStatistics() => default;
         public void Dispose() { }
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -214,7 +214,7 @@ public sealed class EmulationRuntimeStabilityTests
     public void StopSummary_ContainsEveryRequiredField()
     {
         var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, 1200, 1800, 96, 192, 10000, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, 123, "Normal", 100, 4, 1.04, 1.5, 1, 0, 0, 0, 0, 0, 2, 0.1, 0.2, 0.3, 0.4, 0.05, 0.01, statistics);
+        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, 123, "Normal", 100, 4, 1.04, 1.5, 1, 0, 0, 0, 0, 0, 2, 0.1, 0.2, 0.3, 0.4, 0.05, 0.01, "WaitableTimer", true, true, 100, 2, 1, 3, 0.2, 30005, 0.02, 1, 0, 0, 0, 0, 0, 30005, 0.01, 12, 0.03, 12, 0.04, 2, "trace.csv", statistics);
         foreach (var field in new[]
         {
             "wallMs=", "emulatedMs=", "ratio=", "slices=", "catchUpSlices=", "maxCatchUpBatch=", "discardedMs=",
@@ -222,9 +222,15 @@ public sealed class EmulationRuntimeStabilityTests
             "underrunEpisodes=", "startupRingFrames=", "minimumRingFrames=", "maximumRingFrames=", "currentRingFrames=", "ringCapacityFrames=",
             "writableFramesAtLargestCatchUpBatch=", "capacityLimitedCatchUpBatches=", "retainedDebtIterations=",
             "maxRetainedSlices=", "runnerThreadId=", "runnerThreadPriority=", "singleSliceBatches=", "multiSliceBatches=",
-            "averageBatchSize=", "catchUpSlicePercent=", "maxWakeLatenessMs=", "wakeLateOver2Ms=", "wakeLateOver5Ms=",
+            "averageBatchSize=", "catchUpSlicePercent=", "timingMode=", "highResolutionTimerActive=", "mmcssRegistered=",
+            "timedWaitCount=", "debtContinuationCount=", "capacityContinuationCount=", "yieldContinuationCount=",
+            "averageTimedWakeLatenessMs=", "maxTimedWakeLatenessMs=", "wakeLateOver2Ms=", "wakeLateOver5Ms=",
             "wakeLateOver10Ms=", "wakeLateOver20Ms=", "wakeLateOver50Ms=", "wakeLateOver100Ms=",
-            "longestConsecutiveLateWakes=", "maxAdvanceDurationMs=", "maxReadAudioDurationMs=", "maxSnapshotDurationMs=",
+            "longestConsecutiveLateWakes=", "advanceCalls=", "averageAdvanceDurationMs=", "maxAdvanceDurationMs=",
+            "advanceOver2Ms=", "advanceOver5Ms=", "advanceOver10Ms=", "advanceOver20Ms=", "advanceOver50Ms=", "advanceOver100Ms=",
+            "readAudioCalls=", "averageReadAudioDurationMs=", "maxReadAudioDurationMs=",
+            "snapshotCalls=", "averageSnapshotDurationMs=", "maxSnapshotDurationMs=",
+            "publishCalls=", "averagePublishDurationMs=", "stallTraceCount=", "stallTracePath=",
             "maxPublishDurationMs=", "maxInputDurationMs=", "maxSessionGateWaitMs=",
             "maxFramesGeneratedByOneSlice=", "minimumRequestedFrames=", "maximumRequestedFrames=",
             "totalRequestedFrames=", "playbackStarted="
@@ -238,7 +244,7 @@ public sealed class EmulationRuntimeStabilityTests
     public void RingRejection_IsReportedIndependentlyInStatisticsShape()
     {
         var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, 120, 96, 48, 96, 100, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, 123, "Normal", 1000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, statistics);
+        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, 123, "Normal", 1000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "ManagedWait", false, false, 1, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, string.Empty, statistics);
         Assert.Contains("ringRejected=7", summary);
         Assert.Contains("devicePcmFrames=93", summary);
         Assert.Contains("silenceFrames=0", summary);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -214,14 +214,19 @@ public sealed class EmulationRuntimeStabilityTests
     public void StopSummary_ContainsEveryRequiredField()
     {
         var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, 1200, 1800, 96, 192, 10000, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, statistics);
+        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, 123, "Normal", 100, 4, 1.04, 1.5, 1, 0, 0, 0, 0, 0, 2, 0.1, 0.2, 0.3, 0.4, 0.05, 0.01, statistics);
         foreach (var field in new[]
         {
             "wallMs=", "emulatedMs=", "ratio=", "slices=", "catchUpSlices=", "maxCatchUpBatch=", "discardedMs=",
             "fabricAudioFrames=", "ringWritten=", "ringRejected=", "devicePcmFrames=", "silenceFrames=",
             "underrunEpisodes=", "startupRingFrames=", "minimumRingFrames=", "maximumRingFrames=", "currentRingFrames=", "ringCapacityFrames=",
             "writableFramesAtLargestCatchUpBatch=", "capacityLimitedCatchUpBatches=", "retainedDebtIterations=",
-            "maxRetainedSlices=", "maxFramesGeneratedByOneSlice=", "minimumRequestedFrames=", "maximumRequestedFrames=",
+            "maxRetainedSlices=", "runnerThreadId=", "runnerThreadPriority=", "singleSliceBatches=", "multiSliceBatches=",
+            "averageBatchSize=", "catchUpSlicePercent=", "maxWakeLatenessMs=", "wakeLateOver2Ms=", "wakeLateOver5Ms=",
+            "wakeLateOver10Ms=", "wakeLateOver20Ms=", "wakeLateOver50Ms=", "wakeLateOver100Ms=",
+            "longestConsecutiveLateWakes=", "maxAdvanceDurationMs=", "maxReadAudioDurationMs=", "maxSnapshotDurationMs=",
+            "maxPublishDurationMs=", "maxInputDurationMs=", "maxSessionGateWaitMs=",
+            "maxFramesGeneratedByOneSlice=", "minimumRequestedFrames=", "maximumRequestedFrames=",
             "totalRequestedFrames=", "playbackStarted="
         })
         {
@@ -233,7 +238,7 @@ public sealed class EmulationRuntimeStabilityTests
     public void RingRejection_IsReportedIndependentlyInStatisticsShape()
     {
         var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, 120, 96, 48, 96, 100, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, statistics);
+        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, 123, "Normal", 1000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, statistics);
         Assert.Contains("ringRejected=7", summary);
         Assert.Contains("devicePcmFrames=93", summary);
         Assert.Contains("silenceFrames=0", summary);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -1,0 +1,115 @@
+using System.Runtime.InteropServices;
+using NAudio.Wave;
+using Xunit;
+
+namespace OasisEditor.Tests;
+
+public sealed class EmulationRuntimeStabilityTests
+{
+    [Fact]
+    public void Coalescer_CollapsesRepeatedLampAndSchedulesOneCallback()
+    {
+        var scheduled = new Queue<Action>();
+        MachineOutputBatch? applied = null;
+        var coalescer = new CoalescedMachineOutputDispatcher(a => scheduled.Enqueue(a), b => applied = b);
+        for (var i = 0; i < 1000; i++) coalescer.EnqueueLamp(7, i);
+        Assert.Single(scheduled);
+        Assert.True(coalescer.DispatchPending);
+        Assert.Equal(1, coalescer.PendingEntryCount);
+        scheduled.Dequeue()();
+        Assert.NotNull(applied);
+        Assert.Equal(new LampValue(7, 999), applied!.Lamps.Single());
+    }
+
+    [Fact]
+    public void Coalescer_BatchesTypesAndReschedulesOnceForConcurrentArrivals()
+    {
+        var scheduled = new Queue<Action>();
+        var batches = new List<MachineOutputBatch>();
+        CoalescedMachineOutputDispatcher? coalescer = null;
+        coalescer = new(a => scheduled.Enqueue(a), b => { batches.Add(b); coalescer!.EnqueueLamp(1, 2); });
+        coalescer.EnqueueLamp(1, 1);
+        coalescer.EnqueueReel(2, 3);
+        coalescer.EnqueueSegment(4, 5, SegmentOutputType.Digit);
+        coalescer.EnqueueVfdBrightness(6, .7);
+        Assert.Single(scheduled);
+        scheduled.Dequeue()();
+        Assert.Single(scheduled);
+        Assert.Equal(4, batches[0].Lamps.Length + batches[0].Reels.Length + batches[0].Segments.Length + batches[0].VfdBrightness.Length);
+    }
+
+    [Fact]
+    public void RingBuffer_PreservesStereoOrderingAcrossWrapAndPartialOperations()
+    {
+        var ring = new PcmFrameRingBuffer(2, 3);
+        Assert.Equal(2, ring.Write(new short[] { 1, 10, 2, 20 }, 2));
+        var read = new short[2];
+        Assert.Equal(1, ring.Read(read, 1));
+        Assert.Equal(new short[] { 1, 10 }, read);
+        Assert.Equal(2, ring.Write(new short[] { 3, 30, 4, 40, 5, 50 }, 3));
+        var all = new short[6];
+        Assert.Equal(3, ring.Read(all, 3));
+        Assert.Equal(new short[] { 2, 20, 3, 30, 4, 40 }, all);
+    }
+
+    [Fact]
+    public void RingBuffer_DoesNotOverwriteAndClearResetsDepth()
+    {
+        var ring = new PcmFrameRingBuffer(1, 2);
+        Assert.Equal(2, ring.Write(new short[] { 1, 2, 3 }, 3));
+        Assert.Equal(0, ring.WritableFrames);
+        ring.Clear();
+        Assert.Equal(0, ring.ReadableFrames);
+        Assert.Equal(2, ring.WritableFrames);
+    }
+
+    [Fact]
+    public async Task RingBuffer_ConcurrentProducerConsumerStressIsSafe()
+    {
+        var ring = new PcmFrameRingBuffer(1, 64);
+        var produced = 0;
+        var consumed = 0;
+        var producer = Task.Run(() => { var sample = new short[1]; for (var i = 0; i < 20000; i++) { sample[0] = (short)i; if (ring.Write(sample, 1) == 1) Interlocked.Increment(ref produced); } });
+        var consumer = Task.Run(() => { var sample = new short[1]; while (!producer.IsCompleted || ring.ReadableFrames > 0) if (ring.Read(sample, 1) == 1) Interlocked.Increment(ref consumed); });
+        await Task.WhenAll(producer, consumer);
+        Assert.Equal(produced, consumed);
+    }
+
+    [Fact]
+    public void WaveProvider_BulkCopiesPcmAndFillsPartialSilence()
+    {
+        var ring = new PcmFrameRingBuffer(2, 8);
+        ring.Write(new short[] { 1, 2, 3, 4 }, 2);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 2));
+        var bytes = new byte[12];
+        Assert.Equal(12, provider.Read(bytes, 0, bytes.Length));
+        var samples = MemoryMarshal.Cast<byte, short>(bytes).ToArray();
+        Assert.Equal(new short[] { 1, 2, 3, 4, 0, 0 }, samples);
+        Assert.Equal(1, provider.UnderrunEpisodes);
+    }
+
+    [Fact]
+    public void WaveProvider_UnderrunEpisodesAreDistinctAndRecover()
+    {
+        var ring = new PcmFrameRingBuffer(1, 8);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
+        var bytes = new byte[4];
+        provider.Read(bytes, 0, bytes.Length);
+        provider.Read(bytes, 0, bytes.Length);
+        ring.Write(new short[] { 9, 10 }, 2);
+        provider.Read(bytes, 0, bytes.Length);
+        provider.Read(bytes, 0, bytes.Length);
+        Assert.Equal(2, provider.UnderrunEpisodes);
+    }
+
+    [Fact]
+    public void PrebufferPolicy_UsesSeventyFivePercentCapacity()
+    {
+        var format = new EmulationAudioFormat(48000, 2, 16);
+        Assert.Equal(2400, AudioPrebufferPolicy.CalculateCapacityFrames(format, 50));
+        Assert.Equal(38, AudioPrebufferPolicy.CalculateThresholdMilliseconds(50));
+        var policy = new AudioPrebufferPolicy(format, 50);
+        Assert.False(policy.ObserveQueuedFrames(1823));
+        Assert.True(policy.ObserveQueuedFrames(1824));
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -112,4 +112,66 @@ public sealed class EmulationRuntimeStabilityTests
         Assert.False(policy.ObserveQueuedFrames(1823));
         Assert.True(policy.ObserveQueuedFrames(1824));
     }
+
+    [Fact]
+    public void WaveProvider_StatisticsSeparatePcmAndSilenceFrames()
+    {
+        var ring = new PcmFrameRingBuffer(1, 8);
+        ring.Write(new short[] { 1, 2 }, 2);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
+        provider.Read(new byte[8], 0, 8);
+        Assert.Equal(2, provider.FramesDelivered);
+        Assert.Equal(2, provider.SilenceFrames);
+        Assert.Equal(1, provider.UnderrunEpisodes);
+    }
+
+    [Fact]
+    public void WaveProvider_NoUnderrunReportsZeroSilenceAndZeroEpisodes()
+    {
+        var ring = new PcmFrameRingBuffer(1, 8);
+        ring.Write(new short[] { 1, 2, 3, 4 }, 4);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
+        provider.Read(new byte[8], 0, 8);
+        Assert.Equal(4, provider.FramesDelivered);
+        Assert.Equal(0, provider.SilenceFrames);
+        Assert.Equal(0, provider.UnderrunEpisodes);
+    }
+
+    [Fact]
+    public void WaveProvider_MinimumDepthIsMeasuredWhenDeviceReadsAfterPlaybackStarts()
+    {
+        var ring = new PcmFrameRingBuffer(1, 8);
+        ring.Write(new short[] { 1, 2, 3, 4 }, 4);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
+        provider.Read(new byte[4], 0, 4);
+        provider.Read(new byte[4], 0, 4);
+        Assert.Equal(2, provider.MinimumRingFrames);
+    }
+
+    [Fact]
+    public void StopSummary_ContainsEveryRequiredField()
+    {
+        var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, statistics);
+        foreach (var field in new[]
+        {
+            "wallMs=", "emulatedMs=", "ratio=", "slices=", "catchUpSlices=", "maxCatchUpBatch=", "discardedMs=",
+            "fabricAudioFrames=", "ringWritten=", "ringRejected=", "devicePcmFrames=", "silenceFrames=",
+            "underrunEpisodes=", "minimumRingFrames=", "currentRingFrames=", "ringCapacityFrames=", "playbackStarted="
+        })
+        {
+            Assert.Contains(field, summary);
+        }
+    }
+
+    [Fact]
+    public void RingRejection_IsReportedIndependentlyInStatisticsShape()
+    {
+        var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, statistics);
+        Assert.Contains("ringRejected=7", summary);
+        Assert.Contains("devicePcmFrames=93", summary);
+        Assert.Contains("silenceFrames=0", summary);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -197,54 +197,87 @@ public sealed class EmulationRuntimeStabilityTests
         Assert.Equal(1, provider.UnderrunEpisodes);
     }
 
+
     [Fact]
-    public void WaveProvider_TracksActualDeviceRequestSizes()
+    public void LowLatencyRing_CapacityAwareCatchUpAfterProducerDelayRejectsNoPcmAndAvoidsSilence()
     {
-        var ring = new PcmFrameRingBuffer(1, 16);
-        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
-        provider.Read(new byte[4], 0, 4);
-        provider.Read(new byte[10], 0, 10);
-        Assert.Equal(2, provider.MinimumRequestedFrames);
-        Assert.Equal(5, provider.MaximumRequestedFrames);
-        Assert.Equal(7, provider.TotalRequestedFrames);
+        var format = new EmulationAudioFormat(48000, 2, 16);
+        var ring = new PcmFrameRingBuffer(format.Channels, AudioPrebufferPolicy.CalculateCapacityFrames(format, 50));
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels));
+        var initialReserveFrames = new AudioPrebufferPolicy(format, 50).ThresholdFrames;
+        var samplesPerFrame = format.Channels;
+        var reserve = new short[initialReserveFrames * samplesPerFrame];
+        Assert.Equal(initialReserveFrames, ring.Write(reserve, initialReserveFrames));
+
+        var requestedDuringDelayFrames = 30 * FabricEmulationBackend.CalculateSafeFramesPerSlice(format.SampleRate);
+        Assert.Equal(requestedDuringDelayFrames * format.Channels * sizeof(short),
+            provider.Read(new byte[requestedDuringDelayFrames * format.Channels * sizeof(short)], 0, requestedDuringDelayFrames * format.Channels * sizeof(short)));
+
+        var dueSlices = 64;
+        var executableSlices = Math.Min(dueSlices, FabricEmulationBackend.CalculateAudioCapacityLimitedSlices(format.SampleRate, ring.WritableFrames));
+        var framesPerSlice = FabricEmulationBackend.CalculateSafeFramesPerSlice(format.SampleRate);
+        var catchUpFrames = executableSlices * framesPerSlice;
+        Assert.Equal(catchUpFrames, ring.Write(new short[catchUpFrames * samplesPerFrame], catchUpFrames));
+
+        Assert.True(executableSlices < dueSlices);
+        Assert.Equal(0, provider.SilenceFrames);
+        Assert.Equal(0, provider.UnderrunEpisodes);
+        Assert.True(ring.ReadableFrames > 0);
+    }
+
+    [Fact]
+    public void Coalescer_LongRunningOutputGenerationKeepsPendingStateBoundedAndStopsCleanly()
+    {
+        var scheduled = new Queue<Action>();
+        var batches = 0;
+        var coalescer = new CoalescedMachineOutputDispatcher(a => scheduled.Enqueue(a), _ => batches++);
+        for (var i = 0; i < 100_000; i++)
+        {
+            coalescer.EnqueueLamp(i % 32, i);
+            coalescer.EnqueueReel(i % 8, i);
+            coalescer.EnqueueSegment(i % 16, i, SegmentOutputType.Digit);
+            coalescer.EnqueueVfdBrightness(i % 16, i / 100_000d);
+        }
+
+        Assert.Single(scheduled);
+        Assert.Equal(72, coalescer.PendingEntryCount);
+        scheduled.Dequeue()();
+        coalescer.Detach();
+        coalescer.EnqueueLamp(1, 1);
+
+        Assert.Empty(scheduled);
+        Assert.Equal(1, batches);
+        Assert.False(coalescer.DispatchPending);
     }
 
 
     [Fact]
-    public void StopSummary_ContainsEveryRequiredField()
+    public void StopSummary_ContainsProductionRuntimeFields()
     {
-        var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, 1200, 1800, 96, 192, 10000, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, 123, "Normal", 100, 4, 1.04, 1.5, 1, 0, 0, 0, 0, 0, 2, 0.1, 0.2, 0.3, 0.4, 0.05, 0.01, "WaitableTimer", true, true, 100, 2, 1, 3, 0.2, 30005, 0.02, 1, 0, 0, 0, 0, 0, 30005, 0.01, 12, 0.03, 12, 0.04, 2, "trace.csv", statistics);
+        var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, 25, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 6, 0, 1440240, "WaitableTimer", true, true, statistics);
         foreach (var field in new[]
         {
-            "wallMs=", "emulatedMs=", "ratio=", "slices=", "catchUpSlices=", "maxCatchUpBatch=", "discardedMs=",
+            "wallMs=", "emulatedMs=", "ratio=", "slices=", "maximumCatchUpBatch=", "discardedMs=",
             "fabricAudioFrames=", "ringWritten=", "ringRejected=", "devicePcmFrames=", "silenceFrames=",
-            "underrunEpisodes=", "startupRingFrames=", "minimumRingFrames=", "maximumRingFrames=", "currentRingFrames=", "ringCapacityFrames=",
-            "writableFramesAtLargestCatchUpBatch=", "capacityLimitedCatchUpBatches=", "retainedDebtIterations=",
-            "maxRetainedSlices=", "runnerThreadId=", "runnerThreadPriority=", "singleSliceBatches=", "multiSliceBatches=",
-            "averageBatchSize=", "catchUpSlicePercent=", "timingMode=", "highResolutionTimerActive=", "mmcssRegistered=",
-            "timedWaitCount=", "debtContinuationCount=", "capacityContinuationCount=", "yieldContinuationCount=",
-            "averageTimedWakeLatenessMs=", "maxTimedWakeLatenessMs=", "wakeLateOver2Ms=", "wakeLateOver5Ms=",
-            "wakeLateOver10Ms=", "wakeLateOver20Ms=", "wakeLateOver50Ms=", "wakeLateOver100Ms=",
-            "longestConsecutiveLateWakes=", "advanceCalls=", "averageAdvanceDurationMs=", "maxAdvanceDurationMs=",
-            "advanceOver2Ms=", "advanceOver5Ms=", "advanceOver10Ms=", "advanceOver20Ms=", "advanceOver50Ms=", "advanceOver100Ms=",
-            "readAudioCalls=", "averageReadAudioDurationMs=", "maxReadAudioDurationMs=",
-            "snapshotCalls=", "averageSnapshotDurationMs=", "maxSnapshotDurationMs=",
-            "publishCalls=", "averagePublishDurationMs=", "stallTraceCount=", "stallTracePath=",
-            "maxPublishDurationMs=", "maxInputDurationMs=", "maxSessionGateWaitMs=",
-            "maxFramesGeneratedByOneSlice=", "minimumRequestedFrames=", "maximumRequestedFrames=",
-            "totalRequestedFrames=", "playbackStarted="
+            "underrunEpisodes=", "minimumRingFrames=", "ringCapacityFrames=",
+            "timingMode=", "highResolutionTimerActive=", "mmcssRegistered="
         })
         {
             Assert.Contains(field, summary);
         }
+
+        Assert.DoesNotContain("stallTrace", summary);
+        Assert.DoesNotContain("wakeLateOver", summary);
+        Assert.DoesNotContain("catchUpSlicePercent", summary);
     }
+
 
     [Fact]
     public void RingRejection_IsReportedIndependentlyInStatisticsShape()
     {
-        var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, 120, 96, 48, 96, 100, 25, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, 123, "Normal", 1000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, "ManagedWait", false, false, 1, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 0, 0, 0, string.Empty, statistics);
+        var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, 25, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 1, 0, 100, "ManagedWait", false, false, statistics);
         Assert.Contains("ringRejected=7", summary);
         Assert.Contains("devicePcmFrames=93", summary);
         Assert.Contains("silenceFrames=0", summary);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs
@@ -106,6 +106,8 @@ public sealed class EmulationRuntimeStabilityTests
     public void PrebufferPolicy_UsesSeventyFivePercentCapacity()
     {
         var format = new EmulationAudioFormat(48000, 2, 16);
+        Assert.Equal(4800, AudioPrebufferPolicy.CalculateCapacityFrames(format, 100));
+        Assert.Equal(75, AudioPrebufferPolicy.CalculateThresholdMilliseconds(100));
         Assert.Equal(2400, AudioPrebufferPolicy.CalculateCapacityFrames(format, 50));
         Assert.Equal(38, AudioPrebufferPolicy.CalculateThresholdMilliseconds(50));
         var policy = new AudioPrebufferPolicy(format, 50);
@@ -148,16 +150,79 @@ public sealed class EmulationRuntimeStabilityTests
         Assert.Equal(2, provider.MinimumRingFrames);
     }
 
+
+
+    [Fact]
+    public void CapacityAwareSliceLimit_RunsOnlySlicesThatFitAndRetainsDebtByCalculation()
+    {
+        var available = FabricEmulationBackend.CalculateAvailableSlices(now: 39, nextDeadline: 0, pumpTicks: 1);
+        var executable = Math.Min(available, FabricEmulationBackend.CalculateAudioCapacityLimitedSlices(48000, 480));
+        Assert.Equal(40, available);
+        Assert.Equal(10, executable);
+        Assert.Equal(30, available - executable);
+    }
+
+    [Fact]
+    public void CapacityAwareSliceLimit_ZeroWritableFramesExecutesNoAudioSlices()
+    {
+        Assert.Equal(0, FabricEmulationBackend.CalculateAudioCapacityLimitedSlices(48000, 0));
+    }
+
+
+    [Theory]
+    [InlineData(48000, 48)]
+    [InlineData(44100, 45)]
+    [InlineData(32000, 32)]
+    public void FrameCapacity_UsesCeilingSafeFramesPerOneMillisecondSlice(int sampleRate, int expectedFrames)
+    {
+        Assert.Equal(expectedFrames, FabricEmulationBackend.CalculateSafeFramesPerSlice(sampleRate));
+    }
+
+    [Fact]
+    public void WaveProvider_UnderrunCountersExcludeInactivePlaybackReads()
+    {
+        var active = false;
+        var ring = new PcmFrameRingBuffer(1, 8);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1), () => active);
+        provider.Read(new byte[8], 0, 8);
+        Assert.Equal(0, provider.SilenceFrames);
+        Assert.Equal(0, provider.UnderrunEpisodes);
+        active = true;
+        provider.Read(new byte[8], 0, 8);
+        Assert.Equal(4, provider.SilenceFrames);
+        Assert.Equal(1, provider.UnderrunEpisodes);
+        active = false;
+        provider.Read(new byte[8], 0, 8);
+        Assert.Equal(4, provider.SilenceFrames);
+        Assert.Equal(1, provider.UnderrunEpisodes);
+    }
+
+    [Fact]
+    public void WaveProvider_TracksActualDeviceRequestSizes()
+    {
+        var ring = new PcmFrameRingBuffer(1, 16);
+        var provider = new PcmRingWaveProvider(ring, new WaveFormat(48000, 16, 1));
+        provider.Read(new byte[4], 0, 4);
+        provider.Read(new byte[10], 0, 10);
+        Assert.Equal(2, provider.MinimumRequestedFrames);
+        Assert.Equal(5, provider.MaximumRequestedFrames);
+        Assert.Equal(7, provider.TotalRequestedFrames);
+    }
+
+
     [Fact]
     public void StopSummary_ContainsEveryRequiredField()
     {
-        var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, statistics);
+        var statistics = new EmulationAudioPlaybackStatistics(10, 2, 8, 3, 1, 0, 4, 2400, 1800, 38, 1200, 1800, 96, 192, 10000, 25, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(30012.4, 30005, 0.99975, 30005, 42, 6, 0, 1440240, 0, 48, 48, 2, 2, 30, 1440, statistics);
         foreach (var field in new[]
         {
             "wallMs=", "emulatedMs=", "ratio=", "slices=", "catchUpSlices=", "maxCatchUpBatch=", "discardedMs=",
             "fabricAudioFrames=", "ringWritten=", "ringRejected=", "devicePcmFrames=", "silenceFrames=",
-            "underrunEpisodes=", "minimumRingFrames=", "currentRingFrames=", "ringCapacityFrames=", "playbackStarted="
+            "underrunEpisodes=", "startupRingFrames=", "minimumRingFrames=", "maximumRingFrames=", "currentRingFrames=", "ringCapacityFrames=",
+            "writableFramesAtLargestCatchUpBatch=", "capacityLimitedCatchUpBatches=", "retainedDebtIterations=",
+            "maxRetainedSlices=", "maxFramesGeneratedByOneSlice=", "minimumRequestedFrames=", "maximumRequestedFrames=",
+            "totalRequestedFrames=", "playbackStarted="
         })
         {
             Assert.Contains(field, summary);
@@ -167,8 +232,8 @@ public sealed class EmulationRuntimeStabilityTests
     [Fact]
     public void RingRejection_IsReportedIndependentlyInStatisticsShape()
     {
-        var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, true);
-        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, statistics);
+        var statistics = new EmulationAudioPlaybackStatistics(100, 7, 93, 0, 0, 12, 64, 128, 96, 38, 120, 96, 48, 96, 100, 25, true);
+        var summary = FabricEmulationBackend.FormatStopSummary(1000, 1000, 1, 1000, 0, 1, 0, 100, 0, 48, 48, 0, 0, 0, 128, statistics);
         Assert.Contains("ringRejected=7", summary);
         Assert.Contains("devicePcmFrames=93", summary);
         Assert.Contains("silenceFrames=0", summary);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -396,8 +396,49 @@ public sealed class FabricManagedBehaviorTests
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Null(backend.LastFailure);
-        Assert.Empty(errors);
+        Assert.Equal(2, errors.Count);
+        Assert.StartsWith("Fabric audio startup:", errors[0]);
+        Assert.StartsWith("Fabric stop summary:", errors[1]);
         Assert.Equal(EmulationBackendState.Stopped, backend.State);
+    }
+
+
+    [Fact]
+    public async Task Backend_StopEmitsExactlyOneCombinedSummaryAndNoCallbackSummaries()
+    {
+        var session = new FakeSession { FramesToWrite = 48 };
+        var messages = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
+            new FakeAudioSink { Statistics = new(100, 3, 90, 10, 1, 0, 120, 2400, 1800, 38, true) }, new FakeClock(), messages.Add);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.FirstAudioRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(1, messages.Count(message => message.StartsWith("Fabric audio startup:")));
+        var summary = Assert.Single(messages.Where(message => message.StartsWith("Fabric stop summary:")));
+        Assert.Contains("fabricAudioFrames=", summary);
+        Assert.Contains("ringRejected=3", summary);
+        Assert.Contains("devicePcmFrames=90", summary);
+        Assert.Contains("silenceFrames=10", summary);
+        Assert.Contains("underrunEpisodes=1", summary);
+    }
+
+    [Fact]
+    public async Task Backend_StopWithoutAudioCapabilityStillEmitsSafeSummary()
+    {
+        var session = new FakeSession { Capabilities = new((ulong)FabricCapability.DigitalInput) };
+        var messages = new List<string>();
+        var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
+            new FakeAudioSink(), new FakeClock(), messages.Add);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await backend.StopAsync(CancellationToken.None);
+
+        var summary = Assert.Single(messages.Where(message => message.StartsWith("Fabric stop summary:")));
+        Assert.Contains("ringCapacityFrames=0", summary);
+        Assert.DoesNotContain(messages, message => message.StartsWith("Fabric audio startup:"));
     }
 
     [Theory]
@@ -517,7 +558,7 @@ public sealed class FabricManagedBehaviorTests
         public int DisposeCount { get; private set; }
         public int FramesToWrite { get; init; }
         public List<ulong> Advances { get; } = [];
-        public FabricCapabilities Capabilities => new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
+        public FabricCapabilities Capabilities { get; init; } = new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
         public void Initialise() => Invoke(() => { });
         public void Reset() => Invoke(() => ResetCount++);
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
@@ -561,10 +602,12 @@ public sealed class FabricManagedBehaviorTests
         public int StopCount { get; private set; }
         public EmulationAudioFormat? StartedFormat { get; private set; }
         public int LastPcmBytes { get; private set; }
+        public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, true);
         public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
         public void PushPcm(ReadOnlySpan<byte> pcmBytes) => LastPcmBytes = pcmBytes.Length;
         public void Stop() => StopCount++;
         public void Clear() { }
+        public EmulationAudioPlaybackStatistics GetStatistics() => Statistics;
         public void Dispose() { }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -396,9 +396,7 @@ public sealed class FabricManagedBehaviorTests
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Null(backend.LastFailure);
-        Assert.Equal(2, errors.Count);
-        Assert.StartsWith("Fabric audio startup:", errors[0]);
-        Assert.StartsWith("Fabric stop summary:", errors[1]);
+        Assert.Empty(errors);
         Assert.Equal(EmulationBackendState.Stopped, backend.State);
     }
 
@@ -409,7 +407,7 @@ public sealed class FabricManagedBehaviorTests
         var session = new FakeSession { FramesToWrite = 48 };
         var messages = new List<string>();
         var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
-            new FakeAudioSink { Statistics = new(100, 3, 90, 10, 1, 0, 120, 2400, 1800, 38, true) }, new FakeClock(), messages.Add);
+            new FakeAudioSink { Statistics = new(100, 3, 90, 10, 1, 0, 120, 2400, 1800, 38, 2000, 1800, 48, 192, 100, 25, true) }, new FakeClock(), null, messages.Add);
 
         await backend.StartAsync(CreateRequest(), CancellationToken.None);
         await session.FirstAudioRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -430,7 +428,7 @@ public sealed class FabricManagedBehaviorTests
         var session = new FakeSession { Capabilities = new((ulong)FabricCapability.DigitalInput) };
         var messages = new List<string>();
         var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
-            new FakeAudioSink(), new FakeClock(), messages.Add);
+            new FakeAudioSink(), new FakeClock(), null, messages.Add);
 
         await backend.StartAsync(CreateRequest(), CancellationToken.None);
         await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -602,12 +600,14 @@ public sealed class FabricManagedBehaviorTests
         public int StopCount { get; private set; }
         public EmulationAudioFormat? StartedFormat { get; private set; }
         public int LastPcmBytes { get; private set; }
-        public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, true);
+        public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, 2000, 1800, 48, 192, 100, 25, true);
         public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
         public void PushPcm(ReadOnlySpan<byte> pcmBytes) => LastPcmBytes = pcmBytes.Length;
         public void Stop() => StopCount++;
         public void Clear() { }
         public EmulationAudioPlaybackStatistics GetStatistics() => Statistics;
+        public int WritableFrames { get; init; } = int.MaxValue;
+        public int CapacityFrames { get; init; } = int.MaxValue;
         public void Dispose() { }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -407,7 +407,7 @@ public sealed class FabricManagedBehaviorTests
         var session = new FakeSession { FramesToWrite = 48 };
         var messages = new List<string>();
         var backend = new FabricEmulationBackend("runtime", "amber", _ => new FakeRuntime(session),
-            new FakeAudioSink { Statistics = new(100, 3, 90, 10, 1, 0, 120, 2400, 1800, 38, 2000, 1800, 48, 192, 100, 25, true) }, new FakeClock(), null, messages.Add);
+            new FakeAudioSink { Statistics = new(100, 3, 90, 10, 1, 0, 120, 2400, 1800, 38, 25, true) }, new FakeClock(), null, messages.Add);
 
         await backend.StartAsync(CreateRequest(), CancellationToken.None);
         await session.FirstAudioRead.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -600,7 +600,7 @@ public sealed class FabricManagedBehaviorTests
         public int StopCount { get; private set; }
         public EmulationAudioFormat? StartedFormat { get; private set; }
         public int LastPcmBytes { get; private set; }
-        public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, 2000, 1800, 48, 192, 100, 25, true);
+        public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, 25, true);
         public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
         public void PushPcm(ReadOnlySpan<byte> pcmBytes) => LastPcmBytes = pcmBytes.Length;
         public void Stop() => StopCount++;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -19,31 +19,12 @@ public sealed class NAudioEmulationAudioSinkTests
     {
         var policy = new AudioPrebufferPolicy(new(48000, 2, 16), 50);
 
-        Assert.Equal(7296, policy.ThresholdBytes);
-        Assert.False(policy.ObserveQueuedBytes(7292));
-        Assert.True(policy.ObserveQueuedBytes(7296));
+        Assert.Equal(1824, policy.ThresholdFrames);
+        Assert.False(policy.ObserveQueuedFrames(1823));
+        Assert.True(policy.ObserveQueuedFrames(1824));
         policy.Reset();
         Assert.False(policy.PlaybackStarted);
-        Assert.False(policy.ObserveQueuedBytes(192));
-    }
-
-    [Theory]
-    [InlineData(48000, 2, 192)]
-    [InlineData(48000, 1, 96)]
-    [InlineData(44100, 2, 176)]
-    public void BufferDepthByteRate_AccountsForChannelsExactlyOnce(int rate, int channels, int expected)
-    {
-        Assert.Equal(expected, new EmulationAudioFormat(rate, channels, 16).BytesPerMillisecond());
-    }
-    [Theory]
-    [InlineData(800, 1000, 192, false)]
-    [InlineData(900, 1000, 192, true)]
-    [InlineData(1000, 1000, 1, true)]
-    public void IncomingBlockIsDroppedRatherThanRequiringBufferedAudioToBeCleared(
-        int bufferedBytes, int capacityBytes, int incomingBytes, bool expectedDrop)
-    {
-        Assert.Equal(expectedDrop,
-            NAudioEmulationAudioSink.ShouldDropIncomingBlock(bufferedBytes, capacityBytes, incomingBytes));
+        Assert.False(policy.ObserveQueuedFrames(48));
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -45,4 +45,13 @@ public sealed class NAudioEmulationAudioSinkTests
         Assert.Equal(expectedDrop,
             NAudioEmulationAudioSink.ShouldDropIncomingBlock(bufferedBytes, capacityBytes, incomingBytes));
     }
+
+    [Fact]
+    public void WasapiLatency_IsIndependentFromRingReserveCapacity()
+    {
+        using var sink = new NAudioEmulationAudioSink(bufferLengthMilliseconds: 100, wasapiLatencyMilliseconds: 25);
+
+        Assert.Equal(100, sink.BufferLengthMilliseconds);
+        Assert.Equal(25, sink.WasapiLatencyMilliseconds);
+    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/NAudioEmulationAudioSinkTests.cs
@@ -5,11 +5,11 @@ namespace OasisEditor.Tests;
 public sealed class NAudioEmulationAudioSinkTests
 {
     [Theory]
-    [InlineData(50, 10)]
-    [InlineData(100, 10)]
-    [InlineData(10, 5)]
+    [InlineData(50, 38)]
+    [InlineData(100, 75)]
+    [InlineData(10, 8)]
     [InlineData(1, 1)]
-    public void PrebufferThreshold_IsBoundedByTenMillisecondsAndHalfTheBuffer(int buffer, int expected)
+    public void PrebufferThreshold_IsSeventyFivePercentOfBuffer(int buffer, int expected)
     {
         Assert.Equal(expected, AudioPrebufferPolicy.CalculateThresholdMilliseconds(buffer));
     }
@@ -19,9 +19,9 @@ public sealed class NAudioEmulationAudioSinkTests
     {
         var policy = new AudioPrebufferPolicy(new(48000, 2, 16), 50);
 
-        Assert.Equal(1920, policy.ThresholdBytes);
-        Assert.False(policy.ObserveQueuedBytes(1919));
-        Assert.True(policy.ObserveQueuedBytes(1920));
+        Assert.Equal(7296, policy.ThresholdBytes);
+        Assert.False(policy.ObserveQueuedBytes(7292));
+        Assert.True(policy.ObserveQueuedBytes(7296));
         policy.Reset();
         Assert.False(policy.PlaybackStarted);
         Assert.False(policy.ObserveQueuedBytes(192));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -23,7 +23,7 @@ public sealed class OasisPlayerPreferences
 
 public sealed class NativeEmulationPreferences
 {
-    public const int DefaultAudioBufferLengthMilliseconds = 50;
+    public const int DefaultAudioBufferLengthMilliseconds = 100;
 
     public string FabricRuntimeLibraryPath { get; init; } = string.Empty;
     public string ProductionAmberLibraryPath { get; init; } = string.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorPreferences.cs
@@ -23,7 +23,7 @@ public sealed class OasisPlayerPreferences
 
 public sealed class NativeEmulationPreferences
 {
-    public const int DefaultAudioBufferLengthMilliseconds = 100;
+    public const int DefaultAudioBufferLengthMilliseconds = 50;
 
     public string FabricRuntimeLibraryPath { get; init; } = string.Empty;
     public string ProductionAmberLibraryPath { get; init; } = string.Empty;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/CoalescedMachineOutputDispatcher.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/CoalescedMachineOutputDispatcher.cs
@@ -1,0 +1,74 @@
+namespace OasisEditor;
+
+internal sealed class CoalescedMachineOutputDispatcher
+{
+    private readonly Action<Action> _schedule;
+    private readonly Action<MachineOutputBatch> _apply;
+    private readonly object _gate = new();
+    private readonly Dictionary<int, int> _lamps = [];
+    private readonly Dictionary<int, int> _reels = [];
+    private readonly Dictionary<SegmentKey, SegmentValue> _segments = [];
+    private readonly Dictionary<int, double> _vfdBrightness = [];
+    private bool _dispatchPending;
+    private bool _detached;
+
+    public CoalescedMachineOutputDispatcher(Action<Action> schedule, Action<MachineOutputBatch> apply)
+    {
+        _schedule = schedule ?? throw new ArgumentNullException(nameof(schedule));
+        _apply = apply ?? throw new ArgumentNullException(nameof(apply));
+    }
+
+    public int PendingEntryCount { get { lock (_gate) return _lamps.Count + _reels.Count + _segments.Count + _vfdBrightness.Count; } }
+    public bool DispatchPending { get { lock (_gate) return _dispatchPending; } }
+
+    public void EnqueueLamp(int id, int value) { lock (_gate) { if (_detached) return; _lamps[id] = value; ScheduleLocked(); } }
+    public void EnqueueReel(int id, int value) { lock (_gate) { if (_detached) return; _reels[id] = value; ScheduleLocked(); } }
+    public void EnqueueSegment(int id, int mask, SegmentOutputType type) { lock (_gate) { if (_detached) return; _segments[new(id, type)] = new(id, mask, type); ScheduleLocked(); } }
+    public void EnqueueVfdBrightness(int id, double value) { lock (_gate) { if (_detached) return; _vfdBrightness[id] = value; ScheduleLocked(); } }
+
+    public void Detach()
+    {
+        lock (_gate)
+        {
+            _detached = true;
+            _lamps.Clear(); _reels.Clear(); _segments.Clear(); _vfdBrightness.Clear();
+        }
+    }
+
+    private void ScheduleLocked()
+    {
+        if (_dispatchPending) return;
+        _dispatchPending = true;
+        _schedule(ApplyPending);
+    }
+
+    private void ApplyPending()
+    {
+        MachineOutputBatch batch;
+        lock (_gate)
+        {
+            if (_detached) { _dispatchPending = false; return; }
+            batch = new(
+                _lamps.Select(kv => new LampValue(kv.Key, kv.Value)).ToArray(),
+                _reels.Select(kv => new ReelValue(kv.Key, kv.Value)).ToArray(),
+                _segments.Values.ToArray(),
+                _vfdBrightness.Select(kv => new VfdBrightnessValue(kv.Key, kv.Value)).ToArray());
+            _lamps.Clear(); _reels.Clear(); _segments.Clear(); _vfdBrightness.Clear();
+        }
+        _apply(batch);
+        lock (_gate)
+        {
+            _dispatchPending = false;
+            if (!_detached && (_lamps.Count != 0 || _reels.Count != 0 || _segments.Count != 0 || _vfdBrightness.Count != 0))
+                ScheduleLocked();
+        }
+    }
+
+    private readonly record struct SegmentKey(int CellId, SegmentOutputType OutputType);
+}
+
+internal sealed record MachineOutputBatch(LampValue[] Lamps, ReelValue[] Reels, SegmentValue[] Segments, VfdBrightnessValue[] VfdBrightness);
+internal readonly record struct LampValue(int Id, int Value);
+internal readonly record struct ReelValue(int Id, int Value);
+internal readonly record struct SegmentValue(int Id, int Mask, SegmentOutputType OutputType);
+internal readonly record struct VfdBrightnessValue(int Id, double Value);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
@@ -13,11 +13,6 @@ public readonly record struct EmulationAudioPlaybackStatistics(
     int CapacityFrames,
     int PrebufferThresholdFrames,
     int PrebufferThresholdMilliseconds,
-    int MaximumRingFrames,
-    int StartupRingFrames,
-    int MinimumRequestedFrames,
-    int MaximumRequestedFrames,
-    long TotalRequestedFrames,
     int WasapiLatencyMilliseconds,
     bool PlaybackStarted);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
@@ -2,10 +2,24 @@ namespace OasisEditor;
 
 public readonly record struct EmulationAudioFormat(int SampleRate, int Channels, int BitsPerSample);
 
+public readonly record struct EmulationAudioPlaybackStatistics(
+    long RingFramesWritten,
+    long RingFramesRejected,
+    long DeviceFramesDelivered,
+    long SilenceFrames,
+    long UnderrunEpisodes,
+    int MinimumRingFrames,
+    int CurrentRingFrames,
+    int CapacityFrames,
+    int PrebufferThresholdFrames,
+    int PrebufferThresholdMilliseconds,
+    bool PlaybackStarted);
+
 public interface IEmulationAudioSink : IDisposable
 {
     void Start(EmulationAudioFormat format);
     void PushPcm(ReadOnlySpan<byte> pcmBytes);
     void Stop();
     void Clear();
+    EmulationAudioPlaybackStatistics GetStatistics();
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationAudio.cs
@@ -13,6 +13,12 @@ public readonly record struct EmulationAudioPlaybackStatistics(
     int CapacityFrames,
     int PrebufferThresholdFrames,
     int PrebufferThresholdMilliseconds,
+    int MaximumRingFrames,
+    int StartupRingFrames,
+    int MinimumRequestedFrames,
+    int MaximumRequestedFrames,
+    long TotalRequestedFrames,
+    int WasapiLatencyMilliseconds,
     bool PlaybackStarted);
 
 public interface IEmulationAudioSink : IDisposable
@@ -22,4 +28,6 @@ public interface IEmulationAudioSink : IDisposable
     void Stop();
     void Clear();
     EmulationAudioPlaybackStatistics GetStatistics();
+    int WritableFrames { get; }
+    int CapacityFrames { get; }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendFactory.cs
@@ -16,12 +16,14 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
     private readonly Func<int, IEmulationAudioSink> _audioSinkFactory;
     private readonly IFabricClock _clock;
     private readonly Action<string>? _errorLogger;
+    private readonly Action<string>? _infoLogger;
 
     public EmulationBackendFactory(
         Func<string?> fabricRuntimePathProvider,
         Func<string?> productionAmberPathProvider,
         Func<int>? audioBufferLengthMillisecondsProvider = null,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? infoLogger = null)
         : this(
             fabricRuntimePathProvider,
             productionAmberPathProvider,
@@ -29,7 +31,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             static path => new FabricRuntimeLibrary(path),
             static bufferLength => new NAudioEmulationAudioSink(bufferLength),
             new StopwatchFabricClock(),
-            errorLogger)
+            errorLogger,
+            infoLogger)
     {
     }
 
@@ -40,7 +43,8 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         Func<int, IEmulationAudioSink> audioSinkFactory,
         IFabricClock clock,
-        Action<string>? errorLogger)
+        Action<string>? errorLogger,
+        Action<string>? infoLogger = null)
     {
         _fabricRuntimePathProvider = fabricRuntimePathProvider ?? throw new ArgumentNullException(nameof(fabricRuntimePathProvider));
         _productionAmberPathProvider = productionAmberPathProvider ?? throw new ArgumentNullException(nameof(productionAmberPathProvider));
@@ -49,6 +53,7 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
         _audioSinkFactory = audioSinkFactory ?? throw new ArgumentNullException(nameof(audioSinkFactory));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _errorLogger = errorLogger;
+        _infoLogger = infoLogger;
     }
 
     public IEmulationBackend? CreateBackend(FruitMachinePlatformType platform)
@@ -76,6 +81,6 @@ public sealed class EmulationBackendFactory : IEmulationBackendFactory
             throw new FileNotFoundException("The production Amber API v2 provider DLL was not found at the configured path. Select a valid provider under Preferences > Fabric Emulation.", amberPath);
 
         return new FabricEmulationBackend(runtimePath, amberPath, _runtimeFactory,
-            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger);
+            _audioSinkFactory(_audioBufferLengthMillisecondsProvider()), _clock, _errorLogger, _infoLogger);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace OasisEditor;
@@ -49,60 +48,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private long _scheduleGeneration;
     private long _runnerStartTimestamp;
     private long _totalEmulationSlices;
-    private long _catchUpSlices;
     private long _maxCatchUpBatch;
     private long _exceptionalDiscardedTicks;
     private long _fabricAudioFramesRead;
-    private long _zeroAudioSlices;
-    private long _minFramesPerSlice = long.MaxValue;
-    private long _maxFramesPerSlice;
-    private long _capacityLimitedCatchUpBatches;
-    private long _retainedDebtIterations;
-    private long _maxRetainedSlices;
-    private long _writableFramesAtLargestCatchUpBatch;
-    private long _runnerThreadId;
-    private ThreadPriority _runnerThreadPriority = ThreadPriority.Normal;
-    private long _singleSliceBatches;
-    private long _multiSliceBatches;
-    private long _timedWaitCount;
-    private long _timedWaitLatenessTicksTotal;
-    private long _maxWakeLatenessTicks;
-    private long _wakeLateOver2Ms;
-    private long _wakeLateOver5Ms;
-    private long _wakeLateOver10Ms;
-    private long _wakeLateOver20Ms;
-    private long _wakeLateOver50Ms;
-    private long _wakeLateOver100Ms;
-    private long _currentConsecutiveLateWakes;
-    private long _longestConsecutiveLateWakes;
-    private long _maxAdvanceDurationTicks;
-    private long _maxReadAudioDurationTicks;
-    private long _maxSnapshotDurationTicks;
-    private long _maxPublishDurationTicks;
-    private long _maxInputDurationTicks;
-    private long _maxSessionGateWaitTicks;
-    private long _debtContinuationCount;
-    private long _capacityLimitedContinuationCount;
-    private long _yieldContinuationCount;
     private string _timingMode = "Unstarted";
     private bool _highResolutionTimerActive;
     private bool _mmcssRegistered;
-    private long _advanceCalls;
-    private long _advanceDurationTicksTotal;
-    private long _advanceOver2Ms;
-    private long _advanceOver5Ms;
-    private long _advanceOver10Ms;
-    private long _advanceOver20Ms;
-    private long _advanceOver50Ms;
-    private long _advanceOver100Ms;
-    private long _readAudioCalls;
-    private long _readAudioDurationTicksTotal;
-    private long _snapshotCalls;
-    private long _snapshotDurationTicksTotal;
-    private long _publishCalls;
-    private long _publishDurationTicksTotal;
-    private readonly ConcurrentQueue<StallTraceRecord> _stallTrace = new();
-    private string _lastStallTracePath = string.Empty;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -372,8 +323,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     {
         try
         {
-            Interlocked.Exchange(ref _runnerThreadId, Environment.CurrentManagedThreadId);
-            _runnerThreadPriority = Thread.CurrentThread.Priority;
             using var timer = new FabricRunnerTimer(_runnerWake);
             using var mmcss = FabricRunnerMmcssRegistration.Register("Games");
             _timingMode = timer.TimingMode;
@@ -402,12 +351,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     slicesSinceSnapshot = 0;
                 }
 
-                var waitedForDeadline = WaitUntil(timer, nextDeadline, cancellationToken);
+                WaitUntil(timer, nextDeadline, cancellationToken);
                 var now = _clock.GetTimestamp();
-                if (waitedForDeadline)
-                    ObserveWakeLateness(now - nextDeadline);
-                else if (now >= nextDeadline)
-                    Interlocked.Increment(ref _debtContinuationCount);
                 var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
                 if (now - nextDeadline > exceptionalCapTicks)
                 {
@@ -425,38 +370,18 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 var slices = Math.Min(schedulerLimitedSlices, capacityLimitedSlices);
                 if (slices <= 0)
                 {
-                    Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
-                    Interlocked.Increment(ref _capacityLimitedContinuationCount);
-                    Interlocked.Increment(ref _retainedDebtIterations);
-                    UpdateMaxRetainedSlices(availableSlices);
                     timer.Wait(PumpInterval, cancellationToken);
                     continue;
                 }
-                if (slices < schedulerLimitedSlices)
-                {
-                    Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
-                    Interlocked.Increment(ref _capacityLimitedContinuationCount);
-                    Interlocked.Increment(ref _retainedDebtIterations);
-                    UpdateMaxRetainedSlices(availableSlices - slices);
-                }
-
                 for (var slice = 0; slice < slices; slice++)
                 {
                     WaitSessionGate(cancellationToken);
                     try
                     {
                         var session = RequireSession();
-                        var advanceStart = _clock.GetTimestamp();
                         session.Advance(NanosecondsPerPump);
-                        ObserveOperationDuration("SessionAdvance", _clock.GetTimestamp() - advanceStart, ref _advanceCalls, ref _advanceDurationTicksTotal, ref _maxAdvanceDurationTicks);
-
-                        var inputStart = _clock.GetTimestamp();
                         ProcessInputs(session);
-                        UpdateMaxDuration(ref _maxInputDurationTicks, _clock.GetTimestamp() - inputStart);
-
-                        var audioStart = _clock.GetTimestamp();
                         ReadAudio(session);
-                        ObserveOperationDuration("ReadAudio", _clock.GetTimestamp() - audioStart, ref _readAudioCalls, ref _readAudioDurationTicksTotal, ref _maxReadAudioDurationTicks);
                     }
                     finally
                     {
@@ -468,15 +393,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 }
 
                 Interlocked.Add(ref _totalEmulationSlices, slices);
-                if (slices == 1)
-                    Interlocked.Increment(ref _singleSliceBatches);
-                else
-                {
-                    Interlocked.Increment(ref _multiSliceBatches);
-                    Interlocked.Add(ref _catchUpSlices, slices - 1);
-                }
-                if (slices > Interlocked.Read(ref _maxCatchUpBatch))
-                    Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, writableFrames);
                 UpdateMaxCatchUpBatch(slices);
 
                 if (slicesSinceSnapshot >= VisualSnapshotCadenceSlices || slices > 1)
@@ -486,10 +402,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 }
 
                 if (_clock.GetTimestamp() >= nextDeadline)
-                {
-                    Interlocked.Increment(ref _yieldContinuationCount);
                     Thread.Yield();
-                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -505,19 +418,18 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private bool WaitUntil(FabricRunnerTimer timer, long deadline, CancellationToken cancellationToken)
+    private void WaitUntil(FabricRunnerTimer timer, long deadline, CancellationToken cancellationToken)
     {
-        var waited = false;
         while (!cancellationToken.IsCancellationRequested)
         {
             var remainingTicks = deadline - _clock.GetTimestamp();
             if (remainingTicks <= 0)
-                return waited;
+                return;
             var remainingMilliseconds = (double)remainingTicks * 1000 / _clock.Frequency;
             if (remainingMilliseconds > 2)
             {
                 var wait = TimeSpan.FromMilliseconds(Math.Max(0, remainingMilliseconds - 1));
-                waited |= timer.Wait(wait, cancellationToken);
+                timer.Wait(wait, cancellationToken);
                 continue;
             }
             var spin = new SpinWait();
@@ -529,21 +441,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 else
                     Thread.Yield();
             }
-            return waited;
+            return;
         }
         cancellationToken.ThrowIfCancellationRequested();
-        return waited;
     }
 
-    private void WaitSessionGate(CancellationToken cancellationToken)
-    {
-        var start = _clock.GetTimestamp();
+    private void WaitSessionGate(CancellationToken cancellationToken) =>
         _sessionGate.Wait(cancellationToken);
-        var elapsed = _clock.GetTimestamp() - start;
-        UpdateMaxDuration(ref _maxSessionGateWaitTicks, elapsed);
-        if (TicksToMilliseconds(elapsed) > 10)
-            EnqueueStallTrace("SessionGateWait", elapsed);
-    }
 
     private void PublishLatestSnapshot(CancellationToken cancellationToken)
     {
@@ -552,44 +456,15 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         try
         {
             var session = RequireSession();
-            var snapshotStart = _clock.GetTimestamp();
             snapshot = session.GetSnapshot();
-            ObserveOperationDuration("GetSnapshot", _clock.GetTimestamp() - snapshotStart, ref _snapshotCalls, ref _snapshotDurationTicksTotal, ref _maxSnapshotDurationTicks);
         }
         finally
         {
             _sessionGate.Release();
         }
 
-        var publishStart = _clock.GetTimestamp();
         PublishSnapshot(snapshot);
-        ObserveOperationDuration("PublishSnapshot", _clock.GetTimestamp() - publishStart, ref _publishCalls, ref _publishDurationTicksTotal, ref _maxPublishDurationTicks);
     }
-
-    private void ObserveWakeLateness(long lateTicks)
-    {
-        Interlocked.Increment(ref _timedWaitCount);
-        Interlocked.Add(ref _timedWaitLatenessTicksTotal, Math.Max(0, lateTicks));
-        if (lateTicks <= 0)
-        {
-            Interlocked.Exchange(ref _currentConsecutiveLateWakes, 0);
-            return;
-        }
-
-        UpdateMax(ref _maxWakeLatenessTicks, lateTicks);
-        if (TicksToMilliseconds(lateTicks) > 10)
-            EnqueueStallTrace("TimedWait", lateTicks);
-        var lateMilliseconds = (double)lateTicks * 1000 / _clock.Frequency;
-        if (lateMilliseconds > 2) Interlocked.Increment(ref _wakeLateOver2Ms);
-        if (lateMilliseconds > 5) Interlocked.Increment(ref _wakeLateOver5Ms);
-        if (lateMilliseconds > 10) Interlocked.Increment(ref _wakeLateOver10Ms);
-        if (lateMilliseconds > 20) Interlocked.Increment(ref _wakeLateOver20Ms);
-        if (lateMilliseconds > 50) Interlocked.Increment(ref _wakeLateOver50Ms);
-        if (lateMilliseconds > 100) Interlocked.Increment(ref _wakeLateOver100Ms);
-        var consecutive = Interlocked.Increment(ref _currentConsecutiveLateWakes);
-        UpdateMax(ref _longestConsecutiveLateWakes, consecutive);
-    }
-
 
     private void ConfigureAudio(IFabricMachineSession session)
     {
@@ -638,10 +513,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         var frameCapacity = _audioBuffer.Length / format.ChannelCount;
         var framesWritten = session.ReadAudio(_audioBuffer, frameCapacity);
         Interlocked.Add(ref _fabricAudioFramesRead, framesWritten);
-        if (framesWritten == 0)
-            Interlocked.Increment(ref _zeroAudioSlices);
-        UpdateMinFramesPerSlice(framesWritten);
-        UpdateMaxFramesPerSlice(framesWritten);
         var sampleCount = checked(framesWritten * format.ChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
         if (!bytes.IsEmpty)
@@ -746,7 +617,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 audioStatistics = _audioSink.GetStatistics();
                 _audioStarted = false;
             }
-            WriteStallTraceFile();
             EmitStopSummary(audioStatistics);
             if (_runtime is not null)
                 TryCleanup(_runtime.Dispose, ref failures);
@@ -769,60 +639,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     {
         Interlocked.Exchange(ref _runnerStartTimestamp, _clock.GetTimestamp());
         Interlocked.Exchange(ref _totalEmulationSlices, 0);
-        Interlocked.Exchange(ref _catchUpSlices, 0);
         Interlocked.Exchange(ref _maxCatchUpBatch, 0);
         Interlocked.Exchange(ref _exceptionalDiscardedTicks, 0);
         Interlocked.Exchange(ref _fabricAudioFramesRead, 0);
-        Interlocked.Exchange(ref _zeroAudioSlices, 0);
-        Interlocked.Exchange(ref _minFramesPerSlice, long.MaxValue);
-        Interlocked.Exchange(ref _maxFramesPerSlice, 0);
-        Interlocked.Exchange(ref _capacityLimitedCatchUpBatches, 0);
-        Interlocked.Exchange(ref _retainedDebtIterations, 0);
-        Interlocked.Exchange(ref _maxRetainedSlices, 0);
-        Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, 0);
-        Interlocked.Exchange(ref _runnerThreadId, 0);
-        _runnerThreadPriority = ThreadPriority.Normal;
-        Interlocked.Exchange(ref _singleSliceBatches, 0);
-        Interlocked.Exchange(ref _multiSliceBatches, 0);
-        Interlocked.Exchange(ref _maxWakeLatenessTicks, 0);
-        Interlocked.Exchange(ref _wakeLateOver2Ms, 0);
-        Interlocked.Exchange(ref _wakeLateOver5Ms, 0);
-        Interlocked.Exchange(ref _wakeLateOver10Ms, 0);
-        Interlocked.Exchange(ref _wakeLateOver20Ms, 0);
-        Interlocked.Exchange(ref _wakeLateOver50Ms, 0);
-        Interlocked.Exchange(ref _wakeLateOver100Ms, 0);
-        Interlocked.Exchange(ref _currentConsecutiveLateWakes, 0);
-        Interlocked.Exchange(ref _longestConsecutiveLateWakes, 0);
-        Interlocked.Exchange(ref _maxAdvanceDurationTicks, 0);
-        Interlocked.Exchange(ref _maxReadAudioDurationTicks, 0);
-        Interlocked.Exchange(ref _maxSnapshotDurationTicks, 0);
-        Interlocked.Exchange(ref _maxPublishDurationTicks, 0);
-        Interlocked.Exchange(ref _maxInputDurationTicks, 0);
-        Interlocked.Exchange(ref _maxSessionGateWaitTicks, 0);
-        Interlocked.Exchange(ref _timedWaitCount, 0);
-        Interlocked.Exchange(ref _timedWaitLatenessTicksTotal, 0);
-        Interlocked.Exchange(ref _debtContinuationCount, 0);
-        Interlocked.Exchange(ref _capacityLimitedContinuationCount, 0);
-        Interlocked.Exchange(ref _yieldContinuationCount, 0);
         _timingMode = "Unstarted";
         _highResolutionTimerActive = false;
         _mmcssRegistered = false;
-        Interlocked.Exchange(ref _advanceCalls, 0);
-        Interlocked.Exchange(ref _advanceDurationTicksTotal, 0);
-        Interlocked.Exchange(ref _advanceOver2Ms, 0);
-        Interlocked.Exchange(ref _advanceOver5Ms, 0);
-        Interlocked.Exchange(ref _advanceOver10Ms, 0);
-        Interlocked.Exchange(ref _advanceOver20Ms, 0);
-        Interlocked.Exchange(ref _advanceOver50Ms, 0);
-        Interlocked.Exchange(ref _advanceOver100Ms, 0);
-        Interlocked.Exchange(ref _readAudioCalls, 0);
-        Interlocked.Exchange(ref _readAudioDurationTicksTotal, 0);
-        Interlocked.Exchange(ref _snapshotCalls, 0);
-        Interlocked.Exchange(ref _snapshotDurationTicksTotal, 0);
-        Interlocked.Exchange(ref _publishCalls, 0);
-        Interlocked.Exchange(ref _publishDurationTicksTotal, 0);
-        while (_stallTrace.TryDequeue(out _)) { }
-        _lastStallTracePath = string.Empty;
     }
 
     internal static int CalculateSafeFramesPerSlice(int sampleRate)
@@ -855,59 +677,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         return checked((int)Math.Min(int.MaxValue, ((now - nextDeadline) / pumpTicks) + 1));
     }
 
-    private void UpdateMinFramesPerSlice(int frames)
-    {
-        var current = Interlocked.Read(ref _minFramesPerSlice);
-        while (frames < current)
-        {
-            var previous = Interlocked.CompareExchange(ref _minFramesPerSlice, frames, current);
-            if (previous == current) return;
-            current = previous;
-        }
-    }
-
-
-    private void ObserveOperationDuration(string operation, long ticks, ref long calls, ref long totalTicks, ref long maxTicks)
-    {
-        Interlocked.Increment(ref calls);
-        Interlocked.Add(ref totalTicks, ticks);
-        UpdateMaxDuration(ref maxTicks, ticks);
-        if (operation == "SessionAdvance")
-            ObserveAdvanceDurationBuckets(ticks);
-        if (TicksToMilliseconds(ticks) > 10)
-            EnqueueStallTrace(operation, ticks);
-    }
-
-    private void ObserveAdvanceDurationBuckets(long ticks)
-    {
-        var ms = TicksToMilliseconds(ticks);
-        if (ms > 2) Interlocked.Increment(ref _advanceOver2Ms);
-        if (ms > 5) Interlocked.Increment(ref _advanceOver5Ms);
-        if (ms > 10) Interlocked.Increment(ref _advanceOver10Ms);
-        if (ms > 20) Interlocked.Increment(ref _advanceOver20Ms);
-        if (ms > 50) Interlocked.Increment(ref _advanceOver50Ms);
-        if (ms > 100) Interlocked.Increment(ref _advanceOver100Ms);
-    }
-
-    private void EnqueueStallTrace(string operation, long ticks)
-    {
-        if (_stallTrace.Count >= 500)
-            return;
-        _stallTrace.Enqueue(new(
-            _clock.GetTimestamp(),
-            operation,
-            TicksToMilliseconds(ticks),
-            Environment.CurrentManagedThreadId,
-            CalculateAvailableSlices(_clock.GetTimestamp(), _clock.GetTimestamp(), Math.Max(1L, _clock.Frequency / EmulationPumpHz)),
-            _audioSink.GetStatistics().CurrentRingFrames,
-            _audioSink.WritableFrames,
-            Interlocked.Read(ref _singleSliceBatches) + Interlocked.Read(ref _multiSliceBatches),
-            null));
-    }
-
-    private void UpdateMaxFramesPerSlice(int frames) => UpdateMax(ref _maxFramesPerSlice, frames);
-    private void UpdateMaxDuration(ref long target, long ticks) => UpdateMax(ref target, ticks);
-    private void UpdateMaxRetainedSlices(long slices) => UpdateMax(ref _maxRetainedSlices, slices);
     private static void UpdateMax(ref long target, long value)
     {
         var current = Interlocked.Read(ref target);
@@ -931,14 +700,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private double TicksToMilliseconds(long ticks) => (double)ticks * 1000 / _clock.Frequency;
-    private double AverageTicksToMilliseconds(long totalTicks, long calls) => calls > 0 ? TicksToMilliseconds(totalTicks) / calls : 0;
-
-    private static double CalculateAverageBatchSize(long slices, long batches) => batches > 0 ? (double)slices / batches : 0;
-
-    private double CalculateAverageBatchSize(long slices) =>
-        CalculateAverageBatchSize(slices, Interlocked.Read(ref _singleSliceBatches) + Interlocked.Read(ref _multiSliceBatches));
-
     private void EmitStopSummary(EmulationAudioPlaybackStatistics audioStatistics)
     {
         var start = Interlocked.Read(ref _runnerStartTimestamp);
@@ -952,60 +713,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             emulatedMs,
             ratio,
             slices,
-            Interlocked.Read(ref _catchUpSlices),
             Interlocked.Read(ref _maxCatchUpBatch),
             discardedMs,
             Interlocked.Read(ref _fabricAudioFramesRead),
-            Interlocked.Read(ref _zeroAudioSlices),
-            Interlocked.Read(ref _minFramesPerSlice) == long.MaxValue ? 0 : Interlocked.Read(ref _minFramesPerSlice),
-            Interlocked.Read(ref _maxFramesPerSlice),
-            Interlocked.Read(ref _capacityLimitedCatchUpBatches),
-            Interlocked.Read(ref _retainedDebtIterations),
-            Interlocked.Read(ref _maxRetainedSlices),
-            Interlocked.Read(ref _writableFramesAtLargestCatchUpBatch),
-            Interlocked.Read(ref _runnerThreadId),
-            _runnerThreadPriority.ToString(),
-            Interlocked.Read(ref _singleSliceBatches),
-            Interlocked.Read(ref _multiSliceBatches),
-            CalculateAverageBatchSize(slices),
-            TicksToMilliseconds(Interlocked.Read(ref _maxWakeLatenessTicks)),
-            Interlocked.Read(ref _wakeLateOver2Ms),
-            Interlocked.Read(ref _wakeLateOver5Ms),
-            Interlocked.Read(ref _wakeLateOver10Ms),
-            Interlocked.Read(ref _wakeLateOver20Ms),
-            Interlocked.Read(ref _wakeLateOver50Ms),
-            Interlocked.Read(ref _wakeLateOver100Ms),
-            Interlocked.Read(ref _longestConsecutiveLateWakes),
-            TicksToMilliseconds(Interlocked.Read(ref _maxAdvanceDurationTicks)),
-            TicksToMilliseconds(Interlocked.Read(ref _maxReadAudioDurationTicks)),
-            TicksToMilliseconds(Interlocked.Read(ref _maxSnapshotDurationTicks)),
-            TicksToMilliseconds(Interlocked.Read(ref _maxPublishDurationTicks)),
-            TicksToMilliseconds(Interlocked.Read(ref _maxInputDurationTicks)),
-            TicksToMilliseconds(Interlocked.Read(ref _maxSessionGateWaitTicks)),
             _timingMode,
             _highResolutionTimerActive,
             _mmcssRegistered,
-            Interlocked.Read(ref _timedWaitCount),
-            Interlocked.Read(ref _debtContinuationCount),
-            Interlocked.Read(ref _capacityLimitedContinuationCount),
-            Interlocked.Read(ref _yieldContinuationCount),
-            AverageTicksToMilliseconds(Interlocked.Read(ref _timedWaitLatenessTicksTotal), Interlocked.Read(ref _timedWaitCount)),
-            Interlocked.Read(ref _advanceCalls),
-            AverageTicksToMilliseconds(Interlocked.Read(ref _advanceDurationTicksTotal), Interlocked.Read(ref _advanceCalls)),
-            Interlocked.Read(ref _advanceOver2Ms),
-            Interlocked.Read(ref _advanceOver5Ms),
-            Interlocked.Read(ref _advanceOver10Ms),
-            Interlocked.Read(ref _advanceOver20Ms),
-            Interlocked.Read(ref _advanceOver50Ms),
-            Interlocked.Read(ref _advanceOver100Ms),
-            Interlocked.Read(ref _readAudioCalls),
-            AverageTicksToMilliseconds(Interlocked.Read(ref _readAudioDurationTicksTotal), Interlocked.Read(ref _readAudioCalls)),
-            Interlocked.Read(ref _snapshotCalls),
-            AverageTicksToMilliseconds(Interlocked.Read(ref _snapshotDurationTicksTotal), Interlocked.Read(ref _snapshotCalls)),
-            Interlocked.Read(ref _publishCalls),
-            AverageTicksToMilliseconds(Interlocked.Read(ref _publishDurationTicksTotal), Interlocked.Read(ref _publishCalls)),
-            _stallTrace.Count,
-            _lastStallTracePath,
             audioStatistics));
     }
 
@@ -1014,80 +727,14 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         double emulatedMilliseconds,
         double ratio,
         long slices,
-        long catchUpSlices,
         long maxCatchUpBatch,
         double discardedMilliseconds,
         long fabricAudioFrames,
-        long zeroAudioSlices,
-        long minFramesPerSlice,
-        long maxFramesPerSlice,
-        long capacityLimitedCatchUpBatches,
-        long retainedDebtIterations,
-        long maxRetainedSlices,
-        long writableFramesAtLargestCatchUpBatch,
-        long runnerThreadId,
-        string runnerThreadPriority,
-        long singleSliceBatches,
-        long multiSliceBatches,
-        double averageBatchSize,
-        double maxWakeLatenessMilliseconds,
-        long wakeLateOver2Ms,
-        long wakeLateOver5Ms,
-        long wakeLateOver10Ms,
-        long wakeLateOver20Ms,
-        long wakeLateOver50Ms,
-        long wakeLateOver100Ms,
-        long longestConsecutiveLateWakes,
-        double maxAdvanceDurationMilliseconds,
-        double maxReadAudioDurationMilliseconds,
-        double maxSnapshotDurationMilliseconds,
-        double maxPublishDurationMilliseconds,
-        double maxInputDurationMilliseconds,
-        double maxSessionGateWaitMilliseconds,
         string timingMode,
         bool highResolutionTimerActive,
         bool mmcssRegistered,
-        long timedWaitCount,
-        long debtContinuationCount,
-        long capacityContinuationCount,
-        long yieldContinuationCount,
-        double averageTimedWakeLatenessMilliseconds,
-        long advanceCalls,
-        double averageAdvanceDurationMilliseconds,
-        long advanceOver2Ms,
-        long advanceOver5Ms,
-        long advanceOver10Ms,
-        long advanceOver20Ms,
-        long advanceOver50Ms,
-        long advanceOver100Ms,
-        long readAudioCalls,
-        double averageReadAudioDurationMilliseconds,
-        long snapshotCalls,
-        double averageSnapshotDurationMilliseconds,
-        long publishCalls,
-        double averagePublishDurationMilliseconds,
-        int stallTraceCount,
-        string stallTracePath,
         EmulationAudioPlaybackStatistics audioStatistics) =>
-        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, runnerThreadId={runnerThreadId}, runnerThreadPriority={runnerThreadPriority}, singleSliceBatches={singleSliceBatches}, multiSliceBatches={multiSliceBatches}, averageBatchSize={averageBatchSize:F2}, catchUpSlicePercent={(slices > 0 ? (double)catchUpSlices * 100 / slices : 0):F2}, timingMode={timingMode}, highResolutionTimerActive={highResolutionTimerActive}, mmcssRegistered={mmcssRegistered}, timedWaitCount={timedWaitCount}, debtContinuationCount={debtContinuationCount}, capacityContinuationCount={capacityContinuationCount}, yieldContinuationCount={yieldContinuationCount}, averageTimedWakeLatenessMs={averageTimedWakeLatenessMilliseconds:F3}, maxTimedWakeLatenessMs={maxWakeLatenessMilliseconds:F3}, wakeLateOver2Ms={wakeLateOver2Ms}, wakeLateOver5Ms={wakeLateOver5Ms}, wakeLateOver10Ms={wakeLateOver10Ms}, wakeLateOver20Ms={wakeLateOver20Ms}, wakeLateOver50Ms={wakeLateOver50Ms}, wakeLateOver100Ms={wakeLateOver100Ms}, longestConsecutiveLateWakes={longestConsecutiveLateWakes}, advanceCalls={advanceCalls}, averageAdvanceDurationMs={averageAdvanceDurationMilliseconds:F3}, maxAdvanceDurationMs={maxAdvanceDurationMilliseconds:F3}, advanceOver2Ms={advanceOver2Ms}, advanceOver5Ms={advanceOver5Ms}, advanceOver10Ms={advanceOver10Ms}, advanceOver20Ms={advanceOver20Ms}, advanceOver50Ms={advanceOver50Ms}, advanceOver100Ms={advanceOver100Ms}, readAudioCalls={readAudioCalls}, averageReadAudioDurationMs={averageReadAudioDurationMilliseconds:F3}, snapshotCalls={snapshotCalls}, averageSnapshotDurationMs={averageSnapshotDurationMilliseconds:F3}, publishCalls={publishCalls}, averagePublishDurationMs={averagePublishDurationMilliseconds:F3}, stallTraceCount={stallTraceCount}, stallTracePath={stallTracePath}, maxReadAudioDurationMs={maxReadAudioDurationMilliseconds:F3}, maxSnapshotDurationMs={maxSnapshotDurationMilliseconds:F3}, maxPublishDurationMs={maxPublishDurationMilliseconds:F3}, maxInputDurationMs={maxInputDurationMilliseconds:F3}, maxSessionGateWaitMs={maxSessionGateWaitMilliseconds:F3}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
-
-    private void WriteStallTraceFile()
-    {
-        if (_stallTrace.IsEmpty)
-            return;
-        var path = Path.Combine(Path.GetTempPath(), $"oasis-fabric-runner-stalls-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}.csv");
-        var lines = new List<string>(_stallTrace.Count + 1)
-        {
-            "timestamp,operation,durationMs,runnerThreadId,currentDebtSlices,ringReadableFrames,ringWritableFrames,batchIndex,applicationActive"
-        };
-        lines.AddRange(_stallTrace.Select(record =>
-            FormattableString.Invariant($"{record.Timestamp},{record.Operation},{record.DurationMilliseconds:F3},{record.RunnerThreadId},{record.CurrentDebtSlices},{record.RingReadableFrames},{record.RingWritableFrames},{record.BatchIndex},{record.ApplicationActive}")));
-        File.WriteAllLines(path, lines);
-        _lastStallTracePath = path;
-    }
-
-
-    private readonly record struct StallTraceRecord(long Timestamp, string Operation, double DurationMilliseconds, int RunnerThreadId, int CurrentDebtSlices, int RingReadableFrames, int RingWritableFrames, long BatchIndex, bool? ApplicationActive);
+        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, maximumCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRingFrames={audioStatistics.MinimumRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, timingMode={timingMode}, highResolutionTimerActive={highResolutionTimerActive}, mmcssRegistered={mmcssRegistered}.";
 
     private static void TryCleanup(Action action, ref List<Exception>? failures)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -12,6 +12,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private const ulong NanosecondsPerPump = 1_000_000;
     private const int MaxCatchUpSlices = 64;
     private const int ExceptionalDelayCapMilliseconds = 500;
+    private const int VisualSnapshotCadenceSlices = 16;
+    private const long NanosecondsPerMillisecond = 1_000_000;
     private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
     private static readonly EmulationBackendCapabilities BackendCapabilities =
         new(true, true, true, true, false, false, false);
@@ -35,7 +37,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private IFabricRuntimeLibrary? _runtime;
     private IFabricMachineSession? _session;
     private CancellationTokenSource? _pumpCancellation;
-    private Task? _pumpTask;
+    private Thread? _pumpThread;
+    private readonly ManualResetEventSlim _runnerWake = new(false);
     private FabricAudioFormat? _audioFormat;
     private short[] _audioBuffer = [];
     private EmulationBackendState _state = EmulationBackendState.Stopped;
@@ -56,6 +59,25 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private long _retainedDebtIterations;
     private long _maxRetainedSlices;
     private long _writableFramesAtLargestCatchUpBatch;
+    private long _runnerThreadId;
+    private ThreadPriority _runnerThreadPriority = ThreadPriority.Normal;
+    private long _singleSliceBatches;
+    private long _multiSliceBatches;
+    private long _maxWakeLatenessTicks;
+    private long _wakeLateOver2Ms;
+    private long _wakeLateOver5Ms;
+    private long _wakeLateOver10Ms;
+    private long _wakeLateOver20Ms;
+    private long _wakeLateOver50Ms;
+    private long _wakeLateOver100Ms;
+    private long _currentConsecutiveLateWakes;
+    private long _longestConsecutiveLateWakes;
+    private long _maxAdvanceDurationTicks;
+    private long _maxReadAudioDurationTicks;
+    private long _maxSnapshotDurationTicks;
+    private long _maxPublishDurationTicks;
+    private long _maxInputDurationTicks;
+    private long _maxSessionGateWaitTicks;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -131,7 +153,14 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             ResetRunnerStatistics();
             LastFailure = null;
             _pumpCancellation = new CancellationTokenSource();
-            _pumpTask = Task.Run(() => PumpAsync(_pumpCancellation.Token), CancellationToken.None);
+            _runnerWake.Reset();
+            _pumpThread = new Thread(() => Pump(_pumpCancellation.Token))
+            {
+                Name = "Oasis Fabric Emulation Runner",
+                IsBackground = true,
+                Priority = ThreadPriority.Normal
+            };
+            _pumpThread.Start();
             SetState(EmulationBackendState.Running);
         }
         catch
@@ -149,21 +178,16 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (State != EmulationBackendState.Failed)
             SetState(EmulationBackendState.Stopping);
 
-        if (_pumpCancellation is not null)
-            await _pumpCancellation.CancelAsync().ConfigureAwait(false);
-        if (_pumpTask is not null && Task.CurrentId != _pumpTask.Id)
+        _pumpCancellation?.Cancel();
+        _runnerWake.Set();
+        var thread = _pumpThread;
+        if (thread is not null && thread.ManagedThreadId != Environment.CurrentManagedThreadId)
         {
-            try
+            while (thread.IsAlive)
             {
-                await _pumpTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // The caller may stop waiting, but native cleanup below is never abandoned.
-            }
-            catch
-            {
-                // LastFailure retains the pump exception; cleanup must continue.
+                cancellationToken.ThrowIfCancellationRequested();
+                if (thread.Join(25))
+                    break;
             }
         }
         await CleanupResourcesAsync().ConfigureAwait(false);
@@ -175,7 +199,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
         if (State == EmulationBackendState.Running)
+        {
             SetState(EmulationBackendState.Paused);
+            _runnerWake.Set();
+        }
         return Task.CompletedTask;
     }
 
@@ -187,6 +214,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             Interlocked.Increment(ref _scheduleGeneration);
             SetState(EmulationBackendState.Running);
+            _runnerWake.Set();
         }
         return Task.CompletedTask;
     }
@@ -204,6 +232,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             ClearOutputCaches();
             _audioSink.Clear();
             Interlocked.Increment(ref _scheduleGeneration);
+            _runnerWake.Set();
         }
         finally
         {
@@ -265,6 +294,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             return;
         await StopAsync(CancellationToken.None).ConfigureAwait(false);
         _audioSink.Dispose();
+        _runnerWake.Dispose();
         _sessionGate.Dispose();
         _disposed = true;
     }
@@ -313,20 +343,25 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private async Task PumpAsync(CancellationToken cancellationToken)
+    private void Pump(CancellationToken cancellationToken)
     {
         try
         {
+            Interlocked.Exchange(ref _runnerThreadId, Environment.CurrentManagedThreadId);
+            _runnerThreadPriority = Thread.CurrentThread.Priority;
             var pumpTicks = Math.Max(1L, _clock.Frequency / EmulationPumpHz);
             var nextDeadline = _clock.GetTimestamp();
             var scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
+            var slicesSinceSnapshot = 0;
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (State != EmulationBackendState.Running)
                 {
-                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    _runnerWake.Wait(PumpInterval, cancellationToken);
+                    _runnerWake.Reset();
                     nextDeadline = _clock.GetTimestamp();
                     scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
+                    slicesSinceSnapshot = 0;
                     continue;
                 }
 
@@ -335,9 +370,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 {
                     nextDeadline = _clock.GetTimestamp();
                     scheduleGeneration = currentGeneration;
+                    slicesSinceSnapshot = 0;
                 }
 
+                WaitUntil(nextDeadline, cancellationToken);
                 var now = _clock.GetTimestamp();
+                ObserveWakeLateness(now - nextDeadline);
                 var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
                 if (now - nextDeadline > exceptionalCapTicks)
                 {
@@ -347,11 +385,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
                 var availableSlices = CalculateAvailableSlices(now, nextDeadline, pumpTicks);
                 if (availableSlices <= 0)
-                {
-                    var remaining = TimeSpan.FromSeconds((double)(nextDeadline - now) / _clock.Frequency);
-                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
                     continue;
-                }
 
                 var writableFrames = _audioStarted ? _audioSink.WritableFrames : int.MaxValue;
                 var capacityLimitedSlices = CalculateAudioCapacityLimitedSlices(writableFrames);
@@ -362,7 +396,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
                     Interlocked.Increment(ref _retainedDebtIterations);
                     UpdateMaxRetainedSlices(availableSlices);
-                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    _runnerWake.Wait(PumpInterval, cancellationToken);
+                    _runnerWake.Reset();
                     continue;
                 }
                 if (slices < schedulerLimitedSlices)
@@ -374,13 +409,21 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
                 for (var slice = 0; slice < slices; slice++)
                 {
-                    await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    WaitSessionGate(cancellationToken);
                     try
                     {
                         var session = RequireSession();
+                        var advanceStart = _clock.GetTimestamp();
                         session.Advance(NanosecondsPerPump);
+                        UpdateMaxDuration(ref _maxAdvanceDurationTicks, _clock.GetTimestamp() - advanceStart);
+
+                        var inputStart = _clock.GetTimestamp();
                         ProcessInputs(session);
+                        UpdateMaxDuration(ref _maxInputDurationTicks, _clock.GetTimestamp() - inputStart);
+
+                        var audioStart = _clock.GetTimestamp();
                         ReadAudio(session);
+                        UpdateMaxDuration(ref _maxReadAudioDurationTicks, _clock.GetTimestamp() - audioStart);
                     }
                     finally
                     {
@@ -388,35 +431,29 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     }
 
                     nextDeadline += pumpTicks;
+                    slicesSinceSnapshot++;
                 }
 
                 Interlocked.Add(ref _totalEmulationSlices, slices);
-                if (slices > 1)
+                if (slices == 1)
+                    Interlocked.Increment(ref _singleSliceBatches);
+                else
+                {
+                    Interlocked.Increment(ref _multiSliceBatches);
                     Interlocked.Add(ref _catchUpSlices, slices - 1);
+                }
                 if (slices > Interlocked.Read(ref _maxCatchUpBatch))
                     Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, writableFrames);
                 UpdateMaxCatchUpBatch(slices);
 
-                await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
+                if (slicesSinceSnapshot >= VisualSnapshotCadenceSlices || slices > 1)
                 {
-                    PublishSnapshot(RequireSession().GetSnapshot());
-                }
-                finally
-                {
-                    _sessionGate.Release();
+                    PublishLatestSnapshot(cancellationToken);
+                    slicesSinceSnapshot = 0;
                 }
 
-                var remainingTicks = nextDeadline - _clock.GetTimestamp();
-                if (remainingTicks > 0)
-                {
-                    var remaining = TimeSpan.FromSeconds((double)remainingTicks / _clock.Frequency);
-                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await Task.Yield();
-                }
+                if (_clock.GetTimestamp() >= nextDeadline)
+                    Thread.Yield();
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -427,9 +464,88 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             LastFailure = exception;
             LogException("Fabric emulation pump failed.", exception);
             _pumpCancellation?.Cancel();
+            _runnerWake.Set();
             SetState(EmulationBackendState.Failed);
         }
     }
+
+    private void WaitUntil(long deadline, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var remainingTicks = deadline - _clock.GetTimestamp();
+            if (remainingTicks <= 0)
+                return;
+            var remainingMilliseconds = (double)remainingTicks * 1000 / _clock.Frequency;
+            if (remainingMilliseconds > 2)
+            {
+                var wait = TimeSpan.FromMilliseconds(Math.Max(0, remainingMilliseconds - 1));
+                _runnerWake.Wait(wait, cancellationToken);
+                _runnerWake.Reset();
+                continue;
+            }
+            var spin = new SpinWait();
+            while (_clock.GetTimestamp() < deadline)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (spin.Count < 10)
+                    spin.SpinOnce();
+                else
+                    Thread.Yield();
+            }
+            return;
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private void WaitSessionGate(CancellationToken cancellationToken)
+    {
+        var start = _clock.GetTimestamp();
+        _sessionGate.Wait(cancellationToken);
+        UpdateMaxDuration(ref _maxSessionGateWaitTicks, _clock.GetTimestamp() - start);
+    }
+
+    private void PublishLatestSnapshot(CancellationToken cancellationToken)
+    {
+        FabricMachineSnapshot snapshot;
+        WaitSessionGate(cancellationToken);
+        try
+        {
+            var session = RequireSession();
+            var snapshotStart = _clock.GetTimestamp();
+            snapshot = session.GetSnapshot();
+            UpdateMaxDuration(ref _maxSnapshotDurationTicks, _clock.GetTimestamp() - snapshotStart);
+        }
+        finally
+        {
+            _sessionGate.Release();
+        }
+
+        var publishStart = _clock.GetTimestamp();
+        PublishSnapshot(snapshot);
+        UpdateMaxDuration(ref _maxPublishDurationTicks, _clock.GetTimestamp() - publishStart);
+    }
+
+    private void ObserveWakeLateness(long lateTicks)
+    {
+        if (lateTicks <= 0)
+        {
+            Interlocked.Exchange(ref _currentConsecutiveLateWakes, 0);
+            return;
+        }
+
+        UpdateMax(ref _maxWakeLatenessTicks, lateTicks);
+        var lateMilliseconds = (double)lateTicks * 1000 / _clock.Frequency;
+        if (lateMilliseconds > 2) Interlocked.Increment(ref _wakeLateOver2Ms);
+        if (lateMilliseconds > 5) Interlocked.Increment(ref _wakeLateOver5Ms);
+        if (lateMilliseconds > 10) Interlocked.Increment(ref _wakeLateOver10Ms);
+        if (lateMilliseconds > 20) Interlocked.Increment(ref _wakeLateOver20Ms);
+        if (lateMilliseconds > 50) Interlocked.Increment(ref _wakeLateOver50Ms);
+        if (lateMilliseconds > 100) Interlocked.Increment(ref _wakeLateOver100Ms);
+        var consecutive = Interlocked.Increment(ref _currentConsecutiveLateWakes);
+        UpdateMax(ref _longestConsecutiveLateWakes, consecutive);
+    }
+
 
     private void ConfigureAudio(IFabricMachineSession session)
     {
@@ -593,7 +709,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _audioFormat = null;
             _pumpCancellation?.Dispose();
             _pumpCancellation = null;
-            _pumpTask = null;
+            _pumpThread = null;
             ClearPendingInputs();
         }
         finally
@@ -619,6 +735,25 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Interlocked.Exchange(ref _retainedDebtIterations, 0);
         Interlocked.Exchange(ref _maxRetainedSlices, 0);
         Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, 0);
+        Interlocked.Exchange(ref _runnerThreadId, 0);
+        _runnerThreadPriority = ThreadPriority.Normal;
+        Interlocked.Exchange(ref _singleSliceBatches, 0);
+        Interlocked.Exchange(ref _multiSliceBatches, 0);
+        Interlocked.Exchange(ref _maxWakeLatenessTicks, 0);
+        Interlocked.Exchange(ref _wakeLateOver2Ms, 0);
+        Interlocked.Exchange(ref _wakeLateOver5Ms, 0);
+        Interlocked.Exchange(ref _wakeLateOver10Ms, 0);
+        Interlocked.Exchange(ref _wakeLateOver20Ms, 0);
+        Interlocked.Exchange(ref _wakeLateOver50Ms, 0);
+        Interlocked.Exchange(ref _wakeLateOver100Ms, 0);
+        Interlocked.Exchange(ref _currentConsecutiveLateWakes, 0);
+        Interlocked.Exchange(ref _longestConsecutiveLateWakes, 0);
+        Interlocked.Exchange(ref _maxAdvanceDurationTicks, 0);
+        Interlocked.Exchange(ref _maxReadAudioDurationTicks, 0);
+        Interlocked.Exchange(ref _maxSnapshotDurationTicks, 0);
+        Interlocked.Exchange(ref _maxPublishDurationTicks, 0);
+        Interlocked.Exchange(ref _maxInputDurationTicks, 0);
+        Interlocked.Exchange(ref _maxSessionGateWaitTicks, 0);
     }
 
     internal static int CalculateSafeFramesPerSlice(int sampleRate)
@@ -663,6 +798,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     }
 
     private void UpdateMaxFramesPerSlice(int frames) => UpdateMax(ref _maxFramesPerSlice, frames);
+    private void UpdateMaxDuration(ref long target, long ticks) => UpdateMax(ref target, ticks);
     private void UpdateMaxRetainedSlices(long slices) => UpdateMax(ref _maxRetainedSlices, slices);
     private static void UpdateMax(ref long target, long value)
     {
@@ -686,6 +822,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             current = previous;
         }
     }
+
+    private double TicksToMilliseconds(long ticks) => (double)ticks * 1000 / _clock.Frequency;
+
+    private static double CalculateAverageBatchSize(long slices, long batches) => batches > 0 ? (double)slices / batches : 0;
+
+    private double CalculateAverageBatchSize(long slices) =>
+        CalculateAverageBatchSize(slices, Interlocked.Read(ref _singleSliceBatches) + Interlocked.Read(ref _multiSliceBatches));
 
     private void EmitStopSummary(EmulationAudioPlaybackStatistics audioStatistics)
     {
@@ -711,6 +854,25 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             Interlocked.Read(ref _retainedDebtIterations),
             Interlocked.Read(ref _maxRetainedSlices),
             Interlocked.Read(ref _writableFramesAtLargestCatchUpBatch),
+            Interlocked.Read(ref _runnerThreadId),
+            _runnerThreadPriority.ToString(),
+            Interlocked.Read(ref _singleSliceBatches),
+            Interlocked.Read(ref _multiSliceBatches),
+            CalculateAverageBatchSize(slices),
+            TicksToMilliseconds(Interlocked.Read(ref _maxWakeLatenessTicks)),
+            Interlocked.Read(ref _wakeLateOver2Ms),
+            Interlocked.Read(ref _wakeLateOver5Ms),
+            Interlocked.Read(ref _wakeLateOver10Ms),
+            Interlocked.Read(ref _wakeLateOver20Ms),
+            Interlocked.Read(ref _wakeLateOver50Ms),
+            Interlocked.Read(ref _wakeLateOver100Ms),
+            Interlocked.Read(ref _longestConsecutiveLateWakes),
+            TicksToMilliseconds(Interlocked.Read(ref _maxAdvanceDurationTicks)),
+            TicksToMilliseconds(Interlocked.Read(ref _maxReadAudioDurationTicks)),
+            TicksToMilliseconds(Interlocked.Read(ref _maxSnapshotDurationTicks)),
+            TicksToMilliseconds(Interlocked.Read(ref _maxPublishDurationTicks)),
+            TicksToMilliseconds(Interlocked.Read(ref _maxInputDurationTicks)),
+            TicksToMilliseconds(Interlocked.Read(ref _maxSessionGateWaitTicks)),
             audioStatistics));
     }
 
@@ -730,8 +892,27 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         long retainedDebtIterations,
         long maxRetainedSlices,
         long writableFramesAtLargestCatchUpBatch,
+        long runnerThreadId,
+        string runnerThreadPriority,
+        long singleSliceBatches,
+        long multiSliceBatches,
+        double averageBatchSize,
+        double maxWakeLatenessMilliseconds,
+        long wakeLateOver2Ms,
+        long wakeLateOver5Ms,
+        long wakeLateOver10Ms,
+        long wakeLateOver20Ms,
+        long wakeLateOver50Ms,
+        long wakeLateOver100Ms,
+        long longestConsecutiveLateWakes,
+        double maxAdvanceDurationMilliseconds,
+        double maxReadAudioDurationMilliseconds,
+        double maxSnapshotDurationMilliseconds,
+        double maxPublishDurationMilliseconds,
+        double maxInputDurationMilliseconds,
+        double maxSessionGateWaitMilliseconds,
         EmulationAudioPlaybackStatistics audioStatistics) =>
-        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
+        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, runnerThreadId={runnerThreadId}, runnerThreadPriority={runnerThreadPriority}, singleSliceBatches={singleSliceBatches}, multiSliceBatches={multiSliceBatches}, averageBatchSize={averageBatchSize:F2}, catchUpSlicePercent={(slices > 0 ? (double)catchUpSlices * 100 / slices : 0):F2}, maxWakeLatenessMs={maxWakeLatenessMilliseconds:F3}, wakeLateOver2Ms={wakeLateOver2Ms}, wakeLateOver5Ms={wakeLateOver5Ms}, wakeLateOver10Ms={wakeLateOver10Ms}, wakeLateOver20Ms={wakeLateOver20Ms}, wakeLateOver50Ms={wakeLateOver50Ms}, wakeLateOver100Ms={wakeLateOver100Ms}, longestConsecutiveLateWakes={longestConsecutiveLateWakes}, maxAdvanceDurationMs={maxAdvanceDurationMilliseconds:F3}, maxReadAudioDurationMs={maxReadAudioDurationMilliseconds:F3}, maxSnapshotDurationMs={maxSnapshotDurationMilliseconds:F3}, maxPublishDurationMs={maxPublishDurationMilliseconds:F3}, maxInputDurationMs={maxInputDurationMilliseconds:F3}, maxSessionGateWaitMs={maxSessionGateWaitMilliseconds:F3}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
 
     private static void TryCleanup(Action action, ref List<Exception>? failures)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -10,6 +10,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private const string JpmSystem6MachineIdentifier = "jpm-system6";
     private const int EmulationPumpHz = 1000;
     private const ulong NanosecondsPerPump = 1_000_000;
+    private const int MaxCatchUpSlices = 64;
+    private const int ExceptionalDelayCapMilliseconds = 500;
     private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
     private static readonly EmulationBackendCapabilities BackendCapabilities =
         new(true, true, true, true, false, false, false);
@@ -318,25 +320,42 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     scheduleGeneration = currentGeneration;
                 }
 
+                var slices = 0;
+                var now = _clock.GetTimestamp();
+                var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
+                if (now - nextDeadline > exceptionalCapTicks)
+                    nextDeadline = now - exceptionalCapTicks;
+
+                do
+                {
+                    await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var session = RequireSession();
+                        session.Advance(NanosecondsPerPump);
+                        ProcessInputs(session);
+                        ReadAudio(session);
+                    }
+                    finally
+                    {
+                        _sessionGate.Release();
+                    }
+
+                    nextDeadline += pumpTicks;
+                    slices++;
+                    now = _clock.GetTimestamp();
+                }
+                while (now >= nextDeadline && slices < MaxCatchUpSlices);
+
                 await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    var session = RequireSession();
-                    session.Advance(NanosecondsPerPump);
-                    ProcessInputs(session);
-                    PublishSnapshot(session.GetSnapshot());
-                    ReadAudio(session);
+                    PublishSnapshot(RequireSession().GetSnapshot());
                 }
                 finally
                 {
                     _sessionGate.Release();
                 }
-
-                nextDeadline += pumpTicks;
-                var now = _clock.GetTimestamp();
-                // Execute the current slice, then abandon catch-up once over three ticks late.
-                if (now - nextDeadline > pumpTicks * 3)
-                    nextDeadline = now + pumpTicks;
 
                 var remainingTicks = nextDeadline - _clock.GetTimestamp();
                 if (remainingTicks > 0)
@@ -358,14 +377,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             LastFailure = exception;
             LogException("Fabric emulation pump failed.", exception);
             _pumpCancellation?.Cancel();
-            try
-            {
-                await CleanupResourcesAsync().ConfigureAwait(false);
-            }
-            catch (Exception cleanupException)
-            {
-                LogException("Fabric cleanup after pump failure also failed.", cleanupException);
-            }
             SetState(EmulationBackendState.Failed);
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -22,6 +22,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private readonly IEmulationAudioSink _audioSink;
     private readonly IFabricClock _clock;
     private readonly Action<string> _errorLogger;
+    private readonly Action<string> _infoLogger;
     private readonly SemaphoreSlim _sessionGate = new(1, 1);
     private readonly ConcurrentQueue<InputCommand> _inputCommands = new();
     private readonly HashSet<int> _assertedInputs = [];
@@ -48,6 +49,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private long _maxCatchUpBatch;
     private long _exceptionalDiscardedTicks;
     private long _fabricAudioFramesRead;
+    private long _zeroAudioSlices;
+    private long _minFramesPerSlice = long.MaxValue;
+    private long _maxFramesPerSlice;
+    private long _capacityLimitedCatchUpBatches;
+    private long _retainedDebtIterations;
+    private long _maxRetainedSlices;
+    private long _writableFramesAtLargestCatchUpBatch;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -61,7 +69,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Func<string, IFabricRuntimeLibrary> runtimeFactory,
         IEmulationAudioSink audioSink,
         IFabricClock clock,
-        Action<string>? errorLogger = null)
+        Action<string>? errorLogger = null,
+        Action<string>? infoLogger = null)
     {
         _runtimePath = runtimePath;
         _amberPath = amberPath;
@@ -69,6 +78,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioSink = audioSink;
         _clock = clock;
         _errorLogger = errorLogger ?? WriteDebugError;
+        _infoLogger = infoLogger ?? WriteDebugInfo;
     }
 
     public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
@@ -327,7 +337,6 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     scheduleGeneration = currentGeneration;
                 }
 
-                var slices = 0;
                 var now = _clock.GetTimestamp();
                 var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
                 if (now - nextDeadline > exceptionalCapTicks)
@@ -336,7 +345,34 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     nextDeadline = now - exceptionalCapTicks;
                 }
 
-                do
+                var availableSlices = CalculateAvailableSlices(now, nextDeadline, pumpTicks);
+                if (availableSlices <= 0)
+                {
+                    var remaining = TimeSpan.FromSeconds((double)(nextDeadline - now) / _clock.Frequency);
+                    await Task.Delay(remaining, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var writableFrames = _audioStarted ? _audioSink.WritableFrames : int.MaxValue;
+                var capacityLimitedSlices = CalculateAudioCapacityLimitedSlices(writableFrames);
+                var schedulerLimitedSlices = Math.Min(availableSlices, MaxCatchUpSlices);
+                var slices = Math.Min(schedulerLimitedSlices, capacityLimitedSlices);
+                if (slices <= 0)
+                {
+                    Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
+                    Interlocked.Increment(ref _retainedDebtIterations);
+                    UpdateMaxRetainedSlices(availableSlices);
+                    await Task.Delay(PumpInterval, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+                if (slices < schedulerLimitedSlices)
+                {
+                    Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
+                    Interlocked.Increment(ref _retainedDebtIterations);
+                    UpdateMaxRetainedSlices(availableSlices - slices);
+                }
+
+                for (var slice = 0; slice < slices; slice++)
                 {
                     await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                     try
@@ -352,14 +388,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     }
 
                     nextDeadline += pumpTicks;
-                    slices++;
-                    now = _clock.GetTimestamp();
                 }
-                while (now >= nextDeadline && slices < MaxCatchUpSlices);
 
                 Interlocked.Add(ref _totalEmulationSlices, slices);
                 if (slices > 1)
                     Interlocked.Add(ref _catchUpSlices, slices - 1);
+                if (slices > Interlocked.Read(ref _maxCatchUpBatch))
+                    Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, writableFrames);
                 UpdateMaxCatchUpBatch(slices);
 
                 await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -414,7 +449,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioSink.Start(audioFormat);
         _audioStarted = true;
         var statistics = _audioSink.GetStatistics();
-        _errorLogger($"Fabric audio startup: sampleRate={audioFormat.SampleRate}, channels={audioFormat.Channels}, ringCapacityFrames={statistics.CapacityFrames}, ringCapacityMs={(double)statistics.CapacityFrames * 1000 / audioFormat.SampleRate:F1}, prebufferFrames={statistics.PrebufferThresholdFrames}, prebufferMs={statistics.PrebufferThresholdMilliseconds}, outputBackend=WasapiOut, wasapiLatencyMs={(double)statistics.CapacityFrames * 1000 / audioFormat.SampleRate:F1}.");
+        _infoLogger($"Fabric audio startup: sampleRate={audioFormat.SampleRate}, channels={audioFormat.Channels}, ringCapacityFrames={statistics.CapacityFrames}, ringCapacityMs={(double)statistics.CapacityFrames * 1000 / audioFormat.SampleRate:F1}, prebufferFrames={statistics.PrebufferThresholdFrames}, prebufferMs={statistics.PrebufferThresholdMilliseconds}, outputBackend=WasapiOut, wasapiLatencyMs={statistics.WasapiLatencyMilliseconds}.");
     }
 
     internal static int CalculateAudioFramesPerTick(int sampleRate)
@@ -443,6 +478,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         var frameCapacity = _audioBuffer.Length / format.ChannelCount;
         var framesWritten = session.ReadAudio(_audioBuffer, frameCapacity);
         Interlocked.Add(ref _fabricAudioFramesRead, framesWritten);
+        if (framesWritten == 0)
+            Interlocked.Increment(ref _zeroAudioSlices);
+        UpdateMinFramesPerSlice(framesWritten);
+        UpdateMaxFramesPerSlice(framesWritten);
         var sampleCount = checked(framesWritten * format.ChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
         if (!bytes.IsEmpty)
@@ -573,6 +612,67 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Interlocked.Exchange(ref _maxCatchUpBatch, 0);
         Interlocked.Exchange(ref _exceptionalDiscardedTicks, 0);
         Interlocked.Exchange(ref _fabricAudioFramesRead, 0);
+        Interlocked.Exchange(ref _zeroAudioSlices, 0);
+        Interlocked.Exchange(ref _minFramesPerSlice, long.MaxValue);
+        Interlocked.Exchange(ref _maxFramesPerSlice, 0);
+        Interlocked.Exchange(ref _capacityLimitedCatchUpBatches, 0);
+        Interlocked.Exchange(ref _retainedDebtIterations, 0);
+        Interlocked.Exchange(ref _maxRetainedSlices, 0);
+        Interlocked.Exchange(ref _writableFramesAtLargestCatchUpBatch, 0);
+    }
+
+    internal static int CalculateSafeFramesPerSlice(int sampleRate)
+    {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate));
+        return checked((sampleRate + EmulationPumpHz - 1) / EmulationPumpHz);
+    }
+
+    internal int CalculateAudioCapacityLimitedSlices(int writableFrames)
+    {
+        if (!_audioStarted || _audioFormat is not { } format)
+            return MaxCatchUpSlices;
+        if (writableFrames <= 0)
+            return 0;
+        return CalculateAudioCapacityLimitedSlices(checked((int)format.SampleRate), writableFrames);
+    }
+
+    internal static int CalculateAudioCapacityLimitedSlices(int sampleRate, int writableFrames)
+    {
+        if (writableFrames <= 0)
+            return 0;
+        return writableFrames / CalculateSafeFramesPerSlice(sampleRate);
+    }
+
+    internal static int CalculateAvailableSlices(long now, long nextDeadline, long pumpTicks)
+    {
+        if (now < nextDeadline)
+            return 0;
+        return checked((int)Math.Min(int.MaxValue, ((now - nextDeadline) / pumpTicks) + 1));
+    }
+
+    private void UpdateMinFramesPerSlice(int frames)
+    {
+        var current = Interlocked.Read(ref _minFramesPerSlice);
+        while (frames < current)
+        {
+            var previous = Interlocked.CompareExchange(ref _minFramesPerSlice, frames, current);
+            if (previous == current) return;
+            current = previous;
+        }
+    }
+
+    private void UpdateMaxFramesPerSlice(int frames) => UpdateMax(ref _maxFramesPerSlice, frames);
+    private void UpdateMaxRetainedSlices(long slices) => UpdateMax(ref _maxRetainedSlices, slices);
+    private static void UpdateMax(ref long target, long value)
+    {
+        var current = Interlocked.Read(ref target);
+        while (value > current)
+        {
+            var previous = Interlocked.CompareExchange(ref target, value, current);
+            if (previous == current) return;
+            current = previous;
+        }
     }
 
     private void UpdateMaxCatchUpBatch(int slices)
@@ -595,7 +695,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         var emulatedMs = slices;
         var ratio = wallMs > 0 ? emulatedMs / wallMs : 0;
         var discardedMs = (double)Interlocked.Read(ref _exceptionalDiscardedTicks) * 1000 / _clock.Frequency;
-        _errorLogger(FormatStopSummary(
+        _infoLogger(FormatStopSummary(
             wallMs,
             emulatedMs,
             ratio,
@@ -604,6 +704,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             Interlocked.Read(ref _maxCatchUpBatch),
             discardedMs,
             Interlocked.Read(ref _fabricAudioFramesRead),
+            Interlocked.Read(ref _zeroAudioSlices),
+            Interlocked.Read(ref _minFramesPerSlice) == long.MaxValue ? 0 : Interlocked.Read(ref _minFramesPerSlice),
+            Interlocked.Read(ref _maxFramesPerSlice),
+            Interlocked.Read(ref _capacityLimitedCatchUpBatches),
+            Interlocked.Read(ref _retainedDebtIterations),
+            Interlocked.Read(ref _maxRetainedSlices),
+            Interlocked.Read(ref _writableFramesAtLargestCatchUpBatch),
             audioStatistics));
     }
 
@@ -616,8 +723,15 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         long maxCatchUpBatch,
         double discardedMilliseconds,
         long fabricAudioFrames,
+        long zeroAudioSlices,
+        long minFramesPerSlice,
+        long maxFramesPerSlice,
+        long capacityLimitedCatchUpBatches,
+        long retainedDebtIterations,
+        long maxRetainedSlices,
+        long writableFramesAtLargestCatchUpBatch,
         EmulationAudioPlaybackStatistics audioStatistics) =>
-        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRingFrames={audioStatistics.MinimumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
+        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
 
     private static void TryCleanup(Action action, ref List<Exception>? failures)
     {
@@ -629,6 +743,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _errorLogger($"[Error] {message}{Environment.NewLine}{exception}");
 
     private static void WriteDebugError(string message) => Debug.WriteLine(message);
+    private static void WriteDebugInfo(string message) => Debug.WriteLine(message);
 
     private void ReleaseAssertedInputs()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -42,6 +42,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private bool _audioStarted;
     private bool _disposed;
     private long _scheduleGeneration;
+    private long _runnerStartTimestamp;
+    private long _totalEmulationSlices;
+    private long _catchUpSlices;
+    private long _maxCatchUpBatch;
+    private long _exceptionalDiscardedTicks;
+    private long _fabricAudioFramesRead;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -112,6 +118,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             }
 
             _shutdown = false;
+            ResetRunnerStatistics();
             LastFailure = null;
             _pumpCancellation = new CancellationTokenSource();
             _pumpTask = Task.Run(() => PumpAsync(_pumpCancellation.Token), CancellationToken.None);
@@ -324,7 +331,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 var now = _clock.GetTimestamp();
                 var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
                 if (now - nextDeadline > exceptionalCapTicks)
+                {
+                    Interlocked.Add(ref _exceptionalDiscardedTicks, now - nextDeadline - exceptionalCapTicks);
                     nextDeadline = now - exceptionalCapTicks;
+                }
 
                 do
                 {
@@ -346,6 +356,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     now = _clock.GetTimestamp();
                 }
                 while (now >= nextDeadline && slices < MaxCatchUpSlices);
+
+                Interlocked.Add(ref _totalEmulationSlices, slices);
+                if (slices > 1)
+                    Interlocked.Add(ref _catchUpSlices, slices - 1);
+                UpdateMaxCatchUpBatch(slices);
 
                 await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
@@ -392,11 +407,14 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         _audioFormat = format;
         var frameCapacity = CalculateAudioFramesPerTick(checked((int)format.SampleRate));
         _audioBuffer = new short[checked(frameCapacity * (int)format.ChannelCount)];
-        _audioSink.Start(new(
+        var audioFormat = new EmulationAudioFormat(
             checked((int)format.SampleRate),
             checked((int)format.ChannelCount),
-            checked((int)format.BitsPerSample)));
+            checked((int)format.BitsPerSample));
+        _audioSink.Start(audioFormat);
         _audioStarted = true;
+        var statistics = _audioSink.GetStatistics();
+        _errorLogger($"Fabric audio startup: sampleRate={audioFormat.SampleRate}, channels={audioFormat.Channels}, ringCapacityFrames={statistics.CapacityFrames}, ringCapacityMs={(double)statistics.CapacityFrames * 1000 / audioFormat.SampleRate:F1}, prebufferFrames={statistics.PrebufferThresholdFrames}, prebufferMs={statistics.PrebufferThresholdMilliseconds}, outputBackend=WasapiOut, wasapiLatencyMs={(double)statistics.CapacityFrames * 1000 / audioFormat.SampleRate:F1}.");
     }
 
     internal static int CalculateAudioFramesPerTick(int sampleRate)
@@ -424,6 +442,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             return;
         var frameCapacity = _audioBuffer.Length / format.ChannelCount;
         var framesWritten = session.ReadAudio(_audioBuffer, frameCapacity);
+        Interlocked.Add(ref _fabricAudioFramesRead, framesWritten);
         var sampleCount = checked(framesWritten * format.ChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
         if (!bytes.IsEmpty)
@@ -521,11 +540,14 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 TryCleanup(_session.Dispose, ref failures);
                 _session = null;
             }
+            EmulationAudioPlaybackStatistics audioStatistics = default;
             if (_audioStarted)
             {
                 TryCleanup(_audioSink.Stop, ref failures);
+                audioStatistics = _audioSink.GetStatistics();
                 _audioStarted = false;
             }
+            EmitStopSummary(audioStatistics);
             if (_runtime is not null)
                 TryCleanup(_runtime.Dispose, ref failures);
             _runtime = null;
@@ -542,6 +564,60 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         if (failures is { Count: > 0 })
             throw failures.Count == 1 ? failures[0] : new AggregateException("Multiple Fabric cleanup operations failed.", failures);
     }
+
+    private void ResetRunnerStatistics()
+    {
+        Interlocked.Exchange(ref _runnerStartTimestamp, _clock.GetTimestamp());
+        Interlocked.Exchange(ref _totalEmulationSlices, 0);
+        Interlocked.Exchange(ref _catchUpSlices, 0);
+        Interlocked.Exchange(ref _maxCatchUpBatch, 0);
+        Interlocked.Exchange(ref _exceptionalDiscardedTicks, 0);
+        Interlocked.Exchange(ref _fabricAudioFramesRead, 0);
+    }
+
+    private void UpdateMaxCatchUpBatch(int slices)
+    {
+        var current = Interlocked.Read(ref _maxCatchUpBatch);
+        while (slices > current)
+        {
+            var previous = Interlocked.CompareExchange(ref _maxCatchUpBatch, slices, current);
+            if (previous == current)
+                return;
+            current = previous;
+        }
+    }
+
+    private void EmitStopSummary(EmulationAudioPlaybackStatistics audioStatistics)
+    {
+        var start = Interlocked.Read(ref _runnerStartTimestamp);
+        var wallMs = start == 0 ? 0 : (double)(_clock.GetTimestamp() - start) * 1000 / _clock.Frequency;
+        var slices = Interlocked.Read(ref _totalEmulationSlices);
+        var emulatedMs = slices;
+        var ratio = wallMs > 0 ? emulatedMs / wallMs : 0;
+        var discardedMs = (double)Interlocked.Read(ref _exceptionalDiscardedTicks) * 1000 / _clock.Frequency;
+        _errorLogger(FormatStopSummary(
+            wallMs,
+            emulatedMs,
+            ratio,
+            slices,
+            Interlocked.Read(ref _catchUpSlices),
+            Interlocked.Read(ref _maxCatchUpBatch),
+            discardedMs,
+            Interlocked.Read(ref _fabricAudioFramesRead),
+            audioStatistics));
+    }
+
+    internal static string FormatStopSummary(
+        double wallMilliseconds,
+        double emulatedMilliseconds,
+        double ratio,
+        long slices,
+        long catchUpSlices,
+        long maxCatchUpBatch,
+        double discardedMilliseconds,
+        long fabricAudioFrames,
+        EmulationAudioPlaybackStatistics audioStatistics) =>
+        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRingFrames={audioStatistics.MinimumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
 
     private static void TryCleanup(Action action, ref List<Exception>? failures)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -63,6 +63,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private ThreadPriority _runnerThreadPriority = ThreadPriority.Normal;
     private long _singleSliceBatches;
     private long _multiSliceBatches;
+    private long _timedWaitCount;
+    private long _timedWaitLatenessTicksTotal;
     private long _maxWakeLatenessTicks;
     private long _wakeLateOver2Ms;
     private long _wakeLateOver5Ms;
@@ -78,6 +80,28 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private long _maxPublishDurationTicks;
     private long _maxInputDurationTicks;
     private long _maxSessionGateWaitTicks;
+    private long _debtContinuationCount;
+    private long _capacityLimitedContinuationCount;
+    private long _yieldContinuationCount;
+    private string _timingMode = "Unstarted";
+    private bool _highResolutionTimerActive;
+    private bool _mmcssRegistered;
+    private long _advanceCalls;
+    private long _advanceDurationTicksTotal;
+    private long _advanceOver2Ms;
+    private long _advanceOver5Ms;
+    private long _advanceOver10Ms;
+    private long _advanceOver20Ms;
+    private long _advanceOver50Ms;
+    private long _advanceOver100Ms;
+    private long _readAudioCalls;
+    private long _readAudioDurationTicksTotal;
+    private long _snapshotCalls;
+    private long _snapshotDurationTicksTotal;
+    private long _publishCalls;
+    private long _publishDurationTicksTotal;
+    private readonly ConcurrentQueue<StallTraceRecord> _stallTrace = new();
+    private string _lastStallTracePath = string.Empty;
 
     public FabricEmulationBackend(string runtimePath, string amberPath)
         : this(runtimePath, amberPath, path => new FabricRuntimeLibrary(path),
@@ -349,6 +373,11 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         {
             Interlocked.Exchange(ref _runnerThreadId, Environment.CurrentManagedThreadId);
             _runnerThreadPriority = Thread.CurrentThread.Priority;
+            using var timer = new FabricRunnerTimer(_runnerWake);
+            using var mmcss = FabricRunnerMmcssRegistration.Register("Games");
+            _timingMode = timer.TimingMode;
+            _highResolutionTimerActive = timer.HighResolutionTimerActive;
+            _mmcssRegistered = mmcss.Registered;
             var pumpTicks = Math.Max(1L, _clock.Frequency / EmulationPumpHz);
             var nextDeadline = _clock.GetTimestamp();
             var scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
@@ -357,8 +386,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             {
                 if (State != EmulationBackendState.Running)
                 {
-                    _runnerWake.Wait(PumpInterval, cancellationToken);
-                    _runnerWake.Reset();
+                    timer.Wait(PumpInterval, cancellationToken);
                     nextDeadline = _clock.GetTimestamp();
                     scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
                     slicesSinceSnapshot = 0;
@@ -373,9 +401,12 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     slicesSinceSnapshot = 0;
                 }
 
-                WaitUntil(nextDeadline, cancellationToken);
+                var waitedForDeadline = WaitUntil(timer, nextDeadline, cancellationToken);
                 var now = _clock.GetTimestamp();
-                ObserveWakeLateness(now - nextDeadline);
+                if (waitedForDeadline)
+                    ObserveWakeLateness(now - nextDeadline);
+                else if (now >= nextDeadline)
+                    Interlocked.Increment(ref _debtContinuationCount);
                 var exceptionalCapTicks = pumpTicks * ExceptionalDelayCapMilliseconds;
                 if (now - nextDeadline > exceptionalCapTicks)
                 {
@@ -394,15 +425,16 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 if (slices <= 0)
                 {
                     Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
+                    Interlocked.Increment(ref _capacityLimitedContinuationCount);
                     Interlocked.Increment(ref _retainedDebtIterations);
                     UpdateMaxRetainedSlices(availableSlices);
-                    _runnerWake.Wait(PumpInterval, cancellationToken);
-                    _runnerWake.Reset();
+                    timer.Wait(PumpInterval, cancellationToken);
                     continue;
                 }
                 if (slices < schedulerLimitedSlices)
                 {
                     Interlocked.Increment(ref _capacityLimitedCatchUpBatches);
+                    Interlocked.Increment(ref _capacityLimitedContinuationCount);
                     Interlocked.Increment(ref _retainedDebtIterations);
                     UpdateMaxRetainedSlices(availableSlices - slices);
                 }
@@ -415,7 +447,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                         var session = RequireSession();
                         var advanceStart = _clock.GetTimestamp();
                         session.Advance(NanosecondsPerPump);
-                        UpdateMaxDuration(ref _maxAdvanceDurationTicks, _clock.GetTimestamp() - advanceStart);
+                        ObserveOperationDuration("SessionAdvance", _clock.GetTimestamp() - advanceStart, ref _advanceCalls, ref _advanceDurationTicksTotal, ref _maxAdvanceDurationTicks);
 
                         var inputStart = _clock.GetTimestamp();
                         ProcessInputs(session);
@@ -423,7 +455,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
                         var audioStart = _clock.GetTimestamp();
                         ReadAudio(session);
-                        UpdateMaxDuration(ref _maxReadAudioDurationTicks, _clock.GetTimestamp() - audioStart);
+                        ObserveOperationDuration("ReadAudio", _clock.GetTimestamp() - audioStart, ref _readAudioCalls, ref _readAudioDurationTicksTotal, ref _maxReadAudioDurationTicks);
                     }
                     finally
                     {
@@ -453,7 +485,10 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 }
 
                 if (_clock.GetTimestamp() >= nextDeadline)
+                {
+                    Interlocked.Increment(ref _yieldContinuationCount);
                     Thread.Yield();
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -469,19 +504,19 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private void WaitUntil(long deadline, CancellationToken cancellationToken)
+    private bool WaitUntil(FabricRunnerTimer timer, long deadline, CancellationToken cancellationToken)
     {
+        var waited = false;
         while (!cancellationToken.IsCancellationRequested)
         {
             var remainingTicks = deadline - _clock.GetTimestamp();
             if (remainingTicks <= 0)
-                return;
+                return waited;
             var remainingMilliseconds = (double)remainingTicks * 1000 / _clock.Frequency;
             if (remainingMilliseconds > 2)
             {
                 var wait = TimeSpan.FromMilliseconds(Math.Max(0, remainingMilliseconds - 1));
-                _runnerWake.Wait(wait, cancellationToken);
-                _runnerWake.Reset();
+                waited |= timer.Wait(wait, cancellationToken);
                 continue;
             }
             var spin = new SpinWait();
@@ -493,16 +528,20 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 else
                     Thread.Yield();
             }
-            return;
+            return waited;
         }
         cancellationToken.ThrowIfCancellationRequested();
+        return waited;
     }
 
     private void WaitSessionGate(CancellationToken cancellationToken)
     {
         var start = _clock.GetTimestamp();
         _sessionGate.Wait(cancellationToken);
-        UpdateMaxDuration(ref _maxSessionGateWaitTicks, _clock.GetTimestamp() - start);
+        var elapsed = _clock.GetTimestamp() - start;
+        UpdateMaxDuration(ref _maxSessionGateWaitTicks, elapsed);
+        if (TicksToMilliseconds(elapsed) > 10)
+            EnqueueStallTrace("SessionGateWait", elapsed);
     }
 
     private void PublishLatestSnapshot(CancellationToken cancellationToken)
@@ -514,7 +553,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             var session = RequireSession();
             var snapshotStart = _clock.GetTimestamp();
             snapshot = session.GetSnapshot();
-            UpdateMaxDuration(ref _maxSnapshotDurationTicks, _clock.GetTimestamp() - snapshotStart);
+            ObserveOperationDuration("GetSnapshot", _clock.GetTimestamp() - snapshotStart, ref _snapshotCalls, ref _snapshotDurationTicksTotal, ref _maxSnapshotDurationTicks);
         }
         finally
         {
@@ -523,11 +562,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
 
         var publishStart = _clock.GetTimestamp();
         PublishSnapshot(snapshot);
-        UpdateMaxDuration(ref _maxPublishDurationTicks, _clock.GetTimestamp() - publishStart);
+        ObserveOperationDuration("PublishSnapshot", _clock.GetTimestamp() - publishStart, ref _publishCalls, ref _publishDurationTicksTotal, ref _maxPublishDurationTicks);
     }
 
     private void ObserveWakeLateness(long lateTicks)
     {
+        Interlocked.Increment(ref _timedWaitCount);
+        Interlocked.Add(ref _timedWaitLatenessTicksTotal, Math.Max(0, lateTicks));
         if (lateTicks <= 0)
         {
             Interlocked.Exchange(ref _currentConsecutiveLateWakes, 0);
@@ -535,6 +576,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
 
         UpdateMax(ref _maxWakeLatenessTicks, lateTicks);
+        if (TicksToMilliseconds(lateTicks) > 10)
+            EnqueueStallTrace("TimedWait", lateTicks);
         var lateMilliseconds = (double)lateTicks * 1000 / _clock.Frequency;
         if (lateMilliseconds > 2) Interlocked.Increment(ref _wakeLateOver2Ms);
         if (lateMilliseconds > 5) Interlocked.Increment(ref _wakeLateOver5Ms);
@@ -702,6 +745,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                 audioStatistics = _audioSink.GetStatistics();
                 _audioStarted = false;
             }
+            WriteStallTraceFile();
             EmitStopSummary(audioStatistics);
             if (_runtime is not null)
                 TryCleanup(_runtime.Dispose, ref failures);
@@ -754,6 +798,30 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Interlocked.Exchange(ref _maxPublishDurationTicks, 0);
         Interlocked.Exchange(ref _maxInputDurationTicks, 0);
         Interlocked.Exchange(ref _maxSessionGateWaitTicks, 0);
+        Interlocked.Exchange(ref _timedWaitCount, 0);
+        Interlocked.Exchange(ref _timedWaitLatenessTicksTotal, 0);
+        Interlocked.Exchange(ref _debtContinuationCount, 0);
+        Interlocked.Exchange(ref _capacityLimitedContinuationCount, 0);
+        Interlocked.Exchange(ref _yieldContinuationCount, 0);
+        _timingMode = "Unstarted";
+        _highResolutionTimerActive = false;
+        _mmcssRegistered = false;
+        Interlocked.Exchange(ref _advanceCalls, 0);
+        Interlocked.Exchange(ref _advanceDurationTicksTotal, 0);
+        Interlocked.Exchange(ref _advanceOver2Ms, 0);
+        Interlocked.Exchange(ref _advanceOver5Ms, 0);
+        Interlocked.Exchange(ref _advanceOver10Ms, 0);
+        Interlocked.Exchange(ref _advanceOver20Ms, 0);
+        Interlocked.Exchange(ref _advanceOver50Ms, 0);
+        Interlocked.Exchange(ref _advanceOver100Ms, 0);
+        Interlocked.Exchange(ref _readAudioCalls, 0);
+        Interlocked.Exchange(ref _readAudioDurationTicksTotal, 0);
+        Interlocked.Exchange(ref _snapshotCalls, 0);
+        Interlocked.Exchange(ref _snapshotDurationTicksTotal, 0);
+        Interlocked.Exchange(ref _publishCalls, 0);
+        Interlocked.Exchange(ref _publishDurationTicksTotal, 0);
+        while (_stallTrace.TryDequeue(out _)) { }
+        _lastStallTracePath = string.Empty;
     }
 
     internal static int CalculateSafeFramesPerSlice(int sampleRate)
@@ -797,6 +865,45 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
+
+    private void ObserveOperationDuration(string operation, long ticks, ref long calls, ref long totalTicks, ref long maxTicks)
+    {
+        Interlocked.Increment(ref calls);
+        Interlocked.Add(ref totalTicks, ticks);
+        UpdateMaxDuration(ref maxTicks, ticks);
+        if (operation == "SessionAdvance")
+            ObserveAdvanceDurationBuckets(ticks);
+        if (TicksToMilliseconds(ticks) > 10)
+            EnqueueStallTrace(operation, ticks);
+    }
+
+    private void ObserveAdvanceDurationBuckets(long ticks)
+    {
+        var ms = TicksToMilliseconds(ticks);
+        if (ms > 2) Interlocked.Increment(ref _advanceOver2Ms);
+        if (ms > 5) Interlocked.Increment(ref _advanceOver5Ms);
+        if (ms > 10) Interlocked.Increment(ref _advanceOver10Ms);
+        if (ms > 20) Interlocked.Increment(ref _advanceOver20Ms);
+        if (ms > 50) Interlocked.Increment(ref _advanceOver50Ms);
+        if (ms > 100) Interlocked.Increment(ref _advanceOver100Ms);
+    }
+
+    private void EnqueueStallTrace(string operation, long ticks)
+    {
+        if (_stallTrace.Count >= 500)
+            return;
+        _stallTrace.Enqueue(new(
+            _clock.GetTimestamp(),
+            operation,
+            TicksToMilliseconds(ticks),
+            Environment.CurrentManagedThreadId,
+            CalculateAvailableSlices(_clock.GetTimestamp(), _clock.GetTimestamp(), Math.Max(1L, _clock.Frequency / EmulationPumpHz)),
+            _audioSink.GetStatistics().CurrentRingFrames,
+            _audioSink.WritableFrames,
+            Interlocked.Read(ref _singleSliceBatches) + Interlocked.Read(ref _multiSliceBatches),
+            null));
+    }
+
     private void UpdateMaxFramesPerSlice(int frames) => UpdateMax(ref _maxFramesPerSlice, frames);
     private void UpdateMaxDuration(ref long target, long ticks) => UpdateMax(ref target, ticks);
     private void UpdateMaxRetainedSlices(long slices) => UpdateMax(ref _maxRetainedSlices, slices);
@@ -824,6 +931,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     }
 
     private double TicksToMilliseconds(long ticks) => (double)ticks * 1000 / _clock.Frequency;
+    private double AverageTicksToMilliseconds(long totalTicks, long calls) => calls > 0 ? TicksToMilliseconds(totalTicks) / calls : 0;
 
     private static double CalculateAverageBatchSize(long slices, long batches) => batches > 0 ? (double)slices / batches : 0;
 
@@ -873,6 +981,30 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             TicksToMilliseconds(Interlocked.Read(ref _maxPublishDurationTicks)),
             TicksToMilliseconds(Interlocked.Read(ref _maxInputDurationTicks)),
             TicksToMilliseconds(Interlocked.Read(ref _maxSessionGateWaitTicks)),
+            _timingMode,
+            _highResolutionTimerActive,
+            _mmcssRegistered,
+            Interlocked.Read(ref _timedWaitCount),
+            Interlocked.Read(ref _debtContinuationCount),
+            Interlocked.Read(ref _capacityLimitedContinuationCount),
+            Interlocked.Read(ref _yieldContinuationCount),
+            AverageTicksToMilliseconds(Interlocked.Read(ref _timedWaitLatenessTicksTotal), Interlocked.Read(ref _timedWaitCount)),
+            Interlocked.Read(ref _advanceCalls),
+            AverageTicksToMilliseconds(Interlocked.Read(ref _advanceDurationTicksTotal), Interlocked.Read(ref _advanceCalls)),
+            Interlocked.Read(ref _advanceOver2Ms),
+            Interlocked.Read(ref _advanceOver5Ms),
+            Interlocked.Read(ref _advanceOver10Ms),
+            Interlocked.Read(ref _advanceOver20Ms),
+            Interlocked.Read(ref _advanceOver50Ms),
+            Interlocked.Read(ref _advanceOver100Ms),
+            Interlocked.Read(ref _readAudioCalls),
+            AverageTicksToMilliseconds(Interlocked.Read(ref _readAudioDurationTicksTotal), Interlocked.Read(ref _readAudioCalls)),
+            Interlocked.Read(ref _snapshotCalls),
+            AverageTicksToMilliseconds(Interlocked.Read(ref _snapshotDurationTicksTotal), Interlocked.Read(ref _snapshotCalls)),
+            Interlocked.Read(ref _publishCalls),
+            AverageTicksToMilliseconds(Interlocked.Read(ref _publishDurationTicksTotal), Interlocked.Read(ref _publishCalls)),
+            _stallTrace.Count,
+            _lastStallTracePath,
             audioStatistics));
     }
 
@@ -911,8 +1043,50 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         double maxPublishDurationMilliseconds,
         double maxInputDurationMilliseconds,
         double maxSessionGateWaitMilliseconds,
+        string timingMode,
+        bool highResolutionTimerActive,
+        bool mmcssRegistered,
+        long timedWaitCount,
+        long debtContinuationCount,
+        long capacityContinuationCount,
+        long yieldContinuationCount,
+        double averageTimedWakeLatenessMilliseconds,
+        long advanceCalls,
+        double averageAdvanceDurationMilliseconds,
+        long advanceOver2Ms,
+        long advanceOver5Ms,
+        long advanceOver10Ms,
+        long advanceOver20Ms,
+        long advanceOver50Ms,
+        long advanceOver100Ms,
+        long readAudioCalls,
+        double averageReadAudioDurationMilliseconds,
+        long snapshotCalls,
+        double averageSnapshotDurationMilliseconds,
+        long publishCalls,
+        double averagePublishDurationMilliseconds,
+        int stallTraceCount,
+        string stallTracePath,
         EmulationAudioPlaybackStatistics audioStatistics) =>
-        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, runnerThreadId={runnerThreadId}, runnerThreadPriority={runnerThreadPriority}, singleSliceBatches={singleSliceBatches}, multiSliceBatches={multiSliceBatches}, averageBatchSize={averageBatchSize:F2}, catchUpSlicePercent={(slices > 0 ? (double)catchUpSlices * 100 / slices : 0):F2}, maxWakeLatenessMs={maxWakeLatenessMilliseconds:F3}, wakeLateOver2Ms={wakeLateOver2Ms}, wakeLateOver5Ms={wakeLateOver5Ms}, wakeLateOver10Ms={wakeLateOver10Ms}, wakeLateOver20Ms={wakeLateOver20Ms}, wakeLateOver50Ms={wakeLateOver50Ms}, wakeLateOver100Ms={wakeLateOver100Ms}, longestConsecutiveLateWakes={longestConsecutiveLateWakes}, maxAdvanceDurationMs={maxAdvanceDurationMilliseconds:F3}, maxReadAudioDurationMs={maxReadAudioDurationMilliseconds:F3}, maxSnapshotDurationMs={maxSnapshotDurationMilliseconds:F3}, maxPublishDurationMs={maxPublishDurationMilliseconds:F3}, maxInputDurationMs={maxInputDurationMilliseconds:F3}, maxSessionGateWaitMs={maxSessionGateWaitMilliseconds:F3}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
+        $"Fabric stop summary: wallMs={wallMilliseconds:F1}, emulatedMs={emulatedMilliseconds:F1}, ratio={ratio:F5}, slices={slices}, catchUpSlices={catchUpSlices}, maxCatchUpBatch={maxCatchUpBatch}, discardedMs={discardedMilliseconds:F1}, fabricAudioFrames={fabricAudioFrames}, zeroAudioSlices={zeroAudioSlices}, minFramesPerSlice={minFramesPerSlice}, maxFramesPerSlice={maxFramesPerSlice}, startupRingFrames={audioStatistics.StartupRingFrames}, minimumRingFrames={audioStatistics.MinimumRingFrames}, maximumRingFrames={audioStatistics.MaximumRingFrames}, currentRingFrames={audioStatistics.CurrentRingFrames}, ringCapacityFrames={audioStatistics.CapacityFrames}, writableFramesAtLargestCatchUpBatch={writableFramesAtLargestCatchUpBatch}, capacityLimitedCatchUpBatches={capacityLimitedCatchUpBatches}, retainedDebtIterations={retainedDebtIterations}, maxRetainedSlices={maxRetainedSlices}, runnerThreadId={runnerThreadId}, runnerThreadPriority={runnerThreadPriority}, singleSliceBatches={singleSliceBatches}, multiSliceBatches={multiSliceBatches}, averageBatchSize={averageBatchSize:F2}, catchUpSlicePercent={(slices > 0 ? (double)catchUpSlices * 100 / slices : 0):F2}, timingMode={timingMode}, highResolutionTimerActive={highResolutionTimerActive}, mmcssRegistered={mmcssRegistered}, timedWaitCount={timedWaitCount}, debtContinuationCount={debtContinuationCount}, capacityContinuationCount={capacityContinuationCount}, yieldContinuationCount={yieldContinuationCount}, averageTimedWakeLatenessMs={averageTimedWakeLatenessMilliseconds:F3}, maxTimedWakeLatenessMs={maxWakeLatenessMilliseconds:F3}, wakeLateOver2Ms={wakeLateOver2Ms}, wakeLateOver5Ms={wakeLateOver5Ms}, wakeLateOver10Ms={wakeLateOver10Ms}, wakeLateOver20Ms={wakeLateOver20Ms}, wakeLateOver50Ms={wakeLateOver50Ms}, wakeLateOver100Ms={wakeLateOver100Ms}, longestConsecutiveLateWakes={longestConsecutiveLateWakes}, advanceCalls={advanceCalls}, averageAdvanceDurationMs={averageAdvanceDurationMilliseconds:F3}, maxAdvanceDurationMs={maxAdvanceDurationMilliseconds:F3}, advanceOver2Ms={advanceOver2Ms}, advanceOver5Ms={advanceOver5Ms}, advanceOver10Ms={advanceOver10Ms}, advanceOver20Ms={advanceOver20Ms}, advanceOver50Ms={advanceOver50Ms}, advanceOver100Ms={advanceOver100Ms}, readAudioCalls={readAudioCalls}, averageReadAudioDurationMs={averageReadAudioDurationMilliseconds:F3}, snapshotCalls={snapshotCalls}, averageSnapshotDurationMs={averageSnapshotDurationMilliseconds:F3}, publishCalls={publishCalls}, averagePublishDurationMs={averagePublishDurationMilliseconds:F3}, stallTraceCount={stallTraceCount}, stallTracePath={stallTracePath}, maxReadAudioDurationMs={maxReadAudioDurationMilliseconds:F3}, maxSnapshotDurationMs={maxSnapshotDurationMilliseconds:F3}, maxPublishDurationMs={maxPublishDurationMilliseconds:F3}, maxInputDurationMs={maxInputDurationMilliseconds:F3}, maxSessionGateWaitMs={maxSessionGateWaitMilliseconds:F3}, maxFramesGeneratedByOneSlice={maxFramesPerSlice}, ringWritten={audioStatistics.RingFramesWritten}, ringRejected={audioStatistics.RingFramesRejected}, devicePcmFrames={audioStatistics.DeviceFramesDelivered}, silenceFrames={audioStatistics.SilenceFrames}, underrunEpisodes={audioStatistics.UnderrunEpisodes}, minimumRequestedFrames={audioStatistics.MinimumRequestedFrames}, maximumRequestedFrames={audioStatistics.MaximumRequestedFrames}, totalRequestedFrames={audioStatistics.TotalRequestedFrames}, playbackStarted={audioStatistics.PlaybackStarted}.";
+
+    private void WriteStallTraceFile()
+    {
+        if (_stallTrace.IsEmpty)
+            return;
+        var path = Path.Combine(Path.GetTempPath(), $"oasis-fabric-runner-stalls-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}.csv");
+        var lines = new List<string>(_stallTrace.Count + 1)
+        {
+            "timestamp,operation,durationMs,runnerThreadId,currentDebtSlices,ringReadableFrames,ringWritableFrames,batchIndex,applicationActive"
+        };
+        lines.AddRange(_stallTrace.Select(record =>
+            FormattableString.Invariant($"{record.Timestamp},{record.Operation},{record.DurationMilliseconds:F3},{record.RunnerThreadId},{record.CurrentDebtSlices},{record.RingReadableFrames},{record.RingWritableFrames},{record.BatchIndex},{record.ApplicationActive}")));
+        File.WriteAllLines(path, lines);
+        _lastStallTracePath = path;
+    }
+
+
+    private readonly record struct StallTraceRecord(long Timestamp, string Operation, double DurationMilliseconds, int RunnerThreadId, int CurrentDebtSlices, int RingReadableFrames, int RingWritableFrames, long BatchIndex, bool? ApplicationActive);
 
     private static void TryCleanup(Action action, ref List<Exception>? failures)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricRunnerTiming.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricRunnerTiming.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace OasisEditor;
+
+internal sealed class FabricRunnerTimer : IDisposable
+{
+    private const uint CreateWaitableTimerHighResolution = 0x00000002;
+    private const uint TimerAllAccess = 0x001F0003;
+    private readonly SafeWaitHandle? _timerHandle;
+    private readonly WaitHandle? _timerWaitHandle;
+    private readonly ManualResetEventSlim _wake;
+
+    public FabricRunnerTimer(ManualResetEventSlim wake)
+    {
+        _wake = wake;
+        if (!OperatingSystem.IsWindows())
+        {
+            TimingMode = "ManagedWait";
+            return;
+        }
+
+        _timerHandle = CreateWaitableTimerEx(IntPtr.Zero, null, CreateWaitableTimerHighResolution, TimerAllAccess);
+        if (_timerHandle.IsInvalid)
+            _timerHandle = CreateWaitableTimerEx(IntPtr.Zero, null, 0, TimerAllAccess);
+        if (_timerHandle.IsInvalid)
+        {
+            TimingMode = "ManagedWait";
+            _timerHandle.Dispose();
+            _timerHandle = null;
+            return;
+        }
+
+        HighResolutionTimerActive = true;
+        TimingMode = "WaitableTimer";
+        _timerWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset) { SafeWaitHandle = _timerHandle };
+    }
+
+    public string TimingMode { get; }
+    public bool HighResolutionTimerActive { get; }
+
+    public bool Wait(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        if (delay <= TimeSpan.Zero)
+            return false;
+        if (_timerWaitHandle is null)
+        {
+            _wake.Wait(delay, cancellationToken);
+            _wake.Reset();
+            return true;
+        }
+
+        var dueTime = -Math.Max(1, delay.Ticks);
+        if (!SetWaitableTimer(_timerHandle!, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false))
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        var index = WaitHandle.WaitAny([_timerWaitHandle, _wake.WaitHandle, cancellationToken.WaitHandle]);
+        _wake.Reset();
+        cancellationToken.ThrowIfCancellationRequested();
+        return index == 0;
+    }
+
+    public void Dispose()
+    {
+        _timerWaitHandle?.Dispose();
+        _timerHandle?.Dispose();
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeWaitHandle CreateWaitableTimerEx(IntPtr lpTimerAttributes, string? lpTimerName, uint dwFlags, uint dwDesiredAccess);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetWaitableTimer(SafeWaitHandle hTimer, ref long lpDueTime, int lPeriod, IntPtr pfnCompletionRoutine, IntPtr lpArgToCompletionRoutine, bool fResume);
+}
+
+internal sealed class FabricRunnerMmcssRegistration : IDisposable
+{
+    private IntPtr _handle;
+
+    private FabricRunnerMmcssRegistration(IntPtr handle, bool registered)
+    {
+        _handle = handle;
+        Registered = registered;
+    }
+
+    public bool Registered { get; }
+
+    public static FabricRunnerMmcssRegistration Register(string taskName)
+    {
+        if (!OperatingSystem.IsWindows())
+            return new(IntPtr.Zero, false);
+        var taskIndex = 0u;
+        var handle = AvSetMmThreadCharacteristics(taskName, ref taskIndex);
+        return new(handle, handle != IntPtr.Zero);
+    }
+
+    public void Dispose()
+    {
+        if (_handle == IntPtr.Zero)
+            return;
+        AvRevertMmThreadCharacteristics(_handle);
+        _handle = IntPtr.Zero;
+    }
+
+    [DllImport("avrt.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr AvSetMmThreadCharacteristics(string taskName, ref uint taskIndex);
+
+    [DllImport("avrt.dll", SetLastError = true)]
+    private static extern bool AvRevertMmThreadCharacteristics(IntPtr avrtHandle);
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricRunnerTiming.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricRunnerTiming.cs
@@ -22,6 +22,7 @@ internal sealed class FabricRunnerTimer : IDisposable
         }
 
         _timerHandle = CreateWaitableTimerEx(IntPtr.Zero, null, CreateWaitableTimerHighResolution, TimerAllAccess);
+        HighResolutionTimerActive = !_timerHandle.IsInvalid;
         if (_timerHandle.IsInvalid)
             _timerHandle = CreateWaitableTimerEx(IntPtr.Zero, null, 0, TimerAllAccess);
         if (_timerHandle.IsInvalid)
@@ -32,7 +33,6 @@ internal sealed class FabricRunnerTimer : IDisposable
             return;
         }
 
-        HighResolutionTimerActive = true;
         TimingMode = "WaitableTimer";
         _timerWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset) { SafeWaitHandle = _timerHandle };
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
@@ -6,28 +7,23 @@ namespace OasisEditor;
 
 public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 {
-    private const int DiagnosticPushLimit = 32;
+    private readonly object _lifecycleGate = new();
     private readonly int _bufferLengthMilliseconds;
-
-    private BufferedWaveProvider? _buffer;
-    private WasapiOut? _output;
-    private EmulationAudioFormat? _format;
-    private AudioPrebufferPolicy? _prebuffer;
-    private long _droppedBlocks;
-    private long _droppedBytes;
-    private long _runtimeStarvationEvents;
-    private long _pushCount;
-    private int _minimumBufferedBytes = int.MaxValue;
-    private bool _playbackStarted;
+    private PlaybackState? _state;
+    private long _ringFramesWritten;
+    private long _ringFramesRejected;
+    private long _firstOverflowWarningWritten;
 
     internal int BufferLengthMilliseconds => _bufferLengthMilliseconds;
     internal int PrebufferThresholdMilliseconds => AudioPrebufferPolicy.CalculateThresholdMilliseconds(_bufferLengthMilliseconds);
-    internal int PrebufferThresholdBytes => _prebuffer?.ThresholdBytes ?? 0;
-    internal long DroppedBlocks => Interlocked.Read(ref _droppedBlocks);
-    internal long DroppedBytes => Interlocked.Read(ref _droppedBytes);
-    internal long RuntimeStarvationEvents => Interlocked.Read(ref _runtimeStarvationEvents);
-    internal int MinimumObservedBufferedBytes => _minimumBufferedBytes == int.MaxValue ? 0 : _minimumBufferedBytes;
-    internal bool PlaybackStarted => _playbackStarted;
+    internal int PrebufferThresholdFrames => _state?.Prebuffer.ThresholdFrames ?? 0;
+    internal long RingFramesWritten => Interlocked.Read(ref _ringFramesWritten);
+    internal long RingFramesRejected => Interlocked.Read(ref _ringFramesRejected);
+    internal long DeviceFramesDelivered => _state?.Provider.FramesDelivered ?? 0;
+    internal long SilenceFrames => _state?.Provider.SilenceFrames ?? 0;
+    internal long UnderrunEpisodes => _state?.Provider.UnderrunEpisodes ?? 0;
+    internal int MinimumObservedRingFrames => _state?.MinimumObservedRingFramesValue ?? 0;
+    internal bool PlaybackStarted => _state?.Prebuffer.PlaybackStarted ?? false;
 
     public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
     {
@@ -40,83 +36,60 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     {
         ValidateFormat(format);
         Stop();
-
         var waveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
-        _buffer = new BufferedWaveProvider(waveFormat)
-        {
-            BufferDuration = TimeSpan.FromMilliseconds(_bufferLengthMilliseconds),
-            DiscardOnBufferOverflow = true
-        };
-        _output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
-        _output.Init(_buffer);
-        _format = format;
-        _prebuffer = new AudioPrebufferPolicy(format, _bufferLengthMilliseconds);
+        var capacityFrames = AudioPrebufferPolicy.CalculateCapacityFrames(format, _bufferLengthMilliseconds);
+        var ring = new PcmFrameRingBuffer(format.Channels, capacityFrames);
+        var provider = new PcmRingWaveProvider(ring, waveFormat);
+        var output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
+        output.Init(provider);
+        var state = new PlaybackState(format, ring, provider, output, new AudioPrebufferPolicy(format, _bufferLengthMilliseconds));
         ResetDiagnostics();
-        // Play is deliberately deferred until enough PCM (including digital silence) is queued.
+        lock (_lifecycleGate)
+            _state = state;
+        Debug.WriteLine($"NAudio emulation buffer: started; capacityFrames={capacityFrames}, prebufferFrames={state.Prebuffer.ThresholdFrames}.");
     }
 
     public void PushPcm(ReadOnlySpan<byte> pcmBytes)
     {
-        if (pcmBytes.IsEmpty || _buffer is null)
+        var state = Volatile.Read(ref _state);
+        if (state is null || state.IsStopping || pcmBytes.IsEmpty)
             return;
-
-        var format = _format ?? throw new InvalidOperationException("Audio sink has not been started.");
-        var before = _buffer.BufferedBytes;
-        var capacity = _buffer.BufferLength;
-        var push = Interlocked.Increment(ref _pushCount);
-        ObserveMinimum(before);
-
-        if (_playbackStarted && before < format.BytesPerMillisecond())
+        var samples = MemoryMarshal.Cast<byte, short>(pcmBytes);
+        var frameCount = samples.Length / state.Format.Channels;
+        if (frameCount <= 0) return;
+        state.ObserveDepthBeforeWrite();
+        var written = state.Ring.Write(samples[..(frameCount * state.Format.Channels)], frameCount);
+        Interlocked.Add(ref _ringFramesWritten, written);
+        var rejected = frameCount - written;
+        if (rejected > 0)
         {
-            var starvation = Interlocked.Increment(ref _runtimeStarvationEvents);
-            if (starvation == 1 || IsPowerOfTwo(starvation))
-                WriteDepthDiagnostic("runtime starvation risk", pcmBytes.Length, before, before, capacity);
+            Interlocked.Add(ref _ringFramesRejected, rejected);
+            if (Interlocked.Exchange(ref _firstOverflowWarningWritten, 1) == 0)
+                Debug.WriteLine($"NAudio emulation buffer: ring overflow; rejectedFrames={rejected}.");
         }
-
-        if (ShouldDropIncomingBlock(before, capacity, pcmBytes.Length))
-        {
-            var droppedBlocks = Interlocked.Increment(ref _droppedBlocks);
-            Interlocked.Add(ref _droppedBytes, pcmBytes.Length);
-            if (droppedBlocks == 1 || IsPowerOfTwo(droppedBlocks))
-                WriteDepthDiagnostic("dropped incoming block", pcmBytes.Length, before, before, capacity);
-            return;
-        }
-
-        var bytes = pcmBytes.ToArray();
-        _buffer.AddSamples(bytes, 0, bytes.Length);
-        var after = _buffer.BufferedBytes;
-        if (push <= DiagnosticPushLimit)
-            WriteDepthDiagnostic("push", bytes.Length, before, after, capacity);
-
-        if (!_playbackStarted && _prebuffer!.ObserveQueuedBytes(after))
-        {
-            _output!.Play();
-            _playbackStarted = true;
-            Debug.WriteLine($"NAudio emulation buffer: startup prebuffer complete; thresholdBytes={_prebuffer.ThresholdBytes}, bufferedBytes={after}.");
-        }
+        if (!state.Prebuffer.PlaybackStarted && state.Prebuffer.ObserveQueuedFrames(state.Ring.ReadableFrames))
+            state.PlayOnce();
     }
 
     public void Clear()
     {
-        if (_output is not null && _playbackStarted)
-            _output.Stop();
-        _buffer?.ClearBuffer();
-        _playbackStarted = false;
-        _prebuffer?.Reset();
-        _minimumBufferedBytes = int.MaxValue;
+        PlaybackState? state;
+        lock (_lifecycleGate) state = _state;
+        state?.ClearForFreshPrebuffer();
     }
 
     public void Stop()
     {
-        if (_format is not null)
-            Debug.WriteLine($"NAudio emulation buffer: stop summary; pushes={_pushCount}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, starvationRiskEvents={RuntimeStarvationEvents}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
-        _output?.Stop();
-        _output?.Dispose();
-        _output = null;
-        _buffer = null;
-        _format = null;
-        _prebuffer = null;
-        _playbackStarted = false;
+        PlaybackState? state;
+        lock (_lifecycleGate)
+        {
+            state = _state;
+            if (state is not null) state.IsStopping = true;
+            _state = null;
+        }
+        if (state is null) return;
+        Debug.WriteLine($"NAudio emulation buffer: stop summary; ringFramesWritten={RingFramesWritten}, ringFramesRejected={RingFramesRejected}, deviceFramesDelivered={state.Provider.FramesDelivered}, silenceFrames={state.Provider.SilenceFrames}, underrunEpisodes={state.Provider.UnderrunEpisodes}, minimumRingFrames={state.MinimumObservedRingFramesValue}.");
+        state.StopDisposeAndClear();
     }
 
     public void Dispose() => Stop();
@@ -126,29 +99,52 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 
     private void ResetDiagnostics()
     {
-        Interlocked.Exchange(ref _droppedBlocks, 0);
-        Interlocked.Exchange(ref _droppedBytes, 0);
-        Interlocked.Exchange(ref _runtimeStarvationEvents, 0);
-        Interlocked.Exchange(ref _pushCount, 0);
-        _minimumBufferedBytes = int.MaxValue;
-        _playbackStarted = false;
+        Interlocked.Exchange(ref _ringFramesWritten, 0);
+        Interlocked.Exchange(ref _ringFramesRejected, 0);
+        Interlocked.Exchange(ref _firstOverflowWarningWritten, 0);
     }
-
-    private void ObserveMinimum(int bufferedBytes) => _minimumBufferedBytes = Math.Min(_minimumBufferedBytes, bufferedBytes);
-
-    private void WriteDepthDiagnostic(string reason, int incoming, int before, int after, int capacity)
-    {
-        var bytesPerMillisecond = _format!.Value.BytesPerMillisecond();
-        Debug.WriteLine($"NAudio emulation buffer: {reason}; incomingBytes={incoming}, bufferedBefore={before}, bufferedAfter={after}, capacity={capacity}, millisecondsBefore={(double)before / bytesPerMillisecond:F2}, millisecondsAfter={(double)after / bytesPerMillisecond:F2}, droppedBlocks={DroppedBlocks}, droppedBytes={DroppedBytes}, minimumBufferedBytes={MinimumObservedBufferedBytes}.");
-    }
-
-    private static bool IsPowerOfTwo(long value) => (value & (value - 1)) == 0;
 
     private static void ValidateFormat(EmulationAudioFormat format)
     {
         if (format.SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio sample rate must be greater than zero.");
         if (format.Channels <= 0) throw new ArgumentOutOfRangeException(nameof(format), "Audio channel count must be greater than zero.");
         if (format.BitsPerSample != 16) throw new NotSupportedException($"Only 16-bit PCM audio is supported; native core reported {format.BitsPerSample} bits per sample.");
+    }
+
+    private sealed class PlaybackState
+    {
+        private int _playStarted;
+        private int _minimumObservedRingFrames = int.MaxValue;
+        public PlaybackState(EmulationAudioFormat format, PcmFrameRingBuffer ring, PcmRingWaveProvider provider, WasapiOut output, AudioPrebufferPolicy prebuffer)
+        { Format = format; Ring = ring; Provider = provider; Output = output; Prebuffer = prebuffer; }
+        public EmulationAudioFormat Format { get; }
+        public PcmFrameRingBuffer Ring { get; }
+        public PcmRingWaveProvider Provider { get; }
+        public WasapiOut Output { get; }
+        public AudioPrebufferPolicy Prebuffer { get; }
+        public volatile bool IsStopping;
+        public int MinimumObservedRingFramesValue => _minimumObservedRingFrames == int.MaxValue ? 0 : _minimumObservedRingFrames;
+        public void ObserveDepthBeforeWrite() => _minimumObservedRingFrames = Math.Min(_minimumObservedRingFrames, Ring.ReadableFrames);
+        public void PlayOnce()
+        {
+            if (IsStopping || Interlocked.Exchange(ref _playStarted, 1) != 0) return;
+            Output.Play();
+        }
+        public void ClearForFreshPrebuffer()
+        {
+            IsStopping = false;
+            Output.Stop();
+            Ring.Clear();
+            Prebuffer.Reset();
+            Interlocked.Exchange(ref _playStarted, 0);
+            _minimumObservedRingFrames = int.MaxValue;
+        }
+        public void StopDisposeAndClear()
+        {
+            try { Output.Stop(); } catch { }
+            try { Output.Dispose(); } catch { }
+            Ring.Clear();
+        }
     }
 }
 
@@ -157,25 +153,20 @@ internal sealed class AudioPrebufferPolicy
     internal AudioPrebufferPolicy(EmulationAudioFormat format, int bufferLengthMilliseconds)
     {
         ThresholdMilliseconds = CalculateThresholdMilliseconds(bufferLengthMilliseconds);
-        var numerator = checked((long)format.SampleRate * format.Channels * (format.BitsPerSample / 8) * ThresholdMilliseconds);
-        ThresholdBytes = checked((int)((numerator + 999) / 1000));
+        BytesPerFrame = checked(format.Channels * (format.BitsPerSample / 8));
+        ThresholdFrames = Math.Max(1, checked((int)(((long)format.SampleRate * ThresholdMilliseconds + 999) / 1000)));
+        ThresholdBytes = checked(ThresholdFrames * BytesPerFrame);
     }
-
     internal int ThresholdMilliseconds { get; }
+    internal int ThresholdFrames { get; }
     internal int ThresholdBytes { get; }
+    private int BytesPerFrame { get; }
     internal bool PlaybackStarted { get; private set; }
-
-    internal bool ObserveQueuedBytes(int bufferedBytes)
-    {
-        if (!PlaybackStarted && bufferedBytes >= ThresholdBytes)
-            PlaybackStarted = true;
-        return PlaybackStarted;
-    }
-
+    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) PlaybackStarted = true; return PlaybackStarted; }
+    internal bool ObserveQueuedBytes(int bufferedBytes) => ObserveQueuedFrames(bufferedBytes / BytesPerFrame);
     internal void Reset() => PlaybackStarted = false;
-
-    internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) =>
-        Math.Max(1, Math.Min(10, bufferLengthMilliseconds / 2));
+    internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) => Math.Max(1, (bufferLengthMilliseconds * 3 + 3) / 4);
+    internal static int CalculateCapacityFrames(EmulationAudioFormat format, int bufferLengthMilliseconds) => Math.Max(1, checked((int)(((long)format.SampleRate * bufferLengthMilliseconds + 999) / 1000)));
 }
 
 internal static class EmulationAudioFormatExtensions

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -54,7 +54,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         var provider = new PcmRingWaveProvider(ring, waveFormat, () => state?.IsPlaybackActive == true);
         var output = new WasapiOut(AudioClientShareMode.Shared, _wasapiLatencyMilliseconds);
         output.Init(provider);
-        state = new PlaybackState(format, ring, provider, output, new AudioPrebufferPolicy(format, _bufferLengthMilliseconds));
+        state = new PlaybackState(format, ring, provider, output, new AudioPrebufferPolicy(format, _bufferLengthMilliseconds), _wasapiLatencyMilliseconds);
         ResetDiagnostics();
         lock (_lifecycleGate)
             _state = state;
@@ -131,13 +131,14 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     private sealed class PlaybackState
     {
         private int _playStarted;
-        public PlaybackState(EmulationAudioFormat format, PcmFrameRingBuffer ring, PcmRingWaveProvider provider, WasapiOut output, AudioPrebufferPolicy prebuffer)
-        { Format = format; Ring = ring; Provider = provider; Output = output; Prebuffer = prebuffer; }
+        public PlaybackState(EmulationAudioFormat format, PcmFrameRingBuffer ring, PcmRingWaveProvider provider, WasapiOut output, AudioPrebufferPolicy prebuffer, int wasapiLatencyMilliseconds)
+        { Format = format; Ring = ring; Provider = provider; Output = output; Prebuffer = prebuffer; WasapiLatencyMilliseconds = wasapiLatencyMilliseconds; }
         public EmulationAudioFormat Format { get; }
         public PcmFrameRingBuffer Ring { get; }
         public PcmRingWaveProvider Provider { get; }
         public WasapiOut Output { get; }
         public AudioPrebufferPolicy Prebuffer { get; }
+        public int WasapiLatencyMilliseconds { get; }
         public volatile bool IsStopping;
         private volatile bool _playbackActive;
         public bool IsPlaybackActive => _playbackActive && !IsStopping;
@@ -180,7 +181,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             Provider.MinimumRequestedFrames,
             Provider.MaximumRequestedFrames,
             Provider.TotalRequestedFrames,
-            _wasapiLatencyMilliseconds,
+            WasapiLatencyMilliseconds,
             Prebuffer.PlaybackStarted);
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -8,7 +8,9 @@ namespace OasisEditor;
 public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
 {
     private readonly object _lifecycleGate = new();
+    private const int DefaultWasapiLatencyMilliseconds = 25;
     private readonly int _bufferLengthMilliseconds;
+    private readonly int _wasapiLatencyMilliseconds;
     private PlaybackState? _state;
     private long _ringFramesWritten;
     private long _ringFramesRejected;
@@ -16,6 +18,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     private EmulationAudioPlaybackStatistics _lastStatistics;
 
     internal int BufferLengthMilliseconds => _bufferLengthMilliseconds;
+    internal int WasapiLatencyMilliseconds => _wasapiLatencyMilliseconds;
     internal int PrebufferThresholdMilliseconds => AudioPrebufferPolicy.CalculateThresholdMilliseconds(_bufferLengthMilliseconds);
     internal int PrebufferThresholdFrames => _state?.Prebuffer.ThresholdFrames ?? 0;
     internal long RingFramesWritten => Interlocked.Read(ref _ringFramesWritten);
@@ -25,12 +28,19 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     internal long UnderrunEpisodes => _state?.Provider.UnderrunEpisodes ?? 0;
     internal int MinimumObservedRingFrames => GetStatistics().MinimumRingFrames;
     internal bool PlaybackStarted => _state?.Prebuffer.PlaybackStarted ?? false;
+    public int WritableFrames => Volatile.Read(ref _state)?.Ring.WritableFrames ?? 0;
+    public int CapacityFrames => Volatile.Read(ref _state)?.Ring.CapacityFrames ?? 0;
 
-    public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
+    public NAudioEmulationAudioSink(
+        int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds,
+        int wasapiLatencyMilliseconds = DefaultWasapiLatencyMilliseconds)
     {
         if (bufferLengthMilliseconds <= 0)
             throw new ArgumentOutOfRangeException(nameof(bufferLengthMilliseconds), bufferLengthMilliseconds, "Audio buffer length must be greater than zero.");
+        if (wasapiLatencyMilliseconds <= 0)
+            throw new ArgumentOutOfRangeException(nameof(wasapiLatencyMilliseconds), wasapiLatencyMilliseconds, "WASAPI latency must be greater than zero.");
         _bufferLengthMilliseconds = bufferLengthMilliseconds;
+        _wasapiLatencyMilliseconds = wasapiLatencyMilliseconds;
     }
 
     public void Start(EmulationAudioFormat format)
@@ -40,10 +50,11 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         var waveFormat = new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels);
         var capacityFrames = AudioPrebufferPolicy.CalculateCapacityFrames(format, _bufferLengthMilliseconds);
         var ring = new PcmFrameRingBuffer(format.Channels, capacityFrames);
-        var provider = new PcmRingWaveProvider(ring, waveFormat);
-        var output = new WasapiOut(AudioClientShareMode.Shared, _bufferLengthMilliseconds);
+        PlaybackState? state = null;
+        var provider = new PcmRingWaveProvider(ring, waveFormat, () => state?.IsPlaybackActive == true);
+        var output = new WasapiOut(AudioClientShareMode.Shared, _wasapiLatencyMilliseconds);
         output.Init(provider);
-        var state = new PlaybackState(format, ring, provider, output, new AudioPrebufferPolicy(format, _bufferLengthMilliseconds));
+        state = new PlaybackState(format, ring, provider, output, new AudioPrebufferPolicy(format, _bufferLengthMilliseconds));
         ResetDiagnostics();
         lock (_lifecycleGate)
             _state = state;
@@ -128,14 +139,18 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         public WasapiOut Output { get; }
         public AudioPrebufferPolicy Prebuffer { get; }
         public volatile bool IsStopping;
+        private volatile bool _playbackActive;
+        public bool IsPlaybackActive => _playbackActive && !IsStopping;
         public void PlayOnce()
         {
             if (IsStopping || Interlocked.Exchange(ref _playStarted, 1) != 0) return;
+            _playbackActive = true;
             Output.Play();
         }
         public void ClearForFreshPrebuffer()
         {
             IsStopping = false;
+            _playbackActive = false;
             Output.Stop();
             Ring.Clear();
             Prebuffer.Reset();
@@ -143,6 +158,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         }
         public void StopDisposeAndClear()
         {
+            _playbackActive = false;
             try { Output.Stop(); } catch { }
             try { Output.Dispose(); } catch { }
             Ring.Clear();
@@ -159,6 +175,12 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             Ring.CapacityFrames,
             Prebuffer.ThresholdFrames,
             Prebuffer.ThresholdMilliseconds,
+            Provider.MaximumRingFrames,
+            Prebuffer.StartupRingFrames,
+            Provider.MinimumRequestedFrames,
+            Provider.MaximumRequestedFrames,
+            Provider.TotalRequestedFrames,
+            _wasapiLatencyMilliseconds,
             Prebuffer.PlaybackStarted);
     }
 }
@@ -177,9 +199,10 @@ internal sealed class AudioPrebufferPolicy
     internal int ThresholdBytes { get; }
     private int BytesPerFrame { get; }
     internal bool PlaybackStarted { get; private set; }
-    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) PlaybackStarted = true; return PlaybackStarted; }
+    internal int StartupRingFrames { get; private set; }
+    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) { StartupRingFrames = queuedFrames; PlaybackStarted = true; } return PlaybackStarted; }
     internal bool ObserveQueuedBytes(int bufferedBytes) => ObserveQueuedFrames(bufferedBytes / BytesPerFrame);
-    internal void Reset() => PlaybackStarted = false;
+    internal void Reset() { PlaybackStarted = false; StartupRingFrames = 0; }
     internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) => Math.Max(1, (bufferLengthMilliseconds * 3 + 3) / 4);
     internal static int CalculateCapacityFrames(EmulationAudioFormat format, int bufferLengthMilliseconds) => Math.Max(1, checked((int)(((long)format.SampleRate * bufferLengthMilliseconds + 999) / 1000)));
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -111,9 +111,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         return state?.CreateStatistics(RingFramesWritten, RingFramesRejected) ?? _lastStatistics;
     }
 
-    internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes)
-        => incomingBytes > bufferCapacityBytes - bufferedBytes;
-
     private void ResetDiagnostics()
     {
         Interlocked.Exchange(ref _ringFramesWritten, 0);
@@ -176,11 +173,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             Ring.CapacityFrames,
             Prebuffer.ThresholdFrames,
             Prebuffer.ThresholdMilliseconds,
-            Provider.MaximumRingFrames,
-            Prebuffer.StartupRingFrames,
-            Provider.MinimumRequestedFrames,
-            Provider.MaximumRequestedFrames,
-            Provider.TotalRequestedFrames,
             WasapiLatencyMilliseconds,
             Prebuffer.PlaybackStarted);
     }
@@ -191,25 +183,13 @@ internal sealed class AudioPrebufferPolicy
     internal AudioPrebufferPolicy(EmulationAudioFormat format, int bufferLengthMilliseconds)
     {
         ThresholdMilliseconds = CalculateThresholdMilliseconds(bufferLengthMilliseconds);
-        BytesPerFrame = checked(format.Channels * (format.BitsPerSample / 8));
         ThresholdFrames = Math.Max(1, checked((int)(((long)format.SampleRate * ThresholdMilliseconds + 999) / 1000)));
-        ThresholdBytes = checked(ThresholdFrames * BytesPerFrame);
     }
     internal int ThresholdMilliseconds { get; }
     internal int ThresholdFrames { get; }
-    internal int ThresholdBytes { get; }
-    private int BytesPerFrame { get; }
     internal bool PlaybackStarted { get; private set; }
-    internal int StartupRingFrames { get; private set; }
-    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) { StartupRingFrames = queuedFrames; PlaybackStarted = true; } return PlaybackStarted; }
-    internal bool ObserveQueuedBytes(int bufferedBytes) => ObserveQueuedFrames(bufferedBytes / BytesPerFrame);
-    internal void Reset() { PlaybackStarted = false; StartupRingFrames = 0; }
+    internal bool ObserveQueuedFrames(int queuedFrames) { if (!PlaybackStarted && queuedFrames >= ThresholdFrames) PlaybackStarted = true; return PlaybackStarted; }
+    internal void Reset() => PlaybackStarted = false;
     internal static int CalculateThresholdMilliseconds(int bufferLengthMilliseconds) => Math.Max(1, (bufferLengthMilliseconds * 3 + 3) / 4);
     internal static int CalculateCapacityFrames(EmulationAudioFormat format, int bufferLengthMilliseconds) => Math.Max(1, checked((int)(((long)format.SampleRate * bufferLengthMilliseconds + 999) / 1000)));
-}
-
-internal static class EmulationAudioFormatExtensions
-{
-    internal static int BytesPerMillisecond(this EmulationAudioFormat format) =>
-        Math.Max(1, checked((format.SampleRate * format.Channels * (format.BitsPerSample / 8)) / 1000));
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/NAudioEmulationAudioSink.cs
@@ -13,6 +13,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     private long _ringFramesWritten;
     private long _ringFramesRejected;
     private long _firstOverflowWarningWritten;
+    private EmulationAudioPlaybackStatistics _lastStatistics;
 
     internal int BufferLengthMilliseconds => _bufferLengthMilliseconds;
     internal int PrebufferThresholdMilliseconds => AudioPrebufferPolicy.CalculateThresholdMilliseconds(_bufferLengthMilliseconds);
@@ -22,7 +23,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     internal long DeviceFramesDelivered => _state?.Provider.FramesDelivered ?? 0;
     internal long SilenceFrames => _state?.Provider.SilenceFrames ?? 0;
     internal long UnderrunEpisodes => _state?.Provider.UnderrunEpisodes ?? 0;
-    internal int MinimumObservedRingFrames => _state?.MinimumObservedRingFramesValue ?? 0;
+    internal int MinimumObservedRingFrames => GetStatistics().MinimumRingFrames;
     internal bool PlaybackStarted => _state?.Prebuffer.PlaybackStarted ?? false;
 
     public NAudioEmulationAudioSink(int bufferLengthMilliseconds = NativeEmulationPreferences.DefaultAudioBufferLengthMilliseconds)
@@ -46,7 +47,7 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         ResetDiagnostics();
         lock (_lifecycleGate)
             _state = state;
-        Debug.WriteLine($"NAudio emulation buffer: started; capacityFrames={capacityFrames}, prebufferFrames={state.Prebuffer.ThresholdFrames}.");
+        _lastStatistics = state.CreateStatistics(RingFramesWritten, RingFramesRejected);
     }
 
     public void PushPcm(ReadOnlySpan<byte> pcmBytes)
@@ -57,7 +58,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         var samples = MemoryMarshal.Cast<byte, short>(pcmBytes);
         var frameCount = samples.Length / state.Format.Channels;
         if (frameCount <= 0) return;
-        state.ObserveDepthBeforeWrite();
         var written = state.Ring.Write(samples[..(frameCount * state.Format.Channels)], frameCount);
         Interlocked.Add(ref _ringFramesWritten, written);
         var rejected = frameCount - written;
@@ -88,11 +88,17 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             _state = null;
         }
         if (state is null) return;
-        Debug.WriteLine($"NAudio emulation buffer: stop summary; ringFramesWritten={RingFramesWritten}, ringFramesRejected={RingFramesRejected}, deviceFramesDelivered={state.Provider.FramesDelivered}, silenceFrames={state.Provider.SilenceFrames}, underrunEpisodes={state.Provider.UnderrunEpisodes}, minimumRingFrames={state.MinimumObservedRingFramesValue}.");
+        _lastStatistics = state.CreateStatistics(RingFramesWritten, RingFramesRejected);
         state.StopDisposeAndClear();
     }
 
     public void Dispose() => Stop();
+
+    public EmulationAudioPlaybackStatistics GetStatistics()
+    {
+        var state = Volatile.Read(ref _state);
+        return state?.CreateStatistics(RingFramesWritten, RingFramesRejected) ?? _lastStatistics;
+    }
 
     internal static bool ShouldDropIncomingBlock(int bufferedBytes, int bufferCapacityBytes, int incomingBytes)
         => incomingBytes > bufferCapacityBytes - bufferedBytes;
@@ -114,7 +120,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
     private sealed class PlaybackState
     {
         private int _playStarted;
-        private int _minimumObservedRingFrames = int.MaxValue;
         public PlaybackState(EmulationAudioFormat format, PcmFrameRingBuffer ring, PcmRingWaveProvider provider, WasapiOut output, AudioPrebufferPolicy prebuffer)
         { Format = format; Ring = ring; Provider = provider; Output = output; Prebuffer = prebuffer; }
         public EmulationAudioFormat Format { get; }
@@ -123,8 +128,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
         public WasapiOut Output { get; }
         public AudioPrebufferPolicy Prebuffer { get; }
         public volatile bool IsStopping;
-        public int MinimumObservedRingFramesValue => _minimumObservedRingFrames == int.MaxValue ? 0 : _minimumObservedRingFrames;
-        public void ObserveDepthBeforeWrite() => _minimumObservedRingFrames = Math.Min(_minimumObservedRingFrames, Ring.ReadableFrames);
         public void PlayOnce()
         {
             if (IsStopping || Interlocked.Exchange(ref _playStarted, 1) != 0) return;
@@ -137,7 +140,6 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             Ring.Clear();
             Prebuffer.Reset();
             Interlocked.Exchange(ref _playStarted, 0);
-            _minimumObservedRingFrames = int.MaxValue;
         }
         public void StopDisposeAndClear()
         {
@@ -145,6 +147,19 @@ public sealed class NAudioEmulationAudioSink : IEmulationAudioSink
             try { Output.Dispose(); } catch { }
             Ring.Clear();
         }
+
+        public EmulationAudioPlaybackStatistics CreateStatistics(long ringFramesWritten, long ringFramesRejected) => new(
+            ringFramesWritten,
+            ringFramesRejected,
+            Provider.FramesDelivered,
+            Provider.SilenceFrames,
+            Provider.UnderrunEpisodes,
+            Provider.MinimumRingFrames,
+            Ring.ReadableFrames,
+            Ring.CapacityFrames,
+            Prebuffer.ThresholdFrames,
+            Prebuffer.ThresholdMilliseconds,
+            Prebuffer.PlaybackStarted);
     }
 }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmFrameRingBuffer.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmFrameRingBuffer.cs
@@ -1,0 +1,86 @@
+namespace OasisEditor;
+
+internal sealed class PcmFrameRingBuffer
+{
+    private readonly short[] _samples;
+    private readonly object _gate = new();
+    private int _readFrame;
+    private int _readableFrames;
+
+    public PcmFrameRingBuffer(int channels, int capacityFrames)
+    {
+        if (channels <= 0) throw new ArgumentOutOfRangeException(nameof(channels));
+        if (capacityFrames <= 0) throw new ArgumentOutOfRangeException(nameof(capacityFrames));
+        Channels = channels;
+        CapacityFrames = capacityFrames;
+        _samples = new short[checked(channels * capacityFrames)];
+    }
+
+    public int Channels { get; }
+    public int CapacityFrames { get; }
+    public int ReadableFrames { get { lock (_gate) return _readableFrames; } }
+    public int WritableFrames { get { lock (_gate) return CapacityFrames - _readableFrames; } }
+
+    public int Write(ReadOnlySpan<short> samples, int frameCount)
+    {
+        ValidateFrameSpan(samples.Length, frameCount);
+        lock (_gate)
+        {
+            var frames = Math.Min(frameCount, CapacityFrames - _readableFrames);
+            if (frames <= 0) return 0;
+            var writeFrame = (_readFrame + _readableFrames) % CapacityFrames;
+            CopyFrames(samples, _samples, writeFrame, frames);
+            _readableFrames += frames;
+            return frames;
+        }
+    }
+
+    public int Read(Span<short> destination, int frameCount)
+    {
+        ValidateFrameSpan(destination.Length, frameCount);
+        lock (_gate)
+        {
+            var frames = Math.Min(frameCount, _readableFrames);
+            if (frames <= 0) return 0;
+            CopyFrames(_samples, _readFrame, destination, frames);
+            _readFrame = (_readFrame + frames) % CapacityFrames;
+            _readableFrames -= frames;
+            return frames;
+        }
+    }
+
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _readFrame = 0;
+            _readableFrames = 0;
+            Array.Clear(_samples);
+        }
+    }
+
+    private void ValidateFrameSpan(int sampleLength, int frameCount)
+    {
+        if (frameCount < 0) throw new ArgumentOutOfRangeException(nameof(frameCount));
+        if (sampleLength < checked(frameCount * Channels))
+            throw new ArgumentException("The sample span is shorter than the requested complete frame count.");
+    }
+
+    private void CopyFrames(ReadOnlySpan<short> source, short[] destination, int destinationFrame, int frameCount)
+    {
+        var firstFrames = Math.Min(frameCount, CapacityFrames - destinationFrame);
+        source[..(firstFrames * Channels)].CopyTo(destination.AsSpan(destinationFrame * Channels));
+        var remaining = frameCount - firstFrames;
+        if (remaining > 0)
+            source.Slice(firstFrames * Channels, remaining * Channels).CopyTo(destination);
+    }
+
+    private void CopyFrames(short[] source, int sourceFrame, Span<short> destination, int frameCount)
+    {
+        var firstFrames = Math.Min(frameCount, CapacityFrames - sourceFrame);
+        source.AsSpan(sourceFrame * Channels, firstFrames * Channels).CopyTo(destination);
+        var remaining = frameCount - firstFrames;
+        if (remaining > 0)
+            source.AsSpan(0, remaining * Channels).CopyTo(destination[(firstFrames * Channels)..]);
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
@@ -12,10 +12,6 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
     private long _framesDelivered;
     private long _silenceFrames;
     private int _minimumRingFrames = int.MaxValue;
-    private int _maximumRingFrames;
-    private int _minimumRequestedFrames = int.MaxValue;
-    private int _maximumRequestedFrames;
-    private long _totalRequestedFrames;
     private long _underrunEpisodes;
 
     public PcmRingWaveProvider(PcmFrameRingBuffer ring, WaveFormat waveFormat, Func<bool>? isPlaybackActive = null)
@@ -32,10 +28,6 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
     public long FramesDelivered => Interlocked.Read(ref _framesDelivered);
     public long SilenceFrames => Interlocked.Read(ref _silenceFrames);
     public int MinimumRingFrames => _minimumRingFrames == int.MaxValue ? 0 : _minimumRingFrames;
-    public int MaximumRingFrames => Volatile.Read(ref _maximumRingFrames);
-    public int MinimumRequestedFrames => _minimumRequestedFrames == int.MaxValue ? 0 : _minimumRequestedFrames;
-    public int MaximumRequestedFrames => Volatile.Read(ref _maximumRequestedFrames);
-    public long TotalRequestedFrames => Interlocked.Read(ref _totalRequestedFrames);
     public long UnderrunEpisodes => Interlocked.Read(ref _underrunEpisodes);
 
     public int Read(byte[] buffer, int offset, int count)
@@ -43,7 +35,6 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         var bytesPerFrame = WaveFormat.BlockAlign;
         var requestedFrames = count / bytesPerFrame;
         var requestedBytes = requestedFrames * bytesPerFrame;
-        ObserveRequestedFrames(requestedFrames);
         var destinationBytes = buffer.AsSpan(offset, requestedBytes);
         var destinationSamples = MemoryMarshal.Cast<byte, short>(destinationBytes);
         var playbackActive = _isPlaybackActive();
@@ -84,18 +75,10 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         return count;
     }
 
-    private void ObserveRequestedFrames(int requestedFrames)
-    {
-        Interlocked.Add(ref _totalRequestedFrames, requestedFrames);
-        UpdateMinimum(ref _minimumRequestedFrames, requestedFrames);
-        UpdateMaximum(ref _maximumRequestedFrames, requestedFrames);
-    }
-
     private void ObserveRingFrames()
     {
         var depth = _ring.ReadableFrames;
         UpdateMinimum(ref _minimumRingFrames, depth);
-        UpdateMaximum(ref _maximumRingFrames, depth);
     }
 
     private static void UpdateMinimum(ref int target, int value)
@@ -109,14 +92,4 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         }
     }
 
-    private static void UpdateMaximum(ref int target, int value)
-    {
-        var current = Volatile.Read(ref target);
-        while (value > current)
-        {
-            var previous = Interlocked.CompareExchange(ref target, value, current);
-            if (previous == current) return;
-            current = previous;
-        }
-    }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
@@ -6,16 +6,22 @@ namespace OasisEditor;
 internal sealed class PcmRingWaveProvider : IWaveProvider
 {
     private readonly PcmFrameRingBuffer _ring;
+    private readonly Func<bool> _isPlaybackActive;
     private readonly short[] _scratch;
     private bool _inUnderrun;
     private long _framesDelivered;
     private long _silenceFrames;
     private int _minimumRingFrames = int.MaxValue;
+    private int _maximumRingFrames;
+    private int _minimumRequestedFrames = int.MaxValue;
+    private int _maximumRequestedFrames;
+    private long _totalRequestedFrames;
     private long _underrunEpisodes;
 
-    public PcmRingWaveProvider(PcmFrameRingBuffer ring, WaveFormat waveFormat)
+    public PcmRingWaveProvider(PcmFrameRingBuffer ring, WaveFormat waveFormat, Func<bool>? isPlaybackActive = null)
     {
         _ring = ring ?? throw new ArgumentNullException(nameof(ring));
+        _isPlaybackActive = isPlaybackActive ?? (() => true);
         WaveFormat = waveFormat ?? throw new ArgumentNullException(nameof(waveFormat));
         if (waveFormat.BitsPerSample != 16 || waveFormat.Channels != ring.Channels)
             throw new ArgumentException("Wave format must be 16-bit PCM and match the ring channel count.");
@@ -26,6 +32,10 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
     public long FramesDelivered => Interlocked.Read(ref _framesDelivered);
     public long SilenceFrames => Interlocked.Read(ref _silenceFrames);
     public int MinimumRingFrames => _minimumRingFrames == int.MaxValue ? 0 : _minimumRingFrames;
+    public int MaximumRingFrames => Volatile.Read(ref _maximumRingFrames);
+    public int MinimumRequestedFrames => _minimumRequestedFrames == int.MaxValue ? 0 : _minimumRequestedFrames;
+    public int MaximumRequestedFrames => Volatile.Read(ref _maximumRequestedFrames);
+    public long TotalRequestedFrames => Interlocked.Read(ref _totalRequestedFrames);
     public long UnderrunEpisodes => Interlocked.Read(ref _underrunEpisodes);
 
     public int Read(byte[] buffer, int offset, int count)
@@ -33,9 +43,12 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         var bytesPerFrame = WaveFormat.BlockAlign;
         var requestedFrames = count / bytesPerFrame;
         var requestedBytes = requestedFrames * bytesPerFrame;
+        ObserveRequestedFrames(requestedFrames);
         var destinationBytes = buffer.AsSpan(offset, requestedBytes);
         var destinationSamples = MemoryMarshal.Cast<byte, short>(destinationBytes);
-        ObserveMinimumRingFrames();
+        var playbackActive = _isPlaybackActive();
+        if (playbackActive)
+            ObserveRingFrames();
         var framesRead = 0;
         while (framesRead < requestedFrames)
         {
@@ -49,11 +62,14 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         if (silenceFrames > 0)
         {
             destinationSamples[(framesRead * _ring.Channels)..(requestedFrames * _ring.Channels)].Clear();
-            Interlocked.Add(ref _silenceFrames, silenceFrames);
-            if (!_inUnderrun)
+            if (playbackActive)
             {
-                _inUnderrun = true;
-                Interlocked.Increment(ref _underrunEpisodes);
+                Interlocked.Add(ref _silenceFrames, silenceFrames);
+                if (!_inUnderrun)
+                {
+                    _inUnderrun = true;
+                    Interlocked.Increment(ref _underrunEpisodes);
+                }
             }
         }
         else
@@ -61,21 +77,45 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
             _inUnderrun = false;
         }
         Interlocked.Add(ref _framesDelivered, framesRead);
-        ObserveMinimumRingFrames();
+        if (playbackActive)
+            ObserveRingFrames();
         if (count > requestedBytes)
             buffer.AsSpan(offset + requestedBytes, count - requestedBytes).Clear();
         return count;
     }
 
-    private void ObserveMinimumRingFrames()
+    private void ObserveRequestedFrames(int requestedFrames)
+    {
+        Interlocked.Add(ref _totalRequestedFrames, requestedFrames);
+        UpdateMinimum(ref _minimumRequestedFrames, requestedFrames);
+        UpdateMaximum(ref _maximumRequestedFrames, requestedFrames);
+    }
+
+    private void ObserveRingFrames()
     {
         var depth = _ring.ReadableFrames;
-        var current = _minimumRingFrames;
-        while (depth < current)
+        UpdateMinimum(ref _minimumRingFrames, depth);
+        UpdateMaximum(ref _maximumRingFrames, depth);
+    }
+
+    private static void UpdateMinimum(ref int target, int value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value < current)
         {
-            var previous = Interlocked.CompareExchange(ref _minimumRingFrames, depth, current);
-            if (previous == current)
-                return;
+            var previous = Interlocked.CompareExchange(ref target, value, current);
+            if (previous == current) return;
+            current = previous;
+        }
+    }
+
+    private static void UpdateMaximum(ref int target, int value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value > current)
+        {
+            var previous = Interlocked.CompareExchange(ref target, value, current);
+            if (previous == current) return;
             current = previous;
         }
     }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
@@ -10,6 +10,7 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
     private bool _inUnderrun;
     private long _framesDelivered;
     private long _silenceFrames;
+    private int _minimumRingFrames = int.MaxValue;
     private long _underrunEpisodes;
 
     public PcmRingWaveProvider(PcmFrameRingBuffer ring, WaveFormat waveFormat)
@@ -24,6 +25,7 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
     public WaveFormat WaveFormat { get; }
     public long FramesDelivered => Interlocked.Read(ref _framesDelivered);
     public long SilenceFrames => Interlocked.Read(ref _silenceFrames);
+    public int MinimumRingFrames => _minimumRingFrames == int.MaxValue ? 0 : _minimumRingFrames;
     public long UnderrunEpisodes => Interlocked.Read(ref _underrunEpisodes);
 
     public int Read(byte[] buffer, int offset, int count)
@@ -33,6 +35,7 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         var requestedBytes = requestedFrames * bytesPerFrame;
         var destinationBytes = buffer.AsSpan(offset, requestedBytes);
         var destinationSamples = MemoryMarshal.Cast<byte, short>(destinationBytes);
+        ObserveMinimumRingFrames();
         var framesRead = 0;
         while (framesRead < requestedFrames)
         {
@@ -57,9 +60,23 @@ internal sealed class PcmRingWaveProvider : IWaveProvider
         {
             _inUnderrun = false;
         }
-        Interlocked.Add(ref _framesDelivered, requestedFrames);
+        Interlocked.Add(ref _framesDelivered, framesRead);
+        ObserveMinimumRingFrames();
         if (count > requestedBytes)
             buffer.AsSpan(offset + requestedBytes, count - requestedBytes).Clear();
         return count;
+    }
+
+    private void ObserveMinimumRingFrames()
+    {
+        var depth = _ring.ReadableFrames;
+        var current = _minimumRingFrames;
+        while (depth < current)
+        {
+            var previous = Interlocked.CompareExchange(ref _minimumRingFrames, depth, current);
+            if (previous == current)
+                return;
+            current = previous;
+        }
     }
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/PcmRingWaveProvider.cs
@@ -1,0 +1,65 @@
+using System.Runtime.InteropServices;
+using NAudio.Wave;
+
+namespace OasisEditor;
+
+internal sealed class PcmRingWaveProvider : IWaveProvider
+{
+    private readonly PcmFrameRingBuffer _ring;
+    private readonly short[] _scratch;
+    private bool _inUnderrun;
+    private long _framesDelivered;
+    private long _silenceFrames;
+    private long _underrunEpisodes;
+
+    public PcmRingWaveProvider(PcmFrameRingBuffer ring, WaveFormat waveFormat)
+    {
+        _ring = ring ?? throw new ArgumentNullException(nameof(ring));
+        WaveFormat = waveFormat ?? throw new ArgumentNullException(nameof(waveFormat));
+        if (waveFormat.BitsPerSample != 16 || waveFormat.Channels != ring.Channels)
+            throw new ArgumentException("Wave format must be 16-bit PCM and match the ring channel count.");
+        _scratch = new short[Math.Max(ring.Channels, (waveFormat.AverageBytesPerSecond / 10) / sizeof(short))];
+    }
+
+    public WaveFormat WaveFormat { get; }
+    public long FramesDelivered => Interlocked.Read(ref _framesDelivered);
+    public long SilenceFrames => Interlocked.Read(ref _silenceFrames);
+    public long UnderrunEpisodes => Interlocked.Read(ref _underrunEpisodes);
+
+    public int Read(byte[] buffer, int offset, int count)
+    {
+        var bytesPerFrame = WaveFormat.BlockAlign;
+        var requestedFrames = count / bytesPerFrame;
+        var requestedBytes = requestedFrames * bytesPerFrame;
+        var destinationBytes = buffer.AsSpan(offset, requestedBytes);
+        var destinationSamples = MemoryMarshal.Cast<byte, short>(destinationBytes);
+        var framesRead = 0;
+        while (framesRead < requestedFrames)
+        {
+            var framesThisRead = Math.Min(requestedFrames - framesRead, _scratch.Length / _ring.Channels);
+            var read = _ring.Read(_scratch.AsSpan(0, framesThisRead * _ring.Channels), framesThisRead);
+            if (read == 0) break;
+            _scratch.AsSpan(0, read * _ring.Channels).CopyTo(destinationSamples[(framesRead * _ring.Channels)..]);
+            framesRead += read;
+        }
+        var silenceFrames = requestedFrames - framesRead;
+        if (silenceFrames > 0)
+        {
+            destinationSamples[(framesRead * _ring.Channels)..(requestedFrames * _ring.Channels)].Clear();
+            Interlocked.Add(ref _silenceFrames, silenceFrames);
+            if (!_inUnderrun)
+            {
+                _inUnderrun = true;
+                Interlocked.Increment(ref _underrunEpisodes);
+            }
+        }
+        else
+        {
+            _inUnderrun = false;
+        }
+        Interlocked.Add(ref _framesDelivered, requestedFrames);
+        if (count > requestedBytes)
+            buffer.AsSpan(offset + requestedBytes, count - requestedBytes).Clear();
+        return count;
+    }
+}

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1916,6 +1916,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         ToolWindowCloseRequested?.Invoke(EditorToolWindowId.Preferences);
     }
 
+    private CoalescedMachineOutputDispatcher? _machineOutputDispatcher;
+
     private static void DispatchToUiThread(Action work)
     {
         ArgumentNullException.ThrowIfNull(work);
@@ -2017,6 +2019,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             ?? throw new InvalidOperationException($"No emulation backend is available for platform '{SelectedFruitMachinePlatform}'.");
 
         _activeEmulationBackend = backend;
+        _machineOutputDispatcher = new CoalescedMachineOutputDispatcher(DispatchToUiThread, ApplyMachineOutputBatch);
         backend.StateChanged += OnActiveBackendStateChanged;
         backend.LampChanged += OnActiveBackendLampChanged;
         backend.ReelChanged += OnActiveBackendReelChanged;
@@ -2034,6 +2037,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             backend.ReelChanged -= OnActiveBackendReelChanged;
             backend.SegmentChanged -= OnActiveBackendSegmentChanged;
             backend.VfdBrightnessChanged -= OnActiveBackendVfdBrightnessChanged;
+            _machineOutputDispatcher?.Detach();
+            _machineOutputDispatcher = null;
             await backend.DisposeAsync().ConfigureAwait(false);
             _activeEmulationBackend = null;
             throw;
@@ -2266,24 +2271,28 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             : fullPath;
     }
 
-    private void OnActiveBackendLampChanged(object? sender, MachineLampChangedEventArgs e)
-    {
-        _lampRuntimeAdapter.ApplyLampState(e.LampId, e.Value);
-    }
+    private void OnActiveBackendLampChanged(object? sender, MachineLampChangedEventArgs e) =>
+        _machineOutputDispatcher?.EnqueueLamp(e.LampId, e.Value);
 
-    private void OnActiveBackendReelChanged(object? sender, MachineReelChangedEventArgs e)
-    {
-        _reelRuntimeAdapter.ApplyReelState(e.ReelId, e.Position);
-    }
+    private void OnActiveBackendReelChanged(object? sender, MachineReelChangedEventArgs e) =>
+        _machineOutputDispatcher?.EnqueueReel(e.ReelId, e.Position);
 
-    private void OnActiveBackendSegmentChanged(object? sender, MachineSegmentChangedEventArgs e)
-    {
-        _segmentRuntimeAdapter.ApplySegmentState(e.CellId, e.SegmentMask, e.OutputType);
-    }
+    private void OnActiveBackendSegmentChanged(object? sender, MachineSegmentChangedEventArgs e) =>
+        _machineOutputDispatcher?.EnqueueSegment(e.CellId, e.SegmentMask, e.OutputType);
 
-    private void OnActiveBackendVfdBrightnessChanged(object? sender, MachineVfdBrightnessChangedEventArgs e)
+    private void OnActiveBackendVfdBrightnessChanged(object? sender, MachineVfdBrightnessChangedEventArgs e) =>
+        _machineOutputDispatcher?.EnqueueVfdBrightness(e.CellId, e.NormalizedBrightness);
+
+    private void ApplyMachineOutputBatch(MachineOutputBatch batch)
     {
-        _segmentRuntimeAdapter.ApplyVfdBrightness(e.CellId, e.NormalizedBrightness);
+        foreach (var lamp in batch.Lamps)
+            _lampRuntimeAdapter.ApplyLampState(lamp.Id, lamp.Value);
+        foreach (var reel in batch.Reels)
+            _reelRuntimeAdapter.ApplyReelState(reel.Id, reel.Value);
+        foreach (var segment in batch.Segments)
+            _segmentRuntimeAdapter.ApplySegmentState(segment.Id, segment.Mask, segment.OutputType);
+        foreach (var brightness in batch.VfdBrightness)
+            _segmentRuntimeAdapter.ApplyVfdBrightness(brightness.Id, brightness.Value);
     }
 
     private void OnActiveBackendStateChanged(object? sender, EmulationBackendState state)
@@ -2336,6 +2345,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         backend.ReelChanged -= OnActiveBackendReelChanged;
         backend.SegmentChanged -= OnActiveBackendSegmentChanged;
         backend.VfdBrightnessChanged -= OnActiveBackendVfdBrightnessChanged;
+        _machineOutputDispatcher?.Detach();
+        _machineOutputDispatcher = null;
         await backend.DisposeAsync();
         _activeEmulationBackend = null;
         _playViewInputRouter = null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1682,16 +1682,13 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var handled = await dispatcher.TryHandleKeyDownAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, isRepeat, cancellationToken).ConfigureAwait(false);
-        if (!handled && canRoute && isFocused && !isRepeat && !IsStandaloneAltShortcut(keyboardShortcut) && !dispatcher.CanResolveShortcut(keyboardShortcut))
+        if (!handled && canRoute && isFocused && !isRepeat && !dispatcher.CanResolveShortcut(keyboardShortcut))
         {
             AddOutputEntry($"Play View key input unresolved: '{keyboardShortcut}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
         }
 
         return handled;
     }
-
-    private static bool IsStandaloneAltShortcut(string keyboardShortcut) =>
-        string.Equals(keyboardShortcut, "ALT", StringComparison.OrdinalIgnoreCase);
 
     public Task<bool> TryHandlePlayViewKeyUpAsync(string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -245,7 +245,8 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _emulationBackendFactory = new EmulationBackendFactory(
             () => FabricRuntimeLibraryPath, () => ProductionAmberLibraryPath,
             () => System6AudioBufferLengthMilliseconds,
-            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error));
+            errorLogger: message => AddOutputEntry(message, OutputLogStatus.Error),
+            infoLogger: message => AddOutputEntry(message, OutputLogStatus.Info));
 
         RecentProjects = new ObservableCollection<string>(_recentProjectsStore.Load());
         OpenDocuments = new ObservableCollection<DocumentTabViewModel>();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -1682,13 +1682,16 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         }
 
         var handled = await dispatcher.TryHandleKeyDownAsync(SelectedFruitMachinePlatform, keyboardShortcut, isFocused, isRepeat, cancellationToken).ConfigureAwait(false);
-        if (!handled && canRoute && isFocused && !isRepeat && !dispatcher.CanResolveShortcut(keyboardShortcut))
+        if (!handled && canRoute && isFocused && !isRepeat && !IsStandaloneAltShortcut(keyboardShortcut) && !dispatcher.CanResolveShortcut(keyboardShortcut))
         {
             AddOutputEntry($"Play View key input unresolved: '{keyboardShortcut}' on platform '{SelectedFruitMachinePlatform}'.", OutputLogStatus.Warning);
         }
 
         return handled;
     }
+
+    private static bool IsStandaloneAltShortcut(string keyboardShortcut) =>
+        string.Equals(keyboardShortcut, "ALT", StringComparison.OrdinalIgnoreCase);
 
     public Task<bool> TryHandlePlayViewKeyUpAsync(string keyboardShortcut, bool isFocused, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
### Motivation

- Prevent unbounded WPF dispatcher backlog and UI floods by coalescing machine output events (lamps, reels, segments, VFD). 
- Eliminate live audio crackle by replacing the push-only buffering approach with a single, frame-aligned PCM ring buffer and a pull-based `IWaveProvider` for NAudio. 
- Preserve and harden Fabric pump ownership and timing while making short host delays recoverable and avoiding recursive cleanup from the pump thread.

### Description

- Add a coalesced machine-output dispatcher that keeps the latest value per output identity, schedules at most one UI callback at a time, swaps pending state into a batch, applies it on the UI thread, and reschedules at most once if new changes arrive during application (`Emulation/CoalescedMachineOutputDispatcher.cs`); main window now routes backend events through this coalescer and detaches it on backend teardown (`MainWindowViewModel.cs`).
- Implement a bounded, frame-based PCM16 ring buffer with explicit channel count and lock-protected read/write semantics that support partial/ wraparound operations and prevent overwrites (`Emulation/PcmFrameRingBuffer.cs`).
- Add an allocation-free, bulk-copy `IWaveProvider` backed by the ring that reads complete frames, bulk-copies via spans/memory casting, fills underruns with zeroed silence, and counts distinct underrun episodes (`Emulation/PcmRingWaveProvider.cs`).
- Rework `NAudioEmulationAudioSink` to use an immutable per-session `PlaybackState` (format, ring, provider, `WasapiOut`, prebuffer policy) published under a lifecycle gate so `Start`/`PushPcm`/`Clear`/`Stop` are race-safe and the provider/ring remain valid for device callbacks (`Emulation/NAudioEmulationAudioSink.cs`).
- Adjust Fabric pump scheduling to retain ordinary short lateness, perform a bounded number of immediate 1 ms catch-up slices (advancing the deadline exactly once per slice), always read audio per slice, and publish a single snapshot after the batch; cap exceptional retained lateness to avoid unbounded catch-up and avoid performing full cleanup directly from the pump catch block (`Emulation/Fabric/FabricEmulationBackend.cs`).
- Add unit/regression tests that verify coalescing behavior, ring buffer correctness (ordering/wrap/partial/clear) and concurrency, provider underrun/ recovery semantics, and the 75% startup prebuffer policy (`OasisEditor.Tests/EmulationRuntimeStabilityTests.cs` and updates to `NAudioEmulationAudioSinkTests.cs`).

### Testing

- No automated tests were executed in this environment because the execution environment lacks the Windows/.NET/WPF toolchain required to run the test suite; the repo `AGENTS.md` prohibits running builds/tests here. 
- Added unit tests exercise coalescing, ring buffer semantics, provider underrun behavior, and prebuffer threshold; these live in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationRuntimeStabilityTests.cs` and updated `NAudioEmulationAudioSinkTests.cs` and should be run locally. 
- To validate locally on a Windows machine with the native Fabric runtime and .NET toolchain, run: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` and perform the manual long-running stability/audio validations described in the project acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a725a8fd17c83279c210129b4b04ae2)