### PR TITLE
Add Unthrottled Fabric emulation mode

### DIFF
--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs
@@ -14,6 +14,15 @@ public sealed class FabricManagedBehaviorTests
     }
 
     [Fact]
+    public void Backend_ReportsThrottleSupportAndDefaultsToThrottled()
+    {
+        var backend = CreateBackend(new FakeSession(), new FakeAudioSink());
+
+        Assert.True(backend.Capabilities.SupportsThrottle);
+        Assert.True(backend.IsThrottleEnabled);
+    }
+
+    [Fact]
     public unsafe void NativeCharacterDisplayConversionPreservesBrightnessAndRejectsNonFiniteValues()
     {
         var native = new FabricCharacterDisplayNative { Brightness = 0.625f };
@@ -599,6 +608,53 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(48 * 2 * sizeof(short), audio.LastPcmBytes);
     }
 
+    [Fact]
+    public async Task Backend_UnthrottledRunsFixedSlicesWithoutAudioCapacityOrPcmPlayback()
+    {
+        var session = new FakeSession { FramesToWrite = 48 };
+        var audio = new FakeAudioSink { WritableFrames = 0 };
+        var backend = CreateBackend(session, audio);
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await backend.SetThrottleEnabledAsync(false, CancellationToken.None);
+        await WaitForAdvanceCountAsync(session, 100);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.All(session.Advances, value => Assert.Equal(1_000_000UL, value));
+        Assert.True(session.AudioReadCount >= 100);
+        Assert.Equal(0, audio.PcmPushCount);
+        Assert.True(audio.ClearCount >= 1);
+        Assert.True(backend.IsThrottleEnabled);
+    }
+
+    [Fact]
+    public async Task Backend_UnthrottledSnapshotsAreWallClockLimitedAndPauseResetRemainResponsive()
+    {
+        var session = new FakeSession();
+        var backend = CreateBackend(session, new FakeAudioSink { WritableFrames = 0 });
+
+        await backend.StartAsync(CreateRequest(), CancellationToken.None);
+        await backend.SetThrottleEnabledAsync(false, CancellationToken.None);
+        await WaitForAdvanceCountAsync(session, 200);
+        await backend.PauseAsync(CancellationToken.None);
+        var pausedCount = session.Advances.Count;
+        await Task.Delay(20);
+        Assert.InRange(session.Advances.Count, pausedCount, pausedCount + 1);
+        Assert.False(backend.IsThrottleEnabled);
+
+        await backend.ResetAsync(CancellationToken.None);
+        await backend.ResumeAsync(CancellationToken.None);
+        await WaitForAdvanceCountAsync(session, pausedCount + 50);
+        await backend.SetThrottleEnabledAsync(true, CancellationToken.None);
+        var switchedCount = session.Advances.Count;
+        await Task.Delay(20);
+        await backend.StopAsync(CancellationToken.None);
+
+        Assert.Equal(1, session.ResetCount);
+        Assert.True(session.SnapshotCount < session.Advances.Count / 16);
+        Assert.InRange(session.Advances.Count - switchedCount, 0, 64);
+    }
+
     [Theory]
     [InlineData(48000, 2, 16, false, true, true)]
     [InlineData(48000, 2, 16, true, false, true)]
@@ -637,6 +693,14 @@ public sealed class FabricManagedBehaviorTests
         Assert.Equal(state, backend.State);
     }
 
