### PR TITLE
Support MFME Background OffsetX/OffsetY during FML import

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecoderRegressionTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlDecoderRegressionTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using MfmeFmlDecoder.Decoder;
 using MfmeFmlDecoder.src.Decoder.Component.Core;
+using MfmeFmlDecoder.src.Decoder.Component;
 using MfmeFmlDecoder.src.Model;
 using MfmeFmlDecoder.Model;
 using Xunit;
@@ -52,6 +53,38 @@ public sealed class FmlDecoderRegressionTests
         Assert.DoesNotContain(0x18u, absent.PresentTagIds);
         Assert.Equal(0u, explicitZero.UInt32sByAttributeName["ButtonNumber"]);
         Assert.Contains(0x18u, explicitZero.PresentTagIds);
+    }
+
+    [Fact]
+    public void BackgroundNestedOffsets_DecodeAsSignedInt32WithZeroDefaults()
+    {
+        var bytes = new byte[]
+        {
+            0x4C, 0x00, 0x00,
+            0x0A, 0xEC, 0xFF, 0xFF, 0xFF,
+            0x0B, 0xF6, 0xFF, 0xFF, 0xFF,
+            0x00,
+            0x00
+        };
+
+        var parsed = new ExtendedTagParser().Parse(
+            BackgroundParser.ComponentTagMap,
+            bytes,
+            0,
+            ExtendedTagParser.Options.Default.WithoutMatchedTagLogging());
+
+        Assert.NotNull(parsed.NestedTagBlockResult);
+        Assert.Equal(-20, parsed.NestedTagBlockResult.Int32sByAttributeName["OffsetX"]);
+        Assert.Equal(-10, parsed.NestedTagBlockResult.Int32sByAttributeName["OffsetY"]);
+
+        var onlyOffsetX = new byte[] { 0x4C, 0x00, 0x00, 0x0A, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        var parsedWithAbsentY = new ExtendedTagParser().Parse(
+            BackgroundParser.ComponentTagMap,
+            onlyOffsetX,
+            0,
+            ExtendedTagParser.Options.Default.WithoutMatchedTagLogging());
+        Assert.Equal(5, parsedWithAbsentY.NestedTagBlockResult!.Int32sByAttributeName["OffsetX"]);
+        Assert.Equal(0, parsedWithAbsentY.NestedTagBlockResult.Int32sByAttributeName["OffsetY"]);
     }
 
     private static byte[] BuildTlv(params (uint Tag, byte[] Value)[] records)

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FmlToOasisMapperTests.cs
@@ -226,6 +226,21 @@ public sealed class FmlToOasisMapperTests
     }
 
     [Fact]
+    public void MfmeBackground_ImageOffsetsDoNotChangeMappedElementGeometry()
+    {
+        var background = new Background { X = 12, Y = 34, Width = 800, Height = 600 };
+        background.Int32s["OffsetX"] = -50;
+        background.Int32s["OffsetY"] = 25;
+
+        var result = new FmlToOasisMapper().Map(new Layout([background]), new Dictionary<FmlDecodedImageKey, string>());
+
+        var element = Assert.Single(result.Elements);
+        Assert.Equal((12d, 34d, 800d, 600d), (element.X, element.Y, element.Width, element.Height));
+        Assert.Equal(-50, element.SourceImageOffsetX);
+        Assert.Equal(25, element.SourceImageOffsetY);
+    }
+
+    [Fact]
     public void Frame_IsReportedAsUnsupported()
     {
         var frame = new Frame { X = 1, Y = 2, Width = 3, Height = 4 };

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LayoutImportAssetCopierTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/LayoutImportAssetCopierTests.cs
@@ -206,6 +206,85 @@ public sealed class LayoutImportAssetCopierTests
         }
     }
 
