### PR TITLE
Simplify emulation reset API to a single Reset operation and update UI/tests

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/EmulationBackendAbstractionsTests.cs
@@ -11,16 +11,14 @@ public sealed class EmulationBackendAbstractionsTests
         var capabilities = new EmulationBackendCapabilities(
             SupportsPause: true,
             SupportsResume: true,
-            SupportsSoftReset: true,
-            SupportsHardReset: true,
+            SupportsReset: true,
             SupportsSaveState: true,
             SupportsLoadState: true,
             SupportsThrottle: true);
 
         Assert.True(capabilities.SupportsPause);
         Assert.True(capabilities.SupportsResume);
-        Assert.True(capabilities.SupportsSoftReset);
-        Assert.True(capabilities.SupportsHardReset);
+        Assert.True(capabilities.SupportsReset);
         Assert.True(capabilities.SupportsSaveState);
         Assert.True(capabilities.SupportsLoadState);
         Assert.True(capabilities.SupportsThrottle);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -6,6 +6,14 @@ namespace OasisEditor.Tests;
 public sealed class FabricManagedBehaviorTests
 {
     [Fact]
+    public void Backend_ReportsResetSupport()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+
+        Assert.True(backend.Capabilities.SupportsReset);
+    }
+
+    [Fact]
     public unsafe void NativeCharacterDisplayConversionPreservesBrightnessAndRejectsNonFiniteValues()
     {
         var native = new FabricCharacterDisplayNative { Brightness = 0.625f };
@@ -145,7 +153,7 @@ public sealed class FabricManagedBehaviorTests
 
         await backend.StartAsync(CreateRequest(), CancellationToken.None);
         backend.PublishSnapshot(snapshot);
-        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        await backend.ResetAsync(CancellationToken.None);
         backend.PublishSnapshot(snapshot);
         await backend.StopAsync(CancellationToken.None);
 
@@ -312,7 +320,7 @@ public sealed class FabricManagedBehaviorTests
 
         await backend.StartAsync(request, CancellationToken.None);
         await session.FirstAdvance.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        await backend.ResetAsync(EmulationResetKind.Soft, CancellationToken.None);
+        await backend.ResetAsync(CancellationToken.None);
         await backend.StopAsync(CancellationToken.None);
 
         Assert.Equal("C:/fabric/FabricRuntime.dll", runtimePath);

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -79,7 +79,7 @@ public sealed class PlayViewInputRouterTests
         public List<(string, bool)> Inputs { get; } = [];
         public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
         public EmulationBackendState State => EmulationBackendState.Running;
-        public EmulationBackendCapabilities Capabilities { get; } = new(true, true, true, true, false, false, false);
+        public EmulationBackendCapabilities Capabilities { get; } = new(true, true, true, false, false, false);
         public event EventHandler<EmulationBackendState>? StateChanged { add { } remove { } }
         public event EventHandler<MachineLampChangedEventArgs>? LampChanged { add { } remove { } }
         public event EventHandler<MachineReelChangedEventArgs>? ReelChanged { add { } remove { } }
@@ -90,7 +90,7 @@ public sealed class PlayViewInputRouterTests
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task ResetAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, isPressed)); return Task.CompletedTask; }
         public Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, true)); return Task.FromResult(CoinInputResult.Accepted); }
         public Task ReleaseCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, false)); return Task.CompletedTask; }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -22,7 +22,7 @@ public interface IEmulationBackend : IAsyncDisposable
     Task PauseAsync(CancellationToken cancellationToken);
     Task ResumeAsync(CancellationToken cancellationToken);
 
-    Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken);
+    Task ResetAsync(CancellationToken cancellationToken);
 
     Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken);
     Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken);
@@ -46,17 +46,10 @@ public enum EmulationBackendState
     Failed
 }
 
-public enum EmulationResetKind
-{
-    Soft,
-    Hard
-}
-
 public sealed record EmulationBackendCapabilities(
     bool SupportsPause,
     bool SupportsResume,
-    bool SupportsSoftReset,
-    bool SupportsHardReset,
+    bool SupportsReset,
     bool SupportsSaveState,
     bool SupportsLoadState,
     bool SupportsThrottle);

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -21,7 +21,13 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private const long NanosecondsPerMillisecond = 1_000_000;
     private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
     private static readonly EmulationBackendCapabilities BackendCapabilities =
-        new(true, true, true, true, false, false, false);
+        new(
+            SupportsPause: true,
+            SupportsResume: true,
+            SupportsReset: true,
+            SupportsSaveState: false,
+            SupportsLoadState: false,
+            SupportsThrottle: false);
 
     private readonly string _runtimePath;
     private readonly string _amberPath;
@@ -227,7 +233,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         return Task.CompletedTask;
     }
 
-    public async Task ResetAsync(EmulationResetKind resetKind, CancellationToken cancellationToken)
+    public async Task ResetAsync(CancellationToken cancellationToken)
     {
         ThrowIfDisposed();
         EnsureAcceptingOperations();

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -156,8 +156,7 @@
                 <MenuItem Header="_Stop" Command="{Binding StopEmulationCommand}" />
                 <MenuItem Header="_Pause" Command="{Binding TogglePauseEmulationCommand}" IsCheckable="True" IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}" />
                 <Separator />
-                <MenuItem Header="Soft _Reset" Command="{Binding SoftResetEmulationCommand}" />
-                <MenuItem Header="_Hard Reset" Command="{Binding HardResetEmulationCommand}" />
+                <MenuItem Header="_Reset" Command="{Binding ResetEmulationCommand}" />
             </MenuItem>
         </Menu>
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -190,8 +190,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         StartEmulationCommand = new RelayCommand(StartEmulation, CanStartEmulation);
         StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
         TogglePauseEmulationCommand = new RelayCommand(TogglePauseEmulation, CanTogglePauseEmulation);