+    private static async Task WaitForAdvanceCountAsync(FakeSession session, int count)
+    {
+        var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (session.Advances.Count < count && DateTime.UtcNow < timeout)
+            await Task.Delay(1);
+        Assert.True(session.Advances.Count >= count, $"Expected at least {count} advances, got {session.Advances.Count}.");
+    }
+
     private sealed class FakeClock : IFabricClock
     {
         private long _timestamp;
@@ -673,15 +737,21 @@ public sealed class FabricManagedBehaviorTests
         public int ShutdownCount { get; private set; }
         public int DisposeCount { get; private set; }
         public int FramesToWrite { get; init; }
+        public int AudioReadCount { get; private set; }
+        public int SnapshotCount { get; private set; }
         public List<ulong> Advances { get; } = [];
         public FabricCapabilities Capabilities { get; init; } = new((ulong)(FabricCapability.DigitalInput | FabricCapability.Audio));
         public void Initialise() => Invoke(() => { if (InitialiseFailure is not null) throw InitialiseFailure; });
         public void Reset() => Invoke(() => ResetCount++);
         public void Advance(ulong elapsedNanoseconds) => Invoke(() => { Advances.Add(elapsedNanoseconds); FirstAdvance.TrySetResult(); if (AdvanceFailure is not null) throw AdvanceFailure; });
         public FabricResult SubmitInput(FabricInput input) => Invoke(() => FabricResult.Ok);
-        public FabricMachineSnapshot GetSnapshot() => Invoke(() => SnapshotFailure is null
-            ? new FabricMachineSnapshot(1, [], [], [], [])
-            : throw SnapshotFailure);
+        public FabricMachineSnapshot GetSnapshot() => Invoke(() =>
+        {
+            SnapshotCount++;
+            return SnapshotFailure is null
+                ? new FabricMachineSnapshot(1, [], [], [], [])
+                : throw SnapshotFailure;
+        });
         public FabricAudioFormat GetAudioFormat() => Invoke(() => GetAudioFormatFailure is null ? AudioFormat : throw GetAudioFormatFailure);
         public int ReadAudio(Span<short> samples, int frameCapacity)
         {
@@ -690,6 +760,7 @@ public sealed class FabricManagedBehaviorTests
             {
                 LastFrameCapacity = frameCapacity;
                 LastSampleCapacity = sampleCapacity;
+                AudioReadCount++;
                 FirstAudioRead.TrySetResult();
                 if (AudioFailure is not null) throw AudioFailure;
                 return Math.Min(FramesToWrite, frameCapacity);
@@ -718,11 +789,13 @@ public sealed class FabricManagedBehaviorTests
         public int StopCount { get; private set; }
         public EmulationAudioFormat? StartedFormat { get; private set; }
         public int LastPcmBytes { get; private set; }
+        public int PcmPushCount { get; private set; }
+        public int ClearCount { get; private set; }
         public EmulationAudioPlaybackStatistics Statistics { get; init; } = new(10, 0, 8, 0, 0, 2, 4, 2400, 1800, 38, 25, true);
         public void Start(EmulationAudioFormat format) { StartedFormat = format; StartCount++; }
-        public void PushPcm(ReadOnlySpan<byte> pcmBytes) => LastPcmBytes = pcmBytes.Length;
+        public void PushPcm(ReadOnlySpan<byte> pcmBytes) { LastPcmBytes = pcmBytes.Length; PcmPushCount++; }
         public void Stop() => StopCount++;
-        public void Clear() { }
+        public void Clear() => ClearCount++;
         public EmulationAudioPlaybackStatistics GetStatistics() => Statistics;
         public int WritableFrames { get; init; } = int.MaxValue;
         public int CapacityFrames { get; init; } = int.MaxValue;

--- a/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor.Tests/PlayViewInputRouterTests.cs
@@ -80,6 +80,7 @@ public sealed class PlayViewInputRouterTests
         public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
         public EmulationBackendState State => EmulationBackendState.Running;
         public EmulationBackendCapabilities Capabilities { get; } = new(true, true, true, false, false, false);
+        public bool IsThrottleEnabled => true;
         public event EventHandler<EmulationBackendState>? StateChanged { add { } remove { } }
         public event EventHandler<MachineLampChangedEventArgs>? LampChanged { add { } remove { } }
         public event EventHandler<MachineReelChangedEventArgs>? ReelChanged { add { } remove { } }
@@ -90,6 +91,7 @@ public sealed class PlayViewInputRouterTests
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task PauseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResumeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SetThrottleEnabledAsync(bool enabled, CancellationToken cancellationToken) => Task.CompletedTask;
         public Task ResetAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task SetInputStateAsync(InputDefinitionModel inputDefinition, bool isPressed, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, isPressed)); return Task.CompletedTask; }
         public Task<CoinInputResult> InsertCoinAsync(InputDefinitionModel inputDefinition, CancellationToken cancellationToken) { Inputs.Add((inputDefinition.Id, true)); return Task.FromResult(CoinInputResult.Accepted); }

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/EmulationBackendAbstractions.cs
@@ -8,6 +8,8 @@ public interface IEmulationBackend : IAsyncDisposable
 
     EmulationBackendCapabilities Capabilities { get; }
 
+    bool IsThrottleEnabled { get; }
+
     event EventHandler<EmulationBackendState>? StateChanged;
 
     event EventHandler<MachineLampChangedEventArgs>? LampChanged;
@@ -21,6 +23,8 @@ public interface IEmulationBackend : IAsyncDisposable
 
     Task PauseAsync(CancellationToken cancellationToken);
     Task ResumeAsync(CancellationToken cancellationToken);
+
+    Task SetThrottleEnabledAsync(bool enabled, CancellationToken cancellationToken);
 
     Task ResetAsync(CancellationToken cancellationToken);
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -18,6 +18,8 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private const int MaxCatchUpSlices = 64;
     private const int ExceptionalDelayCapMilliseconds = 500;
     private const int VisualSnapshotCadenceSlices = 16;
+    private const int UnthrottledBatchSlices = 32;
+    private const int UnthrottledVisualSnapshotHz = 60;
     private const long NanosecondsPerMillisecond = 1_000_000;
     private static readonly TimeSpan PumpInterval = TimeSpan.FromMilliseconds(1);
     private static readonly EmulationBackendCapabilities BackendCapabilities =
@@ -27,7 +29,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             SupportsReset: true,
             SupportsSaveState: false,
             SupportsLoadState: false,
-            SupportsThrottle: false);
+            SupportsThrottle: true);
 
     private readonly string _runtimePath;
     private readonly string _amberPath;
