### PR TITLE
Normalize Amber reel direction across Fabric cores

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
@@ -15,6 +15,7 @@ public sealed class ZeroBasedReelRuntimeTests
         backend.PublishSnapshot(CreateSnapshot());
 
         Assert.Equal([0, 1, 2, 3], changes.Select(change => change.ReelId));
+        Assert.All(changes, change => Assert.Equal(ReelPositionConvention.Amber, change.Convention));
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public sealed class ZeroBasedReelRuntimeTests
         var adapter = new MachineReelRuntimeAdapter(() => [document], () => FruitMachinePlatformType.Impact,
             () => false, _ => { }, dispatches.Add);
         var backend = new FabricEmulationBackend("fabric", "amber");
-        backend.ReelChanged += (_, change) => adapter.ApplyReelState(change.ReelId, change.Position);
+        backend.ReelChanged += (_, change) => adapter.ApplyReelState(change.ReelId, change.Position, change.Convention);
 
         backend.PublishSnapshot(CreateSnapshot());
         Assert.Single(dispatches)();
@@ -47,24 +48,26 @@ public sealed class ZeroBasedReelRuntimeTests
     }
 
     [Theory]
-    [InlineData(FruitMachinePlatformType.Impact, 0, 96, 0d)]
-    [InlineData(FruitMachinePlatformType.Impact, 1, 96, 95d)]
-    [InlineData(FruitMachinePlatformType.Impact, 95, 96, 1d)]
-    [InlineData(FruitMachinePlatformType.Impact, 96, 96, 0d)]
-    [InlineData(FruitMachinePlatformType.Impact, 97, 96, 95d)]
-    [InlineData(FruitMachinePlatformType.Impact, -1, 96, 1d)]
-    [InlineData(FruitMachinePlatformType.Scorpion4, 10, 96, 10d)]
-    [InlineData(FruitMachinePlatformType.Impact, 10, 48, 76d)]
-    public void PlatformNormalization_UsesConfiguredBackendMotorStepRange(
-        FruitMachinePlatformType platform, int position, int positionCount, double expected)
+    [InlineData(ReelPositionConvention.Amber, 0, 96, 0d)]
+    [InlineData(ReelPositionConvention.Amber, 1, 96, 95d)]
+    [InlineData(ReelPositionConvention.Amber, 95, 96, 1d)]
+    [InlineData(ReelPositionConvention.Amber, 96, 96, 0d)]
+    [InlineData(ReelPositionConvention.Amber, 97, 96, 95d)]
+    [InlineData(ReelPositionConvention.Amber, -1, 96, 1d)]
+    [InlineData(ReelPositionConvention.Oasis, 10, 96, 10d)]
+    [InlineData(ReelPositionConvention.Amber, 10, 48, 76d)]
+    public void BackendNormalization_UsesConventionAndConfiguredMotorStepRange(
+        ReelPositionConvention convention, int position, int positionCount, double expected)
     {
-        Assert.Equal(expected, MachineReelRuntimeAdapter.NormalizePlatformReelPosition(platform, position, positionCount));
+        Assert.Equal(expected, MachineReelRuntimeAdapter.NormalizeBackendReelPosition(convention, position, positionCount));
     }
 
     [Theory]
-    [InlineData(false, 86d)]
-    [InlineData(true, 10d)]
-    public void ImpactPlatformCorrection_PrecedesComponentReversal(bool isReversed, double expected)
+    [InlineData(FruitMachinePlatformType.Impact, false, 86d)]
+    [InlineData(FruitMachinePlatformType.Impact, true, 10d)]
+    [InlineData(FruitMachinePlatformType.MPU5, false, 86d)]
+    [InlineData(FruitMachinePlatformType.MPU5, true, 10d)]
+    public void FabricAmberNormalization_AppliesOnceBeforeComponentReversal(FruitMachinePlatformType platform, bool isReversed, double expected)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
         document.SetPanelElements([new PanelElementModel
@@ -73,13 +76,33 @@ public sealed class ZeroBasedReelRuntimeTests
             Stops = 24, IsReversed = isReversed
         }]);
         var dispatches = new List<Action>();