-        SoftResetEmulationCommand = new RelayCommand(SoftResetEmulation, CanResetEmulation);
-        HardResetEmulationCommand = new RelayCommand(HardResetEmulation, CanResetEmulation);
+        ResetEmulationCommand = new RelayCommand(ResetEmulation, CanResetEmulation);
 
         _outputLog = new OutputLogViewModel();
         _outputLog.PropertyChanged += OnOutputLogPropertyChanged;
@@ -432,8 +431,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand StartEmulationCommand { get; }
     public ICommand StopEmulationCommand { get; }
     public ICommand TogglePauseEmulationCommand { get; }
-    public ICommand SoftResetEmulationCommand { get; }
-    public ICommand HardResetEmulationCommand { get; }
+    public ICommand ResetEmulationCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
     public ObservableCollection<AssetBrowserItemViewModel> AssetBrowserItems { get; }
@@ -2528,21 +2526,15 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
 
     private bool CanResetEmulation()
     {
-        return _activeEmulationBackend is not null && EmulationState is EmulationBackendState.Running or EmulationBackendState.Paused;
+        return _activeEmulationBackend?.Capabilities.SupportsReset == true
+            && EmulationState is EmulationBackendState.Running or EmulationBackendState.Paused;
     }
 
-    private async void SoftResetEmulation()
+    private async void ResetEmulation()
     {
-        await SendEmulationCommandAsync(CanResetEmulation, "Emulation soft reset requested.",
-            "Emulation failed to soft reset", cancellationToken =>
-                _activeEmulationBackend!.ResetAsync(EmulationResetKind.Soft, cancellationToken));
-    }
-
-    private async void HardResetEmulation()
-    {
-        await SendEmulationCommandAsync(CanResetEmulation, "Emulation hard reset requested.",
-            "Emulation failed to hard reset", cancellationToken =>
-                _activeEmulationBackend!.ResetAsync(EmulationResetKind.Hard, cancellationToken));
+        await SendEmulationCommandAsync(CanResetEmulation, "Emulation reset requested.",
+            "Emulation failed to reset", cancellationToken =>
+                _activeEmulationBackend!.ResetAsync(cancellationToken));
     }
 
     private async Task<bool> SendEmulationCommandAsync(
@@ -3456,8 +3448,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(StartEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(StopEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(TogglePauseEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(SoftResetEmulationCommand);
-        RaiseEmulationCommandCanExecuteChanged(HardResetEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(ResetEmulationCommand);
     }
 
     private static void RaiseEmulationCommandCanExecuteChanged(ICommand command)


### PR DESCRIPTION
### Motivation
- Remove obsolete MAME-era soft/hard reset distinction and reflect Fabric/Amber's single reset operation in the Editor API and UI.
- Simplify backend capabilities to a single `SupportsReset` flag so callers have a clear, consistent contract.
- Reduce API surface and eliminate unused/meaningless parameters to make backends and tests easier to maintain.

### Description
- Replaced `ResetAsync(EmulationResetKind, CancellationToken)` with `ResetAsync(CancellationToken)` across the editor and tests and deleted `EmulationResetKind` from the abstractions (`Emulation/EmulationBackendAbstractions.cs`).
- Consolidated `EmulationBackendCapabilities` fields `SupportsSoftReset`/`SupportsHardReset` into a single `SupportsReset` boolean and updated construction sites accordingly (notably the Fabric backend reports `SupportsReset = true`) (`Emulation/EmulationBackendAbstractions.cs`, `Emulation/Fabric/FabricEmulationBackend.cs`).
- Updated `FabricEmulationBackend.ResetAsync` to the new signature while preserving the existing reset behaviour (release asserted inputs, clear pending inputs, call Fabric session `Reset()`, clear output/audio caches, increment schedule generation and wake the runner) (`Emulation/Fabric/FabricEmulationBackend.cs`).
- Replaced `SoftResetEmulationCommand` and `HardResetEmulationCommand` with a single `ResetEmulationCommand` in the view model and adapted command enablement to rely on `Capabilities.SupportsReset` (`MainWindowViewModel.cs`).
- Replaced the two Emulation menu items (`Soft Reset`, `Hard Reset`) with a single `Reset` bound to `ResetEmulationCommand` (`MainWindow.xaml`).
- Updated tests and test fakes to use the new `ResetAsync` signature and the consolidated capability: `EmulationBackendAbstractionsTests`, `PlayViewInputRouterTests`, and `FabricManagedBehaviorTests`; added a test `Backend_ReportsResetSupport` to assert Fabric reports `SupportsReset` (`OasisEditor.Tests/*`).
- Committed changes on the working branch (commit message: "Simplify editor emulation reset API").

### Testing
- Adjusted and ran repository searches to confirm removal of obsolete reset terminology (`rg` checks) and ensured no lingering references to the old API remain; the searches succeeded.
- Updated unit tests to the new API and added one coverage test (`Backend_ReportsResetSupport`), but automated test execution (`dotnet test` / `dotnet build`) was not performed in this environment due to the repository's `AGENTS.md` constraints that prohibit running the Windows/.NET/WPF toolchain here; therefore compilation and test execution must be verified locally.
- Local verification recommended: run `dotnet build` and `dotnet test OasisEditor.Tests/OasisEditor.Tests.csproj` on a Windows/.NET environment to ensure all tests compile and pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a806d6611688327b84fb459e20ce586)