### PR TITLE
Fix MPU5 16-cell alpha ordering by centralizing Amber-backed platform logic

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs
@@ -5,6 +5,60 @@ namespace OasisEditor.Tests;
 
 public sealed class FabricSevenSegmentRuntimeTests
 {
+    [Theory]
+    [InlineData(FruitMachinePlatformType.Impact)]
+    [InlineData(FruitMachinePlatformType.MPU5)]
+    public void AmberPlatformsInvertImportedAlphaReversedMeaning(FruitMachinePlatformType platform)
+    {
+        Assert.Equal(15, AlphaCellOrder.SourceIndexForCanonicalCell(0, 16, false, platform));
+        Assert.Equal(0, AlphaCellOrder.SourceIndexForCanonicalCell(0, 16, true, platform));
+        Assert.Equal(0, AlphaCellOrder.SourceIndexForCanonicalCell(15, 16, false, platform));
+        Assert.Equal(15, AlphaCellOrder.SourceIndexForCanonicalCell(15, 16, true, platform));
+    }
+
+    [Fact]
+    public void NonAmberPlatformRetainsImportedAlphaReversedMeaning()
+    {
+        Assert.Equal(0, AlphaCellOrder.SourceIndexForCanonicalCell(
+            canonicalIndex: 0,
+            cellCount: 16,
+            sourceAddressingReversed: false,
+            FruitMachinePlatformType.MPU4));
+        Assert.Equal(15, AlphaCellOrder.SourceIndexForCanonicalCell(
+            canonicalIndex: 0,
+            cellCount: 16,
+            sourceAddressingReversed: true,
+            FruitMachinePlatformType.MPU4));
+    }
+
+    [Theory]
+    [InlineData(FruitMachinePlatformType.Impact)]
+    [InlineData(FruitMachinePlatformType.MPU5)]
+    public void AmberPlatformRuntimeUsesForwardSourceOrderWhenAlphaIsReversed(FruitMachinePlatformType platform)
+    {
+        var document = new DocumentTabViewModel(
+            EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements([
+            new PanelElementModel
+            {
+                ObjectId = "alpha-0",
+                Kind = PanelElementKind.Alpha,
+                DisplayNumber = 0,
+                IsReversed = true
+            }
+        ]);
+        var dispatches = new List<Action>();
+        var adapter = new MachineSegmentRuntimeAdapter(() => [document], dispatches.Add, () => platform);
+
+        for (var cell = 0; cell < 16; cell++)
+        {
+            adapter.ApplySegmentState(cell, cell + 1, SegmentOutputType.NativeAlpha);
+        }
+        Assert.Single(dispatches)();
+
+        Assert.Equal(Enumerable.Range(1, 16), document.RuntimeState.GetSegmentCellMasks("alpha-0", 16));
+    }
+
     [Fact]
     public void AlphaBrightnessAtEachDisplayBaseIndexReachesRuntimeCells()
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineSegmentRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineSegmentRuntimeAdapter.cs
@@ -255,9 +255,21 @@ internal static class AlphaCellOrder
 {
     internal static int SourceIndexForCanonicalCell(int canonicalIndex, int cellCount, bool sourceAddressingReversed, FruitMachinePlatformType platform)
     {
-        var reverseSource = platform == FruitMachinePlatformType.Impact
+        var reverseSource = IsAmberBackedPlatform(platform)
             ? !sourceAddressingReversed
             : sourceAddressingReversed;
         return reverseSource ? cellCount - 1 - canonicalIndex : canonicalIndex;
+    }
+
+    // Amber providers expose alpha cells using the opposite source-addressing convention.
+    // Add future Amber-backed platforms here so they share the same runtime mapping.
+    internal static bool IsAmberBackedPlatform(FruitMachinePlatformType platform)
+    {
+        return platform switch
+        {
+            FruitMachinePlatformType.Impact => true,
+            FruitMachinePlatformType.MPU5 => true,
+            _ => false
+        };
     }
 }


### PR DESCRIPTION
### Motivation

- MPU5 uses the same Amber/Amber-backed character-addressing convention as Impact, but the runtime only compensated for `FruitMachinePlatformType.Impact`, causing MPU5 alpha displays to render in the opposite order.
- Centralize the Amber-provider ordering decision so future Amber-backed platforms share the same runtime mapping without duplicating logic per platform.

### Description

- Replace the one-off `Impact` special-case in `AlphaCellOrder.SourceIndexForCanonicalCell` with a centralized predicate `AlphaCellOrder.IsAmberBackedPlatform(FruitMachinePlatformType)` implemented as a `switch` expression that currently returns `true` for `Impact` and `MPU5` and `false` otherwise.
- Preserve the persisted/imported `IsReversed` value and do not change FML import, serialization, inspector behavior, segment-mask bit ordering, or the alpha renderer.
- Add unit tests to `FabricSevenSegmentRuntimeTests` covering Amber parity and regression cases: `AmberPlatformsInvertImportedAlphaReversedMeaning`, `NonAmberPlatformRetainsImportedAlphaReversedMeaning`, and `AmberPlatformRuntimeUsesForwardSourceOrderWhenAlphaIsReversed`.
- Files changed: `WindowsNetProjects/OasisEditor/OasisEditor/MachineSegmentRuntimeAdapter.cs` and `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricSevenSegmentRuntimeTests.cs`.

### Testing

- Ran `git diff --check` and `git status --porcelain` to validate repository state and diffs, and both checks passed in this environment.
- Did not run `dotnet build` or `dotnet test` in this execution environment because the repository's `AGENTS.md` notes the required Windows/.NET/WPF toolchain is not available here; the new and existing unit tests must be executed locally with `dotnet test` against `WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` (they were added but not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a74d2d0415c8327bb77d43a329e8bce)