+    [Theory]
+    [InlineData(0, 0, 0, 0, 0, 0)]
+    [InlineData(2, 1, 0, 0, 2, 1)]
+    [InlineData(-2, -1, 2, 1, 0, 0)]
+    public void CopyAssetsFromStaging_MfmeBackgroundOffsetPlacesPixelsAtNativeScale(
+        int offsetX,
+        int offsetY,
+        int sourceX,
+        int sourceY,
+        int destinationX,
+        int destinationY)
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var stagingRoot = Path.Combine(tempRoot, "staging");
+            var assetsRoot = Path.Combine(tempRoot, "project", "Assets");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
+            var sourcePixels = CreateCoordinatePixels(8, 6);
+            WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), 8, 6, sourcePixels);
+            var background = new PanelElementModel
+            {
+                ObjectId = "bg", Kind = PanelElementKind.Background, Width = 8, Height = 6,
+                AssetPath = "background/bg.bmp", SourceImageOffsetX = offsetX, SourceImageOffsetY = offsetY
+            };
+
+            var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "Offset", assetsRoot, true, [background]);
+
+            Assert.True(result.Succeeded);
+            var imported = Assert.Single(result.Elements);
+            var output = ReadPixels(ResolveAsset(assetsRoot, imported.AssetPath!), out var width, out _);
+            Assert.Equal(sourcePixels[(sourceY * 8) + sourceX], output[(destinationY * width) + destinationX]);
+            if (offsetX > 0 || offsetY > 0)
+            {
+                Assert.Equal(0, output[0].A);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyAssetsFromStaging_OversizedShiftedBackgroundIsClippedBeforeUnshiftedReelCutout()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "OasisEditorTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var stagingRoot = Path.Combine(tempRoot, "staging");
+            var assetsRoot = Path.Combine(tempRoot, "project", "Assets");
+            Directory.CreateDirectory(Path.Combine(stagingRoot, "background"));
+            var sourcePixels = CreateCoordinatePixels(1000, 750);
+            WriteBgra32Bmp(Path.Combine(stagingRoot, "background", "bg.bmp"), 1000, 750, sourcePixels);
+            var background = new PanelElementModel
+            {
+                ObjectId = "bg", Kind = PanelElementKind.Background, Width = 800, Height = 600,
+                AssetPath = "background/bg.bmp", SourceImageOffsetX = -50, SourceImageOffsetY = -25
+            };
+            var reel = new PanelElementModel { ObjectId = "reel", Kind = PanelElementKind.Reel, X = 200, Y = 150, Width = 50, Height = 100 };
+
+            var result = new LayoutImportAssetCopier().CopyAssetsFromStaging(stagingRoot, "Shifted Cutout", assetsRoot, true, [background, reel]);
+
+            Assert.True(result.Succeeded);
+            var imported = Assert.Single(result.Elements.Where(element => element.Kind == PanelElementKind.Background));
+            var output = ReadPixels(ResolveAsset(assetsRoot, imported.AssetPath!), out var width, out var height);
+            Assert.Equal((800, 600), (width, height));
+            Assert.Equal(sourcePixels[(25 * 1000) + 50], output[0]);
+            Assert.Equal(sourcePixels[(149 + 25) * 1000 + (199 + 50)], output[(149 * width) + 199]);
+            Assert.Equal(0, output[(150 * width) + 200].A);
+            Assert.Equal(0, output[(249 * width) + 249].A);
+            Assert.NotEqual(0, output[(250 * width) + 250].A);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
     private static void WriteBgra32Bmp(string path, int width, int height, IReadOnlyList<Color> pixels)
     {
         const int headerSize = 54;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/FmlImport/FmlToOasisMapper.cs
@@ -67,7 +67,8 @@ internal sealed class FmlToOasisMapper
     {
         ObjectId = Guid.NewGuid().ToString("N"), Name = "Background", Kind = PanelElementKind.Background,
         X = c.X, Y = c.Y, Width = Math.Max(1, c.Width), Height = Math.Max(1, c.Height),
-        AssetPath = BackgroundAssetPath(c, images, index), IsTransformLocked = true, OnColorHex = Color(c, "Colour") ?? Color(c, "Color") ?? Color(c, "BackgroundColour") ?? Color(c, "BackgroundColor"), SourceComponentIndex = index, ImportSource = Source(c, index)
+        AssetPath = BackgroundAssetPath(c, images, index), IsTransformLocked = true, OnColorHex = Color(c, "Colour") ?? Color(c, "Color") ?? Color(c, "BackgroundColour") ?? Color(c, "BackgroundColor"), SourceComponentIndex = index, ImportSource = Source(c, index),
+        SourceImageOffsetX = Int(c, "OffsetX"), SourceImageOffsetY = Int(c, "OffsetY")
     };
 
     private static PanelElementModel MapImage(BaseComponent c, int index, IReadOnlyDictionary<FmlDecodedImageKey, string> images) => new()
@@ -262,6 +263,7 @@ internal sealed class FmlToOasisMapper
     }
     private static string? Str(BaseComponent c, string key) => c.Strings.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value.Trim() : null;
     private static uint? UInt(BaseComponent c, string key) => c.UInt32s.TryGetValue(key, out var v) ? v : null;
+    private static int Int(BaseComponent c, string key) => c.Int32s.TryGetValue(key, out var v) ? v : 0;
     private static double? Double(BaseComponent c, string key) => c.Floats.TryGetValue(key, out var f) ? f : c.UInt32s.TryGetValue(key, out var u) ? u : null;
     private static bool? Bool(BaseComponent c, string key) => c.Booleans.TryGetValue(key, out var v) ? v : null;
     private static int? Number(BaseComponent c) => c.Int32s.TryGetValue("Number", out var n) ? n : c.UInt32s.TryGetValue("Number", out var u) ? (int)u : c.Number != 0 ? c.Number : null;

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/LayoutImportAssetCopier.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/LayoutImportAssetCopier.cs
@@ -104,7 +104,12 @@ internal sealed class LayoutImportAssetCopier
             if (!string.IsNullOrWhiteSpace(updatedBackgroundPath))
             {
                 updatedElements = (PanelElementModel[])updatedElements.Clone();
-                updatedElements[index] = CloneWithAssetPath(background, updatedBackgroundPath);
+                updatedElements[index] = PanelElementModelCloner.Clone(
+                    background,
+                    assetPath: updatedBackgroundPath,
+                    overrideAssetPath: true,
+                    sourceImageOffsetX: 0,
+                    sourceImageOffsetY: 0);
             }
         }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/MfmeBackgroundOverlayPostProcessor.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Features/LayoutImport/MfmeBackgroundOverlayPostProcessor.cs
