### PR TITLE
Correct MPU5 reel opto defaults (Barcrest MPU5 0..2)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
@@ -51,8 +51,26 @@ public sealed class EmulationBackendAbstractionsTests
     {
         Assert.NotNull(typeof(Mpu5ReelSettings).GetProperty(nameof(Mpu5ReelSettings.Apply)));
         Assert.Null(typeof(Mpu5ReelSettings).GetProperty("Enabled"));
-        Assert.Equal(8, new Mpu5NativeRomSettings().Reels.Count);
+        var reels = new Mpu5NativeRomSettings().Reels;
+        Assert.Equal(8, reels.Count);
+        Assert.All(reels, reel =>
+        {
+            Assert.Equal(0, reel.OptoStart);
+            Assert.Equal(2, reel.OptoEnd);
+        });
         Assert.Equal(6, new Mpu5NativeRomSettings().Coins.Count);
+    }
+
+    [Fact]
+    public void System6ReelsRetainTheirPlatformSpecificOptoDefaults()
+    {
+        var reels = new System6NativeRomSettings().ReelOptos;
+
+        Assert.All(reels, reel =>
+        {
+            Assert.Equal(5, reel.OptoStart);
+            Assert.Equal(7, reel.OptoEnd);
+        });
     }
 
     [Fact]

--- a/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs
@@ -60,11 +60,14 @@ public sealed class Mpu5NativeRomSettings
 
 public sealed class Mpu5ReelSettings
 {
+    public const int DefaultOptoStart = 0;
+    public const int DefaultOptoEnd = 2;
+
     public bool Apply { get; set; }
     public int ReelIndex { get; set; }
     public int Steps { get; set; } = 96;
-    public int OptoStart { get; set; } = 5;
-    public int OptoEnd { get; set; } = 7;
+    public int OptoStart { get; set; } = DefaultOptoStart;
+    public int OptoEnd { get; set; } = DefaultOptoEnd;
     public bool OptoInvert { get; set; }
     public static Mpu5ReelSettings CreateDefault(int index) => new() { ReelIndex = index };
 }


### PR DESCRIPTION
### Motivation

- The MPU5 reel defaults were incorrectly using the Impact/System 6 opto values (start `5`, end `7`) instead of the Barcrest MPU5 defaults (`0` and `2`).

### Description

- Add `DefaultOptoStart` and `DefaultOptoEnd` constants to `Mpu5ReelSettings` and set `OptoStart`/`OptoEnd` to those constants in `WindowsNetProjects/OasisEditor/OasisEditor/EditorProject.cs`.
- Preserve the existing System 6 opto constants and behavior in `System6ReelOptoSettings` so Impact/JPM System 6 remains `5`/`7`.
- Update `WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs` to assert MPU5 reels have `OptoStart == 0` and `OptoEnd == 2`, and add a new test `System6ReelsRetainTheirPlatformSpecificOptoDefaults` that asserts System 6 reels remain `5`/`7`.

### Testing

- Ran `git diff --check` to validate there are no whitespace or index issues and it completed successfully.
- Updated unit tests were added to `OasisEditor.Tests`, but per the repository `AGENTS.md` the Windows/.NET toolchain is not available in this environment so `dotnet test` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a74e42dd1b083279defd5d628f19b06)