@@ -58,6 +60,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     private bool _sessionInitialised;
     private bool _audioStarted;
     private bool _disposed;
+    private volatile bool _throttleEnabled = true;
     private long _scheduleGeneration;
     private long _runnerStartTimestamp;
     private long _totalEmulationSlices;
@@ -95,6 +98,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
     public EmulationBackendKind BackendKind => EmulationBackendKind.Fabric;
     public EmulationBackendCapabilities Capabilities => BackendCapabilities;
     public EmulationBackendState State { get { lock (_stateGate) return _state; } }
+    public bool IsThrottleEnabled => _throttleEnabled;
     public Exception? LastFailure { get; private set; }
     internal IEmulationAudioSink AudioSink => _audioSink;
 
@@ -114,6 +118,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             throw new InvalidOperationException($"Fabric backend cannot start while it is {State}.");
 
         SetState(EmulationBackendState.Starting);
+        _throttleEnabled = true;
         try
         {
             var (machineIdentifier, resources, configuration) = request.Platform switch
@@ -205,6 +210,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             }
         }
         await CleanupResourcesAsync().ConfigureAwait(false);
+        _throttleEnabled = true;
         SetState(EmulationBackendState.Stopped);
     }
 
@@ -231,6 +237,27 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             _runnerWake.Set();
         }
         return Task.CompletedTask;
+    }
+
+    public async Task SetThrottleEnabledAsync(bool enabled, CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        EnsureAcceptingOperations();
+        if (_throttleEnabled == enabled)
+            return;
+
+        await _sessionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _throttleEnabled = enabled;
+            _audioSink.Clear();
+            Interlocked.Increment(ref _scheduleGeneration);
+            _runnerWake.Set();
+        }
+        finally
+        {
+            _sessionGate.Release();
+        }
     }
 
     public async Task ResetAsync(CancellationToken cancellationToken)
@@ -422,6 +449,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
             var nextDeadline = _clock.GetTimestamp();
             var scheduleGeneration = Interlocked.Read(ref _scheduleGeneration);
             var slicesSinceSnapshot = 0;
+            var nextUnthrottledSnapshot = _clock.GetTimestamp();
             while (!cancellationToken.IsCancellationRequested)
             {
                 if (State != EmulationBackendState.Running)
@@ -439,6 +467,43 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                     nextDeadline = _clock.GetTimestamp();
                     scheduleGeneration = currentGeneration;
                     slicesSinceSnapshot = 0;
+                    nextUnthrottledSnapshot = _clock.GetTimestamp();
+                }
+
+                if (!_throttleEnabled)
+                {
+                    var completedSlices = 0;
+                    for (; completedSlices < UnthrottledBatchSlices
+                           && !cancellationToken.IsCancellationRequested
+                           && State == EmulationBackendState.Running
+                           && !_throttleEnabled;
+                         completedSlices++)
+                    {
+                        WaitSessionGate(cancellationToken);
+                        try
+                        {
+                            var session = RequireSession();
+                            session.Advance(NanosecondsPerPump);
+                            ProcessInputs(session);
+                            ReadAudio(session, pushToSink: false);
+                        }
+                        finally
+                        {
+                            _sessionGate.Release();
+                        }
+
+                        var snapshotNow = _clock.GetTimestamp();
+                        if (snapshotNow >= nextUnthrottledSnapshot)
+                        {
+                            PublishLatestSnapshot(cancellationToken);
+                            nextUnthrottledSnapshot = snapshotNow + Math.Max(1L, _clock.Frequency / UnthrottledVisualSnapshotHz);
+                        }
+                    }
+
+                    Interlocked.Add(ref _totalEmulationSlices, completedSlices);
+                    UpdateMaxCatchUpBatch(completedSlices);
+                    Thread.Yield();
+                    continue;
                 }
 
                 WaitUntil(timer, nextDeadline, cancellationToken);