@@ -29,11 +29,20 @@ internal static class MfmeBackgroundOverlayPostProcessor
 
             var source = LoadBgra32(backgroundPath);
             var normalized = new PixelBuffer(width, height, checked(width * 4), new byte[checked(width * height * 4)]);
-            var copyWidth = Math.Min(source.Width, normalized.Width);
-            var copyHeight = Math.Min(source.Height, normalized.Height);
+            var sourceX = (int)Math.Min(source.Width, Math.Max(0L, -(long)background.SourceImageOffsetX));
+            var sourceY = (int)Math.Min(source.Height, Math.Max(0L, -(long)background.SourceImageOffsetY));
+            var destinationX = (int)Math.Min(normalized.Width, Math.Max(0L, background.SourceImageOffsetX));
+            var destinationY = (int)Math.Min(normalized.Height, Math.Max(0L, background.SourceImageOffsetY));
+            var copyWidth = Math.Min(source.Width - sourceX, normalized.Width - destinationX);
+            var copyHeight = Math.Min(source.Height - sourceY, normalized.Height - destinationY);
             for (var y = 0; y < copyHeight; y++)
             {
-                Buffer.BlockCopy(source.Pixels, y * source.Stride, normalized.Pixels, y * normalized.Stride, copyWidth * 4);
+                Buffer.BlockCopy(
+                    source.Pixels,
+                    ((sourceY + y) * source.Stride) + (sourceX * 4),
+                    normalized.Pixels,
+                    ((destinationY + y) * normalized.Stride) + (destinationX * 4),
+                    copyWidth * 4);
             }
 
             var outputPath = ResolveOutputPath(backgroundPath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs
@@ -13,7 +13,7 @@ namespace MfmeFmlDecoder.src.Decoder.Component
         private const uint TiledTagId = 0x0D;
         private const uint RandomTileTagId = 0x0E;
 
-        private ComponentTagMap componentTagMap = new ComponentTagMap
+        internal static ComponentTagMap ComponentTagMap { get; } = new ComponentTagMap
         {
             { 0x09, new TagInfo(0x01, "Unknown 0x09", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x0A, new TagInfo(0x01, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
@@ -32,8 +32,8 @@ namespace MfmeFmlDecoder.src.Decoder.Component
             { 0x0E, new TagInfo(0x01, "RandomTile", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x0F, new TagInfo(0x01, "Transparency_UseAlphaChannel", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
             { 0x08, new TagInfo(0x01, "Transparency_UseColour", new byte[] { 0x00 }, ValueRole.BOOLEAN) },
-            { 0x0A, new TagInfo(0x04, "Unknown 0x0A", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
-            { 0x0B, new TagInfo(0x04, "Unknown 0x0B", new byte[] { 0x00 }, ValueRole.ARGB_COLOR) },
+            { 0x0A, new TagInfo(0x04, "OffsetX", new byte[] { 0x00 }, ValueRole.INT32) },
+            { 0x0B, new TagInfo(0x04, "OffsetY", new byte[] { 0x00 }, ValueRole.INT32) },
         });
 
         public Background Parse(long componentOffset, uint componentId, byte[] data)
@@ -56,9 +56,9 @@ namespace MfmeFmlDecoder.src.Decoder.Component
                     [0x08] = "Use Colour",
                     [0x0F] = "Use Alpha Channel",
                 });
-            var parseResult = ParseExtendedTags(component, componentTagMap, parseData, offset, parseOptions);
+            var parseResult = ParseExtendedTags(component, ComponentTagMap, parseData, offset, parseOptions);
 
-            ApplyExtendedTags(component, parseResult, componentTagMap);
+            ApplyExtendedTags(component, parseResult, ComponentTagMap);
 
             return component;
         }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Panel2DDocumentModel.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace OasisEditor;
 
@@ -72,6 +73,10 @@ internal sealed class PanelElementModel
     public int? SharedSourceSetCount { get; init; }
     public bool SourceBlend { get; init; }
     public PanelElementImportSourceModel? ImportSource { get; init; }
+    [JsonIgnore]
+    public int SourceImageOffsetX { get; init; }
+    [JsonIgnore]
+    public int SourceImageOffsetY { get; init; }
 }
 
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PanelElementModelCloner.cs
@@ -17,7 +17,9 @@ internal static class PanelElementModelCloner
         string? reelLampTransmissionMaskAssetPath = null,
         bool overrideReelLampTransmissionMaskAssetPath = false,
         bool? isTransformLocked = null,
-        bool? isVisible = null)
+        bool? isVisible = null,
+        int? sourceImageOffsetX = null,
+        int? sourceImageOffsetY = null)
     {
         ArgumentNullException.ThrowIfNull(source);
 
@@ -61,7 +63,9 @@ internal static class PanelElementModelCloner
             SharedSourceSetId = source.SharedSourceSetId,
             SharedSourceSetCount = source.SharedSourceSetCount,
             SourceBlend = source.SourceBlend,
-            ImportSource = CloneImportSource(source.ImportSource)
+            ImportSource = CloneImportSource(source.ImportSource),
+            SourceImageOffsetX = sourceImageOffsetX ?? source.SourceImageOffsetX,
+            SourceImageOffsetY = sourceImageOffsetY ?? source.SourceImageOffsetY
         };
     }
 


### PR DESCRIPTION
### Motivation

- Ensure MFME Background nested tags 0x0A/0x0B decode as signed INT32 `OffsetX`/`OffsetY` so image offsets are available to the importer.
- Apply those offsets when normalizing MFME Background bitmaps so the source image is placed and clipped inside the Background viewport at native 1:1 pixels.
- Keep the Background element geometry (X, Y, Width, Height) unchanged and treat offsets as import-only image-placement values.

### Description

- Decoder: updated Background parser tag map so nested tags `0x0A`/`0x0B` are parsed as `ValueRole.INT32` with attribute names `OffsetX` / `OffsetY`, and exposed the component tag map as `ComponentTagMap`. (OasisEditor/FmlDecoder/Decoder/Component/BackgroundParser.cs)
- Mapping: carried decoded offsets through `FmlToOasisMapper.MapBackground()` into the mapped `PanelElementModel` as explicit, JSON-ignored import-time fields `SourceImageOffsetX` / `SourceImageOffsetY` without changing element `X`/`Y`/`Width`/`Height`. (OasisEditor/Features/FmlImport/FmlToOasisMapper.cs, OasisEditor/Panel2DDocumentModel.cs)
- Normalization: changed `MfmeBackgroundOverlayPostProcessor.TryNormalizeBackground()` to place the source bitmap into the destination using the MFME sign convention so the copy is conceptually `destination(x+OffsetX, y+OffsetY) = source(x,y)` with clipping and no resampling. (OasisEditor/Features/LayoutImport/MfmeBackgroundOverlayPostProcessor.cs)
- Clearing offsets: after producing a normalized asset, the transient offsets are cleared (set to zero) when the background element is replaced with the new asset to avoid double-applying offsets during overlay/cutout baking. (OasisEditor/Features/LayoutImport/LayoutImportAssetCopier.cs)
- Model plumbing: added `SourceImageOffsetX`/`SourceImageOffsetY` to `PanelElementModel` (JSON-ignored), and propagated them through `PanelElementModelCloner` with optional override parameters. (OasisEditor/Panel2DDocumentModel.cs, OasisEditor/PanelElementModelCloner.cs)
- Tests: added focused regression/unit tests covering decoder parsing of signed offsets and defaults, mapper geometry preservation, native 1:1 placement for positive/negative offsets, oversized source + offsets clipping, and overlay/cutout behaviour. Tests added/modified in: OasisEditor.Tests/FmlDecoderRegressionTests.cs, OasisEditor.Tests/FmlToOasisMapperTests.cs, OasisEditor.Tests/LayoutImportAssetCopierTests.cs.

### Testing

- Repository checks and commit were performed successfully (`git diff --check` passed and changes were committed).
- No unit tests were executed in this environment because the execution policy and the environment lack the required Windows/.NET/WPF toolchain per project guidance; new unit tests were added but not run here. (See added tests in `OasisEditor.Tests`.)
- To validate locally, run the test suite on a machine with the project toolchain: `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` and verify the new tests pass (decoder regression, mapper geometry, and the LayoutImport asset copier scenarios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a783db72554832797d96fb3c0672ad9)