### PR TITLE
Fix Epoch reel visual direction

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FaceReelDisplayTests.cs
@@ -136,4 +136,27 @@ public sealed class FaceReelDisplayTests
         Assert.Equal(79.2d, position, 2);
     }
 
+    [Theory]
+    [InlineData(false, 10d)]
+    [InlineData(true, 86d)]
+    public void RuntimeResolver_AppliesEpochPlatformReversalLikePanelReels(bool isReversed, double expected)
+    {
+        var runtimeState = new MachineRuntimeState
+        {
+            FruitMachinePlatform = FruitMachinePlatformType.Epoch
+        };
+        runtimeState.SetReelPositionIfChanged(MachineObjectReference.Reel(2), 86d);
+        var reel = new FaceReelDisplayElement
+        {
+            ObjectId = "face-reel-2",
+            LinkedMachineObjectReference = MachineObjectReference.Reel(2),
+            Stops = 24,
+            IsReversed = isReversed
+        };
+
+        var position = FaceRuntimeStateResolver.Instance.GetReelPosition(reel, runtimeState);
+
+        Assert.Equal(expected, position);
+    }
+
 }

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
@@ -67,6 +67,8 @@ public sealed class ZeroBasedReelRuntimeTests
     [InlineData(FruitMachinePlatformType.Impact, true, 10d)]
     [InlineData(FruitMachinePlatformType.MPU5, false, 86d)]
     [InlineData(FruitMachinePlatformType.MPU5, true, 10d)]
+    [InlineData(FruitMachinePlatformType.Epoch, false, 10d)]
+    [InlineData(FruitMachinePlatformType.Epoch, true, 86d)]
     public void FabricAmberNormalization_AppliesOnceBeforeComponentReversal(FruitMachinePlatformType platform, bool isReversed, double expected)
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/FaceRuntimeStateResolver.cs
@@ -64,18 +64,13 @@ public sealed class FaceRuntimeStateResolver : IFaceRuntimeStateResolver
         const double positionsPerRevolution = 96d;
         var safeStops = Math.Max(1, stops);
         var wrapped = ((rawReelPosition % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
-        var shouldReverse = RequiresPlatformReversal(platform) ^ reelReversed;
+        var shouldReverse = PlatformReelDirectionResolver.RequiresReversal(platform) ^ reelReversed;
         var directionAdjusted = shouldReverse && wrapped != 0d
             ? positionsPerRevolution - wrapped
             : wrapped;
         var platformOffset = MachineReelRuntimeAdapter.ResolvePlatformBandOffsetNormalized(platform, safeStops);
         var offsetAdjusted = directionAdjusted + ((platformOffset + reelBandOffset) * positionsPerRevolution);
         return ((offsetAdjusted % positionsPerRevolution) + positionsPerRevolution) % positionsPerRevolution;
-    }
-
-    private static bool RequiresPlatformReversal(FruitMachinePlatformType platform)
-    {
-        return platform == FruitMachinePlatformType.MPU4;
     }
 
     public bool TryGetSevenSegmentDisplayReference(FaceSevenSegmentDisplayElement display, out MachineObjectReference reference)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MachineReelRuntimeAdapter.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MachineReelRuntimeAdapter.cs
@@ -220,7 +220,7 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
     private static double ResolveEffectiveReelPosition(double canonicalPosition, int stops, bool reelReversed, double reelBandOffset, FruitMachinePlatformType platform)
     {
         var wrapped = ((canonicalPosition % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
-        var platformReversed = RequiresLegacyPlatformReversal(platform);
+        var platformReversed = PlatformReelDirectionResolver.RequiresReversal(platform);
         var shouldReverse = platformReversed ^ reelReversed;
         var directionAdjusted = shouldReverse && wrapped != 0
             ? ReelPositionsPerRevolution - wrapped
@@ -230,11 +230,6 @@ public sealed class MachineReelRuntimeAdapter : IMachineReelRuntimeAdapter
         var offsetSteps = totalOffset * ReelPositionsPerRevolution;
         var offsetAdjusted = directionAdjusted + offsetSteps;
         return ((offsetAdjusted % ReelPositionsPerRevolution) + ReelPositionsPerRevolution) % ReelPositionsPerRevolution;
-    }
-
-    private static bool RequiresLegacyPlatformReversal(FruitMachinePlatformType platform)
-    {
-        return platform == FruitMachinePlatformType.MPU4;
     }
 
     internal static double ResolvePlatformBandOffsetNormalized(FruitMachinePlatformType platform, int stops)

--- a/WindowsNetProjects/OasisEditor/OasisEditor/PlatformReelDirectionResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/PlatformReelDirectionResolver.cs
@@ -1,0 +1,9 @@
+namespace OasisEditor;
+
+internal static class PlatformReelDirectionResolver
+{
+    internal static bool RequiresReversal(FruitMachinePlatformType platform)
+    {
+        return platform is FruitMachinePlatformType.MPU4 or FruitMachinePlatformType.Epoch;
+    }
+}


### PR DESCRIPTION
### Motivation

- Epoch-backed machines render reels in the wrong visual direction because the platform-level reversal rule did not include `Epoch`, causing a mismatch between the Amber backend normalization and the visual display.

### Description

- Added a small shared helper `PlatformReelDirectionResolver` that returns true for `FruitMachinePlatformType.MPU4` and `FruitMachinePlatformType.Epoch` to centralize platform reversal knowledge and avoid duplicated logic (`OasisEditor/PlatformReelDirectionResolver.cs`).
- Updated `MachineReelRuntimeAdapter` to use the shared helper and keep the effective direction rule as `platformRequiresReversal XOR reel.IsReversed` while preserving normalization and band-offset behavior (`OasisEditor/MachineReelRuntimeAdapter.cs`).
- Updated `FaceRuntimeStateResolver` to use the same shared helper so Face-linked reel displays follow the exact same visual rule as Panel2D reels (`OasisEditor/FaceRuntimeStateResolver.cs`).
- Extended unit test coverage by adding Epoch cases in `ZeroBasedReelRuntimeTests` and a new Epoch face reel test in `FaceReelDisplayTests` to assert that Epoch toggles visual direction while Impact and MPU5 remain unchanged (`OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs`, `OasisEditor.Tests/FaceReelDisplayTests.cs`).

### Testing

- No automated tests were executed in this environment due to the repository's `AGENTS.md` constraints preventing builds and test runs here.
- Unit tests updated/added: `OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs` (added `Epoch` inline data rows) and `OasisEditor.Tests/FaceReelDisplayTests.cs` (added `RuntimeResolver_AppliesEpochPlatformReversalLikePanelReels`).
- To verify locally run `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj`, which should show the new Epoch cases passing and confirm Impact/MPU5 behaviour remains unchanged with the effective rule `platformRequiresReversal XOR reel.IsReversed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a78719e4f4483278f01b18b955d745c)