@@ -471,7 +536,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                         var session = RequireSession();
                         session.Advance(NanosecondsPerPump);
                         ProcessInputs(session);
-                        ReadAudio(session);
+                        ReadAudio(session, pushToSink: true);
                     }
                     finally
                     {
@@ -604,7 +669,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         }
     }
 
-    private void ReadAudio(IFabricMachineSession session)
+    private void ReadAudio(IFabricMachineSession session, bool pushToSink)
     {
         if (_audioFormat is not { } format)
             return;
@@ -613,7 +678,7 @@ public sealed class FabricEmulationBackend : IEmulationBackend
         Interlocked.Add(ref _fabricAudioFramesRead, framesWritten);
         var sampleCount = checked(framesWritten * format.ChannelCount);
         var bytes = MemoryMarshal.AsBytes(_audioBuffer.AsSpan(0, sampleCount));
-        if (!bytes.IsEmpty)
+        if (pushToSink && !bytes.IsEmpty)
             _audioSink.PushPcm(bytes);
     }
 

--- a/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/Emulation/Fabric/FabricEmulationBackend.cs
@@ -485,6 +485,9 @@ public sealed class FabricEmulationBackend : IEmulationBackend
                             var session = RequireSession();
                             session.Advance(NanosecondsPerPump);
                             ProcessInputs(session);
+                            // Fabric/Amber still generates accelerated audio, so drain it to prevent
+                            // accumulation, but do not feed a real-time sink: that would throttle or
+                            // backlog the runner. Normal playback resumes in throttled mode.
                             ReadAudio(session, pushToSink: false);
                         }
                         finally

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindow.xaml
@@ -155,6 +155,7 @@
                 <MenuItem Header="_Start" Command="{Binding StartEmulationCommand}" />
                 <MenuItem Header="_Stop" Command="{Binding StopEmulationCommand}" />
                 <MenuItem Header="_Pause" Command="{Binding TogglePauseEmulationCommand}" IsCheckable="True" IsChecked="{Binding IsPauseEmulationChecked, Mode=OneWay}" />
+                <MenuItem Header="_Unthrottled" Command="{Binding ToggleUnthrottledEmulationCommand}" IsCheckable="True" IsChecked="{Binding IsUnthrottledEmulationChecked, Mode=OneWay}" />
                 <Separator />
                 <MenuItem Header="_Reset" Command="{Binding ResetEmulationCommand}" />
             </MenuItem>

--- a/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
+++ b/WindowsNetProjects/OasisEditor/OasisEditor/MainWindowViewModel.cs
@@ -190,6 +190,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         StartEmulationCommand = new RelayCommand(StartEmulation, CanStartEmulation);
         StopEmulationCommand = new RelayCommand(StopEmulation, CanStopEmulation);
         TogglePauseEmulationCommand = new RelayCommand(TogglePauseEmulation, CanTogglePauseEmulation);
+        ToggleUnthrottledEmulationCommand = new RelayCommand(ToggleUnthrottledEmulation, CanToggleUnthrottledEmulation);
         ResetEmulationCommand = new RelayCommand(ResetEmulation, CanResetEmulation);
 
         _outputLog = new OutputLogViewModel();
@@ -431,6 +432,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
     public ICommand StartEmulationCommand { get; }
     public ICommand StopEmulationCommand { get; }
     public ICommand TogglePauseEmulationCommand { get; }
+    public ICommand ToggleUnthrottledEmulationCommand { get; }
     public ICommand ResetEmulationCommand { get; }
     public ObservableCollection<string> RecentProjects { get; }
     public ObservableCollection<DocumentTabViewModel> OpenDocuments { get; }
@@ -700,12 +702,14 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
             if (SetProperty(ref _emulationState, value))
             {
                 OnPropertyChanged(nameof(IsPauseEmulationChecked));
+                OnPropertyChanged(nameof(IsUnthrottledEmulationChecked));
                 NotifyEmulationCommands();
             }
         }
     }
 
     public bool IsPauseEmulationChecked => EmulationState == EmulationBackendState.Paused;
+    public bool IsUnthrottledEmulationChecked => _activeEmulationBackend is { IsThrottleEnabled: false };
 
     public string ProjectFilePath
     {
@@ -2524,6 +2528,22 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(IsPauseEmulationChecked));
     }
 
