### PR TITLE
Add MFME Background diagnostic hexdump in BackgroundParser

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
@@ -1,8 +1,10 @@
 using MfmeFmlDecoder.Model;
 using MfmeFmlDecoder.src.Decoder.Component.Core;
 using MfmeFmlDecoder.src.Model.Component;
+using MfmeFmlDecoder.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace MfmeFmlDecoder.src.Decoder.Component
 {
@@ -46,6 +48,8 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                     RewriteTriggerOffsetDelta: 0,
                     ValidAngleOffsetDelta: 0));
 
+            WriteDiagnosticDump(componentOffset, componentId, parseData, offset);
+
             var parseOptions = ExtendedTagParser.Options
                 .WithBitmapTags(0x03, 0x36, 0x0C)
                 .WithFlagDropdown(
@@ -61,6 +65,61 @@ namespace MfmeFmlDecoder.src.Decoder.Component
             ApplyExtendedTags(component, parseResult, componentTagMap);
 
             return component;
+        }
+
+        private static void WriteDiagnosticDump(long componentOffset, uint componentId, byte[] parseData, long offset)
+        {
+            const int completeDumpThreshold = 512;
+            const int bytesBeforeOffset = 64;
+            const int bytesFromOffset = 128;
+
+            RunLog.WriteDiagnosticLine("=== MFME Background diagnostic begin ===");
+            RunLog.WriteDiagnosticLine($"componentOffset={componentOffset} (0x{componentOffset:X})");
+            RunLog.WriteDiagnosticLine($"componentId={componentId} (0x{componentId:X})");
+            RunLog.WriteDiagnosticLine($"parseDataLength={parseData.Length}");
+            RunLog.WriteDiagnosticLine($"extendedOffset=0x{offset:X} ({offset})");
+
+            if (parseData.Length <= completeDumpThreshold)
+            {
+                RunLog.WriteDiagnosticLine("decodedParseData=complete");
+                WriteHexRange(parseData, 0, parseData.Length);
+            }
+            else
+            {
+                int boundedOffset = checked((int)Math.Max(0, Math.Min(offset, parseData.Length)));
+                int contextStart = Math.Max(0, boundedOffset - bytesBeforeOffset);
+                int contextEnd = Math.Min(parseData.Length, boundedOffset + bytesFromOffset);
+
+                RunLog.WriteDiagnosticLine(
+                    $"decodedParseData=context [0x{contextStart:X}, 0x{contextEnd:X})");
+                WriteHexRange(parseData, contextStart, contextEnd);
+            }
+
+            RunLog.WriteDiagnosticLine("=== MFME Background diagnostic end ===");
+        }
+
+        private static void WriteHexRange(byte[] data, int start, int end)
+        {
+            const int bytesPerLine = 16;
+
+            if (start >= end)
+            {
+                RunLog.WriteDiagnosticLine("(no data)");
+                return;
+            }
+
+            for (int lineOffset = start; lineOffset < end; lineOffset += bytesPerLine)
+            {
+                int lineEnd = Math.Min(lineOffset + bytesPerLine, end);
+                var line = new StringBuilder($"{lineOffset:X8}:");
+
+                for (int byteOffset = lineOffset; byteOffset < lineEnd; byteOffset++)
+                {
+                    line.Append($" {data[byteOffset]:X2}");
+                }
+
+                RunLog.WriteDiagnosticLine(line.ToString());
+            }
         }
 
         private void ApplyExtendedTags(Background component, ExtendedTagParser.ParseResult parseResult, ComponentTagMap componentTagMap)


### PR DESCRIPTION
### Motivation

- Provide a temporary, diagnostic-only view of the already-decrypted/decompressed Background component payload so offset bytes for MFME `Offset X`/`Offset Y` can be reverse-engineered. 
- Keep the scope narrowly limited to the MFME `Background` component path and avoid changing decoding, tag maps, or import behavior. 

### Description

- Instrumented `BackgroundParser.Parse(...)` to call `WriteDiagnosticDump(...)` immediately after `ParseBase(...)` and before `ParseExtendedTags(...)`, scoped to `BackgroundParser` only. 
- Diagnostic output uses the existing logging mechanism via `RunLog.WriteDiagnosticLine(...)` and prints `componentOffset`, `componentId`, `parseData.Length`, the returned `offset`, and a plain-text hex dump. 
- For small payloads (<= 512 bytes) the full decoded `parseData` is dumped; for larger payloads the dump includes ~64 bytes before the returned offset and ~128 bytes starting at the offset; each line shows a zero-padded offset and up to 16 hex bytes. 
- No decoding logic, tag maps, tag roles, or extended-tag parsing behaviour was changed. 

### Testing

- Repository checks (`git diff --check`) and workspace status checks completed with no outstanding whitespace or diff errors. 
- No build or automated unit tests were executed because the Windows/.NET/WPF toolchain is not available in this environment per repository guidance, so runtime/build tests must be run locally. 
- Manual verification guidance: run the Editor import on representative MFME FML files and capture diagnostic output (stderr/stdout depending on `RunLog.Quiet`) to compare the printed hex windows for different Background `Offset X/Y` values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a773db1d06c8327a7a65bc5d2ee0a68)