### PR TITLE
Preserve native MFME background pixel mapping

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LayoutImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LayoutImportAssetCopierTests.cs
@@ -16,11 +16,12 @@ public sealed class LayoutImportAssetCopierTests
         var projectRoot = Path.Combine(tempRoot, "project");
         var assetsRoot = Path.Combine(projectRoot, "Assets");
         Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
-        File.WriteAllBytes(Path.Combine(stagingRoot, "background", "bg.png"), [1, 2, 3]);
+        WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), 10, 10,
+            Enumerable.Repeat(Colors.Black, 100).ToArray());
 
         var elements = new[]
         {
-            new PanelElementModel { ObjectId = "bg", Name = "Background", Kind = PanelElementKind.Background, Width = 10, Height = 10, AssetPath = "background/bg.png" }
+            new PanelElementModel { ObjectId = "bg", Name = "Background", Kind = PanelElementKind.Background, Width = 10, Height = 10, AssetPath = "background/bg.bmp" }
         };
 
         var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "My Layout", assetsRoot, copyAssets: true, elements);
@@ -28,6 +29,102 @@ public sealed class LayoutImportAssetCopierTests
         Assert.True(result.Succeeded);
         Assert.Contains("Assets/FmlImport/My Layout/Background/bg.png", result.CopiedAssetRelativePaths);
         Assert.Contains(result.Elements, element => element.Kind == PanelElementKind.Background && element.AssetPath == "Assets/FmlImport/My Layout/Background/bg.png");
+    }
+
+    [Fact]
+    public void CopyAssetsFromStaging_OversizedMfmeBackgroundIsCroppedAtNativePixelScale()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var stagingRoot = Path.Combine(tempRoot, "staging");
+            var assetsRoot = Path.Combine(tempRoot, "project", "Assets");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
+            var sourcePixels = CreateCoordinatePixels(1000, 750);
+            WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), 1000, 750, sourcePixels);
+            var background = new PanelElementModel { ObjectId = "bg", Kind = PanelElementKind.Background, X = 0, Y = 0, Width = 800, Height = 600, AssetPath = "background/bg.bmp" };
+            var lamp = new PanelElementModel { ObjectId = "lamp", Kind = PanelElementKind.Lamp, X = 91, Y = 123, Width = 20, Height = 30 };
+
+            var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "Native Background", assetsRoot, true, [background, lamp]);
+
+            Assert.True(result.Succeeded);
+            var importedBackground = Assert.Single(result.Elements.Where(element => element.Kind == PanelElementKind.Background));
+            var importedLamp = Assert.Single(result.Elements.Where(element => element.Kind == PanelElementKind.Lamp));
+            var pixels = ReadPixels(ResolveAsset(assetsRoot, importedBackground.AssetPath!), out var width, out var height);
+            Assert.Equal((800, 600), (width, height));
+            Assert.Equal(sourcePixels[0], pixels[0]);
+            Assert.Equal(sourcePixels[(599 * 1000) + 799], pixels[(599 * 800) + 799]);
+            Assert.NotEqual(sourcePixels[^1], pixels[^1]);
+            Assert.Equal((0d, 0d, 800d, 600d), (importedBackground.X, importedBackground.Y, importedBackground.Width, importedBackground.Height));
+            Assert.Equal((91d, 123d, 20d, 30d), (importedLamp.X, importedLamp.Y, importedLamp.Width, importedLamp.Height));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyAssetsFromStaging_OversizedBackgroundCutoutUsesUnscaledCoordinates()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var stagingRoot = Path.Combine(tempRoot, "staging");
+            var assetsRoot = Path.Combine(tempRoot, "project", "Assets");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
+            WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), 1000, 750,
+                Enumerable.Repeat(Colors.Red, 1000 * 750).ToArray());
+            var background = new PanelElementModel { ObjectId = "bg", Kind = PanelElementKind.Background, Width = 800, Height = 600, AssetPath = "background/bg.bmp" };
+            var reel = new PanelElementModel { ObjectId = "reel", Kind = PanelElementKind.Reel, X = 100, Y = 200, Width = 50, Height = 80 };
+
+            var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "Cutout", assetsRoot, true, [background, reel]);
+
+            Assert.True(result.Succeeded);
+            var importedBackground = Assert.Single(result.Elements.Where(element => element.Kind == PanelElementKind.Background));
+            var pixels = ReadPixels(ResolveAsset(assetsRoot, importedBackground.AssetPath!), out var width, out _);
+            Assert.Equal(0, pixels[(200 * width) + 100].A);
+            Assert.Equal(0, pixels[(279 * width) + 149].A);
+            Assert.Equal(255, pixels[(199 * width) + 100].A);
+            Assert.Equal(255, pixels[(250 * width) + 160].A);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(800, 600)]
+    [InlineData(400, 300)]
+    public void CopyAssetsFromStaging_BackgroundAtOrBelowLayoutSizeIsNotScaled(int sourceWidth, int sourceHeight)
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var stagingRoot = Path.Combine(tempRoot, "staging");
+            var assetsRoot = Path.Combine(tempRoot, "project", "Assets");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
+            var sourcePixels = CreateCoordinatePixels(sourceWidth, sourceHeight);
+            WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), sourceWidth, sourceHeight, sourcePixels);
+            var background = new PanelElementModel { ObjectId = "bg", Kind = PanelElementKind.Background, Width = 800, Height = 600, AssetPath = "background/bg.bmp" };
+
+            var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "No Scaling", assetsRoot, true, [background]);
+
+            Assert.True(result.Succeeded);
+            var imported = Assert.Single(result.Elements);
+            var pixels = ReadPixels(ResolveAsset(assetsRoot, imported.AssetPath!), out var width, out var height);
+            Assert.Equal((800, 600), (width, height));
+            Assert.Equal(sourcePixels[(sourceHeight - 1) * sourceWidth + sourceWidth - 1], pixels[(sourceHeight - 1) * width + sourceWidth - 1]);
+            if (sourceWidth < width || sourceHeight < height)
+            {
+                Assert.Equal(0, pixels[^1].A);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
     }
 
 