+    private bool CanToggleUnthrottledEmulation() =>
+        _activeEmulationBackend?.Capabilities.SupportsThrottle == true
+        && EmulationState is EmulationBackendState.Running or EmulationBackendState.Paused;
+
+    private async void ToggleUnthrottledEmulation()
+    {
+        if (_activeEmulationBackend is null)
+            return;
+        var enableThrottle = !_activeEmulationBackend.IsThrottleEnabled;
+        await SendEmulationCommandAsync(CanToggleUnthrottledEmulation,
+            enableThrottle ? "Normal-speed emulation requested." : "Unthrottled emulation requested.",
+            "Emulation failed to change throttle mode",
+            cancellationToken => _activeEmulationBackend.SetThrottleEnabledAsync(enableThrottle, cancellationToken));
+        OnPropertyChanged(nameof(IsUnthrottledEmulationChecked));
+    }
+
     private bool CanResetEmulation()
     {
         return _activeEmulationBackend?.Capabilities.SupportsReset == true
@@ -3448,6 +3468,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged
         RaiseEmulationCommandCanExecuteChanged(StartEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(StopEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(TogglePauseEmulationCommand);
+        RaiseEmulationCommandCanExecuteChanged(ToggleUnthrottledEmulationCommand);
         RaiseEmulationCommandCanExecuteChanged(ResetEmulationCommand);
     }
 


### PR DESCRIPTION
### Motivation
- Restore and adapt the previous MAME-era "unthrottled" capability for the Fabric/Amber pipeline so the editor can drive Fabric at maximum practical speed without changing Fabric/Amber internals. 
- Ensure each Fabric `Advance` still represents the same 1 ms slice while letting the editor run those slices as fast as CPU permits, avoid audio/sink-based implicit throttling, and keep UI snapshot updates rate-limited.

### Description
- Add observable throttle control to the backend contract by introducing `bool IsThrottleEnabled` and `Task SetThrottleEnabledAsync(bool enabled, CancellationToken)` to `IEmulationBackend`.
- Enable Fabric backend throttle capability and default to normal (throttled) operation by setting `SupportsThrottle: true` and `_throttleEnabled = true` in `FabricEmulationBackend`.
- Implement `SetThrottleEnabledAsync` in `FabricEmulationBackend` to atomically switch modes, clear real-time audio state via `_audioSink.Clear()`, bump the existing `_scheduleGeneration` and wake the runner so scheduler deadlines are rebased when returning to throttled mode.
- Add an unthrottled fast path in the Fabric pump loop that runs bounded batches (`UnthrottledBatchSlices`) of fixed 1 ms `session.Advance(NanosecondsPerPump)` calls, continues processing inputs, drains Fabric-side audio (reads it) but does not push accelerated PCM into the real-time audio sink, yields periodically, and publishes visual snapshots on a wall-clock cadence (~60 Hz) instead of per-slice snapshots.
- Preserve the existing throttled scheduler and audio-capacity pacing unchanged for normal operation; only the scheduling behaviour switches between the two modes.
- Change audio read path to accept a `pushToSink` flag so unthrottled mode can read/drain audio without pushing PCM to the sink.
- Expose a UI command and menu item: add `ToggleUnthrottledEmulationCommand` and `IsUnthrottledEmulationChecked` in `MainWindowViewModel`, and add the checkable `Unthrottled` item to the Emulation menu in `MainWindow.xaml`; the UI state is driven from the backend capability/state.
- Extend and update unit test helpers and tests (`FabricManagedBehaviorTests`, small test helper changes) to provide coverage for throttle capability, default state, unthrottled advances, audio bypass/drain behaviour, snapshot pacing, and pause/reset responsiveness while unthrottled.

### Testing
- Added/modified unit tests: `WindowsNetProjects/OasisEditor/OasisEditor.Tests/FabricManagedBehaviorTests.cs` and small test-helper changes in `PlayViewInputRouterTests.cs` to cover throttle capability, unthrottled advances, audio draining without PCM playback, snapshot rate-limiting, and lifecycle (pause/reset/stop) behaviour; these tests are included in the patch but not executed here.
- Ran repository sanity checks: `git diff --check` and working-tree status checks passed.
- Did not run `dotnet test` or build in this environment because `AGENTS.md` states the required Windows/.NET/WPF toolchain is unavailable, so unit tests must be executed locally (or in CI) to validate behaviour end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a807116d7508327a0a415140d6cee65)