+        var adapter = new MachineReelRuntimeAdapter(() => [document], () => platform,
+            () => false, _ => { }, dispatches.Add);
+
+        adapter.ApplyReelState(0, 10, ReelPositionConvention.Amber);
+        Assert.Single(dispatches)();
+
+        Assert.Equal(expected, document.RuntimeState.GetReelPosition("reel-0"));
+        Assert.Equal(86d, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(0)));
+    }
+
+    [Fact]
+    public void ConventionNeutralBackend_RemainsUnreversed()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements([new PanelElementModel
+        {
+            ObjectId = "reel-0", Kind = PanelElementKind.Reel, DisplayNumber = 0, Stops = 24
+        }]);
+        var dispatches = new List<Action>();
         var adapter = new MachineReelRuntimeAdapter(() => [document], () => FruitMachinePlatformType.Impact,
             () => false, _ => { }, dispatches.Add);
 
         adapter.ApplyReelState(0, 10);
         Assert.Single(dispatches)();
 
-        Assert.Equal(expected, document.RuntimeState.GetReelPosition("reel-0"));
+        Assert.Equal(10d, document.RuntimeState.GetReelPosition("reel-0"));
+        Assert.Equal(10d, document.RuntimeState.GetReelPosition(MachineObjectReference.Reel(0)));
     }
 
     [Fact]
@@ -90,7 +113,7 @@ public sealed class ZeroBasedReelRuntimeTests
     }
 
     [Fact]