@@ -151,6 +248,18 @@ public sealed class LayoutImportAssetCopierTests
         return Enumerable.Range(0, width * height)
             .Select(index => Color.FromArgb(pixels[(index * 4) + 3], pixels[(index * 4) + 2], pixels[(index * 4) + 1], pixels[index * 4]))
             .ToArray();
+    }
+
+    private static Color[] CreateCoordinatePixels(int width, int height)
+    {
+        return Enumerable.Range(0, width * height)
+            .Select(index => Color.FromArgb(255, (byte)(index / width % 251), (byte)(index % width % 253), (byte)((index / width + index % width) % 249)))
+            .ToArray();
+    }
+
+    private static string ResolveAsset(string assetsRoot, string assetPath)
+    {
+        return Path.Combine(assetsRoot, assetPath["Assets/".Length..].Replace('/', Path.DirectorySeparatorChar));
     }
 
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/LayoutImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/LayoutImportAssetCopier.cs
@@ -48,6 +48,13 @@ internal sealed class LayoutImportAssetCopier
         if (errors.Count == 0)
         {
             mappedElements = backgroundMode == FmlBackgroundMode.ImageBackedBackground
+                ? NormalizeBackgroundAssets(mappedElements, projectAssetsRoot, copied, errors)
+                : mappedElements;
+        }
+
+        if (errors.Count == 0)
+        {
+            mappedElements = backgroundMode == FmlBackgroundMode.ImageBackedBackground
                 ? BakeDisplayOverlaysIntoBackgrounds(mappedElements, projectAssetsRoot, copied, errors)
                 : mappedElements;
         }
@@ -65,6 +72,43 @@ internal sealed class LayoutImportAssetCopier
             Warnings = warnings,
             Errors = []
         };
