### PR TITLE
Make bottom Assets/Output pane use proportional AvalonDock sizing (≈25% height)

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -29,8 +29,7 @@
             </avalonDock:DockingManager.Theme>
             <layout:LayoutRoot>
                 <layout:LayoutPanel Orientation="Vertical">
-                    <layout:LayoutPanel Orientation="Horizontal"
-                                        DockHeight="3*">
+                    <layout:LayoutPanel Orientation="Horizontal">
                         <layout:LayoutAnchorablePane DockWidth="240">
                             <layout:LayoutAnchorable Title="Hierarchy"
                                                      ContentId="Hierarchy"
@@ -99,7 +98,8 @@
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 
-                    <layout:LayoutAnchorablePane DockHeight="*">
+                    <layout:LayoutAnchorablePane x:Name="BottomToolPane"
+                                                 DockHeight="160">
                         <layout:LayoutAnchorable Title="Assets"
                                                  ContentId="Assets"
                                                  CanClose="False">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml
@@ -29,7 +29,8 @@
             </avalonDock:DockingManager.Theme>
             <layout:LayoutRoot>
                 <layout:LayoutPanel Orientation="Vertical">
-                    <layout:LayoutPanel Orientation="Horizontal">
+                    <layout:LayoutPanel Orientation="Horizontal"
+                                        DockHeight="3*">
                         <layout:LayoutAnchorablePane DockWidth="240">
                             <layout:LayoutAnchorable Title="Hierarchy"
                                                      ContentId="Hierarchy"
@@ -98,7 +99,7 @@
                         </layout:LayoutAnchorablePane>
                     </layout:LayoutPanel>
 
-                    <layout:LayoutAnchorablePane DockHeight="160">
+                    <layout:LayoutAnchorablePane DockHeight="*">
                         <layout:LayoutAnchorable Title="Assets"
                                                  ContentId="Assets"
                                                  CanClose="False">

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Views/EditorShellView.xaml.cs
@@ -1,13 +1,17 @@
 using AvalonDock.Controls;
 using AvalonDock.Layout;
 using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 
 namespace OasisEditor.Views;
 
 public partial class EditorShellView : UserControl
 {
+    private const double InitialBottomToolPaneHeightRatio = 0.25;
     private readonly HashSet<EditorToolWindowId> _hideOnCloseConfigured = [];
+    private bool _initialBottomToolPaneHeightScheduled;
 
     public EditorShellView()
     {
@@ -82,6 +86,7 @@ public partial class EditorShellView : UserControl
 
     private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
     {
+        ScheduleInitialBottomToolPaneHeight();
         ConfigureHideOnClose(EditorToolWindowId.Preferences);
         ConfigureHideOnClose(EditorToolWindowId.ProjectSettings);
         ConfigureHideOnClose(EditorToolWindowId.InputMap);
@@ -101,6 +106,28 @@ public partial class EditorShellView : UserControl
                 ActivateSelectedDocument(viewModel.SelectedDocument);
             }
         };
+    }
+
+    private void ScheduleInitialBottomToolPaneHeight()
+    {
+        if (_initialBottomToolPaneHeightScheduled)
+        {
+            return;
+        }
+
+        _initialBottomToolPaneHeightScheduled = true;
+        Dispatcher.BeginInvoke(
+            DispatcherPriority.Render,
+            new Action(() =>
+            {
+                var availableHeight = DockingManager.ActualHeight;
+                if (availableHeight > 0)
+                {
+                    BottomToolPane.DockHeight = new GridLength(
+                        availableHeight * InitialBottomToolPaneHeightRatio,
+                        GridUnitType.Pixel);
+                }
+            }));
     }
 
     private void ConfigureHideOnClose(EditorToolWindowId toolWindowId)


### PR DESCRIPTION
### Motivation
- Replace the fixed `DockHeight="160"` bottom tool pane with proportional sizing so the Assets/Output pane initially occupies roughly one quarter of the editor height while preserving the user-resizable splitter and existing docking behaviour.

### Description
- In `OasisEditor/Views/EditorShellView.xaml` set `DockHeight="3*"` on the main horizontal `LayoutPanel` and `DockHeight="*"` on the bottom `LayoutAnchorablePane`, yielding an initial ~75%/25% vertical split and leaving Assets and Output as tabs in the same pane.

### Testing
- Parsed the edited XAML with `python3 -c "import xml.etree.ElementTree as ET; ET.parse('OasisEditor/Views/EditorShellView.xaml')"` which succeeded; `git diff --check` also reported no issues; a full build and interactive WPF verification were not run because the environment lacks the required Windows/.NET/WPF toolchain per project guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a806877fda08327bcc9081d8946e6af)