### PR TITLE
Add Epoch 12-stop internal reel offset (-0.16)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InternalReelOffsetResolverTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/InternalReelOffsetResolverTests.cs
@@ -5,11 +5,19 @@ namespace OasisEditor.Tests;
 
 public sealed class InternalReelOffsetResolverTests
 {
+    [Fact]
+    public void ResolveNormalizedOffset_ReturnsExactEpochTwelveStopCorrection()
+    {
+        Assert.Equal(-0.16d, InternalReelOffsetResolver.ResolveNormalizedOffset(FruitMachinePlatformType.Epoch, 12));
+    }
+
     [Theory]
     [InlineData(FruitMachinePlatformType.MPU5, 16, -0.22d)]
     [InlineData(FruitMachinePlatformType.MPU5, 12, -0.075d)]
     [InlineData(FruitMachinePlatformType.MPU5, 24, 0d)]
     [InlineData(FruitMachinePlatformType.MPU4, 16, -0.05d)]
+    [InlineData(FruitMachinePlatformType.Epoch, 12, -0.16d)]
+    [InlineData(FruitMachinePlatformType.Epoch, 16, 0d)]
     [InlineData(FruitMachinePlatformType.Impact, 12, 0.025d)]
     [InlineData(FruitMachinePlatformType.Impact, 16, -0.018d)]
     [InlineData(FruitMachinePlatformType.Scorpion4, 12, 0.2d)]

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs
@@ -115,6 +115,41 @@ public sealed class ZeroBasedReelRuntimeTests
     }
 
     [Fact]
+    public void EpochTwelveStopCorrection_UsesSameEffectivePositionPipelineForPanelAndFaceReels()
+    {
+        var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));
+        document.SetPanelElements([new PanelElementModel
+        {
+            ObjectId = "reel-0", Kind = PanelElementKind.Reel, DisplayNumber = 0,
+            Stops = 12, BandOffset = 0.05d
+        }]);
+        var dispatches = new List<Action>();
+        var adapter = new MachineReelRuntimeAdapter(() => [document], () => FruitMachinePlatformType.Epoch,
+            () => false, _ => { }, dispatches.Add);
+
+        adapter.ApplyReelState(0, 10, ReelPositionConvention.Oasis);
+        Assert.Single(dispatches)();
+
+        var faceRuntimeState = new MachineRuntimeState
+        {
+            FruitMachinePlatform = FruitMachinePlatformType.Epoch
+        };
+        faceRuntimeState.SetReelPositionIfChanged(MachineObjectReference.Reel(0), 10d);
+        var faceReel = new FaceReelDisplayElement
+        {
+            LinkedMachineObjectReference = MachineObjectReference.Reel(0),
+            Stops = 12,
+            BandOffset = 0.05d
+        };
+
+        var panelPosition = document.RuntimeState.GetReelPosition("reel-0");
+        var facePosition = FaceRuntimeStateResolver.Instance.GetReelPosition(faceReel, faceRuntimeState);
+
+        Assert.Equal(75.44d, panelPosition, 6);
+        Assert.Equal(panelPosition, facePosition, 6);
+    }
+
+    [Fact]
     public void AmberAdapter_AllowsEachReelToUseItsConfiguredMotorStepCount()
     {
         var document = new DocumentTabViewModel(EditorDocument.CreateFromFile("panel.panel2d", "panel", "panel"));

--- a/WindowsNetProjects/OasisEditor/OasisEditor/InternalReelOffsetResolver.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/InternalReelOffsetResolver.cs
@@ -15,6 +15,7 @@ internal static class InternalReelOffsetResolver
             FruitMachinePlatformType.MPU4 when safeStops == 16 => -0.05d,
             FruitMachinePlatformType.MPU5 when safeStops == 12 => -0.075d,
             FruitMachinePlatformType.MPU5 when safeStops == 16 => -0.22d,
+            FruitMachinePlatformType.Epoch when safeStops == 12 => -0.16d,
             FruitMachinePlatformType.Impact when safeStops == 12 =>
                 ImpactTwelveStopBaseOffset + ImpactTwelveStopBandCorrection,
             FruitMachinePlatformType.Impact when safeStops == 16 =>


### PR DESCRIPTION
### Motivation
- Provide an OasisEditor-only internal correction for Epoch reels with 12 stops so rendered reel alignment matches the physical/emulated reel without changing imported data or runtime ABIs.
- Ensure the correction is applied through the existing platform band-offset mechanism and is visible to both Panel2D and Face reel consumers of the resolver.

### Description
- Added the Epoch 12-stop normalized offset rule `FruitMachinePlatformType.Epoch when safeStops == 12 => -0.16d` to `InternalReelOffsetResolver.ResolveNormalizedOffset`. (`OasisEditor/InternalReelOffsetResolver.cs`).
- Extended `InternalReelOffsetResolver` unit coverage by adding an exact assertion for the Epoch 12-stop rule and included Epoch cases in the existing theory (`OasisEditor.Tests/InternalReelOffsetResolverTests.cs`).
- Added a runtime test verifying the Epoch 12-stop correction flows through the existing effective-position pipeline and that Panel2D and Face reel resolution produce the same effective position (`OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs`).
- Files changed: `OasisEditor/InternalReelOffsetResolver.cs`, `OasisEditor.Tests/InternalReelOffsetResolverTests.cs`, and `OasisEditor.Tests/ZeroBasedReelRuntimeTests.cs` (commit message: "Add Epoch 12-stop reel offset").

### Testing
- No automated tests were executed in this environment because the container lacks the Windows/.NET/WPF toolchain as noted in `AGENTS.md`, so there are no test run results here; please run `dotnet test WindowsNetProjects/OasisEditor/OasisEditor.Tests` locally to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a788cc63d008327b799446a9c2451f7)