+    }
+
+    private static PanelElementModel[] NormalizeBackgroundAssets(
+        PanelElementModel[] elements,
+        string projectAssetsRoot,
+        ICollection<string> copied,
+        ICollection<string> errors)
+    {
+        var updatedElements = elements;
+        for (var index = 0; index < updatedElements.Length; index++)
+        {
+            var background = updatedElements[index];
+            if (background.Kind != PanelElementKind.Background || string.IsNullOrWhiteSpace(background.AssetPath))
+            {
+                continue;
+            }
+
+            var backgroundPath = TryResolveProjectAssetPath(background.AssetPath, projectAssetsRoot);
+            if (backgroundPath is null || !File.Exists(backgroundPath))
+            {
+                continue;
+            }
+
+            if (!MfmeBackgroundOverlayPostProcessor.TryNormalizeBackground(backgroundPath, background, projectAssetsRoot, copied, out var updatedBackgroundPath, out var processingError))
+            {
+                errors.Add($"Failed to normalize MFME background asset '{background.AssetPath}': {processingError}");
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(updatedBackgroundPath))
+            {
+                updatedElements = (PanelElementModel[])updatedElements.Clone();
+                updatedElements[index] = CloneWithAssetPath(background, updatedBackgroundPath);
+            }
+        }
+
+        return updatedElements;
     }
 
     private static readonly IReadOnlyDictionary<string, string> StagingFolderToProjectFolder = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -7,6 +7,52 @@ namespace OasisEditor.Features.LayoutImport;
 
 internal static class MfmeBackgroundOverlayPostProcessor
 {
+    public static bool TryNormalizeBackground(
+        string backgroundPath,
+        PanelElementModel background,
+        string projectAssetsRoot,
+        ICollection<string> copied,
+        out string? updatedBackgroundPath,
+        out string? error)
+    {
+        updatedBackgroundPath = null;
+        error = null;
+
+        try
+        {
+            var width = (int)Math.Round(background.Width);
+            var height = (int)Math.Round(background.Height);
+            if (width <= 0 || height <= 0)
+            {
+                return true;
+            }
+
+            var source = LoadBgra32(backgroundPath);
+            var normalized = new PixelBuffer(width, height, checked(width * 4), new byte[checked(width * height * 4)]);
+            var copyWidth = Math.Min(source.Width, normalized.Width);
+            var copyHeight = Math.Min(source.Height, normalized.Height);
+            for (var y = 0; y < copyHeight; y++)
+            {
+                Buffer.BlockCopy(source.Pixels, y * source.Stride, normalized.Pixels, y * normalized.Stride, copyWidth * 4);
+            }
+
+            var outputPath = ResolveOutputPath(backgroundPath);
+            SavePng(normalized, outputPath);
+            if (!string.Equals(outputPath, backgroundPath, StringComparison.OrdinalIgnoreCase))
+            {
+                updatedBackgroundPath = ToProjectRelativeAssetPath(outputPath, projectAssetsRoot);
+                copied.Add(updatedBackgroundPath);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
     public static bool TryBakeDisplayOverlays(
         string backgroundPath,
         PanelElementModel background,
@@ -143,12 +189,10 @@ internal static class MfmeBackgroundOverlayPostProcessor
             return new PixelRect(0, 0, 0, 0);
         }
 
-        var scaleX = backgroundImage.Width / background.Width;
-        var scaleY = backgroundImage.Height / background.Height;
-        var x = (int)Math.Round((overlayElement.X - background.X) * scaleX);
-        var y = (int)Math.Round((overlayElement.Y - background.Y) * scaleY);
-        var width = Math.Max(1, (int)Math.Round(overlayElement.Width * scaleX));
-        var height = Math.Max(1, (int)Math.Round(overlayElement.Height * scaleY));
+        var x = (int)Math.Round(overlayElement.X - background.X);
+        var y = (int)Math.Round(overlayElement.Y - background.Y);
+        var width = Math.Max(1, (int)Math.Round(overlayElement.Width));
+        var height = Math.Max(1, (int)Math.Round(overlayElement.Height));
         return new PixelRect(x, y, width, height);
     }
 


### PR DESCRIPTION
### Motivation
- MFME background components sometimes reference bitmaps larger than the MFME window and are displayed at native 1:1 pixels with clipping, but the importer treated the size difference as a scale factor causing stretched/squashed Oasis assets and mis-positioned overlays.

### Description
- Add `TryNormalizeBackground` to `MfmeBackgroundOverlayPostProcessor` to produce a normalized BG bitmap whose dimensions equal the MFME Background component and which copies source pixels at 1:1, clipping or transparent-padding as required.
- Call the normalization step from `LayoutImportAssetCopier.CopyAssetsFromStaging` (for `FmlBackgroundMode.ImageBackedBackground`) before baking overlays so subsequent overlay/cutout processing operates on component-sized image assets.
- Remove the previous scale-based coordinate math in `GetElementDestinationRect()` and use direct component-relative coordinates so overlays/cutouts map 1:1 to background pixels (while preserving non-zero background origins).
- Add regression tests in `LayoutImportAssetCopierTests` that cover oversized-background cropping (1000×750 -> 800×600), overlay/cutout positioning with oversized sources, matching-size behavior, and smaller-bitmaps-not-scaled behavior.

### Testing
- Added unit tests (new/updated tests in `WindowsNetProjects/OasisEditor/OasisEditor.Tests/LayoutImportAssetCopierTests.cs`) covering oversized, overlay/cutout, matching-size, and smaller-image cases; these tests were added but not executed in this environment because the repository requires a Windows/.NET/WPF toolchain that is unavailable here.
- Performed repository checks (`git diff --check`) and repository status validation, and committed the changes (`Fix MFME background image import scaling`).
- Recommended local verification: run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests/OasisEditor.Tests.csproj` on a Windows machine with the required toolchain to execute the new tests and validate behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7734594c98832797d0ca4235069189)