-    public void ImpactAdapter_AllowsEachReelToUseItsConfiguredMotorStepCount()
+    public void AmberAdapter_AllowsEachReelToUseItsConfiguredMotorStepCount()
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
         document.SetPanelElements(Enumerable.Range(0, 2).Select(reelId => new PanelElementModel
@@ -102,8 +125,8 @@ public sealed class ZeroBasedReelRuntimeTests
         var adapter = new MachineReelRuntimeAdapter(() => [document], () => FruitMachinePlatformType.Impact,
             () => false, _ => { }, dispatches.Add, reelId => reelId == 0 ? 48 : 96);
 
-        adapter.ApplyReelState(0, 10);
-        adapter.ApplyReelState(1, 10);
+        adapter.ApplyReelState(0, 10, ReelPositionConvention.Amber);
+        adapter.ApplyReelState(1, 10, ReelPositionConvention.Amber);
         Assert.Single(dispatches)();
 
         Assert.Equal(76d, document.RuntimeState.GetReelPosition("reel-0"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/CoalescedMachineOutputDispatcher.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/CoalescedMachineOutputDispatcher.cs
@@ -6,7 +6,7 @@ internal sealed class CoalescedMachineOutputDispatcher
     private readonly Action<MachineOutputBatch> _apply;
     private readonly object _gate = new();
     private readonly Dictionary<int, int> _lamps = [];
-    private readonly Dictionary<int, int> _reels = [];
+    private readonly Dictionary<int, ReelValue> _reels = [];
     private readonly Dictionary<SegmentKey, SegmentValue> _segments = [];
     private readonly Dictionary<int, double> _vfdBrightness = [];
     private bool _dispatchPending;
@@ -22,7 +22,7 @@ internal sealed class CoalescedMachineOutputDispatcher
     public bool DispatchPending { get { lock (_gate) return _dispatchPending; } }
 
     public void EnqueueLamp(int id, int value) { lock (_gate) { if (_detached) return; _lamps[id] = value; ScheduleLocked(); } }
-    public void EnqueueReel(int id, int value) { lock (_gate) { if (_detached) return; _reels[id] = value; ScheduleLocked(); } }
+    public void EnqueueReel(int id, int value, ReelPositionConvention convention = ReelPositionConvention.Oasis) { lock (_gate) { if (_detached) return; _reels[id] = new(id, value, convention); ScheduleLocked(); } }
     public void EnqueueSegment(int id, int mask, SegmentOutputType type) { lock (_gate) { if (_detached) return; _segments[new(id, type)] = new(id, mask, type); ScheduleLocked(); } }
     public void EnqueueVfdBrightness(int id, double value) { lock (_gate) { if (_detached) return; _vfdBrightness[id] = value; ScheduleLocked(); } }
 
@@ -50,7 +50,7 @@ internal sealed class CoalescedMachineOutputDispatcher
             if (_detached) { _dispatchPending = false; return; }
             batch = new(
                 _lamps.Select(kv => new LampValue(kv.Key, kv.Value)).ToArray(),
-                _reels.Select(kv => new ReelValue(kv.Key, kv.Value)).ToArray(),
+                _reels.Values.ToArray(),
                 _segments.Values.ToArray(),
                 _vfdBrightness.Select(kv => new VfdBrightnessValue(kv.Key, kv.Value)).ToArray());
             _lamps.Clear(); _reels.Clear(); _segments.Clear(); _vfdBrightness.Clear();
@@ -69,6 +69,6 @@ internal sealed class CoalescedMachineOutputDispatcher
 
 internal sealed record MachineOutputBatch(LampValue[] Lamps, ReelValue[] Reels, SegmentValue[] Segments, VfdBrightnessValue[] VfdBrightness);
 internal readonly record struct LampValue(int Id, int Value);
-internal readonly record struct ReelValue(int Id, int Value);
+internal readonly record struct ReelValue(int Id, int Value, ReelPositionConvention Convention);
 internal readonly record struct SegmentValue(int Id, int Mask, SegmentOutputType OutputType);
 internal readonly record struct VfdBrightnessValue(int Id, double Value);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -96,14 +96,22 @@ public sealed class MachineLampChangedEventArgs : EventArgs
 
 public sealed class MachineReelChangedEventArgs : EventArgs
 {
-    public MachineReelChangedEventArgs(int reelId, int position)
+    public MachineReelChangedEventArgs(int reelId, int position, ReelPositionConvention convention = ReelPositionConvention.Oasis)
     {
         ReelId = reelId;
         Position = position;
+        Convention = convention;
     }
 
     public int ReelId { get; }
     public int Position { get; }
+    public ReelPositionConvention Convention { get; }
+}
+
+public enum ReelPositionConvention
+{
+    Oasis,
+    Amber
 }
 
 public sealed class MachineSegmentChangedEventArgs : EventArgs

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -553,7 +553,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             if (_reels.TryGetValue(reel.NumericalIndex, out var previous) && previous == reel.Position)
                 continue;
             _reels[reel.NumericalIndex] = reel.Position;
-            ReelChanged?.Invoke(this, new(reel.NumericalIndex, reel.Position));
+            ReelChanged?.Invoke(this, new(reel.NumericalIndex, reel.Position, ReelPositionConvention.Amber));
         }
         for (var displayOrdinal = 0; displayOrdinal < snapshot.CharacterDisplays.Count; displayOrdinal++)
         {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineReelRuntimeAdapter.cs
@@ -10,8 +10,8 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
     private readonly Func<bool> _debugOutputEnabledProvider;
     private readonly Action<string> _infoLogger;
     private readonly Action<Action> _uiDispatch;
-    private readonly Dictionary<int, int> _pendingReelValues = new();
-    private readonly Dictionary<int, int> _latestReelValues = new();
+    private readonly Dictionary<int, PendingReelValue> _pendingReelValues = new();
+    private readonly Dictionary<int, PendingReelValue> _latestReelValues = new();
     private readonly Dictionary<Guid, ReelDocumentMappingCacheEntry> _reelMappingsByDocumentId = new();
     private readonly IMachineObjectReferenceResolver _machineObjectReferenceResolver;
     private bool _uiUpdateScheduled;
@@ -33,12 +33,12 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
         _machineObjectReferenceResolver = MachineObjectReferenceResolver.Instance;
     }
 
-    public void ApplyReelState(int reelId, int reelValue)
+    public void ApplyReelState(int reelId, int reelValue, ReelPositionConvention convention = ReelPositionConvention.Oasis)
     {
         lock (_pendingSync)
         {
-            _pendingReelValues[reelId] = reelValue;
-            _latestReelValues[reelId] = reelValue;
+            _pendingReelValues[reelId] = new(reelValue, convention);
+            _latestReelValues[reelId] = new(reelValue, convention);
             if (_uiUpdateScheduled)
             {
                 return;
@@ -52,10 +52,10 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
 
     private void ApplyPendingOnUiThread()
     {
-        Dictionary<int, int> snapshot;
+        Dictionary<int, PendingReelValue> snapshot;
         lock (_pendingSync)
         {
-            snapshot = new Dictionary<int, int>(_pendingReelValues);
+            snapshot = new Dictionary<int, PendingReelValue>(_pendingReelValues);
             _pendingReelValues.Clear();
             _uiUpdateScheduled = false;
         }
@@ -77,11 +77,12 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
             var changedObjectIds = new HashSet<string>(StringComparer.Ordinal);
             var changedFaceObjectIds = new HashSet<string>(StringComparer.Ordinal);
 
-            foreach (var (reelId, reelValue) in snapshot)
+            foreach (var (reelId, pendingValue) in snapshot)
             {
+                var reelValue = pendingValue.Position;
                 var reelReference = MachineObjectReference.Reel(reelId);
                 var positionCount = _reelPositionCountProvider(reelId);
-                var machinePosition = NormalizePlatformReelPosition(platform, reelValue, positionCount);
+                var machinePosition = NormalizeBackendReelPosition(pendingValue.Convention, reelValue, positionCount);
                 if (document.RuntimeState.SetReelPositionIfChanged(reelReference, machinePosition)
                     && faceObjectIdsByReel.TryGetValue(reelReference, out var matchingFaceObjectIds))
                 {
@@ -98,7 +99,7 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
 
                 foreach (var objectId in objectIds)
                 {
-                    if (!TryResolveEffectiveReelPosition(document, objectId, reelValue, positionCount, out var effectiveReelPosition, out var stops, out var normalizedPosition))
+                    if (!TryResolveEffectiveReelPosition(document, objectId, reelValue, positionCount, pendingValue.Convention, out var effectiveReelPosition, out var stops, out var normalizedPosition))
                     {
                         continue;
                     }
@@ -168,11 +169,11 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
         return cacheEntry.MappingByReelId;
     }
 
-    internal static double NormalizePlatformReelPosition(FruitMachinePlatformType platform, int backendPosition, int positionCount)
+    internal static double NormalizeBackendReelPosition(ReelPositionConvention convention, int backendPosition, int positionCount)
     {
         var safePositionCount = positionCount > 0 ? positionCount : ReelPositionsPerRevolution;
         var normalizedBackendPosition = WrapPosition(backendPosition, safePositionCount);
-        var platformPosition = platform == FruitMachinePlatformType.Impact
+        var platformPosition = convention == ReelPositionConvention.Amber
             ? ReversePosition(normalizedBackendPosition, safePositionCount)
             : normalizedBackendPosition;
         return platformPosition * (double)ReelPositionsPerRevolution / safePositionCount;
@@ -194,7 +195,7 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
         return ((position % positionCount) + positionCount) % positionCount;
     }
 
-    private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, int positionCount, out double effectiveReelPosition, out int stops, out double normalizedPosition)
+    private bool TryResolveEffectiveReelPosition(DocumentTabViewModel document, string objectId, int rawReelValue, int positionCount, ReelPositionConvention convention, out double effectiveReelPosition, out int stops, out double normalizedPosition)
     {
         effectiveReelPosition = 0d;
         stops = 0;
@@ -209,7 +210,7 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
 
         stops = reelElement.Stops.Value;
         var platform = _platformProvider();
-        var canonicalPosition = NormalizePlatformReelPosition(platform, rawReelValue, positionCount);
+        var canonicalPosition = NormalizeBackendReelPosition(convention, rawReelValue, positionCount);
         effectiveReelPosition = ResolveEffectiveReelPosition(canonicalPosition, reelElement.Stops.Value, reelElement.IsReversed == true, reelElement.BandOffset ?? 0d, platform);
         var wrappedPosition = ((effectiveReelPosition % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
         normalizedPosition = wrappedPosition / ReelPositionsPerRevolution;
@@ -260,6 +261,8 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
 
         _uiDispatch(ApplyPendingOnUiThread);
     }
+
+    private readonly record struct PendingReelValue(int Position, ReelPositionConvention Convention);
 
     private sealed class ReelDocumentMappingCacheEntry
     {

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeAdapters.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineRuntimeAdapters.cs
@@ -7,7 +7,7 @@ public interface IMachineLampRuntimeAdapter
 
 public interface IMachineReelRuntimeAdapter
 {
-    void ApplyReelState(int reelId, int reelValue);
+    void ApplyReelState(int reelId, int reelValue, ReelPositionConvention convention = ReelPositionConvention.Oasis);
 }
 
 public interface IMachineSegmentRuntimeAdapter

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -250,8 +250,11 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             () => OpenDocuments, () => false, _ => { }, DispatchToUiThread);
         _reelRuntimeAdapter = new MachineReelRuntimeAdapter(
             () => OpenDocuments, () => SelectedFruitMachinePlatform, () => false, _ => { }, DispatchToUiThread,
-            reelId => System6ReelOptos.FirstOrDefault(reel => reel.ReelIndex == reelId)?.Steps
-                ?? System6ReelOptoSettings.DefaultSteps);
+            reelId => SelectedFruitMachinePlatform == FruitMachinePlatformType.MPU5
+                ? LoadedProject?.Mpu5NativeRoms.Reels.FirstOrDefault(reel => reel.ReelIndex == reelId)?.Steps
+                    ?? System6ReelOptoSettings.DefaultSteps
+                : System6ReelOptos.FirstOrDefault(reel => reel.ReelIndex == reelId)?.Steps
+                    ?? System6ReelOptoSettings.DefaultSteps);
         _segmentRuntimeAdapter = new MachineSegmentRuntimeAdapter(
             () => OpenDocuments,
             DispatchToUiThread,
@@ -2383,7 +2386,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         _machineOutputDispatcher?.EnqueueLamp(e.LampId, e.Value);
 
     private void OnActiveBackendReelChanged(object? sender, MachineReelChangedEventArgs e) =>
-        _machineOutputDispatcher?.EnqueueReel(e.ReelId, e.Position);
+        _machineOutputDispatcher?.EnqueueReel(e.ReelId, e.Position, e.Convention);
 
     private void OnActiveBackendSegmentChanged(object? sender, MachineSegmentChangedEventArgs e) =>
         _machineOutputDispatcher?.EnqueueSegment(e.CellId, e.SegmentMask, e.OutputType);
@@ -2396,7 +2399,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         foreach (var lamp in batch.Lamps)
             _lampRuntimeAdapter.ApplyLampState(lamp.Id, lamp.Value);
         foreach (var reel in batch.Reels)
-            _reelRuntimeAdapter.ApplyReelState(reel.Id, reel.Value);
+            _reelRuntimeAdapter.ApplyReelState(reel.Id, reel.Value, reel.Convention);
         foreach (var segment in batch.Segments)
             _segmentRuntimeAdapter.ApplySegmentState(segment.Id, segment.Mask, segment.OutputType);
         foreach (var brightness in batch.VfdBrightness)


### PR DESCRIPTION
### Motivation

- Fabric (Amber) backend emitted reel positions in Amber convention but the runtime only reversed for `Impact`, causing MPU5/Amber-driven reels to render reversed.
- The intent is to treat the Amber direction convention as a backend convention (not a list of platform names) and apply a single normalization before component-level `IsReversed` and band offsets.

### Description

- Introduces an explicit `ReelPositionConvention` on reel events and threads it through the output pipeline so Amber-originated positions are labelled `Amber` while other sources remain `Oasis` (`Emulation/EmulationBackendAbstractions.cs`, `Emulation/Fabric/FabricEmulationBackend.cs`).
- Carries the convention through the coalescer into `MachineReelRuntimeAdapter.ApplyReelState(...)` and normalizes based on the convention via `NormalizeBackendReelPosition(...)` instead of platform-name checks (`Emulation/CoalescedMachineOutputDispatcher.cs`, `MachineReelRuntimeAdapter.cs`, `MachineRuntimeAdapters.cs`, `MainWindowViewModel.cs`).
- Moves the Amber normalization to a single place so the canonical machine-level reel reference receives the Amber-normalized position and individual panel reel state still applies `IsReversed` and band offsets afterward (composition preserved in `TryResolveEffectiveReelPosition` / `ResolveEffectiveReelPosition`).
- Uses per-reel `Steps` where available for MPU5 (via the existing project `Mpu5NativeRoms.Reels`) while preserving System6 per-reel opto defaults to support 48/96 step configurations (`MainWindowViewModel.cs`).
- Updated tests in `ZeroBasedReelRuntimeTests.cs` to cover Amber convention metadata, MPU5 and Impact through Amber, component `IsReversed` composition, wrapping behavior, and per-reel step counts.

### Testing

- Updated unit tests: `OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs` to assert convention metadata and normalization behavior; these tests are included in the change set but were not executed in this environment. 
- No automated test run was performed here because the execution environment lacks the Windows/.NET/WPF toolchain as documented in the repository `AGENTS.md` (do not run tests in this agent environment). 
- To verify locally run: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests -v minimal` and expect all tests to pass, especially the updated zero-based reel runtime tests which exercise Amber normalization, MPU5/Impact parity, `IsReversed` composition, wrapping, and 48/96-step cases.

Files changed: `Emulation/EmulationBackendAbstractions.cs`, `Emulation/Fabric/FabricEmulationBackend.cs`, `Emulation/CoalescedMachineOutputDispatcher.cs`, `MachineReelRuntimeAdapter.cs`, `MachineRuntimeAdapters.cs`, `MainWindowViewModel.cs`, and `OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a74e98a80108327b1806388fa1b1b61)