### PR TITLE
Fix MFME multi-sublamp image inheritance

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -88,6 +88,64 @@ public sealed class FmlToOasisMapperTests
     }
 
     [Fact]
+    public void Map_WithMultiSublampMasks_InheritsFirstMainImageAndPreservesIndividualMasks()
+    {
+        var lamp = new Lamp
+        {
+            Width = 30,
+            Height = 40,
+            SublampTable =
+            [
+                new LampSublampTableEntry(1, 10),
+                new LampSublampTableEntry(2, 11),
+                new LampSublampTableEntry(3, 12)
+            ]
+        };
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Sublamp 1 Main")] = "lamps/shared-main.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Mask")] = "lamps/mask-1.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 2 Mask")] = "lamps/mask-2.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 3 Mask")] = "lamps/mask-3.bmp"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), images);
+
+        Assert.Equal([10, 11, 12], result.Elements.Select(element => element.DisplayNumber));
+        Assert.All(result.Elements, element => Assert.Equal("lamps/shared-main.bmp", element.AssetPath));
+        Assert.Equal(
+            ["lamps/mask-1.bmp", "lamps/mask-2.bmp", "lamps/mask-3.bmp"],
+            result.Elements.Select(element => element.SecondaryAssetPath));
+    }
+
+    [Fact]
+    public void Map_WithSublampSpecificMainImage_PrefersItOverInheritedFirstMainImage()
+    {
+        var lamp = new Lamp
+        {
+            Width = 30,
+            Height = 40,
+            SublampTable =
+            [
+                new LampSublampTableEntry(1, 10),
+                new LampSublampTableEntry(2, 11)
+            ]
+        };
+        var images = new Dictionary<FmlDecodedImageKey, string>
+        {
+            [new FmlDecodedImageKey(0, "Sublamp 1 Main")] = "lamps/main-1.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 1 Mask")] = "lamps/mask-1.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 2 Main")] = "lamps/main-2.bmp",
+            [new FmlDecodedImageKey(0, "Sublamp 2 Mask")] = "lamps/mask-2.bmp"
+        };
+
+        var result = new FmlToOasisMapper().Map(new Layout([lamp]), images);
+
+        Assert.Equal(["lamps/main-1.bmp", "lamps/main-2.bmp"], result.Elements.Select(element => element.AssetPath));
+        Assert.Equal(["lamps/mask-1.bmp", "lamps/mask-2.bmp"], result.Elements.Select(element => element.SecondaryAssetPath));
+    }
+
+    [Fact]
     public void Map_WithCoreComponentTypes_PreservesDirectMappingBehavior()
     {
         var background = new Background { X = 1, Y = 2, Width = 300, Height = 200 };

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -98,7 +98,7 @@ internal sealed class FmlToOasisMapper
         var hasBorder = noOutline.HasValue ? !noOutline.Value : c is Button;
         foreach (var entry in entries)
         {
-            var main = FindLampImage(images, index, entry.SublampIndex, isMask: false) ?? FindLampImage(images, index, entry.SublampIndex, isMask: null) ?? FirstLampImage(images, index, isMask: false);
+            var main = FindLampImage(images, index, entry.SublampIndex, isMask: false) ?? FirstLampImage(images, index, isMask: false);
             var mask = FindLampImage(images, index, entry.SublampIndex, isMask: true) ?? FirstLampImage(images, index, isMask: true);
             var displayNumber = entry.SublampNumber >= 0 ? entry.SublampNumber : (int?)null;
             var font = Font(c);
@@ -268,10 +268,10 @@ internal sealed class FmlToOasisMapper
     private static string? BackgroundAssetPath(BaseComponent c, IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index) => c is Background ? FirstRoleImage(images, index, IsMainBackgroundImage) : FirstImage(images, index);
     private static string? FirstImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index) => images.Where(k => k.Key.ComponentIndex == index).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
     private static string? FirstRoleImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, Func<string, bool> role) => images.Where(k => k.Key.ComponentIndex == index && role(k.Key.ImageName)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
-    private static string? FindLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, int sub, bool? isMask) => images.Where(k => k.Key.ComponentIndex == index && IsSublamp(k.Key.ImageName, sub) && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
-    private static string? FirstLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, bool? isMask) => images.Where(k => k.Key.ComponentIndex == index && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
+    private static string? FindLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, int sub, bool isMask) => images.Where(k => k.Key.ComponentIndex == index && IsSublamp(k.Key.ImageName, sub) && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
+    private static string? FirstLampImage(IReadOnlyDictionary<FmlDecodedImageKey, string> images, int index, bool isMask) => images.Where(k => k.Key.ComponentIndex == index && MatchesMask(k.Key.ImageName, isMask)).OrderBy(k => k.Key.ImageName, StringComparer.Ordinal).Select(k => k.Value).FirstOrDefault();
     private static bool IsSublamp(string key, int sub) { var n = Norm(key); return n.StartsWith($"sublamp_{sub}_", StringComparison.Ordinal) || key.StartsWith($"Sublamp {sub} ", StringComparison.OrdinalIgnoreCase); }
-    private static bool MatchesMask(string key, bool? mask) => mask is null || Norm(key).Contains("mask", StringComparison.Ordinal) == mask.Value;
+    private static bool MatchesMask(string key, bool mask) => Norm(key).Contains("mask", StringComparison.Ordinal) == mask;
     private static bool IsReelBand(string k) { var n = Norm(k); return n.Contains("band") || n.Contains("gradient") || n.Contains("strip") || n.Contains("reel_image") || n.EndsWith("reel"); }
     private static bool IsOverlay(string k) { var n = Norm(k); return n.Contains("overlay") || n.Contains("over_lay") || n.Contains("window") || n.Contains("cutout") || n.Contains("cut_out") || n.Contains("mask_overlay"); }
     private static bool IsMainBackgroundImage(string k) { var n = Norm(k); return n.Contains("background") && !n.Contains("mask") && !IsOverlay(k); }


### PR DESCRIPTION
### Motivation

- MFME allows a multi-sublamp component to provide a single main image on the first sublamp with per-sublamp masks, and the importer was accidentally treating masks as eligible main images for later sublamps.  
- This caused incorrect/white rendering when a sublamp had only a mask but no main image, because the mask could be selected as the primary `AssetPath`.  
- The intent is to ensure sublamps inherit the first non-mask main image while keeping mask resolution independent and preserving genuine per-sublamp main images.

### Description

- Updated `MapLampLike` to resolve the main image using `FindLampImage(..., isMask: false) ?? FirstLampImage(..., isMask: false)`, removing the previous `isMask: null` fallback that allowed masks to be chosen as main images.  
- Tightened helper signatures so `FindLampImage` and `FirstLampImage` accept a non-nullable `bool isMask` and changed `MatchesMask` accordingly so masks are never eligible when asking for a non-mask main image.  
- Added regression tests to `FmlToOasisMapperTests` covering multi-sublamp behavior: one test verifies sublamps 1–3 inherit sublamp 1's main image while keeping individual masks, and another verifies a sublamp-specific main image overrides inheritance.  
- Verified and removed the prior `FindLampImage(..., isMask: null)` usage in the mapper so mask/null lookups are no longer used for main-image resolution.

### Testing

- Ran repository checks including `git diff --check` which reported no problems.  
- Verified with ripgrep that no `FindLampImage(..., isMask: null)` occurrences remain.  
- Unit tests were not executed in this environment because the required Windows/.NET/WPF toolchain is not available here; please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` locally to validate all tests (new tests are in `FmlToOasisMapperTests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a77292999408327a6bde0393a67ad0a)